### PR TITLE
NH-29204: Fixing chart-release PR's

### DIFF
--- a/.github/workflows/buildAndTest.yml
+++ b/.github/workflows/buildAndTest.yml
@@ -3,7 +3,7 @@ name: Build and Test
 on:
   push:
     branches:
-      - chart-releaser-**
+      - chart-releaser-*
 
   pull_request:
     branches: [gh-pages]

--- a/.github/workflows/buildAndTest.yml
+++ b/.github/workflows/buildAndTest.yml
@@ -3,7 +3,6 @@ name: Build and Test
 on:
   push:
     branches:
-      - gh-pages
       - chart-releaser-**
 
   pull_request:

--- a/.github/workflows/buildAndTest.yml
+++ b/.github/workflows/buildAndTest.yml
@@ -1,6 +1,11 @@
 name: Build and Test
 
 on:
+  push:
+    branches:
+      - gh-pages
+      - chart-releaser-**
+
   pull_request:
     branches: [gh-pages]
 


### PR DESCRIPTION
For some reason chart-releaser PR's don't trigger the build, so fixing by push events that hopefully triggers.
