### PR TITLE
NH-27162 - use `instance` when `node` attribute is not present

### DIFF
--- a/deploy/k8s/manifest.yaml
+++ b/deploy/k8s/manifest.yaml
@@ -628,6 +628,24 @@ data:
                 label_set: [node]
                 aggregation_type: sum
             new_name: k8s.node.fs.writes.bytes.rate_temp
+          - include: (k8s.node.fs.reads.rate_temp|k8s.node.fs.writes.rate_temp)
+            match_type: regexp
+            action: combine
+            submatch_case: lower
+            operations:
+              - action: aggregate_labels
+                label_set:  [node]
+                aggregation_type: sum
+            new_name: k8s.node.fs.iops
+          - include: (k8s.node.fs.reads.bytes.rate_temp|k8s.node.fs.writes.bytes.rate_temp)
+            match_type: regexp
+            action: combine
+            submatch_case: lower
+            operations:
+              - action: aggregate_labels
+                label_set:  [node]
+                aggregation_type: sum
+            new_name: k8s.node.fs.throughput
           - include: k8s.pod.fs.usage.bytes
             action: insert
             operations:
@@ -769,11 +787,7 @@ data:
             - k8s.pod.network.packets_transmitted
             - k8s.pod.network.receive_packets_dropped
             - k8s.pod.network.transmit_packets_dropped
-            - k8s.node.fs.reads.rate_temp
-            - k8s.node.fs.writes.rate_temp
             - k8s.node.fs.iops
-            - k8s.node.fs.reads.bytes.rate_temp
-            - k8s.node.fs.writes.bytes.rate_temp
             - k8s.node.fs.throughput
             - k8s.node.network.bytes_received
             - k8s.node.network.bytes_transmitted
@@ -796,11 +810,7 @@ data:
           - k8s.pod.network.packets_transmitted
           - k8s.pod.network.receive_packets_dropped
           - k8s.pod.network.transmit_packets_dropped
-          - k8s.node.fs.reads.rate_temp
-          - k8s.node.fs.writes.rate_temp
           - k8s.node.fs.iops
-          - k8s.node.fs.reads.bytes.rate_temp
-          - k8s.node.fs.writes.bytes.rate_temp
           - k8s.node.fs.throughput
           - k8s.node.network.bytes_received
           - k8s.node.network.bytes_transmitted
@@ -837,18 +847,6 @@ data:
             metric1: apiserver_request_not_failed_temp
             metric2: apiserver_request_total_temp
             operation: percent
-      experimental_metricsgeneration/node:
-        rules:
-          - name: k8s.node.fs.iops
-            type: calculate
-            metric1: k8s.node.fs.reads.rate_temp
-            metric2: k8s.node.fs.writes.rate_temp
-            operation: add
-          - name: k8s.node.fs.throughput
-            type: calculate
-            metric1: k8s.node.fs.reads.bytes.rate_temp
-            metric2: k8s.node.fs.writes.bytes.rate_temp
-            operation: add
       experimental_metricsgeneration/pod:
         rules:
           - name: k8s.pod.spec.cpu.limit
@@ -1216,7 +1214,6 @@ data:
             - deltatorate
             - metricstransform/aggregate_rate
             - experimental_metricsgeneration/cluster
-            - experimental_metricsgeneration/node
             - experimental_metricsgeneration/pod
             - groupbyattrs/node
             - metricstransform/aggregate_node_level

--- a/deploy/k8s/manifest.yaml
+++ b/deploy/k8s/manifest.yaml
@@ -56,6 +56,30 @@ data:
         metrics:
           statements:
             - convert_gauge_to_sum("cumulative", true) where IsMatch(metric.name, "^.*_total$") == true
+      # unify attributes 
+      attributes/unify:
+        actions:
+          - key: k8s.node.name
+            from_attribute: instance
+            action: insert
+          - key: k8s.node.name
+            from_attribute: kubernetes_io_hostname
+            action: insert
+          - key: k8s.node.name
+            from_attribute: node
+            action: insert
+          - key: k8s.node.name
+            from_attribute: exported_node
+            action: insert
+            
+          - key: instance
+            action: delete
+          - key: kubernetes_io_hostname
+            action: delete
+          - key: node
+            action: delete
+          - key: exported_node
+            action: delete
       # removing attributes of kube-state-metrics on those metrics where it does not identify resource, but identify the source
       #   where kube-state-metric is deployed on
       attributes/remove_node:
@@ -73,6 +97,7 @@ data:
         actions:
           - key: node
             action: delete
+          
           - key: exported_node
             action: delete
       attributes/remove_pod:
@@ -336,7 +361,7 @@ data:
             experimental_match_labels: { "container": "(.|\\s)*\\S(.|\\s)*" }
             operations:
               - action: aggregate_labels
-                label_set: [pod, namespace, node]
+                label_set: [pod, namespace, k8s.node.name]
                 aggregation_type: sum
             new_name: k8s.pod.network.bytes_received
           - include: k8s.container_network_transmit_bytes_total
@@ -345,7 +370,7 @@ data:
             experimental_match_labels: { "container": "(.|\\s)*\\S(.|\\s)*" }
             operations:
               - action: aggregate_labels
-                label_set: [pod, namespace, node]
+                label_set: [pod, namespace, k8s.node.name]
                 aggregation_type: sum
             new_name: k8s.pod.network.bytes_transmitted
           - include: k8s.container_network_receive_packets_total
@@ -354,7 +379,7 @@ data:
             experimental_match_labels: { "container": "(.|\\s)*\\S(.|\\s)*" }
             operations:
               - action: aggregate_labels
-                label_set: [pod, namespace, node]
+                label_set: [pod, namespace, k8s.node.name]
                 aggregation_type: sum
             new_name: k8s.pod.network.packets_received
           - include: k8s.container_network_transmit_packets_total
@@ -363,7 +388,7 @@ data:
             experimental_match_labels: { "container": "(.|\\s)*\\S(.|\\s)*" }
             operations:
               - action: aggregate_labels
-                label_set: [pod, namespace, node]
+                label_set: [pod, namespace, k8s.node.name]
                 aggregation_type: sum
             new_name: k8s.pod.network.packets_transmitted
           - include: k8s.container_network_receive_packets_dropped_total
@@ -372,7 +397,7 @@ data:
             experimental_match_labels: { "container": "(.|\\s)*\\S(.|\\s)*" }
             operations:
               - action: aggregate_labels
-                label_set: [pod, namespace, node]
+                label_set: [pod, namespace, k8s.node.name]
                 aggregation_type: sum
             new_name: k8s.pod.network.receive_packets_dropped
           - include: k8s.container_network_transmit_packets_dropped_total
@@ -381,7 +406,7 @@ data:
             experimental_match_labels: { "container": "(.|\\s)*\\S(.|\\s)*" }
             operations:
               - action: aggregate_labels
-                label_set: [pod, namespace, node]
+                label_set: [pod, namespace, k8s.node.name]
                 aggregation_type: sum
             new_name: k8s.pod.network.transmit_packets_dropped
           - include: k8s.kube_pod_container_status_waiting
@@ -441,7 +466,7 @@ data:
             experimental_match_labels: { "container": "(.|\\s)*\\S(.|\\s)*" }
             operations:
               - action: aggregate_labels
-                label_set: [pod, namespace, node]
+                label_set: [pod, namespace, k8s.node.name]
                 aggregation_type: sum
             new_name: k8s.pod.fs.reads.rate
           - include: k8s.container_fs_writes_total
@@ -451,7 +476,7 @@ data:
             experimental_match_labels: { "container": "(.|\\s)*\\S(.|\\s)*" }
             operations:
               - action: aggregate_labels
-                label_set: [pod, namespace, node]
+                label_set: [pod, namespace, k8s.node.name]
                 aggregation_type: sum
             new_name: k8s.pod.fs.writes.rate
           - include: k8s.container_fs_reads_bytes_total
@@ -461,7 +486,7 @@ data:
             experimental_match_labels: { "container": "(.|\\s)*\\S(.|\\s)*" }
             operations:
               - action: aggregate_labels
-                label_set: [pod, namespace, node]
+                label_set: [pod, namespace, k8s.node.name]
                 aggregation_type: sum
             new_name: k8s.pod.fs.reads.bytes.rate
           - include: k8s.container_fs_writes_bytes_total
@@ -471,7 +496,7 @@ data:
             experimental_match_labels: { "container": "(.|\\s)*\\S(.|\\s)*" }
             operations:
               - action: aggregate_labels
-                label_set: [pod, namespace, node]
+                label_set: [pod, namespace, k8s.node.name]
                 aggregation_type: sum
             new_name: k8s.pod.fs.writes.bytes.rate
           - include: k8s.container_fs_usage_bytes
@@ -481,7 +506,7 @@ data:
             experimental_match_labels: { "container": "(.|\\s)*\\S(.|\\s)*" }
             operations:
               - action: aggregate_labels
-                label_set: [pod, namespace, node]
+                label_set: [pod, namespace, k8s.node.name]
                 aggregation_type: sum
             new_name: k8s.pod.fs.usage.bytes
           # Node metrics
@@ -537,77 +562,77 @@ data:
             action: insert
             operations:
               - action: aggregate_labels
-                label_set: [node]
+                label_set: [k8s.node.name]
                 aggregation_type: sum
             new_name: k8s.node.network.bytes_received
           - include: k8s.pod.network.bytes_transmitted
             action: insert
             operations:
               - action: aggregate_labels
-                label_set: [node]
+                label_set: [k8s.node.name]
                 aggregation_type: sum
             new_name: k8s.node.network.bytes_transmitted
           - include: k8s.pod.network.packets_received
             action: insert
             operations:
               - action: aggregate_labels
-                label_set: [node]
+                label_set: [k8s.node.name]
                 aggregation_type: sum
             new_name: k8s.node.network.packets_received
           - include: k8s.pod.network.packets_transmitted
             action: insert
             operations:
               - action: aggregate_labels
-                label_set: [node]
+                label_set: [k8s.node.name]
                 aggregation_type: sum
             new_name: k8s.node.network.packets_transmitted
           - include: k8s.pod.network.receive_packets_dropped
             action: insert
             operations:
               - action: aggregate_labels
-                label_set: [node]
+                label_set: [k8s.node.name]
                 aggregation_type: sum
             new_name: k8s.node.network.receive_packets_dropped
           - include: k8s.pod.network.transmit_packets_dropped
             action: insert
             operations:
               - action: aggregate_labels
-                label_set: [node]
+                label_set: [k8s.node.name]
                 aggregation_type: sum
             new_name: k8s.node.network.transmit_packets_dropped
           - include: k8s.pod.fs.reads.rate
             action: insert
             operations:
               - action: aggregate_labels
-                label_set: [node]
+                label_set: [k8s.node.name]
                 aggregation_type: sum
             new_name: k8s.node.fs.reads.rate_temp
           - include: k8s.pod.fs.writes.rate
             action: insert
             operations:
               - action: aggregate_labels
-                label_set: [node]
+                label_set: [k8s.node.name]
                 aggregation_type: sum
             new_name: k8s.node.fs.writes.rate_temp
           - include: k8s.pod.fs.reads.bytes.rate
             action: insert
             operations:
               - action: aggregate_labels
-                label_set: [node]
+                label_set: [k8s.node.name]
                 aggregation_type: sum
             new_name: k8s.node.fs.reads.bytes.rate_temp
           - include: k8s.pod.fs.writes.bytes.rate
             action: insert
             operations:
               - action: aggregate_labels
-                label_set: [node]
+                label_set: [k8s.node.name]
                 aggregation_type: sum
             new_name: k8s.node.fs.writes.bytes.rate_temp
           - include: k8s.pod.fs.usage.bytes
             action: insert
             operations:
               - action: aggregate_labels
-                label_set: [node]
+                label_set: [k8s.node.name]
                 aggregation_type: sum
             new_name: k8s.node.fs.usage
 
@@ -833,7 +858,7 @@ data:
             operation: divide
       groupbyattrs/node:
         keys:
-          - node
+          - k8s.node.name
       # Transformations done after grouping per node
       metricstransform/aggregate_node_level:
         transforms:
@@ -859,9 +884,7 @@ data:
                 label_set: []
                 aggregation_type: sum
       groupbyattrs/all:
-        keys:
-          - kubernetes_io_hostname
-          - exported_node
+        keys:         
           - kubelet_version
           - container_runtime_version
           - provider_id
@@ -878,6 +901,7 @@ data:
           - container
           - image
           - image_id
+          - k8s.node.name
           - sw.k8s.pod.status
           - sw.k8s.namespace.status
           - sw.k8s.node.status
@@ -922,23 +946,6 @@ data:
             action: insert
 
           # Node
-          - key: k8s.node.name
-            from_attribute: kubernetes_io_hostname
-            action: insert
-          - key: kubernetes_io_hostname
-            action: delete
-
-          - key: k8s.node.name
-            from_attribute: node
-            action: upsert
-          - key: node
-            action: delete
-
-          - key: k8s.node.name
-            from_attribute: exported_node
-            action: upsert
-          - key: exported_node
-            action: delete
 
           - key: sw.k8s.node.version
             from_attribute: kubelet_version
@@ -1190,6 +1197,7 @@ data:
           processors:
             - memory_limiter
             - transform
+            - attributes/unify
             - attributes/remove_node
             - attributes/remove_pod
             - attributes/remove_container

--- a/deploy/k8s/manifest.yaml
+++ b/deploy/k8s/manifest.yaml
@@ -59,24 +59,24 @@ data:
       # unify attributes 
       attributes/unify:
         actions:
-          - key: k8s.node.name
-            from_attribute: instance
-            action: insert
-          - key: k8s.node.name
-            from_attribute: kubernetes_io_hostname
-            action: insert
-          - key: k8s.node.name
-            from_attribute: node
-            action: insert
-          - key: k8s.node.name
+          - key: node
             from_attribute: exported_node
             action: insert
-            
+          - key: node
+            from_attribute: kubernetes_io_hostname
+            action: insert
+          - key: node
+            from_attribute: instance
+            action: insert
+          - key: node
+            from_attribute: exported_instance
+            action: insert
+          
           - key: instance
             action: delete
           - key: kubernetes_io_hostname
             action: delete
-          - key: node
+          - key: exported_instance
             action: delete
           - key: exported_node
             action: delete
@@ -361,7 +361,7 @@ data:
             experimental_match_labels: { "container": "(.|\\s)*\\S(.|\\s)*" }
             operations:
               - action: aggregate_labels
-                label_set: [pod, namespace, k8s.node.name]
+                label_set: [pod, namespace, node]
                 aggregation_type: sum
             new_name: k8s.pod.network.bytes_received
           - include: k8s.container_network_transmit_bytes_total
@@ -370,7 +370,7 @@ data:
             experimental_match_labels: { "container": "(.|\\s)*\\S(.|\\s)*" }
             operations:
               - action: aggregate_labels
-                label_set: [pod, namespace, k8s.node.name]
+                label_set: [pod, namespace, node]
                 aggregation_type: sum
             new_name: k8s.pod.network.bytes_transmitted
           - include: k8s.container_network_receive_packets_total
@@ -379,7 +379,7 @@ data:
             experimental_match_labels: { "container": "(.|\\s)*\\S(.|\\s)*" }
             operations:
               - action: aggregate_labels
-                label_set: [pod, namespace, k8s.node.name]
+                label_set: [pod, namespace, node]
                 aggregation_type: sum
             new_name: k8s.pod.network.packets_received
           - include: k8s.container_network_transmit_packets_total
@@ -388,7 +388,7 @@ data:
             experimental_match_labels: { "container": "(.|\\s)*\\S(.|\\s)*" }
             operations:
               - action: aggregate_labels
-                label_set: [pod, namespace, k8s.node.name]
+                label_set: [pod, namespace, node]
                 aggregation_type: sum
             new_name: k8s.pod.network.packets_transmitted
           - include: k8s.container_network_receive_packets_dropped_total
@@ -397,7 +397,7 @@ data:
             experimental_match_labels: { "container": "(.|\\s)*\\S(.|\\s)*" }
             operations:
               - action: aggregate_labels
-                label_set: [pod, namespace, k8s.node.name]
+                label_set: [pod, namespace, node]
                 aggregation_type: sum
             new_name: k8s.pod.network.receive_packets_dropped
           - include: k8s.container_network_transmit_packets_dropped_total
@@ -406,7 +406,7 @@ data:
             experimental_match_labels: { "container": "(.|\\s)*\\S(.|\\s)*" }
             operations:
               - action: aggregate_labels
-                label_set: [pod, namespace, k8s.node.name]
+                label_set: [pod, namespace, node]
                 aggregation_type: sum
             new_name: k8s.pod.network.transmit_packets_dropped
           - include: k8s.kube_pod_container_status_waiting
@@ -466,7 +466,7 @@ data:
             experimental_match_labels: { "container": "(.|\\s)*\\S(.|\\s)*" }
             operations:
               - action: aggregate_labels
-                label_set: [pod, namespace, k8s.node.name]
+                label_set: [pod, namespace, node]
                 aggregation_type: sum
             new_name: k8s.pod.fs.reads.rate
           - include: k8s.container_fs_writes_total
@@ -476,7 +476,7 @@ data:
             experimental_match_labels: { "container": "(.|\\s)*\\S(.|\\s)*" }
             operations:
               - action: aggregate_labels
-                label_set: [pod, namespace, k8s.node.name]
+                label_set: [pod, namespace, node]
                 aggregation_type: sum
             new_name: k8s.pod.fs.writes.rate
           - include: k8s.container_fs_reads_bytes_total
@@ -486,7 +486,7 @@ data:
             experimental_match_labels: { "container": "(.|\\s)*\\S(.|\\s)*" }
             operations:
               - action: aggregate_labels
-                label_set: [pod, namespace, k8s.node.name]
+                label_set: [pod, namespace, node]
                 aggregation_type: sum
             new_name: k8s.pod.fs.reads.bytes.rate
           - include: k8s.container_fs_writes_bytes_total
@@ -496,7 +496,7 @@ data:
             experimental_match_labels: { "container": "(.|\\s)*\\S(.|\\s)*" }
             operations:
               - action: aggregate_labels
-                label_set: [pod, namespace, k8s.node.name]
+                label_set: [pod, namespace, node]
                 aggregation_type: sum
             new_name: k8s.pod.fs.writes.bytes.rate
           - include: k8s.container_fs_usage_bytes
@@ -506,7 +506,7 @@ data:
             experimental_match_labels: { "container": "(.|\\s)*\\S(.|\\s)*" }
             operations:
               - action: aggregate_labels
-                label_set: [pod, namespace, k8s.node.name]
+                label_set: [pod, namespace, node]
                 aggregation_type: sum
             new_name: k8s.pod.fs.usage.bytes
           # Node metrics
@@ -562,77 +562,77 @@ data:
             action: insert
             operations:
               - action: aggregate_labels
-                label_set: [k8s.node.name]
+                label_set: [node]
                 aggregation_type: sum
             new_name: k8s.node.network.bytes_received
           - include: k8s.pod.network.bytes_transmitted
             action: insert
             operations:
               - action: aggregate_labels
-                label_set: [k8s.node.name]
+                label_set: [node]
                 aggregation_type: sum
             new_name: k8s.node.network.bytes_transmitted
           - include: k8s.pod.network.packets_received
             action: insert
             operations:
               - action: aggregate_labels
-                label_set: [k8s.node.name]
+                label_set: [node]
                 aggregation_type: sum
             new_name: k8s.node.network.packets_received
           - include: k8s.pod.network.packets_transmitted
             action: insert
             operations:
               - action: aggregate_labels
-                label_set: [k8s.node.name]
+                label_set: [node]
                 aggregation_type: sum
             new_name: k8s.node.network.packets_transmitted
           - include: k8s.pod.network.receive_packets_dropped
             action: insert
             operations:
               - action: aggregate_labels
-                label_set: [k8s.node.name]
+                label_set: [node]
                 aggregation_type: sum
             new_name: k8s.node.network.receive_packets_dropped
           - include: k8s.pod.network.transmit_packets_dropped
             action: insert
             operations:
               - action: aggregate_labels
-                label_set: [k8s.node.name]
+                label_set: [node]
                 aggregation_type: sum
             new_name: k8s.node.network.transmit_packets_dropped
           - include: k8s.pod.fs.reads.rate
             action: insert
             operations:
               - action: aggregate_labels
-                label_set: [k8s.node.name]
+                label_set: [node]
                 aggregation_type: sum
             new_name: k8s.node.fs.reads.rate_temp
           - include: k8s.pod.fs.writes.rate
             action: insert
             operations:
               - action: aggregate_labels
-                label_set: [k8s.node.name]
+                label_set: [node]
                 aggregation_type: sum
             new_name: k8s.node.fs.writes.rate_temp
           - include: k8s.pod.fs.reads.bytes.rate
             action: insert
             operations:
               - action: aggregate_labels
-                label_set: [k8s.node.name]
+                label_set: [node]
                 aggregation_type: sum
             new_name: k8s.node.fs.reads.bytes.rate_temp
           - include: k8s.pod.fs.writes.bytes.rate
             action: insert
             operations:
               - action: aggregate_labels
-                label_set: [k8s.node.name]
+                label_set: [node]
                 aggregation_type: sum
             new_name: k8s.node.fs.writes.bytes.rate_temp
           - include: k8s.pod.fs.usage.bytes
             action: insert
             operations:
               - action: aggregate_labels
-                label_set: [k8s.node.name]
+                label_set: [node]
                 aggregation_type: sum
             new_name: k8s.node.fs.usage
 
@@ -858,7 +858,7 @@ data:
             operation: divide
       groupbyattrs/node:
         keys:
-          - k8s.node.name
+          - node
       # Transformations done after grouping per node
       metricstransform/aggregate_node_level:
         transforms:
@@ -901,7 +901,7 @@ data:
           - container
           - image
           - image_id
-          - k8s.node.name
+          - node
           - sw.k8s.pod.status
           - sw.k8s.namespace.status
           - sw.k8s.node.status
@@ -946,6 +946,11 @@ data:
             action: insert
 
           # Node
+          - key: k8s.node.name
+            from_attribute: node
+            action: upsert
+          - key: node
+            action: delete
 
           - key: sw.k8s.node.version
             from_attribute: kubelet_version

--- a/deploy/k8s/manifest.yaml
+++ b/deploy/k8s/manifest.yaml
@@ -499,6 +499,36 @@ data:
                 label_set: [pod, namespace, node]
                 aggregation_type: sum
             new_name: k8s.pod.fs.writes.bytes.rate
+          - include: k8s.pod.fs.reads.rate
+            action: insert
+            new_name: k8s.pod.fs.reads.rate_temp
+          - include: k8s.pod.fs.writes.rate
+            action: insert
+            new_name: k8s.pod.fs.writes.rate_temp
+          - include: (k8s.pod.fs.reads.rate_temp|k8s.pod.fs.writes.rate_temp)
+            match_type: regexp
+            action: combine
+            submatch_case: lower
+            operations:
+              - action: aggregate_labels
+                label_set:  [pod, namespace, node]
+                aggregation_type: sum
+            new_name: k8s.pod.fs.iops
+          - include: k8s.pod.fs.reads.bytes.rate
+            action: insert
+            new_name: k8s.pod.fs.reads.bytes.rate_temp
+          - include: k8s.pod.fs.writes.bytes.rate
+            action: insert
+            new_name: k8s.pod.fs.writes.bytes_temp
+          - include: (k8s.pod.fs.reads.bytes.rate_temp|k8s.pod.fs.writes.bytes.rate_temp)
+            match_type: regexp
+            action: combine
+            submatch_case: lower
+            operations:
+              - action: aggregate_labels
+                label_set:  [pod, namespace, node]
+                aggregation_type: sum
+            new_name: k8s.pod.fs.throughput
           - include: k8s.container_fs_usage_bytes
             action: insert
             match_type: regexp
@@ -777,6 +807,8 @@ data:
             - k8s.pod.cpu.usage.seconds.rate
             - apiserver_request_not_failed_temp
             - apiserver_request_total_temp
+            - k8s.pod.fs.iops
+            - k8s.pod.fs.throughput
             - k8s.pod.fs.reads.rate
             - k8s.pod.fs.writes.rate
             - k8s.pod.fs.reads.bytes.rate
@@ -800,6 +832,8 @@ data:
         metrics:
           - k8s.node.cpu.usage.seconds.rate
           - k8s.pod.cpu.usage.seconds.rate
+          - k8s.pod.fs.iops
+          - k8s.pod.fs.throughput
           - k8s.pod.fs.reads.rate
           - k8s.pod.fs.writes.rate
           - k8s.pod.fs.reads.bytes.rate


### PR DESCRIPTION
 - Unify node attribute
 - Fix iops and throughput metric as they were not functional due to fact that add operation needs both metrics available. 
 - Add iops and throughput metric for pods