### PR TITLE
NH-30743 - remove deployment logs

### DIFF
--- a/deploy/helm/CHANGELOG.md
+++ b/deploy/helm/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to Helm charts will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+### Changed
+* Remove generated attribute k8s.deployment.name
+
 ## [2.1.0-beta.1] - 2023-02-09
 
 ### Added

--- a/deploy/helm/logs-collector-config.yaml
+++ b/deploy/helm/logs-collector-config.yaml
@@ -25,22 +25,10 @@ processors:
 
   groupbyattrs/all:
     keys:
-      - k8s.deployment.name
       - k8s.container.name
       - k8s.namespace.name
       - k8s.pod.name
       - k8s.pod.uid
-
-  attributes/common:
-    actions:
-      - key: k8s.pod.name
-        pattern: (?P<k8s_deployment>[a-z0-9]+(?:-[a-z0-9]+)*?)-[a-f0-9]{10}-[a-z0-9]{5}
-        action: extract
-      - key: k8s.deployment.name
-        from_attribute: k8s_deployment
-        action: insert
-      - key: k8s_deployment
-        action: delete
       
 
   resource/container:
@@ -239,7 +227,6 @@ service:
 {{- if .Values.otel.logs.filter }}
         - filter
 {{- end }}
-        - attributes/common
         - groupbyattrs/all
         - resource/container
         - batch


### PR DESCRIPTION
Remove deployment name from logs as parsing by regex is not functional in 100% cases and can be false positive.
