### PR TITLE
Adding prometheus annotations, so that prometheus scrape OTEL internal telemetry

### DIFF
--- a/deploy/helm/CHANGELOG.md
+++ b/deploy/helm/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Added
+* if telemetry is enabled (true by default) OTEL collectors will contain prometheus annotations so that telemetry is discovered by Prometheus [#152](https://github.com/solarwinds/swi-k8s-opentelemetry-collector/pull/152).
 
 ## [2.1.0-alpha.3] - 2023-01-31
 ### Added

--- a/deploy/helm/templates/events-collector-deployment.yaml
+++ b/deploy/helm/templates/events-collector-deployment.yaml
@@ -20,6 +20,13 @@ spec:
       labels:
 {{ include "common.template-labels" . | indent 8 }}
         app: {{ include "common.fullname" . }}-events
+{{- if .Values.otel.events.telemetry.metrics.enabled }}
+      annotations:
+        prometheus.io/scrape: "true"
+        prometheus.io/port: {{ (split ":" .Values.otel.events.telemetry.metrics.address)._1 | quote }}
+        prometheus.io/path: "/metrics"
+        prometheus.io/scheme: "http"
+{{- end}}
     spec:
       serviceAccountName: {{ include "common.fullname" . }}
       securityContext: {}

--- a/deploy/helm/templates/logs-daemon-set.yaml
+++ b/deploy/helm/templates/logs-daemon-set.yaml
@@ -23,7 +23,12 @@ spec:
         checksum/config: {{ include (print $.Template.BasePath "/logs-collector-config-map.yaml") . | sha256sum }}
         checksum/config_common_env: {{ include (print $.Template.BasePath "/common-env-config-map.yaml") . | sha256sum }}
         checksum/values: {{ toJson .Values | sha256sum }}
-
+{{- if .Values.otel.logs.telemetry.metrics.enabled }}
+        prometheus.io/scrape: "true"
+        prometheus.io/port: {{ (split ":" .Values.otel.logs.telemetry.metrics.address)._1 | quote }}
+        prometheus.io/path: "/metrics"
+        prometheus.io/scheme: "http"
+{{- end}}
     spec:
       terminationGracePeriodSeconds: 30
       securityContext:

--- a/deploy/helm/templates/metrics-deployment.yaml
+++ b/deploy/helm/templates/metrics-deployment.yaml
@@ -21,6 +21,13 @@ spec:
       labels:
 {{ include "common.template-labels" . | indent 8 }}
         app: {{ include "common.fullname" . }}-metrics
+{{- if .Values.otel.metrics.telemetry.metrics.enabled }}
+      annotations:
+        prometheus.io/scrape: "true"
+        prometheus.io/port: {{ (split ":" .Values.otel.metrics.telemetry.metrics.address)._1 | quote }}
+        prometheus.io/path: "/metrics"
+        prometheus.io/scheme: "http"
+{{- end}}
     spec:
       securityContext: {}
       containers:


### PR DESCRIPTION
This is useful for us (for internal telemetry monitoring) as well as for the customers 

suggested by @jaroslav-fedor-swi 