### PR TITLE
NH-9823: Adding metric 'kube_node_spec_unschedulable'

### DIFF
--- a/deploy/k8s/manifest.yaml
+++ b/deploy/k8s/manifest.yaml
@@ -559,6 +559,7 @@ data:
                   - "kube_resourcequota"
                   - "kube_pod_container_status_restarts_total"
                   - "kube_node_status_allocatable"
+                  - "kube_node_spec_unschedulable"
                   - "kube_pod_container_resource_requests"
                   - '{__name__=~"kube_pod_container_.*"}'
               static_configs:


### PR DESCRIPTION
This metric is indicating whether it is possible to schedule something on the node (useful for Healthscore)
