### PR TITLE
Fix CircleCI build

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -23,7 +23,7 @@ jobs:
       - run:
           name: Setup skaffold
           command: |
-            curl -Lo skaffold https://storage.googleapis.com/skaffold/releases/v1.39.2/skaffold-linux-amd64 && sudo install skaffold /usr/local/bin/
+            curl -Lo skaffold https://storage.googleapis.com/skaffold/releases/v2.0.3/skaffold-linux-amd64 && sudo install skaffold /usr/local/bin/
       - helm/install-helm-client
       - run:
           name: Build


### PR DESCRIPTION
The build scripts now expect Skaffold v2. A follow-up to 2ad5978.