### PR TITLE
NH-9821: Use resource detection processor

### DIFF
--- a/deploy/k8s/manifest.yaml
+++ b/deploy/k8s/manifest.yaml
@@ -407,7 +407,17 @@ data:
 
           - key: host.id
             from_attribute: k8s.node.name
-            action: insert
+            action: update
+
+          - key: provider_id
+            pattern: ^aws.*/(?P<awsInstanceId>[^/]+)$
+            action: extract
+
+          - key: host.id
+            from_attribute: awsInstanceId
+            action: update
+          - key: awsInstanceId
+            action: delete
 
           - key: sw.k8s.node.version
             from_attribute: kubelet_version
@@ -513,11 +523,6 @@ data:
             action: insert
           - key: image
             action: delete
-      
-      resourcedetection:
-        detectors: [eks, ec2, aks, azure]
-        timeout: 2s
-        override: true
 
       batch:
         send_batch_size: 8192
@@ -582,7 +587,6 @@ data:
             - metricstransform/aggregate_pod_level
             - groupbyattrs/all
             - resource
-            - resourcedetection
             - memory_limiter
             - batch
           receivers:


### PR DESCRIPTION
Use resource detection processor in order to fill in host.id in all metrics