### PR TITLE
Disable buffered writes for fileexporter used as mock in tests

### DIFF
--- a/tests/deploy/base/mocks.yaml
+++ b/tests/deploy/base/mocks.yaml
@@ -13,10 +13,16 @@ data:
         loglevel: debug
       file/logs:
         path: /data/logs.json
+        # empty rotation - workaround for https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/18251
+        rotation:
       file/metrics:
         path: /data/metrics.json
+        # empty rotation - workaround for https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/18251
+        rotation:
       file/events:
         path: /data/events.json
+        # empty rotation - workaround for https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/18251
+        rotation:
       prometheus:
         endpoint: "0.0.0.0:8080"
         namespace: output


### PR DESCRIPTION
OTEL Collector in version 0.70.0 implemented buffered writes for `fileexporter`, which breaks our tests. Implement a workaround, since it cannot be disabled at this time.