### PR TITLE
NH-31513: Applying memory optimizations for Log collection

### DIFF
--- a/deploy/helm/CHANGELOG.md
+++ b/deploy/helm/CHANGELOG.md
@@ -11,6 +11,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 * Added telemetry port to kubernetes "ports" [#129](https://github.com/solarwinds/swi-k8s-opentelemetry-collector/pull/129)
 
+### Fixed
+
+* Added optimizations to Log collector preventing Out of Memory situations [#137](https://github.com/solarwinds/swi-k8s-opentelemetry-collector/pull/137)
+    * Added `filelog.storage` to persist checkpoints in persistent storage, not in memory.
+    * Setting `max_concurrent_files` to 10 (from default 1024), this is main memory optimization, reducing amount of concurrent log scans
+    * Increased default memory limit to `700Mi` (which should be enough for large logs)
+    * Having by default `150Mi` difference between OTEL memory limit and Kubernetes memory limit, so that OTEL has enough buffer (this prevents OOMing)
+
 ## [2.0.2] - 2023-01-18
 
 ### Added

--- a/deploy/helm/Chart.yaml
+++ b/deploy/helm/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: swo-k8s-collector
 version: 2.0.2
-appVersion: "0.2.0"
+appVersion: "0.3.0"
 description: SolarWinds Kubernetes Integration
 keywords:
   - monitoring

--- a/deploy/helm/logs-collector-config.yaml
+++ b/deploy/helm/logs-collector-config.yaml
@@ -108,7 +108,7 @@ receivers:
     include_file_path: true
     include_file_name: false
     storage: file_storage
-    max_log_size: 10MiB
+    max_log_size: 1MiB
     max_concurrent_files: 10
     operators:
       # Find out which format is used by kubernetes

--- a/deploy/helm/logs-collector-config.yaml
+++ b/deploy/helm/logs-collector-config.yaml
@@ -104,12 +104,12 @@ receivers:
     include: [ /var/log/pods/*/*/*.log ]
     # Exclude collector container's logs. The file format is /var/log/pods/<namespace_name>_<pod_name>_<pod_uid>/<container_name>/<run_id>.log
     exclude: [ "/var/log/pods/${POD_NAMESPACE}_${POD_NAME}*_*/swi-opentelemetry-collector/*.log" ]
-    start_at: beginning
+    start_at: end
     include_file_path: true
     include_file_name: false
     storage: file_storage
     max_log_size: 10MiB
-    max_concurrent_files: 2
+    max_concurrent_files: 10
     operators:
       # Find out which format is used by kubernetes
       - type: router

--- a/deploy/helm/logs-collector-config.yaml
+++ b/deploy/helm/logs-collector-config.yaml
@@ -6,6 +6,8 @@ exporters:
     headers:
       "Authorization": "Bearer ${SOLARWINDS_API_TOKEN}"
 extensions:
+  file_storage:
+    directory: /var/lib/swo/checkpoints
   health_check: {}
   memory_ballast:
 {{ toYaml .Values.otel.logs.memory_ballast | indent 4 }}
@@ -105,6 +107,9 @@ receivers:
     start_at: beginning
     include_file_path: true
     include_file_name: false
+    storage: file_storage
+    max_log_size: 10MiB
+    max_concurrent_files: 2
     operators:
       # Find out which format is used by kubernetes
       - type: router
@@ -125,7 +130,7 @@ receivers:
         timestamp:
           parse_from: body.time
           layout_type: gotime
-          layout: '2006-01-02T15:04:05.000000000-07:00'
+          layout: '2006-01-02T15:04:05.999999999-07:00'
       # Parse CRI-Containerd format
       - type: regex_parser
         id: parser-containerd
@@ -205,6 +210,7 @@ receivers:
         to: body
 service:
   extensions:
+    - file_storage
     - health_check
     - memory_ballast
   pipelines:

--- a/deploy/helm/templates/logs-daemon-set.yaml
+++ b/deploy/helm/templates/logs-daemon-set.yaml
@@ -92,6 +92,8 @@ spec:
             - mountPath: /run/log/journal
               name: runlogjournal
               readOnly: true
+            - name: logcheckpoints
+              mountPath: /var/lib/swo/checkpoints
       volumes:
         - name: varlogpods
           hostPath:
@@ -105,6 +107,10 @@ spec:
         - name: runlogjournal
           hostPath:
             path: /run/log/journal
+        - name: logcheckpoints
+          hostPath:
+            path: /var/lib/swo/checkpoints
+            type: DirectoryOrCreate
         - name: opentelemetry-collector-configmap
           configMap:
             name: {{ include "common.fullname" . }}-logs-config

--- a/deploy/helm/values.yaml
+++ b/deploy/helm/values.yaml
@@ -192,8 +192,8 @@ otel:
     # see https://github.com/open-telemetry/opentelemetry-collector/tree/main/processor/memorylimiterprocessor for configuration reference
     memory_limiter:
       check_interval: 1s
-      limit_mib: 700
-      spike_limit_mib: 250
+      limit_mib: 550
+      spike_limit_mib: 350
     
     # Memory Ballast enables applications to configure memory ballast for the process.
     # See https://github.com/open-telemetry/opentelemetry-collector/tree/main/extension/ballastextension for configuration reference
@@ -203,9 +203,9 @@ otel:
     # Resource configuration for Log collector
     resources:
       requests:
-        memory: 800Mi
+        memory: 700Mi
       limits:
-        memory: 800Mi
+        memory: 700Mi
 
 cluster:
   name: <CLUSTER_NAME>

--- a/deploy/helm/values.yaml
+++ b/deploy/helm/values.yaml
@@ -192,8 +192,8 @@ otel:
     # see https://github.com/open-telemetry/opentelemetry-collector/tree/main/processor/memorylimiterprocessor for configuration reference
     memory_limiter:
       check_interval: 1s
-      limit_mib: 550
-      spike_limit_mib: 200
+      limit_mib: 700
+      spike_limit_mib: 250
     
     # Memory Ballast enables applications to configure memory ballast for the process.
     # See https://github.com/open-telemetry/opentelemetry-collector/tree/main/extension/ballastextension for configuration reference
@@ -203,9 +203,9 @@ otel:
     # Resource configuration for Log collector
     resources:
       requests:
-        memory: 600Mi
+        memory: 800Mi
       limits:
-        memory: 600Mi
+        memory: 800Mi
 
 cluster:
   name: <CLUSTER_NAME>

--- a/deploy/helm/values.yaml
+++ b/deploy/helm/values.yaml
@@ -146,6 +146,8 @@ otel:
     journal: true
 
     # If true, the container logs will be collected
+    # Log collection uses `filelog` OTEL receiver under the hood 
+    # https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/filelogreceiver
     # Each log has following attributes so they can be filtered out by them using filter configuration:
     #   * sw.k8s.log.type=container
     #   * k8s.cluster.name - name of the cluster (input generated during onboarding)
@@ -193,7 +195,7 @@ otel:
     memory_limiter:
       check_interval: 1s
       limit_mib: 550
-      spike_limit_mib: 350
+      spike_limit_mib: 300
     
     # Memory Ballast enables applications to configure memory ballast for the process.
     # See https://github.com/open-telemetry/opentelemetry-collector/tree/main/extension/ballastextension for configuration reference

--- a/deploy/k8s/manifest.yaml
+++ b/deploy/k8s/manifest.yaml
@@ -202,8 +202,8 @@ data:
         processors:
           memory_limiter:
             check_interval: 1s
-            limit_mib: 700
-            spike_limit_mib: 250
+            limit_mib: 550
+            spike_limit_mib: 300
           # For more all the options about the filtering see https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/processor/filterprocessor
           filter:
             logs: 
@@ -296,12 +296,12 @@ data:
             include: [ /var/log/pods/*/*/*.log ]
             # Exclude collector container's logs. The file format is /var/log/pods/<namespace_name>_<pod_name>_<pod_uid>/<container_name>/<run_id>.log
             exclude: [ "/var/log/pods/${POD_NAMESPACE}_${POD_NAME}*_*/swi-opentelemetry-collector/*.log" ]
-            start_at: beginning
+            start_at: end
             include_file_path: true
             include_file_name: false
             storage: file_storage
             max_log_size: 10MiB
-            max_concurrent_files: 2
+            max_concurrent_files: 10
             operators:
               # Find out which format is used by kubernetes
               - type: router
@@ -1801,9 +1801,9 @@ metadata:
   name: swo-k8s-collector-logs
   namespace: <NAMESPACE>
   annotations:
-    checksum/config: d1d22dc94f7e67f8deb8db20a3a3592cb62c548326eafee9ac35cf6eb219e57f
+    checksum/config: f246678ecb72e826f92512f6617ce9e10b8e8bf1828c072eab0de9e1a584eeed
     checksum/config_common_env: 938c1233ef80a8cdc54819b66c1fab2786c5cea8ae96f872767fbf2dcf342fd6
-    checksum/values: cdf7e222176222d16cf75f58974e3e384a470c442667df6279ab1c4c9fdea8b5
+    checksum/values: 446582cc71e657021c2233b4ef9c2f651393843c09eaf9aec8dd2f333ab0e5dc
   labels:
     app.kubernetes.io/name: swo-k8s-collector
     app.kubernetes.io/instance: swo-k8s-collector
@@ -1818,9 +1818,9 @@ spec:
         app.kubernetes.io/name: swo-k8s-collector
         app.kubernetes.io/instance: swo-k8s-collector
       annotations:
-        checksum/config: d1d22dc94f7e67f8deb8db20a3a3592cb62c548326eafee9ac35cf6eb219e57f
+        checksum/config: f246678ecb72e826f92512f6617ce9e10b8e8bf1828c072eab0de9e1a584eeed
         checksum/config_common_env: 938c1233ef80a8cdc54819b66c1fab2786c5cea8ae96f872767fbf2dcf342fd6
-        checksum/values: cdf7e222176222d16cf75f58974e3e384a470c442667df6279ab1c4c9fdea8b5
+        checksum/values: 446582cc71e657021c2233b4ef9c2f651393843c09eaf9aec8dd2f333ab0e5dc
 
     spec:
       terminationGracePeriodSeconds: 30
@@ -1872,9 +1872,9 @@ spec:
               port: 13133
           resources:
             limits:
-              memory: 800Mi
+              memory: 700Mi
             requests:
-              memory: 800Mi
+              memory: 700Mi
           volumeMounts:
             - mountPath: /var/log/pods
               name: varlogpods
@@ -1926,7 +1926,7 @@ metadata:
   annotations:
     checksum/config: 3079ccec4fe37f496e829f686e34d816b635c3750dea7e078c821010f3d238d8
     checksum/config_common_env: 938c1233ef80a8cdc54819b66c1fab2786c5cea8ae96f872767fbf2dcf342fd6
-    checksum/values: cdf7e222176222d16cf75f58974e3e384a470c442667df6279ab1c4c9fdea8b5
+    checksum/values: 446582cc71e657021c2233b4ef9c2f651393843c09eaf9aec8dd2f333ab0e5dc
   labels:
     app.kubernetes.io/name: swo-k8s-collector
     app.kubernetes.io/instance: swo-k8s-collector
@@ -2003,10 +2003,10 @@ metadata:
   name: swo-k8s-collector-metrics
   namespace: <NAMESPACE>
   annotations:
-    checksum/config: fa02a81d7a487fc97b44a2e5d22c1a3babba6225bbbe834649dadc502911653e
+    checksum/config: 794ec0d208de769e6b9c257bb29696c0656b01bcd309ceeb3d44404a445c7ded
     checksum/config_common_env: 938c1233ef80a8cdc54819b66c1fab2786c5cea8ae96f872767fbf2dcf342fd6
     checksum/config_env: 69527c661c505be09f4d26ac8cf06c6777da5a33ad895e4328c41539aead509a
-    checksum/values: cdf7e222176222d16cf75f58974e3e384a470c442667df6279ab1c4c9fdea8b5
+    checksum/values: 446582cc71e657021c2233b4ef9c2f651393843c09eaf9aec8dd2f333ab0e5dc
   labels:
     app.kubernetes.io/name: swo-k8s-collector
     app.kubernetes.io/instance: swo-k8s-collector

--- a/deploy/k8s/manifest.yaml
+++ b/deploy/k8s/manifest.yaml
@@ -300,7 +300,7 @@ data:
             include_file_path: true
             include_file_name: false
             storage: file_storage
-            max_log_size: 10MiB
+            max_log_size: 1MiB
             max_concurrent_files: 10
             operators:
               # Find out which format is used by kubernetes
@@ -1801,7 +1801,7 @@ metadata:
   name: swo-k8s-collector-logs
   namespace: <NAMESPACE>
   annotations:
-    checksum/config: f246678ecb72e826f92512f6617ce9e10b8e8bf1828c072eab0de9e1a584eeed
+    checksum/config: 4e2d60c876f7cb61720b9bf87a6f6138eca5ea5dfd0d0ba9881473324751d8d2
     checksum/config_common_env: 938c1233ef80a8cdc54819b66c1fab2786c5cea8ae96f872767fbf2dcf342fd6
     checksum/values: 446582cc71e657021c2233b4ef9c2f651393843c09eaf9aec8dd2f333ab0e5dc
   labels:
@@ -1818,7 +1818,7 @@ spec:
         app.kubernetes.io/name: swo-k8s-collector
         app.kubernetes.io/instance: swo-k8s-collector
       annotations:
-        checksum/config: f246678ecb72e826f92512f6617ce9e10b8e8bf1828c072eab0de9e1a584eeed
+        checksum/config: 4e2d60c876f7cb61720b9bf87a6f6138eca5ea5dfd0d0ba9881473324751d8d2
         checksum/config_common_env: 938c1233ef80a8cdc54819b66c1fab2786c5cea8ae96f872767fbf2dcf342fd6
         checksum/values: 446582cc71e657021c2233b4ef9c2f651393843c09eaf9aec8dd2f333ab0e5dc
 

--- a/deploy/k8s/manifest.yaml
+++ b/deploy/k8s/manifest.yaml
@@ -24,7 +24,7 @@ data:
   OTEL_ENVOY_ADDRESS: "<OTEL_ENVOY_ADDRESS>"
   OTEL_ENVOY_ADDRESS_TLS_INSECURE: "false"
   MANIFEST_VERSION: "2.0.2"
-  APP_VERSION: "0.2.0"
+  APP_VERSION: "0.3.0"
 ---
 # Source: swo-k8s-collector/templates/events-collector-config-map.yaml
 apiVersion: v1
@@ -193,6 +193,8 @@ data:
             headers:
               "Authorization": "Bearer ${SOLARWINDS_API_TOKEN}"
         extensions:
+          file_storage:
+            directory: /var/lib/swo/checkpoints
           health_check: {}
           memory_ballast:
             size_mib: 200
@@ -200,8 +202,8 @@ data:
         processors:
           memory_limiter:
             check_interval: 1s
-            limit_mib: 550
-            spike_limit_mib: 200
+            limit_mib: 700
+            spike_limit_mib: 250
           # For more all the options about the filtering see https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/processor/filterprocessor
           filter:
             logs: 
@@ -297,6 +299,9 @@ data:
             start_at: beginning
             include_file_path: true
             include_file_name: false
+            storage: file_storage
+            max_log_size: 10MiB
+            max_concurrent_files: 2
             operators:
               # Find out which format is used by kubernetes
               - type: router
@@ -317,7 +322,7 @@ data:
                 timestamp:
                   parse_from: body.time
                   layout_type: gotime
-                  layout: '2006-01-02T15:04:05.000000000-07:00'
+                  layout: '2006-01-02T15:04:05.999999999-07:00'
               # Parse CRI-Containerd format
               - type: regex_parser
                 id: parser-containerd
@@ -397,6 +402,7 @@ data:
                 to: body
         service:
           extensions:
+            - file_storage
             - health_check
             - memory_ballast
           pipelines:
@@ -1795,9 +1801,9 @@ metadata:
   name: swo-k8s-collector-logs
   namespace: <NAMESPACE>
   annotations:
-    checksum/config: fd93bc26a2c57d2727aca6bb030381339318aa5ac9191711862264a1fc90712a
-    checksum/config_common_env: 17fd36b327b09a676b997c26143c02baa4abeae85c79f3bbc343ecea9a3d57b6
-    checksum/values: f5a89406d17bf611bbc86e9e1cdc83535d2aa1b425aea62312512d068501d1ec
+    checksum/config: d1d22dc94f7e67f8deb8db20a3a3592cb62c548326eafee9ac35cf6eb219e57f
+    checksum/config_common_env: 938c1233ef80a8cdc54819b66c1fab2786c5cea8ae96f872767fbf2dcf342fd6
+    checksum/values: cdf7e222176222d16cf75f58974e3e384a470c442667df6279ab1c4c9fdea8b5
   labels:
     app.kubernetes.io/name: swo-k8s-collector
     app.kubernetes.io/instance: swo-k8s-collector
@@ -1812,9 +1818,9 @@ spec:
         app.kubernetes.io/name: swo-k8s-collector
         app.kubernetes.io/instance: swo-k8s-collector
       annotations:
-        checksum/config: fd93bc26a2c57d2727aca6bb030381339318aa5ac9191711862264a1fc90712a
-        checksum/config_common_env: 17fd36b327b09a676b997c26143c02baa4abeae85c79f3bbc343ecea9a3d57b6
-        checksum/values: f5a89406d17bf611bbc86e9e1cdc83535d2aa1b425aea62312512d068501d1ec
+        checksum/config: d1d22dc94f7e67f8deb8db20a3a3592cb62c548326eafee9ac35cf6eb219e57f
+        checksum/config_common_env: 938c1233ef80a8cdc54819b66c1fab2786c5cea8ae96f872767fbf2dcf342fd6
+        checksum/values: cdf7e222176222d16cf75f58974e3e384a470c442667df6279ab1c4c9fdea8b5
 
     spec:
       terminationGracePeriodSeconds: 30
@@ -1825,7 +1831,7 @@ spec:
         runAsGroup: 0
       containers:
         - name: swi-opentelemetry-collector
-          image: "solarwinds/swi-opentelemetry-collector:0.2.0"
+          image: "solarwinds/swi-opentelemetry-collector:0.3.0"
           imagePullPolicy: IfNotPresent
           command:
             - /swi-otelcol
@@ -1866,9 +1872,9 @@ spec:
               port: 13133
           resources:
             limits:
-              memory: 600Mi
+              memory: 800Mi
             requests:
-              memory: 600Mi
+              memory: 800Mi
           volumeMounts:
             - mountPath: /var/log/pods
               name: varlogpods
@@ -1885,6 +1891,8 @@ spec:
             - mountPath: /run/log/journal
               name: runlogjournal
               readOnly: true
+            - name: logcheckpoints
+              mountPath: /var/lib/swo/checkpoints
       volumes:
         - name: varlogpods
           hostPath:
@@ -1898,6 +1906,10 @@ spec:
         - name: runlogjournal
           hostPath:
             path: /run/log/journal
+        - name: logcheckpoints
+          hostPath:
+            path: /var/lib/swo/checkpoints
+            type: DirectoryOrCreate
         - name: opentelemetry-collector-configmap
           configMap:
             name: swo-k8s-collector-logs-config
@@ -1913,8 +1925,8 @@ metadata:
   namespace: <NAMESPACE>
   annotations:
     checksum/config: 3079ccec4fe37f496e829f686e34d816b635c3750dea7e078c821010f3d238d8
-    checksum/config_common_env: 17fd36b327b09a676b997c26143c02baa4abeae85c79f3bbc343ecea9a3d57b6
-    checksum/values: f5a89406d17bf611bbc86e9e1cdc83535d2aa1b425aea62312512d068501d1ec
+    checksum/config_common_env: 938c1233ef80a8cdc54819b66c1fab2786c5cea8ae96f872767fbf2dcf342fd6
+    checksum/values: cdf7e222176222d16cf75f58974e3e384a470c442667df6279ab1c4c9fdea8b5
   labels:
     app.kubernetes.io/name: swo-k8s-collector
     app.kubernetes.io/instance: swo-k8s-collector
@@ -1938,7 +1950,7 @@ spec:
             - /swi-otelcol
             - --config=/conf/relay.yaml
           securityContext: {}
-          image: "solarwinds/swi-opentelemetry-collector:0.2.0"
+          image: "solarwinds/swi-opentelemetry-collector:0.3.0"
           imagePullPolicy: IfNotPresent
           env:
             - name: MY_POD_IP
@@ -1991,10 +2003,10 @@ metadata:
   name: swo-k8s-collector-metrics
   namespace: <NAMESPACE>
   annotations:
-    checksum/config: 794ec0d208de769e6b9c257bb29696c0656b01bcd309ceeb3d44404a445c7ded
-    checksum/config_common_env: 17fd36b327b09a676b997c26143c02baa4abeae85c79f3bbc343ecea9a3d57b6
+    checksum/config: fa02a81d7a487fc97b44a2e5d22c1a3babba6225bbbe834649dadc502911653e
+    checksum/config_common_env: 938c1233ef80a8cdc54819b66c1fab2786c5cea8ae96f872767fbf2dcf342fd6
     checksum/config_env: 69527c661c505be09f4d26ac8cf06c6777da5a33ad895e4328c41539aead509a
-    checksum/values: f5a89406d17bf611bbc86e9e1cdc83535d2aa1b425aea62312512d068501d1ec
+    checksum/values: cdf7e222176222d16cf75f58974e3e384a470c442667df6279ab1c4c9fdea8b5
   labels:
     app.kubernetes.io/name: swo-k8s-collector
     app.kubernetes.io/instance: swo-k8s-collector
@@ -2017,7 +2029,7 @@ spec:
             - /swi-otelcol
             - --config=/conf/relay.yaml
           securityContext: {}
-          image: "solarwinds/swi-opentelemetry-collector:0.2.0"
+          image: "solarwinds/swi-opentelemetry-collector:0.3.0"
           imagePullPolicy: IfNotPresent
           env:
             - name: MY_POD_IP


### PR DESCRIPTION
Explanation of the changes:
* Setting `filelog.storage`: This persist checkpoints in persistent storage, not in memory
* Setting `max_concurrent_files` to 10 (from default 1024), this is main memory optimization, reducing amount of concurrent log scans
* Increasing memory limit to `700Mi` (which should be enough for large logs)
* Having 150Mi difference between OTEL memory limit and Kubernetes memory limit, so that OTEL has enough buffer (this prevents OOMing)

Furthermore there was a bug when parsing time fraction, see https://stackoverflow.com/questions/53837975/time-parse-in-go-with-varying-fractional-second-length
