### PR TITLE
Making build faster and more stable

### DIFF
--- a/.github/workflows/buildAndDeploy.yml
+++ b/.github/workflows/buildAndDeploy.yml
@@ -40,43 +40,32 @@ jobs:
       - name: Deploy services using Skaffold
         run: skaffold deploy --build-artifacts=/tmp/tags.json
 
-      - name: Tail Otel mock metrics for 60 seconds
+      # this step should produce all types: events, metrics and logs
+      - name: Tail Otel mock for 60 seconds
         run: |
+          kubectl run dummy --image ubuntu -- /bin/bash -ec "while :; do echo '!!testlog!!'; sleep 5 ; done"
           mkdir -p OtelLogs
-          kubetail timeseries-mock-service --namespace monitoring > OtelLogs/metrics.log &
-          sleep 60
-
-      - name: Tail Otel mock events for 60 seconds
-        run: |
-          kubectl run dummy --image ubuntu -- /bin/bash -ec "while :; do echo '.'; sleep 5 ; done"
-          mkdir -p OtelLogs
-          kubetail timeseries-mock-service --namespace monitoring > OtelLogs/events.log &
-          sleep 60
-
-      - name: Tail Otel mock logs for 60 seconds
-        run: |
-          mkdir -p OtelLogs
-          kubetail timeseries-mock-service --namespace monitoring > OtelLogs/logs.log &
+          kubetail timeseries-mock-service --namespace monitoring > OtelLogs/output.log &
           sleep 60
 
       # Delete resources and wait some time for its termination
       - name: Destroy environment
-        run: | 
+        run: |
           skaffold delete
           sleep 20
 
       - name: Evaluate metrics collection functionality
         run: |
-          if grep -q "k8s.kube_pod_info" "OtelLogs/metrics.log"; then
+          if grep -q "k8s.kube_pod_info" "OtelLogs/output.log"; then
             echo "Expected metrics found"
           else
             echo "Metrics are missing"
             exit 1
           fi
-      
+
       - name: Evaluate events collection functionality
         run: |
-          if grep -q "k8s.event." "OtelLogs/events.log"; then
+          if grep -q "k8s.event." "OtelLogs/output.log"; then
             echo "Expected events found"
           else
             echo "Events are missing"
@@ -85,7 +74,7 @@ jobs:
 
       - name: Evaluate logs collection functionality
         run: |
-          if grep -q "#logs" "OtelLogs/logs.log"; then
+          if grep -q "!!testlog!!" "OtelLogs/output.log"; then
             echo "Some logs found"
           else
             echo "Logs are missing"
@@ -167,7 +156,7 @@ jobs:
       - uses: actions/download-artifact@v3
         with:
           name: image
-      
+
       - name: Get image tag
         id: vars
         run: echo ::set-output name=tag::${GITHUB_REF#refs/*/}

--- a/skaffold.yaml
+++ b/skaffold.yaml
@@ -4,20 +4,20 @@ metadata:
   name: swi-k8s-opentelemetry-collector
 build:
   artifacts:
-  - image: swi-k8s-opentelemetry-collector
-    docker:
-      dockerfile: build/docker/Dockerfile
+    - image: swi-k8s-opentelemetry-collector
+      docker:
+        dockerfile: build/docker/Dockerfile
   local:
     push: false
 manifests:
   kustomize:
     paths:
-    - tests/deploy/base
+      - tests/deploy/base
     buildArgs:
-    - --load-restrictor LoadRestrictionsNone
+      - --load-restrictor LoadRestrictionsNone
 deploy:
   kubectl: {}
-  helm: 
+  helm:
     releases:
       - name: swi-k8s-opentelemetry-collector
         chartPath: deploy/helm
@@ -30,6 +30,11 @@ deploy:
           otel.image.repository: "swi-k8s-opentelemetry-collector"
           otel.image.tag: ""
           otel.metrics.prometheus.scrape_interval: "15s"
+          otel.logs.filter.include.record_attributes[0].key: "k8s.namespace.name"
+          otel.logs.filter.include.record_attributes[0].value: "^.*$"
+          otel.logs.filter.exclude.match_type: "strict"
+          otel.logs.filter.exclude.record_attributes[0].key: "k8s.namespace.name"
+          otel.logs.filter.exclude.record_attributes[0].value: "monitoring"
           cluster.name: cluster name
           cluster.uid: cluster-uid-123456789
         upgradeOnChange: true
@@ -46,44 +51,44 @@ deploy:
           prometheus-pushgateway.enabled: false
   kubeContext: docker-desktop
 profiles:
-- name: builder-only
-  build:
-    artifacts:
-    - image: swi-k8s-opentelemetry-collector-builder
-      docker:
-        dockerfile: build/docker/Dockerfile
-        target: builder
-        buildArgs:
-          CREATE_VENDOR_DIR: "true"
-    local:
-      push: false
-- name: remote-prometheus
-  deploy:
-    helm: 
-      releases:
-        - name: swi-k8s-opentelemetry-collector
-          chartPath: deploy/helm
-          namespace: monitoring
-          createNamespace: true
-          setValues:
-            # port forward Prometheus Webserver to localhost:9090
-            otel.metrics.prometheus.url: host.docker.internal:9090
-            otel.endpoint: timeseries-mock-service:9082
-            otel.tls_insecure: true
-            otel.image.repository: "swi-k8s-opentelemetry-collector"
-            otel.image.tag: ""
-            otel.metrics.prometheus.scrape_interval: "15s"
-            cluster.name: cluster name
-            cluster.uid: cluster-uid-123456789
-          upgradeOnChange: true
-- name: ci
-  activation:
-  - env: CI=true
-  build:
-    local:
-      push: false
-      useBuildkit: true
-      concurrency: 0
-  deploy:
-    # `default` is k3s default context name
-    kubeContext: default
+  - name: builder-only
+    build:
+      artifacts:
+        - image: swi-k8s-opentelemetry-collector-builder
+          docker:
+            dockerfile: build/docker/Dockerfile
+            target: builder
+            buildArgs:
+              CREATE_VENDOR_DIR: "true"
+      local:
+        push: false
+  - name: remote-prometheus
+    deploy:
+      helm:
+        releases:
+          - name: swi-k8s-opentelemetry-collector
+            chartPath: deploy/helm
+            namespace: monitoring
+            createNamespace: true
+            setValues:
+              # port forward Prometheus Webserver to localhost:9090
+              otel.metrics.prometheus.url: host.docker.internal:9090
+              otel.endpoint: timeseries-mock-service:9082
+              otel.tls_insecure: true
+              otel.image.repository: "swi-k8s-opentelemetry-collector"
+              otel.image.tag: ""
+              otel.metrics.prometheus.scrape_interval: "15s"
+              cluster.name: cluster name
+              cluster.uid: cluster-uid-123456789
+            upgradeOnChange: true
+  - name: ci
+    activation:
+      - env: CI=true
+    build:
+      local:
+        push: false
+        useBuildkit: true
+        concurrency: 0
+    deploy:
+      # `default` is k3s default context name
+      kubeContext: default


### PR DESCRIPTION
logs were not always produced, so now making sure that we test logs produced by custom `dummy` resource
