### PR TITLE
NH-20269 Support Include\Exclude in filter datapoints action

### DIFF
--- a/deploy/k8s/manifest.yaml
+++ b/deploy/k8s/manifest.yaml
@@ -112,6 +112,12 @@ data:
               - action: filter_datapoints
                 datapoint_value: 0
                 datapoint_value_action: exclude
+          - include: k8s.kube_pod_created
+            action: update
+            operations:
+              - action: filter_datapoints
+                datapoint_value: 0
+                datapoint_value_action: exclude
       metricstransform/preprocessing:
         transforms:
           - include: k8s.kube_namespace_status_phase

--- a/deploy/k8s/manifest.yaml
+++ b/deploy/k8s/manifest.yaml
@@ -59,7 +59,6 @@ data:
               - action: filter_datapoints
                 datapoint_value: 1
                 datapoint_value_action: include
-                value_action: include
               - action: update_label
                 label: status
                 value_actions:
@@ -78,12 +77,14 @@ data:
             operations:
               - action: filter_datapoints
                 datapoint_value: 1
+                datapoint_value_action: include
           - include: k8s.kube_pod_container_status_ready
             action: insert
             new_name: k8s.kube_pod_container_status_ready_false_temp
             operations:
               - action: filter_datapoints
                 datapoint_value: 0
+                datapoint_value_action: include
           - include: k8s.kube_pod_status_phase
             action: update
             operations:
@@ -94,6 +95,18 @@ data:
                 label: phase
                 new_label: sw.k8s.pod.status
           - include: k8s.kube_pod_start_time
+            action: update
+            operations:
+              - action: filter_datapoints
+                datapoint_value: 0
+                datapoint_value_action: exclude
+          - include: k8s.kube_pod_completion_time
+            action: update
+            operations:
+              - action: filter_datapoints
+                datapoint_value: 0
+                datapoint_value_action: exclude
+          - include: k8s.kube_node_created
             action: update
             operations:
               - action: filter_datapoints
@@ -258,26 +271,6 @@ data:
             experimental_match_labels: { "condition": "DiskPressure", "status": "true" }
             action: insert
             new_name: k8s.node.status.condition.diskpressure
-          - include: k8s.kube_pod_status_phase
-            experimental_match_labels: { "condition": "Running" }
-            action: insert
-            new_name: k8s.kube.pod.status.phase.running
-          - include: k8s.kube_pod_status_phase
-            experimental_match_labels: { "condition": "Failed" }
-            action: insert
-            new_name: k8s.kube.pod.status.phase.failed
-          - include: k8s.kube_pod_status_phase
-            experimental_match_labels: { "condition": "Pending" }
-            action: insert
-            new_name: k8s.kube.pod.status.phase.pending
-          - include: k8s.kube_pod_status_phase
-            experimental_match_labels: { "condition": "Succeeded" }
-            action: insert
-            new_name: k8s.kube.pod.status.phase.succeeded
-          - include: k8s.kube_pod_status_phase
-            experimental_match_labels: { "condition": "Unknown" }
-            action: insert
-            new_name: k8s.kube.pod.status.phase.unknown
             # Add dummy `host.id` so that we can update it (and only for this metric) later in Resource Attributes processor
           - include: k8s.kube_node_info
             action: update
@@ -343,6 +336,7 @@ data:
             operations:
               - action: filter_datapoints
                 datapoint_value: 1
+                datapoint_value_action: include
       cumulativetodelta:
         include:
           metrics:
@@ -627,13 +621,13 @@ data:
                   - "kube_node_status_condition"
                   - "kube_pod_created"
                   - "kube_pod_info"
-                  - "kube_pod_start_time"
                   - "kube_pod_completion_time"
                   - "kube_pod_status_phase"
                   - "kube_pod_start_time"
                   - "kube_resourcequota"
                   - "kube_pod_container_status_restarts_total"
                   - "kube_node_status_allocatable"
+                  - "kube_node_spec_unschedulable"
                   - "kube_pod_container_resource_requests"
                   - '{__name__=~"kube_pod_container_.*"}'
               static_configs:

--- a/deploy/k8s/manifest.yaml
+++ b/deploy/k8s/manifest.yaml
@@ -58,6 +58,8 @@ data:
             operations:
               - action: filter_datapoints
                 datapoint_value: 1
+                datapoint_value_action: include
+                value_action: include
               - action: update_label
                 label: status
                 value_actions:
@@ -75,9 +77,16 @@ data:
             operations:
               - action: filter_datapoints
                 datapoint_value: 1
+                datapoint_value_action: include
               - action: update_label
                 label: phase
                 new_label: sw.k8s.pod.status
+          - include: k8s.kube_pod_start_time
+            action: update
+            operations:
+              - action: filter_datapoints
+                datapoint_value: 0
+                datapoint_value_action: exclude
       metricstransform/preprocessing:
         transforms:
           - include: k8s.kube_namespace_status_phase
@@ -210,6 +219,26 @@ data:
             experimental_match_labels: { "condition": "DiskPressure", "status": "true" }
             action: insert
             new_name: k8s.node.status.condition.diskpressure
+          - include: k8s.kube_pod_status_phase
+            experimental_match_labels: { "condition": "Running" }
+            action: insert
+            new_name: k8s.kube.pod.status.phase.running
+          - include: k8s.kube_pod_status_phase
+            experimental_match_labels: { "condition": "Failed" }
+            action: insert
+            new_name: k8s.kube.pod.status.phase.failed
+          - include: k8s.kube_pod_status_phase
+            experimental_match_labels: { "condition": "Pending" }
+            action: insert
+            new_name: k8s.kube.pod.status.phase.pending
+          - include: k8s.kube_pod_status_phase
+            experimental_match_labels: { "condition": "Succeeded" }
+            action: insert
+            new_name: k8s.kube.pod.status.phase.succeeded
+          - include: k8s.kube_pod_status_phase
+            experimental_match_labels: { "condition": "Unknown" }
+            action: insert
+            new_name: k8s.kube.pod.status.phase.unknown
             # Add dummy `host.id` so that we can update it (and only for this metric) later in Resource Attributes processor
           - include: k8s.kube_node_info
             action: update
@@ -559,7 +588,6 @@ data:
                   - "kube_resourcequota"
                   - "kube_pod_container_status_restarts_total"
                   - "kube_node_status_allocatable"
-                  - "kube_node_spec_unschedulable"
                   - "kube_pod_container_resource_requests"
                   - '{__name__=~"kube_pod_container_.*"}'
               static_configs:

--- a/src/processor/swmetricstransformprocessor/config.go
+++ b/src/processor/swmetricstransformprocessor/config.go
@@ -54,6 +54,9 @@ const (
 
 	// DataPointsFieldName is the mapstructure field name for Datapoint field
 	DataPointsFieldName = "datapoint_value"
+
+	// DataValueActionFieldName is the mapstructure field name for Datapoint field
+	DataValueActionFieldName = "datapoint_value_action"
 )
 
 // Config defines configuration for Resource processor.
@@ -129,8 +132,11 @@ type Operation struct {
 	// LabelValue identifies the exact label value to operate on
 	LabelValue string `mapstructure:"label_value"`
 
-	// DataPointValue identifies data point values ​​that should be included in the output
+	// DataPointValue identifies data point values ​​that should be included/excluded in the output
 	DataPointValue float64 `mapstructure:"datapoint_value"`
+
+	// DataPointValueAction is a list of actions for data point values.
+	DataPointValueAction DataPointValueAction `mapstructure:"datapoint_value_action"`
 }
 
 // ValueAction renames label values.
@@ -140,6 +146,29 @@ type ValueAction struct {
 
 	// NewValue specifies the label value to rename to.
 	NewValue string `mapstructure:"new_value"`
+}
+
+// DataPointValueAction is the enum to capture the type of action to perform on a data point.
+type DataPointValueAction string
+
+const (
+	// Include datapoints that match the provided value
+	Include DataPointValueAction = "include"
+
+	// Exclude datapoints that match the provided value
+	Exclude DataPointValueAction = "exclude"
+)
+
+var dataPointActions = []DataPointValueAction{Include, Exclude}
+
+func (da DataPointValueAction) isValid() bool {
+	for _, datapointAction := range dataPointActions {
+		if da == datapointAction {
+			return true
+		}
+	}
+
+	return false
 }
 
 // ConfigAction is the enum to capture the type of action to perform on a metric.

--- a/src/processor/swmetricstransformprocessor/config_test.go
+++ b/src/processor/swmetricstransformprocessor/config_test.go
@@ -120,8 +120,24 @@ func TestLoadingFullConfig(t *testing.T) {
 						NewName: "new_name_copy_3",
 						Operations: []Operation{
 							{
-								Action:         "filter_datapoints",
-								DataPointValue: 1,
+								Action:               "filter_datapoints",
+								DataPointValue:       1,
+								DataPointValueAction: Include,
+							},
+						},
+					},
+					{
+						MetricIncludeFilter: FilterConfig{
+							Include:   "name5",
+							MatchType: "strict",
+						},
+						Action:  "insert",
+						NewName: "new_name_copy_4",
+						Operations: []Operation{
+							{
+								Action:               "filter_datapoints",
+								DataPointValue:       1,
+								DataPointValueAction: Exclude,
 							},
 						},
 					},

--- a/src/processor/swmetricstransformprocessor/factory.go
+++ b/src/processor/swmetricstransformprocessor/factory.go
@@ -125,6 +125,9 @@ func validateConfiguration(config *Config) error {
 			if op.Action == FilterDataPoints && op.DataPointValue == 0 {
 				return fmt.Errorf("operation %v: missing required field %q while %q is %v", i+1, DataPointsFieldName, ActionFieldName, FilterDataPoints)
 			}
+			if op.Action == FilterDataPoints && !op.DataPointValueAction.isValid() {
+				return fmt.Errorf("operation %v: %q must be in %q", i+1, DataValueActionFieldName, dataPointActions)
+			}
 		}
 	}
 	return nil

--- a/src/processor/swmetricstransformprocessor/processor_testcases_test.go
+++ b/src/processor/swmetricstransformprocessor/processor_testcases_test.go
@@ -775,7 +775,7 @@ var (
 		},
 		// filter datapoints
 		{
-			name: "filter_datapoints",
+			name: "filter_datapoints_include",
 			transforms: []internalTransform{
 				{
 					MetricIncludeFilter: internalFilterStrict{include: "metric"},
@@ -783,8 +783,9 @@ var (
 					Operations: []internalOperation{
 						{
 							configOperation: Operation{
-								Action:         FilterDataPoints,
-								DataPointValue: 1,
+								Action:               FilterDataPoints,
+								DataPointValue:       1,
+								DataPointValueAction: Include,
 							},
 						},
 					},
@@ -804,6 +805,40 @@ var (
 					setDataType(metricspb.MetricDescriptor_GAUGE_INT64).
 					addTimeseries(1, []string{"label1value1", "label2value"}).
 					addInt64Point(0, 1, 2).
+					build(),
+			},
+		},
+		{
+			name: "filter_datapoints_exclude",
+			transforms: []internalTransform{
+				{
+					MetricIncludeFilter: internalFilterStrict{include: "metric"},
+					Action:              Update,
+					Operations: []internalOperation{
+						{
+							configOperation: Operation{
+								Action:               FilterDataPoints,
+								DataPointValue:       1,
+								DataPointValueAction: Exclude,
+							},
+						},
+					},
+				},
+			},
+			in: []*metricspb.Metric{
+				metricBuilder().setName("metric").setLabels([]string{"label1", "label2"}).
+					setDataType(metricspb.MetricDescriptor_GAUGE_INT64).
+					addTimeseries(1, []string{"label1value1", "label2value"}).
+					addInt64Point(0, 1, 2).
+					addTimeseries(1, []string{"label1value2", "label2value"}).
+					addInt64Point(1, 0, 2).
+					build(),
+			},
+			out: []*metricspb.Metric{
+				metricBuilder().setName("metric").setLabels([]string{"label1", "label2"}).
+					setDataType(metricspb.MetricDescriptor_GAUGE_INT64).
+					addTimeseries(1, []string{"label1value2", "label2value"}).
+					addInt64Point(0, 0, 2).
 					build(),
 			},
 		},

--- a/src/processor/swmetricstransformprocessor/testdata/config_full.yaml
+++ b/src/processor/swmetricstransformprocessor/testdata/config_full.yaml
@@ -46,6 +46,16 @@ processors:
         operations:
           - action: filter_datapoints
             datapoint_value: 1
+            datapoint_value_action: include
+
+      - include: name5
+        action: insert
+        match_type: strict
+        new_name: new_name_copy_4
+        operations:
+          - action: filter_datapoints
+            datapoint_value: 1
+            datapoint_value_action: exclude
 
 exporters:
   nop:


### PR DESCRIPTION
Adding support for Include\Exclude of data point values in filter datapoints action in order to be able to exclude 0 values from metrics that should not return 0 data points at all.