### PR TITLE
Simplifying modification of `expected_output.json`

### DIFF
--- a/doc/development.md
+++ b/doc/development.md
@@ -99,9 +99,7 @@ Deploy cluster locally using `skaffold dev -p=only-mock` (configured to poll moc
 * You can run it directly in cluster by manually triggering `integration-test` CronJob
 
 ### Updating tests if processing is changed
-* Open `launch.json`, Modify `WRITE_ACTUAL` environment variable in `Python: Pytest` debug configuration to `True`
-* Run tests
-* Read `actual.json`, format it to readable json, review it if it matches expected outcome and save it as `expected_output.json`
+* Run `utils\set_expected_output.py` in Python
 
 ### Updating mocked data if new data are scraped
 * Open/Create `.env` file and set `PROMETHEUS_HOST` variable from where you want to generate mocked data. For example `PROMETHEUS_HOST=localhost:8080`

--- a/tests/integration/test_metric_collection.py
+++ b/tests/integration/test_metric_collection.py
@@ -1,8 +1,7 @@
 import pytest
 import os
 import json
-from jsonmerge import merge
-from test_utils import retry_until_ok
+from test_utils import retry_until_ok, get_merged_json
 import difflib
 
 endpoint = os.getenv("TIMESERIES_MOCK_ENDPOINT", "localhost:8088")
@@ -91,77 +90,6 @@ def print_failure_otel_content(content):
     actual_json = json.dumps(merged_json, sort_keys=True, indent=2)
     print('Actual json:')
     print(actual_json)
-
-
-def resource_sorting_key(metric):
-    return "".join([f"{a['key']}={a['value']['stringValue']}" for a in metric["resource"]["attributes"]])
-
-
-def remove_time_in_datapoint(datapoint):
-    if "timeUnixNano" in datapoint:
-        datapoint["timeUnixNano"] = "0"
-    if "startTimeUnixNano" in datapoint:
-        datapoint["startTimeUnixNano"] = "0"
-
-
-def sort_attributes(element):
-    if "attributes" in element:
-        element["attributes"] = sorted(
-            element["attributes"], key=lambda a: a["key"])
-
-
-def sort_datapoints(metric):
-    def datapoint_sorting_key(datapoint):
-        if "attributes" in datapoint:
-            return "".join([f"{a['key']}={a['value']['stringValue']}" for a in datapoint["attributes"]])
-        elif "asDouble" in datapoint:
-            return datapoint["asDouble"]
-        elif "asInt" in datapoint:
-            return datapoint["asInt"]
-        elif "asString" in datapoint:
-            return datapoint["asString"]
-        else:
-            return datapoint
-
-    metric["dataPoints"] = sorted(
-        metric["dataPoints"], key=datapoint_sorting_key)
-
-
-def process_metric_type(metric):
-    if "dataPoints" in metric:
-        for dp in metric["dataPoints"]:
-            remove_time_in_datapoint(dp)
-            sort_attributes(dp)
-        sort_datapoints(metric)
-
-
-def get_merged_json(content):
-    result = {}
-    for line in content.splitlines():
-        result = merge(result, json.loads(line))
-
-    # Sort the result and set timeStamps to 0 to make it easier to compare
-    for resource in result["resourceMetrics"]:
-        sort_attributes(resource["resource"])
-        for scope in resource["scopeMetrics"]:
-            scope["metrics"] = sorted(
-                scope["metrics"], key=lambda m: m["name"])
-            for metric in scope["metrics"]:
-                if "sum" in metric:
-                    process_metric_type(metric["sum"])
-                if "gauge" in metric:
-                    process_metric_type(metric["gauge"])
-                if "histogram" in metric:
-                    process_metric_type(metric["histogram"])
-
-                # Get rid of value of metric called "scrape_duration_seconds" as it is not stable
-                if metric["name"] == "scrape_duration_seconds":
-                    metric["gauge"]["dataPoints"][0]["asDouble"] = 0
-    result["resourceMetrics"] = sorted(
-        result["resourceMetrics"], key=resource_sorting_key)
-
-    return result
-
 
 def get_unique_metric_names(merged_json):
     result = list(set([metric["name"]

--- a/tests/integration/test_utils.py
+++ b/tests/integration/test_utils.py
@@ -2,6 +2,7 @@ import json
 import time
 import requests
 import traceback
+from jsonmerge import merge
 
 def get_all_bodies(log_bulk):
     result = [records["body"]["stringValue"]
@@ -57,3 +58,73 @@ def retry_until_ok(url, func, print_failure):
             print_failure(response.content)
 
         raise ValueError("Timed out waiting")
+    
+def resource_sorting_key(metric):
+    return "".join([f"{a['key']}={a['value']['stringValue']}" for a in metric["resource"]["attributes"]])
+
+
+def remove_time_in_datapoint(datapoint):
+    if "timeUnixNano" in datapoint:
+        datapoint["timeUnixNano"] = "0"
+    if "startTimeUnixNano" in datapoint:
+        datapoint["startTimeUnixNano"] = "0"
+
+
+def sort_attributes(element):
+    if "attributes" in element:
+        element["attributes"] = sorted(
+            element["attributes"], key=lambda a: a["key"])
+
+
+def sort_datapoints(metric):
+    def datapoint_sorting_key(datapoint):
+        if "attributes" in datapoint:
+            return "".join([f"{a['key']}={a['value']['stringValue']}" for a in datapoint["attributes"]])
+        elif "asDouble" in datapoint:
+            return datapoint["asDouble"]
+        elif "asInt" in datapoint:
+            return datapoint["asInt"]
+        elif "asString" in datapoint:
+            return datapoint["asString"]
+        else:
+            return datapoint
+
+    metric["dataPoints"] = sorted(
+        metric["dataPoints"], key=datapoint_sorting_key)
+
+
+def process_metric_type(metric):
+    if "dataPoints" in metric:
+        for dp in metric["dataPoints"]:
+            remove_time_in_datapoint(dp)
+            sort_attributes(dp)
+        sort_datapoints(metric)
+
+
+def get_merged_json(content):
+    result = {}
+    for line in content.splitlines():
+        result = merge(result, json.loads(line))
+
+    # Sort the result and set timeStamps to 0 to make it easier to compare
+    for resource in result["resourceMetrics"]:
+        sort_attributes(resource["resource"])
+        for scope in resource["scopeMetrics"]:
+            scope["metrics"] = sorted(
+                scope["metrics"], key=lambda m: m["name"])
+            for metric in scope["metrics"]:
+                if "sum" in metric:
+                    process_metric_type(metric["sum"])
+                if "gauge" in metric:
+                    process_metric_type(metric["gauge"])
+                if "histogram" in metric:
+                    process_metric_type(metric["histogram"])
+
+                # Get rid of value of metric called "scrape_duration_seconds" as it is not stable
+                if metric["name"] == "scrape_duration_seconds":
+                    metric["gauge"]["dataPoints"][0]["asDouble"] = 0
+    result["resourceMetrics"] = sorted(
+        result["resourceMetrics"], key=resource_sorting_key)
+
+    return result
+

--- a/utils/set_expected_output.py
+++ b/utils/set_expected_output.py
@@ -1,0 +1,29 @@
+import os
+import sys
+import inspect
+import json
+
+currentdir = os.path.dirname(os.path.abspath(inspect.getfile(inspect.currentframe())))
+parentdir = os.path.dirname(currentdir)
+integration_tests_dir = os.path.join(parentdir, 'tests', 'integration')
+expected_output_file = os.path.join(integration_tests_dir, 'expected_output.json')
+sys.path.insert(0, integration_tests_dir)
+
+from test_utils import retry_until_ok, get_merged_json
+
+endpoint = os.getenv("TIMESERIES_MOCK_ENDPOINT", "localhost:8088")
+url = f'http://{endpoint}/metrics.json'
+
+def set_expected_outcome_from_content(content):
+    merged_json = get_merged_json(content)
+    actual_json = json.dumps(merged_json, sort_keys=True, indent=2)
+    with open(expected_output_file, "w", newline='\n') as f:
+        f.write(actual_json)
+    return True
+
+retry_until_ok(url, 
+               set_expected_outcome_from_content,
+               lambda content: print(f'Failed to download content'))
+
+
+


### PR DESCRIPTION
No need to run tests with adjusted launch.json anymore. Just run `utils/set_expected_output.py`
