### PR TITLE
Removing `insecure_skip_verify` as it is not needed

### DIFF
--- a/deploy/k8s/manifest.yaml
+++ b/deploy/k8s/manifest.yaml
@@ -20,7 +20,6 @@ data:
       otlp:
         endpoint: ${OTEL_ENVOY_ADDRESS}
         tls:
-          insecure_skip_verify: true
           insecure: ${OTEL_ENVOY_ADDRESS_TLS_INSECURE}
         headers:
           "Authorization": "Bearer ${SOLARWINDS_API_TOKEN}"


### PR DESCRIPTION
alpine image has ca_certificate store, so it can verify certificate. I tested it against our staging OTEL endpoint that has valid certificate