### PR TITLE
NH-15657: Adding collection of journal logs

### DIFF
--- a/build/docker/Dockerfile
+++ b/build/docker/Dockerfile
@@ -13,6 +13,10 @@ RUN CGO_ENABLED=0 /go/bin/builder --config ./swi-k8s-opentelemetry-collector.yam
 FROM alpine:latest as prep
 RUN apk --update add ca-certificates
 
+FROM debian:11.4 as journal
+RUN apt update
+RUN apt install -y systemd
+
 FROM scratch
 
 ARG USER_UID=10001
@@ -20,6 +24,35 @@ USER ${USER_UID}
 
 COPY --from=prep /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
 COPY --from=builder /src/swi-k8s-opentelemetry-collector /swi-otelcol
+
+# dynamically linked libraries that are required for journalctl and the journalctl binary itself
+#   use `ldd /bin/journalctl` to get dynamically linked libraries from the binary
+COPY --from=journal /lib/systemd/libsystemd-shared-247.so /lib/systemd/libsystemd-shared-247.so
+COPY --from=journal /lib/x86_64-linux-gnu/libdl.so.2 /lib/x86_64-linux-gnu/libdl.so.2
+COPY --from=journal /lib/x86_64-linux-gnu/libc.so.6 /lib/x86_64-linux-gnu/libc.so.6
+COPY --from=journal /usr/lib/x86_64-linux-gnu/libacl.so.1 /usr/lib/x86_64-linux-gnu/libacl.so.1
+COPY --from=journal /usr/lib/x86_64-linux-gnu/libblkid.so.1 /usr/lib/x86_64-linux-gnu/libblkid.so.1
+COPY --from=journal /lib/x86_64-linux-gnu/libcap.so.2 /lib/x86_64-linux-gnu/libcap.so.2
+COPY --from=journal /lib/x86_64-linux-gnu/libcrypt.so.1 /lib/x86_64-linux-gnu/libcrypt.so.1
+COPY --from=journal /usr/lib/x86_64-linux-gnu/libgcrypt.so.20 /usr/lib/x86_64-linux-gnu/libgcrypt.so.20
+COPY --from=journal /usr/lib/x86_64-linux-gnu/libip4tc.so.2 /usr/lib/x86_64-linux-gnu/libip4tc.so.2
+COPY --from=journal /usr/lib/x86_64-linux-gnu/libkmod.so.2 /usr/lib/x86_64-linux-gnu/libkmod.so.2
+COPY --from=journal /usr/lib/x86_64-linux-gnu/liblz4.so.1 /usr/lib/x86_64-linux-gnu/liblz4.so.1
+COPY --from=journal /usr/lib/x86_64-linux-gnu/libmount.so.1 /usr/lib/x86_64-linux-gnu/libmount.so.1
+COPY --from=journal /lib/x86_64-linux-gnu/libpam.so.0 /lib/x86_64-linux-gnu/libpam.so.0
+COPY --from=journal /lib/x86_64-linux-gnu/librt.so.1 /lib/x86_64-linux-gnu/librt.so.1
+COPY --from=journal /usr/lib/x86_64-linux-gnu/libseccomp.so.2 /usr/lib/x86_64-linux-gnu/libseccomp.so.2
+COPY --from=journal /lib/x86_64-linux-gnu/libselinux.so.1 /lib/x86_64-linux-gnu/libselinux.so.1
+COPY --from=journal /usr/lib/x86_64-linux-gnu/libzstd.so.1 /usr/lib/x86_64-linux-gnu/libzstd.so.1
+COPY --from=journal /lib/x86_64-linux-gnu/liblzma.so.5 /lib/x86_64-linux-gnu/liblzma.so.5
+COPY --from=journal /lib/x86_64-linux-gnu/libpthread.so.0 /lib/x86_64-linux-gnu/libpthread.so.0
+COPY --from=journal /lib64/ld-linux-x86-64.so.2 /lib64/ld-linux-x86-64.so.2
+COPY --from=journal /lib/x86_64-linux-gnu/libgpg-error.so.0 /lib/x86_64-linux-gnu/libgpg-error.so.0
+COPY --from=journal /usr/lib/x86_64-linux-gnu/libcrypto.so.1.1 /usr/lib/x86_64-linux-gnu/libcrypto.so.1.1
+COPY --from=journal /lib/x86_64-linux-gnu/libaudit.so.1 /lib/x86_64-linux-gnu/libaudit.so.1
+COPY --from=journal /usr/lib/x86_64-linux-gnu/libpcre2-8.so.0 /usr/lib/x86_64-linux-gnu/libpcre2-8.so.0
+COPY --from=journal /lib/x86_64-linux-gnu/libcap-ng.so.0 /lib/x86_64-linux-gnu/libcap-ng.so.0
+COPY --from=journal /bin/journalctl /bin/journalctl
 
 ENTRYPOINT ["/swi-otelcol"]
 CMD ["--config=/opt/default-config.yaml"]

--- a/build/swi-k8s-opentelemetry-collector.yaml
+++ b/build/swi-k8s-opentelemetry-collector.yaml
@@ -11,6 +11,7 @@ receivers:
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver v0.51.0
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/k8seventsreceiver v0.51.0
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/filelogreceiver v0.51.0
+  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/journaldreceiver v0.51.0
   
 processors:
   - import: go.opentelemetry.io/collector/processor/batchprocessor

--- a/deploy/k8s/manifest.yaml
+++ b/deploy/k8s/manifest.yaml
@@ -658,10 +658,16 @@ data:
             action: insert
 
       batch:
-        send_batch_size: 8192
-        send_batch_max_size: 8192
+        send_batch_size: 1024
+        send_batch_max_size: 1024
         timeout: 1s
     receivers:
+      journald:
+        directory: /run/log/journal
+        units:
+          - kubelet
+          - docker
+          - containerd
       filelog:
         include: [ /var/log/pods/*/*/*.log ]
         # Exclude collector container's logs. The file format is /var/log/pods/<namespace_name>_<pod_name>_<pod_uid>/<container_name>/<run_id>.log
@@ -781,6 +787,15 @@ data:
             - batch
           receivers:
             - filelog
+        logs/2:
+          exporters:
+            - otlp
+          processors:
+            - groupbyattrs/all
+            - resource
+            - batch
+          receivers:
+            - journald
       telemetry:
         logs:
           level: "info"
@@ -1026,6 +1041,9 @@ spec:
             - mountPath: /conf
               name: opentelemetry-collector-configmap
               readOnly: true
+            - mountPath: /run/log/journal
+              name: runlogjournal
+              readOnly: true
       volumes:
         - name: varlogpods
           hostPath:
@@ -1036,6 +1054,9 @@ spec:
         - name: varlibdockercontainers
           hostPath:
             path: /var/lib/docker/containers
+        - name: runlogjournal
+          hostPath:
+            path: /run/log/journal
         - name: opentelemetry-collector-configmap
           configMap:
             name: swi-opentelemetry-collector


### PR DESCRIPTION
* I decreased batch size for logs as log batches are much larger in size, and I was encountering 
problems in dev testing (batches had cca 8MB's and my mock endpoint couldn't handle that). Decreasing batches to 1024 seems to work fine. 
* adding separate pipeline for journal logs which does not contain filter processor
* adding journalctl to docker image - the binary + all linked dependencies. Taken it from debian:10.8 which is cca 1.5 years old
* tested on local kubernetes with journal logs copied from testing kubernetes