### PR TITLE
NH-17985: Adding limitations sections

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,12 @@ Components that are being deployed:
 ## Installation
 Walk through Add Kubernetes wizard in SolarWinds Observability
 
+## Limitations
+* Supported kubernetes version: 1.18 and higher.
+  * Local kubernetes deployments (e.q. Minikube) are not supported (although most of the functionality may be working).
+* Supported kube-state-metrics: 1.5.0 and higher.
+* Supported architectures: Linux x86-64 (`amd64`).
+
 ## Customization
 The [manifest](https://github.com/solarwinds/swi-k8s-opentelemetry-collector/blob/master/deploy/k8s/manifest.yaml) that you are about to deploy to your cluster using the Add Kubernetes wizard contains [OpenTelemetry configuration](https://opentelemetry.io/docs/collector/configuration/) which defines the metrics and logs to be monitored. It allows you to customize the list of metrics and logs to be monitored, as well as their preprocessing.
 


### PR DESCRIPTION
* After this is merged I will contact Kristy to add it also to our official documentation
* I verified functionality in Kubernetes 1.18 (which is end-of-life over a year). In theory we should be supporting version since 1.9 (as `api/v1` was added there). But I wasn't able to install locally anything older than 1.18. Managed AWS EKS supports 1.19+.
* Kube-state-metrics we should work with 1.5.0 based on CHANGELOG analysis. Metrics we are using:
  * kube_node_status_condition
  * kube_node_status_ready
  * kube_pod_status_phase
  * kube_namespace_status_phase
  * kube_pod_container_status_restarts_total
  * kube_pod_container_resource_requests
  * kube_node_status_capacity (added at v1.4.0)
  * kube_node_status_allocatable (added at v1.4.0)
  * kube_node_info
  * kube_pod_info (added `uid` at v1.5.0)
  * kube_pod_container_info
  * kube_pod_start_time
  * kube_pod_completion_time (added at v1.3.0)
  * kube_pod_container_status_waiting_reason  (added at v1.4.0)
  * kube_pod_container_status_terminated_reason  (added at v1.4.0)
* Also added architecture and minikube related limitation
