### PR TITLE
Renaming binary to `swi-otelcol`

### DIFF
--- a/build/docker/Dockerfile
+++ b/build/docker/Dockerfile
@@ -11,7 +11,7 @@ RUN CGO_ENABLED=0 /go/bin/builder --config ./nighthawk-swi-opentelemetry-collect
 
 FROM alpine@sha256:e7d88de73db3d3fd9b2d63aa7f447a10fd0220b7cbf39803c803f2af9ba256b3
 
-COPY --from=builder /src/nighthawk-swi-opentelemetry-collector /nighthawk-swi-opentelemetry-collector
+COPY --from=builder /src/nighthawk-swi-opentelemetry-collector /swi-otelcol
 
-ENTRYPOINT ["/nighthawk-swi-opentelemetry-collector"]
+ENTRYPOINT ["/swi-otelcol"]
 

--- a/tests/deploy/base/patch-apply-env-variables.yaml
+++ b/tests/deploy/base/patch-apply-env-variables.yaml
@@ -9,7 +9,7 @@ spec:
         - name: opentelemetry-collector
           image: nighthawk-swi-opentelemetry-collector
           command:
-            - /nighthawk-swi-opentelemetry-collector
+            - /swi-otelcol
             - --config=/conf/relay.yaml
           env:
           - name: SOLARWINDS_API_TOKEN


### PR DESCRIPTION
The binary in original otel collector is called `otelcol` so getting our closer to the original. Also image will be publicly available in Dockerhub, so we should avoid nighthawk codename there
