### PR TITLE
NH-21059: Aggregate new cluster metrics

### DIFF
--- a/deploy/k8s/manifest.yaml
+++ b/deploy/k8s/manifest.yaml
@@ -277,6 +277,10 @@ data:
             experimental_match_labels: { "condition": "DiskPressure", "status": "true" }
             action: insert
             new_name: k8s.node.status.condition.diskpressure
+          - include: k8s.kube_pod_status_phase
+            experimental_match_labels: { "sw.k8s.pod.status": "Running" }
+            action: insert
+            new_name: k8s.pod.status.phase.running
             # Add dummy `host.id` so that we can update it (and only for this metric) later in Resource Attributes processor
           - include: k8s.kube_node_info
             action: update
@@ -296,6 +300,34 @@ data:
           - include: k8s.kube_node_info
             action: insert
             new_name: k8s.cluster.nodes
+            operations:
+              - action: aggregate_labels
+                label_set: []
+                aggregation_type: sum
+          - include: k8s.node.status.condition.ready
+            action: insert
+            new_name: k8s.cluster.nodes.ready
+            operations:
+              - action: aggregate_labels
+                label_set: []
+                aggregation_type: sum
+          - include: k8s.container.spec.memory.requests
+            action: insert
+            new_name: k8s.cluster.spec.memory.requests
+            operations:
+              - action: aggregate_labels
+                label_set: []
+                aggregation_type: sum
+          - include: k8s.container.spec.cpu.requests
+            action: insert
+            new_name: k8s.cluster.spec.cpu.requests
+            operations:
+              - action: aggregate_labels
+                label_set: []
+                aggregation_type: sum
+          - include: k8s.pod.status.phase.running
+            action: insert
+            new_name: k8s.cluster.pods.running
             operations:
               - action: aggregate_labels
                 label_set: []


### PR DESCRIPTION
Adding new cluster metrics in order to show them on the new Kubernetes Summary page

- k8s.cluster.nodes.ready
- k8s.cluster.spec.memory.requests
- k8s.cluster.spec.cpu.requests
- k8s.cluster.pods.running