### PR TITLE
Add support for HTTPS proxies

### DIFF
--- a/deploy/helm/templates/common-env-config-map.yaml
+++ b/deploy/helm/templates/common-env-config-map.yaml
@@ -12,3 +12,6 @@ data:
   OTEL_ENVOY_ADDRESS_TLS_INSECURE: {{ quote .Values.otel.tls_insecure }}
   MANIFEST_VERSION: {{ quote .Chart.Version }}
   APP_VERSION: {{ quote .Chart.AppVersion }}
+{{ if .Values.https_proxy_url }}
+  HTTPS_PROXY: {{ quote .Values.https_proxy_url }}
+{{ end }}

--- a/deploy/helm/values.yaml
+++ b/deploy/helm/values.yaml
@@ -11,6 +11,10 @@ otel:
   endpoint: <OTEL_ENVOY_ADDRESS>
   tls_insecure: false
 
+  # The OTEL collector supports an HTTPS proxy. Specify the full URL of the HTTPS
+  # proxy here. e.g. https_proxy: "https://myproxy.mydomain.com:8080"
+  https_proxy_url: ""
+
   image:
     repository: solarwinds/swi-opentelemetry-collector
     # if not set appVersion field from Chart.yaml is used

--- a/deploy/k8s/manifest.yaml
+++ b/deploy/k8s/manifest.yaml
@@ -1795,8 +1795,8 @@ metadata:
   namespace: <NAMESPACE>
   annotations:
     checksum/config: 1e5a65d0e4daea3ba77c82d1097d7e28030ab28fba6ba9ba728b701ca47fb7bc
-    checksum/config_common_env: e751e00734addef64cbd6bf1505e449018bbf8fdce42bca7df4fafcdbe673f63
-    checksum/values: a12f1312eed4b1e8cecd3b734bd29865450524dbae324769735e8ae051d70b33
+    checksum/config_common_env: 53c23d23f8611e8aec5aab3570fda6b45f48cca5634b8b853d8a9ab47a43f169
+    checksum/values: f5a89406d17bf611bbc86e9e1cdc83535d2aa1b425aea62312512d068501d1ec
   labels:
     app.kubernetes.io/name: swi-k8s-opentelemetry-collector
     app.kubernetes.io/instance: swi-k8s-opentelemetry-collector
@@ -1812,8 +1812,8 @@ spec:
         app.kubernetes.io/instance: swi-k8s-opentelemetry-collector
       annotations:
         checksum/config: 1e5a65d0e4daea3ba77c82d1097d7e28030ab28fba6ba9ba728b701ca47fb7bc
-        checksum/config_common_env: e751e00734addef64cbd6bf1505e449018bbf8fdce42bca7df4fafcdbe673f63
-        checksum/values: a12f1312eed4b1e8cecd3b734bd29865450524dbae324769735e8ae051d70b33
+        checksum/config_common_env: 53c23d23f8611e8aec5aab3570fda6b45f48cca5634b8b853d8a9ab47a43f169
+        checksum/values: f5a89406d17bf611bbc86e9e1cdc83535d2aa1b425aea62312512d068501d1ec
 
     spec:
       terminationGracePeriodSeconds: 30
@@ -1908,8 +1908,8 @@ metadata:
   namespace: <NAMESPACE>
   annotations:
     checksum/config: 7d9fdfa8c6329c79dfba5c69b0c983b345bf27c349babf10393a0c7f1f639824
-    checksum/config_common_env: e751e00734addef64cbd6bf1505e449018bbf8fdce42bca7df4fafcdbe673f63
-    checksum/values: a12f1312eed4b1e8cecd3b734bd29865450524dbae324769735e8ae051d70b33
+    checksum/config_common_env: 53c23d23f8611e8aec5aab3570fda6b45f48cca5634b8b853d8a9ab47a43f169
+    checksum/values: f5a89406d17bf611bbc86e9e1cdc83535d2aa1b425aea62312512d068501d1ec
   labels:
     app.kubernetes.io/name: swi-k8s-opentelemetry-collector
     app.kubernetes.io/instance: swi-k8s-opentelemetry-collector
@@ -1983,9 +1983,9 @@ metadata:
   namespace: <NAMESPACE>
   annotations:
     checksum/config: 240be2abafd84363753bd2dd70f0599c59f9286546c2d2ceddca3c1646495699
-    checksum/config_common_env: e751e00734addef64cbd6bf1505e449018bbf8fdce42bca7df4fafcdbe673f63
+    checksum/config_common_env: 53c23d23f8611e8aec5aab3570fda6b45f48cca5634b8b853d8a9ab47a43f169
     checksum/config_env: fba6a0aa0c60ef86a77a6db3750d1ffa8370f0242881e13525cefbfd6144ddf3
-    checksum/values: a12f1312eed4b1e8cecd3b734bd29865450524dbae324769735e8ae051d70b33
+    checksum/values: f5a89406d17bf611bbc86e9e1cdc83535d2aa1b425aea62312512d068501d1ec
   labels:
     app.kubernetes.io/name: swi-k8s-opentelemetry-collector
     app.kubernetes.io/instance: swi-k8s-opentelemetry-collector


### PR DESCRIPTION
The net/http package in Go supports the use of the HTTPS_PROXY environment variable to specify the URL of the proxy server. e.g. https://proxy.mydomain.com:8080. This exposes an otel.https_proxy_url value that users can use to set the environment variable.