### PR TITLE
NH-21202: Removing attributes that are confusing our ingestion

### DIFF
--- a/build/swi-k8s-opentelemetry-collector.yaml
+++ b/build/swi-k8s-opentelemetry-collector.yaml
@@ -25,6 +25,7 @@ processors:
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/processor/cumulativetodeltaprocessor v0.51.0
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/processor/metricsgenerationprocessor v0.51.0
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/processor/filterprocessor v0.51.0
+  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/processor/attributesprocessor v0.51.0
   - gomod: github.com/solarwinds/swi-k8s-opentelemetry-collector/processor/prometheustypeconverterprocessor v0.0.1
     path: "./src/processor/prometheustypeconverterprocessor"
   - gomod: github.com/solarwinds/swi-k8s-opentelemetry-collector/processor/swmetricstransformprocessor v0.0.1

--- a/deploy/k8s/manifest.yaml
+++ b/deploy/k8s/manifest.yaml
@@ -43,6 +43,73 @@ data:
             convert_type: sum
           - include: apiserver_request_total
             convert_type: sum
+      # removing attributes of kube-state-metrics on those metrics where it does not identify resource, but identify the source 
+      #   where kube-state-metric is deployed on
+      attributes/remove_node:
+        include:
+          match_type: regexp
+          metric_names:
+            - kube_.*
+        exclude:
+          match_type: regexp
+          metric_names:
+            - kube_node_.*
+            - kube_pod_info
+        actions:
+          - key: node
+            action: delete
+          - key: exported_node
+            action: delete
+      attributes/remove_pod:
+        include:
+          match_type: regexp
+          metric_names:
+            - kube_.*
+        exclude:
+          match_type: regexp
+          metric_names:
+            - kube_pod_.*
+        actions:
+          - key: pod
+            action: delete
+      attributes/remove_container:
+        include:
+          match_type: regexp
+          metric_names:
+            - kube_.*
+        exclude:
+          match_type: regexp
+          metric_names:
+            - kube_pod_container_.*
+        actions:
+          - key: container
+            action: delete
+      attributes/remove_service:
+        include:
+          match_type: regexp
+          metric_names:
+            - kube_.*
+        exclude:
+          match_type: regexp
+          metric_names:
+            - kube_service_.*
+        actions:
+          - key: service
+            action: delete
+      attributes/remove_other:
+        include:
+          match_type: regexp
+          metric_names:
+            - kube_.*
+        actions:
+          - key: job
+            action: delete
+          - key: instance
+            action: delete
+          - key: exported_job
+            action: delete
+          - key: exported_instance
+            action: delete
       metricstransform/rename:
         transforms:
           # add `k8s.` suffix to all metrics that are clearly provided by Kubernetes
@@ -851,6 +918,11 @@ data:
             - otlp
           processors:
             - prometheustypeconvert
+            - attributes/remove_node
+            - attributes/remove_pod
+            - attributes/remove_container
+            - attributes/remove_service
+            - attributes/remove_other
             - metricstransform/rename
             - swmetricstransform/preprocessing
             - metricstransform/preprocessing


### PR DESCRIPTION
Those attributes are not identifying the target resource, but the source where kube-state-metric is deployed on
