### PR TITLE
NH-33357: Log collector suffix clusterId into folder which it mounts for checkpoints (e.q.`/var/lib/swo/checkpoints/<clusterId>`)

### DIFF
--- a/deploy/helm/CHANGELOG.md
+++ b/deploy/helm/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## Unreleased
 ### Changed
 * Remove generated attribute k8s.deployment.name
+* Log collector suffix clusterId into folder which it mounts for checkpoints (e.q.`/var/lib/swo/checkpoints/<clusterId>`). This avoid unpredictable errors in scenario when previous monitoring was not deleted. [#161](https://github.com/solarwinds/swi-k8s-opentelemetry-collector/pull/161)
 
 ## [2.1.0-beta.1] - 2023-02-09
 

--- a/deploy/helm/templates/logs-daemon-set.yaml
+++ b/deploy/helm/templates/logs-daemon-set.yaml
@@ -98,7 +98,7 @@ spec:
               name: runlogjournal
               readOnly: true
             - name: logcheckpoints
-              mountPath: /var/lib/swo/checkpoints
+              mountPath: {{ .Values.otel.logs.filestorage.directory }}
       volumes:
         - name: varlogpods
           hostPath:
@@ -114,7 +114,7 @@ spec:
             path: /run/log/journal
         - name: logcheckpoints
           hostPath:
-            path: /var/lib/swo/checkpoints
+            path: {{ printf "%s/%s" .Values.otel.logs.filestorage.directory .Values.cluster.uid }}
             type: DirectoryOrCreate
         - name: opentelemetry-collector-configmap
           configMap:


### PR DESCRIPTION
This avoid unpredictable errors in scenario when previous monitoring was not deleted
