### PR TITLE
NH-31472 Introduce cluster version

### DIFF
--- a/deploy/helm/metrics-collector-config.yaml
+++ b/deploy/helm/metrics-collector-config.yaml
@@ -1311,8 +1311,6 @@ service:
         - attributes/remove_pod
         - attributes/remove_container
         - attributes/remove_service
-        # - attributes/extract_node_version
-        # - attributes/extract_apiserver_version
         - attributes/remove_other
         - metricstransform/rename
         - swmetricstransform/preprocessing

--- a/deploy/helm/metrics-collector-config.yaml
+++ b/deploy/helm/metrics-collector-config.yaml
@@ -124,6 +124,7 @@ processors:
         action: delete
       - key: exported_instance
         action: delete
+
   metricstransform/rename:
     transforms:
       # add `k8s.` suffix to all metrics that are clearly provided by Kubernetes
@@ -771,14 +772,14 @@ processors:
             label_set: []
             aggregation_type: sum
       - include: k8s.kubernetes_build_info
-        action: insert
-        match_type: regexp
-        experimental_match_labels: {"exported_job": ".*apiserver.*"}
-        new_name: sw.k8s.cluster.build
+        action: update
         operations:
-          - action: update_label
-            label: git_version
-            new_label: cluster_version
+          - action: delete_label_value
+            label: exported_job
+            label_value: kubernetes-nodes
+          - action: delete_label_value
+            label: exported_job
+            label_value: kubelet
 
       # Prometheus metrics
       - include: apiserver_request_total
@@ -962,7 +963,7 @@ processors:
       - replicaset
       - job_name
       - cronjob
-      - cluster_version
+      - git_version
 {{- if .Values.otel.metrics.filter }}
   filter:
     metrics:
@@ -1003,10 +1004,8 @@ processors:
         action: insert
 
       - key: sw.k8s.cluster.version
-        from_attribute: cluster_version
+        from_attribute: git_version
         action: insert
-      - key: cluster_version
-        action: delete
 
       # Node
       - key: k8s.node.name
@@ -1312,6 +1311,8 @@ service:
         - attributes/remove_pod
         - attributes/remove_container
         - attributes/remove_service
+        # - attributes/extract_node_version
+        # - attributes/extract_apiserver_version
         - attributes/remove_other
         - metricstransform/rename
         - swmetricstransform/preprocessing

--- a/deploy/helm/metrics-collector-config.yaml
+++ b/deploy/helm/metrics-collector-config.yaml
@@ -127,7 +127,7 @@ processors:
   metricstransform/rename:
     transforms:
       # add `k8s.` suffix to all metrics that are clearly provided by Kubernetes
-      - include: ^(kube_|container_)(.*)$$
+      - include: ^(kube_|container_|kubernetes_)(.*)$$
         match_type: regexp
         action: update
         new_name: k8s.$${1}$${2}
@@ -770,6 +770,15 @@ processors:
           - action: aggregate_labels
             label_set: []
             aggregation_type: sum
+      - include: k8s.kubernetes_build_info
+        action: insert
+        match_type: regexp
+        experimental_match_labels: {"exported_job": ".*apiserver.*"}
+        new_name: sw.k8s.cluster.build
+        operations:
+          - action: update_label
+            label: git_version
+            new_label: cluster_version
 
       # Prometheus metrics
       - include: apiserver_request_total
@@ -953,6 +962,7 @@ processors:
       - replicaset
       - job_name
       - cronjob
+      - cluster_version
 {{- if .Values.otel.metrics.filter }}
   filter:
     metrics:
@@ -991,6 +1001,12 @@ processors:
       - key: k8s.cluster.name
         value: ${CLUSTER_NAME}
         action: insert
+
+      - key: sw.k8s.cluster.version
+        from_attribute: cluster_version
+        action: insert
+      - key: cluster_version
+        action: delete
 
       # Node
       - key: k8s.node.name
@@ -1260,7 +1276,7 @@ receivers:
               - "kube_node_status_allocatable"
               - "kube_node_spec_unschedulable"
               - "apiserver_request_total"
-              - "kube_job_info"              
+              - "kube_job_info"
               - "kube_job_owner"
               - "kube_job_created"
               - "kube_job_complete"
@@ -1272,6 +1288,7 @@ receivers:
               - "kube_job_status_completion_time"
               - "kube_job_spec_completions"
               - "kube_job_spec_parallelism"
+              - "kubernetes_build_info"
 {{- if .Values.otel.metrics.extra_scrape_metrics }}
 {{ toYaml .Values.otel.metrics.extra_scrape_metrics | indent 14 }}
 {{- end }}

--- a/doc/exported_metrics.md
+++ b/doc/exported_metrics.md
@@ -19,6 +19,7 @@ The following tables contain the list of all metrics exported by the swi-k8s-ope
 | k8s.cluster.pods.running | Gauge |  | The count of pods in running phase | custom |
 | k8s.cluster.spec.cpu.requests | Gauge | cores | The total number of requested CPU by all containers in a cluster | custom |
 | k8s.cluster.spec.memory.requests | Gauge | bytes | The total number of requested memory by all containers in a cluster | custom |
+| k8s.kubernetes_build_info | Gauge |  | Information about Kubernetes build  | native |
 
 ## Node metrics
 
@@ -52,7 +53,7 @@ The following tables contain the list of all metrics exported by the swi-k8s-ope
 | k8s.node.status.condition.networkunavailable | Gauge |  | The condition networkunavailable of a cluster node (1 when true, 0 when false or unknown) | custom |
 | k8s.node.status.condition.pidpressure | Gauge |  | The condition pidpressure of a cluster node (1 when true, 0 when false or unknown) | custom |
 | k8s.node.status.condition.ready | Gauge |  | The condition ready of a cluster node (1 when true, 0 when false or unknown) | custom |
-| k8s.kubernetes_build_info | Gauge |  | Information about Kubernetes build  | native |
+
 
 ## Pod metrics
 

--- a/doc/exported_metrics.md
+++ b/doc/exported_metrics.md
@@ -52,6 +52,7 @@ The following tables contain the list of all metrics exported by the swi-k8s-ope
 | k8s.node.status.condition.networkunavailable | Gauge |  | The condition networkunavailable of a cluster node (1 when true, 0 when false or unknown) | custom |
 | k8s.node.status.condition.pidpressure | Gauge |  | The condition pidpressure of a cluster node (1 when true, 0 when false or unknown) | custom |
 | k8s.node.status.condition.ready | Gauge |  | The condition ready of a cluster node (1 when true, 0 when false or unknown) | custom |
+| k8s.kubernetes_build_info | Gauge |  | Information about Kubernetes build  | native |
 
 ## Pod metrics
 


### PR DESCRIPTION
Extract **git_version** from **kubernetes_build_info** where **job** is either **apiserver** or **kubernetes-apiservers** (needed for compatibility with docker-desktop). Approach is to remove all datapoints related to nodes in kubernetes_build_info metric and then use **git_version** attribute of remaining datapoints to populate **sw.k8s.cluster.version** 