### PR TITLE
Fixing build

### DIFF
--- a/.github/workflows/buildAndDeploy.yml
+++ b/.github/workflows/buildAndDeploy.yml
@@ -48,7 +48,7 @@ jobs:
 
       - name: Tail Otel mock events for 60 seconds
         run: |
-          kubectl delete pods -l component=node-exporter -n monitoring
+          kubectl run dummy --image ubuntu -- /bin/bash -ec "while :; do echo '.'; sleep 5 ; done"
           mkdir -p OtelLogs
           kubetail timeseries-mock-service --namespace monitoring > OtelLogs/events.log &
           sleep 60


### PR DESCRIPTION
in new version of Helm chart there is probably no component called `node-exporter` so no events are triggered
