### PR TITLE
NH-32001 initContainers health check - include opentelemetry protofiles when helm package is created

### DIFF
--- a/.github/workflows/releaseHelm.yaml
+++ b/.github/workflows/releaseHelm.yaml
@@ -14,6 +14,8 @@ jobs:
     steps:
       - name: Checkout Code
         uses: actions/checkout@v3
+        with:
+          submodules: true
 
       - name: Fetch history
         run: git fetch --prune --unshallow

--- a/deploy/helm/.helmignore
+++ b/deploy/helm/.helmignore
@@ -1,0 +1,15 @@
+.helmignore
+
+.git
+.gitignore
+.gitattributes
+
+.github/
+.vscode/
+
+opentelemetry-proto/*.md
+opentelemetry-proto/*.yaml
+opentelemetry-proto/Makefile
+opentelemetry-proto/LICENSE
+
+

--- a/deploy/helm/CHANGELOG.md
+++ b/deploy/helm/CHANGELOG.md
@@ -9,6 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+## [2.2.0-alpha.3] - 2023-03-07
+
+### Added
+
+- Added opentelemetry protofiles
+
 ## [2.2.0-alpha.2] - 2023-03-02
 
 ### Added

--- a/deploy/helm/Chart.yaml
+++ b/deploy/helm/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: swo-k8s-collector
-version: 2.2.0-alpha.2
+version: 2.2.0-alpha.3
 appVersion: "0.3.0"
 description: SolarWinds Kubernetes Integration
 keywords:

--- a/deploy/helm/metrics-collector-config.yaml
+++ b/deploy/helm/metrics-collector-config.yaml
@@ -8,7 +8,7 @@ exporters:
 extensions:
   health_check:
     check_collector_pipeline:
-      enabled: true
+      enabled: false
       interval: "5m"
       exporter_failure_threshold: 5 
   memory_ballast:

--- a/deploy/helm/templates/metrics-deployment.yaml
+++ b/deploy/helm/templates/metrics-deployment.yaml
@@ -29,10 +29,13 @@ spec:
         app: {{ include "common.fullname" . }}-metrics
     spec:
       securityContext: {}
+      {{- if or .Values.otel.metrics.prometheus_check .Values.otel.metrics.swi_endpoint_check }}
       initContainers:
+        {{- if .Values.otel.metrics.prometheus_check }}
         - name: prometheus-check
           image: busybox
           command: ['sh', '-c', 'until $(wget --spider -nv {{ .Values.otel.metrics.prometheus.url }}/federate?); do echo waiting on prometheus; sleep 1; done']
+        {{- end }}
         {{- if .Values.otel.metrics.swi_endpoint_check }}
         - name: otel-endpoint-check
           image: fullstorydev/grpcurl
@@ -65,7 +68,8 @@ spec:
                   name: solarwinds-api-token
                   key: SOLARWINDS_API_TOKEN
                   optional: true
-        {{- end }}         
+        {{- end }}
+      {{- end }}
       containers:
         - name: swi-opentelemetry-collector
           command:

--- a/deploy/helm/values.yaml
+++ b/deploy/helm/values.yaml
@@ -29,6 +29,9 @@ otel:
     # Check if SWI OTEL endpoint is reachable
     swi_endpoint_check: true
 
+    # Check if Prometheus endpoint is reachable
+    prometheus_check: true
+
     prometheus: 
       # URL of prometheus where to scrape
       url: <PROMETHEUS_URL>

--- a/skaffold.yaml
+++ b/skaffold.yaml
@@ -33,6 +33,7 @@ deploy:
         setValues:
           otel.metrics.prometheus.url: monitoring-prometheus-server.monitoring.svc.cluster.local:80
           otel.metrics.swi_endpoint_check: false
+          otel.metrics.prometheus_check: false
           otel.endpoint: timeseries-mock-service:9082
           otel.tls_insecure: true
           otel.image.repository: "swi-k8s-opentelemetry-collector"


### PR DESCRIPTION
When helm chart package is built, open telemetry proto files submodule should be included as well.
This PR also fixes local Skaffold deployment. 

- disabled `check_collector_pipeline`
- disabled otel endpoint and Prometheus in Skaffold 
- added .helmignore file to exclude unnecessary files from opentelemetry folder
- version updated to `2.2.0-alpha.3`