### PR TITLE
Adding telemetry port to kubernetes "ports" 

### DIFF
--- a/deploy/helm/CHANGELOG.md
+++ b/deploy/helm/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Added
+
+* Added telemetry port to kubernetes "ports" [#129](https://github.com/solarwinds/swi-k8s-opentelemetry-collector/pull/129)
+
 ## [2.0.2] - 2023-01-18
 
 ### Added

--- a/deploy/helm/templates/events-collector-deployment.yaml
+++ b/deploy/helm/templates/events-collector-deployment.yaml
@@ -46,6 +46,12 @@ spec:
           envFrom:
             - configMapRef:
                 name: {{ include "common.fullname" . }}-common-env
+{{- if .Values.otel.events.telemetry.metrics.enabled }}
+          ports:
+            - name: http
+              containerPort: {{ (split ":" .Values.otel.events.telemetry.metrics.address)._1 }}
+              protocol: TCP
+{{- end}}
           livenessProbe:
             httpGet:
               path: /

--- a/deploy/helm/templates/logs-daemon-set.yaml
+++ b/deploy/helm/templates/logs-daemon-set.yaml
@@ -60,6 +60,12 @@ spec:
           envFrom:
             - configMapRef:
                 name: {{ include "common.fullname" . }}-common-env
+{{- if .Values.otel.logs.telemetry.metrics.enabled }}
+          ports:
+            - name: http
+              containerPort: {{ (split ":" .Values.otel.logs.telemetry.metrics.address)._1 }}
+              protocol: TCP
+{{- end}}
           livenessProbe:
             httpGet:
               path: /

--- a/deploy/helm/templates/metrics-deployment.yaml
+++ b/deploy/helm/templates/metrics-deployment.yaml
@@ -43,6 +43,12 @@ spec:
                   name: solarwinds-api-token
                   key: SOLARWINDS_API_TOKEN
                   optional: true
+{{- if .Values.otel.metrics.telemetry.metrics.enabled }}
+          ports:
+            - name: http
+              containerPort: {{ (split ":" .Values.otel.metrics.telemetry.metrics.address)._1 }}
+              protocol: TCP
+{{- end}}
           envFrom:
             - configMapRef:
                 name: {{ include "common.fullname" . }}-common-env

--- a/deploy/k8s/manifest.yaml
+++ b/deploy/k8s/manifest.yaml
@@ -1851,6 +1851,10 @@ spec:
           envFrom:
             - configMapRef:
                 name: swo-k8s-collector-common-env
+          ports:
+            - name: http
+              containerPort: 8888
+              protocol: TCP
           livenessProbe:
             httpGet:
               path: /
@@ -1950,6 +1954,10 @@ spec:
           envFrom:
             - configMapRef:
                 name: swo-k8s-collector-common-env
+          ports:
+            - name: http
+              containerPort: 8888
+              protocol: TCP
           livenessProbe:
             httpGet:
               path: /
@@ -2022,6 +2030,10 @@ spec:
                   name: solarwinds-api-token
                   key: SOLARWINDS_API_TOKEN
                   optional: true
+          ports:
+            - name: http
+              containerPort: 8888
+              protocol: TCP
           envFrom:
             - configMapRef:
                 name: swo-k8s-collector-common-env


### PR DESCRIPTION
This was forgotten. It makes it easier to navigate to "/metrics" internal metrics of OTEL collectors
