### PR TITLE
NH-15440: Temporarily disabling publish of `:latest`

### DIFF
--- a/.github/workflows/buildAndDeploy.yml
+++ b/.github/workflows/buildAndDeploy.yml
@@ -183,5 +183,6 @@ jobs:
       - name: Push as specific
         run: docker push ${{ env.DOCKERHUB_IMAGE }}:${{ steps.vars.outputs.tag }}
 
-      - name: Push as latest
-        run: docker push ${{ env.DOCKERHUB_IMAGE }}:latest
+      # Temporarily disabled
+      # - name: Push as latest
+      #   run: docker push ${{ env.DOCKERHUB_IMAGE }}:latest


### PR DESCRIPTION
it will be re-enabled later, not because it is needed (we won't use it in our published manifest), but because it is good practices in Docker Hub to have latest pointing to the latest image
