### PR TITLE
NH-35068: Use older OTEL image for test mocks

### DIFF
--- a/tests/deploy/base/mocks.yaml
+++ b/tests/deploy/base/mocks.yaml
@@ -124,7 +124,7 @@ spec:
             - --config=/conf/relay.yaml
           securityContext:
             runAsUser: 0
-          image: "otel/opentelemetry-collector-contrib:0.73.0"
+          image: "otel/opentelemetry-collector-contrib:0.69.0"
           imagePullPolicy: IfNotPresent
           ports:
             - name: otlp


### PR DESCRIPTION
In the newer versions the fileexporter seems to save data in 4k chunchs instead of flushing them all. That breaks our current test logic.