### PR TITLE
NH-9821: k8s Node deduplication

### DIFF
--- a/build/otel-collector-config.yaml
+++ b/build/otel-collector-config.yaml
@@ -190,6 +190,13 @@ processors:
         experimental_match_labels: { "condition": "DiskPressure", "status": "true" }
         action: insert
         new_name: k8s.node.status.condition.diskpressure
+        # Add dummy `host.id` so that we can update it (and only for this metric) later in Resource Attributes processor
+      - include: k8s.kube_node_info
+        action: update
+        operations:
+          - action: add_label
+            new_label: host.id
+            new_value: _
 
       # Cluster metrics
       - include: k8s.kube_pod_info
@@ -329,6 +336,7 @@ processors:
       - sw.k8s.pod.status
       - sw.k8s.namespace.status
       - sw.k8s.node.status
+      - host.id
   resource:
     attributes:
       # Remove useless attributes
@@ -343,6 +351,11 @@ processors:
 
       - key: scheme
         action: delete
+
+      # Collector and Manifest version
+      - key: sw.k8s.agent.manifest.version
+        value: "1.0"
+        action: insert
 
       # Cluster
       - key: sw.k8s.cluster.uid
@@ -374,7 +387,17 @@ processors:
 
       - key: host.id
         from_attribute: k8s.node.name
-        action: insert
+        action: update
+
+      - key: provider_id
+        pattern: ^aws.*/(?P<awsInstanceId>[^/]+)$
+        action: extract
+
+      - key: host.id
+        from_attribute: awsInstanceId
+        action: update
+      - key: awsInstanceId
+        action: delete
 
       - key: sw.k8s.node.version
         from_attribute: kubelet_version


### PR DESCRIPTION
* Include `sw.k8s.agent.manifest.version`
  * used as an attribute that is unique to our k8s agent (and not sent by AKS/EKS)
  * it can be used later for [Updating policy](https://swicloud.atlassian.net/wiki/spaces/NIT/pages/3109063738/Research+Updating+k8s+monitoring+agent+in+customer+s+environment)
* Extract AWS InstanceId, if available and send it as `host.id` to enable deduplication with EC2 Host
* ID for Azure VM will be added later
* `host.id` is sent only for metric `kube_node_info`
  * it is InstanceId for AWS managed hosts (until Azure is implemented)
  * it is node name for local machines (we don't have a better unique id now)
  * this way, a k8s Node entity will be created only when this metric is sent to OTEL - other metrics will be associated with the entity, if it already exists, but will not create one