### PR TITLE
NH-9887: Rename kubernetes_io_hostname attribute to k8s.node.name

### DIFF
--- a/build/otel-collector-config.yaml
+++ b/build/otel-collector-config.yaml
@@ -159,11 +159,13 @@ processors:
             aggregation_type: sum
   groupbyattrs/all:
     keys:
+      - kubernetes_io_hostname
       - exported_node
       - kubelet_version
       - provider_id
       - os_image
       - exported_namespace
+      - namespace
       - pod
       - uid
       - pod_ip
@@ -204,8 +206,14 @@ processors:
 
       # Node
       - key: k8s.node.name
-        from_attribute: node
+        from_attribute: kubernetes_io_hostname
         action: insert
+      - key: kubernetes_io_hostname
+        action: delete
+
+      - key: k8s.node.name
+        from_attribute: node
+        action: upsert
       - key: node
         action: delete
 


### PR DESCRIPTION
Container specific metrics do not contain node name in standard `node` attribute but in `kubernetes_io_hostname`. In order to assign these metrics with node entity it needs to contain `k8s.node.name` attribute.