### PR TITLE
Run structure tests only in CI

### DIFF
--- a/skaffold.yaml
+++ b/skaffold.yaml
@@ -9,10 +9,6 @@ build:
         dockerfile: build/docker/Dockerfile
   local:
     push: false
-test:
-- image: swi-k8s-opentelemetry-collector
-  structureTests:
-    - './build/docker/structure-test.yaml'
 manifests:
   kustomize:
     paths:
@@ -93,6 +89,10 @@ profiles:
         push: false
         useBuildkit: true
         concurrency: 0
+    test:
+      - image: swi-k8s-opentelemetry-collector
+        structureTests:
+          - './build/docker/structure-test.yaml'
     deploy:
       # `default` is k3s default context name
       kubeContext: default


### PR DESCRIPTION
A follow-up to https://github.com/solarwinds/swi-k8s-opentelemetry-collector/pull/140

This fixes the `skaffold dev` loop