### PR TITLE
NH-21761: adding Mend scan

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,8 @@
 version: 2.1
 
 orbs:
-  mend: solarwinds/mend@1.5.0
+  mend: solarwinds/mend@1
+  helm: circleci/helm@2.0.1
 
 commands:
   full_checkout:
@@ -23,6 +24,7 @@ jobs:
           name: Setup skaffold
           command: |
             curl -Lo skaffold https://storage.googleapis.com/skaffold/releases/v1.39.2/skaffold-linux-amd64 && sudo install skaffold /usr/local/bin/
+      - helm/install-helm-client
       - run:
           name: Build
           command: |
@@ -31,28 +33,24 @@ jobs:
           name: Get installed packages
           command: |
             docker create --name builder swi-k8s-opentelemetry-collector-builder:${CIRCLE_SHA1}
-            docker cp builder:/go/pkg/mod go-packages
+            docker cp builder:/src/vendor go-packages
       - persist_to_workspace:
           root: .
           paths:
             - go-packages
-  noop:
-    docker:
-      - image: circleci/python:3.6
-    steps:
-      - run:
-          command: |
-            echo "do nothing"
 
 workflows:
   version: 2
   main-build:
-    when: 
-      matches: { pattern: '^\d\.\d\.\d$', value: << pipeline.git.tag >> }
     jobs:
       - build:
           context:
             - common-build-creds
+          filters:
+            tags:
+              only: /.*/
+            branches:
+              ignore: /.*/
       - mend/scan:
           scan-path: go-packages
           context:
@@ -65,7 +63,8 @@ workflows:
           product: ik8s
           requires:
             - build
-  noop:
-    jobs:
-      - noop:
-          context: common-build-creds
+          filters:
+            tags:
+              only: /.*/
+            branches:
+              ignore: /.*/

--- a/build/docker/Dockerfile
+++ b/build/docker/Dockerfile
@@ -10,6 +10,10 @@ WORKDIR /src
 COPY ["./src/", "./src/"]
 RUN CGO_ENABLED=0 /go/bin/builder --config ./swi-k8s-opentelemetry-collector.yaml --output-path ./
 
+# create vendor folder (for mend scanning)
+ARG CREATE_VENDOR_DIR
+RUN if [[ -z "$CREATE_VENDOR_DIR" ]] ; then echo vendor creation skipped ; else go mod vendor ; fi
+
 FROM alpine:latest as prep
 RUN apk --update add ca-certificates
 

--- a/skaffold.yaml
+++ b/skaffold.yaml
@@ -35,6 +35,8 @@ profiles:
         docker:
           dockerfile: build/docker/Dockerfile
           target: builder
+          buildArgs: 
+            CREATE_VENDOR_DIR: "true"
 - name: ci
   activation:
   - env: CI=true


### PR DESCRIPTION
OTEL builder produces combined `go.mod` file with dependencies of all the components, so we just need to call `go mod vendor` and send the output to mend

example scan with this setup is here: https://app.whitesourcesoftware.com/Wss/WSS.html#!project;id=4601181