### PR TITLE
NH-9821: Remove resource detection processor

### DIFF
--- a/build/swi-k8s-opentelemetry-collector.yaml
+++ b/build/swi-k8s-opentelemetry-collector.yaml
@@ -24,7 +24,6 @@ processors:
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/processor/cumulativetodeltaprocessor v0.51.0
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/processor/metricsgenerationprocessor v0.51.0
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/processor/filterprocessor v0.51.0
-  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/processor/resourcedetectionprocessor v0.51.0
   - gomod: github.com/solarwinds/swi-k8s-opentelemetry-collector/processor/prometheustypeconverterprocessor v0.0.1
     path: "./src/processor/prometheustypeconverterprocessor"
   - gomod: github.com/solarwinds/swi-k8s-opentelemetry-collector/processor/swmetricstransformprocessor v0.0.1


### PR DESCRIPTION
Removing resource detection processor from otel collector, as it does not fix our issue with missing host.id