### PR TITLE
NH-34558: Add Prometheus as a sub-chart

### DIFF
--- a/.github/workflows/buildAndDeploy.yml
+++ b/.github/workflows/buildAndDeploy.yml
@@ -44,6 +44,9 @@ jobs:
       - name: Deploy kubernetes
         uses: ./.github/actions/deploy-kubernetes
 
+      - name: Add dependency chart repos
+        run: helm repo add prometheus-community https://prometheus-community.github.io/helm-charts
+
       - name: Deploy services using Skaffold
         run: skaffold deploy --build-artifacts=/tmp/tags.json
 
@@ -77,6 +80,9 @@ jobs:
       - name: Deploy kubernetes
         uses: ./.github/actions/deploy-kubernetes
 
+      - name: Add dependency chart repos
+        run: helm repo add prometheus-community https://prometheus-community.github.io/helm-charts
+
       - name: Build
         run: skaffold build -p=ci-helm-e2e --file-output=/tmp/tags.json
 
@@ -97,6 +103,12 @@ jobs:
         uses: azure/setup-helm@v3
         with:
           version: v3.10.0
+
+      - name: Add dependency chart repos
+        run: helm repo add prometheus-community https://prometheus-community.github.io/helm-charts
+
+      - name: Download chart dependencies before linting
+        run: helm dependency build deploy/helm
 
       - name: Lint helm
         run: helm lint deploy/helm

--- a/.github/workflows/releaseHelm.yaml
+++ b/.github/workflows/releaseHelm.yaml
@@ -30,6 +30,9 @@ jobs:
         with:
           version: v3.9.2
 
+      - name: Add dependency chart repos
+        run: helm repo add prometheus-community https://prometheus-community.github.io/helm-charts
+
       - name: Set env
         run: |
           echo "CR_GIT_REPO=$(cut -d '/' -f 2 <<< $GITHUB_REPOSITORY)" >> $GITHUB_ENV

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .env
+deploy/helm/charts/*.tgz

--- a/README.md
+++ b/README.md
@@ -49,6 +49,22 @@ Internally, it contains [OpenTelemetry Collector configuration](https://opentele
 
 ### Metrics
 
+The `swo-k8s-collector` collects metrics from a Prometheus instance. To configure its address, set
+
+```yaml
+otel:
+  metrics:
+    prometheus:
+      url: <some_address>
+```
+
+Alternatively, **for testing purposes**, you can also let the collector deploy a Prometheus server for you.
+
+```yaml
+prometheus:
+  enabled: true
+```
+
 Once deployed to a Kubernetes cluster, the metrics collection and processing configuration is stored as a ConfigMap under the `metrics.config` key.
 
 In order to reduce the size of the collected data, the `swo-k8s-collector` collects only selected metrics that are key for successful entity ingestion on the SolarWinds Observability side. The list of observed metrics can be extended by setting `otel.metrics.extra_scrape_metrics` value. Example:

--- a/deploy/helm/CHANGELOG.md
+++ b/deploy/helm/CHANGELOG.md
@@ -7,11 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Added
+
+- A new option to deploy `prometheus` as part of the k8s collector chart installation, controlled by setting `prometheus.enabled: true` in `values.yaml`.
+
 ## [2.3.0-alpha.1] - 2023-03-21
 
 ### Changed
 
-- Fix grouping conditions for container*network*_ and container*fs*_ metrics to not relly on container attribute
+- Fix grouping conditions for `container_network_*` and `container_fs_*` metrics to not rely on container attribute
 - Added metrics k8s.cluster.version which extract version from kubernetes_build_info. Metric kubernetes_build_info is not published
 
 ## [2.2.0-beta.1] - 2023-03-16

--- a/deploy/helm/Chart.lock
+++ b/deploy/helm/Chart.lock
@@ -1,0 +1,6 @@
+dependencies:
+- name: prometheus
+  repository: https://prometheus-community.github.io/helm-charts
+  version: 19.7.2
+digest: sha256:00b8669a0ed55ee48504b2c6968eab12f1f2fc39245b93532cbab700d987438b
+generated: "2023-03-21T17:55:23.5394333+01:00"

--- a/deploy/helm/Chart.yaml
+++ b/deploy/helm/Chart.yaml
@@ -1,4 +1,4 @@
-apiVersion: v1
+apiVersion: v2
 name: swo-k8s-collector
 version: 2.3.0-alpha.1
 appVersion: "0.4.0"
@@ -17,3 +17,8 @@ sources:
 maintainers:
   - name: SolarWinds
     email: support@solarwinds.com
+dependencies:
+  - name: prometheus
+    repository: https://prometheus-community.github.io/helm-charts
+    version: "~> 19.7.2"
+    condition: prometheus.enabled

--- a/deploy/helm/templates/metrics-collector-env-config-map.yaml
+++ b/deploy/helm/templates/metrics-collector-env-config-map.yaml
@@ -7,5 +7,9 @@ metadata:
   labels:
 {{ include "common.labels" . | indent 4 }}
 data:
+{{- if .Values.prometheus.enabled }}
+  PROMETHEUS_URL: "{{ .Release.Name }}-prometheus-server.{{ .Release.Namespace }}.svc.cluster.local:80"
+{{- else }}
   PROMETHEUS_URL: {{ quote .Values.otel.metrics.prometheus.url }}
+{{- end }}
 {{- end}}

--- a/deploy/helm/templates/metrics-deployment.yaml
+++ b/deploy/helm/templates/metrics-deployment.yaml
@@ -34,7 +34,10 @@ spec:
         {{- if .Values.otel.metrics.prometheus_check }}
         - name: prometheus-check
           image: busybox
-          command: ['sh', '-c', 'until $(wget --spider -nv {{ .Values.otel.metrics.prometheus.url }}/federate?); do echo waiting on prometheus; sleep 1; done']
+          command: ['sh', '-c', 'until $(wget --spider -nv $PROMETHEUS_URL/federate?); do echo waiting on prometheus; sleep 1; done']
+          envFrom:
+            - configMapRef:
+                name: {{ include "common.fullname" . }}-metrics-env-config
         {{- end }}
         {{- if .Values.otel.metrics.swi_endpoint_check }}
         - name: otel-endpoint-check

--- a/deploy/helm/values.yaml
+++ b/deploy/helm/values.yaml
@@ -1,5 +1,5 @@
 # This values file provides the default values for the chart. Placeholders like
-# <PROMETHEUS_URL> will be provided via the values.yaml provided during the cluster
+# <CLUSTER_NAME> will be provided via the values.yaml provided during the cluster
 # onboarding process--or you can provide your own with the appropriate values
 # given to you during initial onboarding for an initial cluster and region.
 
@@ -34,7 +34,7 @@ otel:
 
     prometheus: 
       # URL of prometheus where to scrape
-      url: <PROMETHEUS_URL>
+      url: ""
 
       # Prometheus URL scheme. It can take the values `http` or `https`
       scheme: http
@@ -302,3 +302,19 @@ autoupdate:
 # Set labels to every deployed resource
 # commonLabels: 
 
+prometheus:
+  # Whether the Prometheus server should be deployed as part of this chart.
+  # If true, the `otel.metrics.prometheus.url` setting is ignored.
+  enabled: false
+
+  alertmanager:
+    enabled: false
+  prometheus-node-exporter:
+    enabled: false
+  prometheus-pushgateway:
+    enabled: false
+  server:
+    # Disabling persistent volume to make the chart compatible with new EKS clusters
+    # (this matches the behavior of `kube-prometheus-stack` chart).
+    persistentVolume:
+      enabled: false

--- a/doc/development.md
+++ b/doc/development.md
@@ -1,5 +1,15 @@
 # Development
 
+## Table of contents
+
+- [Contribution Guidelines](#contribution-guidelines)
+- [Prerequisites](#prerequisites)
+- [Deployment](#deployment)
+- [Develop against remote prometheus](#develop-against-remote-prometheus)
+- [Integration tests](#integration-tests)
+- [Updating Chart dependencies](#updating-chart-dependencies)
+- [Publishing](#publishing)
+
 ## Contribution Guidelines
 
 1. Pull the latest changes from the `master` branch.
@@ -13,8 +23,24 @@
 
 - [Skaffold](https://skaffold.dev) at least [v2.0.3](https://github.com/GoogleContainerTools/skaffold/releases/tag/v2.0.3)
   - On windows, do not install it using choco due to [this issue](https://github.com/GoogleContainerTools/skaffold/issues/4058)
-- [Kustomize](https://kustomize.io): `choco install kustomize`
-- [Helm](https://helm.sh): `choco install kubernetes-helm`
+- [Kustomize](https://kustomize.io):
+
+  ```shell
+  choco install kustomize
+  ```
+
+- [Helm](https://helm.sh):
+
+  ```shell
+  choco install kubernetes-helm
+  ```
+
+- Prometheus community Helm repo - it hosts a dependency for the collector's chart:
+
+  ```shell
+  helm repo add prometheus-community https://prometheus-community.github.io/helm-charts
+  ```
+
 - [Docker desktop](https://www.docker.com/products/docker-desktop) with Kubernetes enabled
 
 ## Deployment
@@ -112,6 +138,20 @@ Deploy cluster locally using `skaffold dev -p=only-mock` (configured to poll moc
 ### Updating utils used for testing
 
 Whenever there is a need to improve the test tooling, eg. the script for scraping test data from a Prometheus (`utils/cleanup_mocked_prometheus_response.py`), or data comparison code, or versions or Python packages, ..., it should always happen in a separate PR. Do not mix changes to the test framework with changes to the k8s collector itself. Otherwise a change to the testing framework might hide an unintentional change to the collector code.
+
+## Updating Chart dependencies
+
+To update a dependency of the Helm chart:
+
+1. Update the `dependencies` section in [deploy/helm/Chart.yaml](../deploy/helm/Chart.yaml).
+2. Run
+
+    ```shell
+    helm dependency update deploy/helm
+    ```
+
+3. Commit changes in [deploy/helm/Chart.lock](../deploy/helm/Chart.lock).
+4. *(Optional)* Delete `*.tgz` files in `/deploy/helm/charts/` - they will be re-downloaded automatically as needed.
 
 ## Publishing
 

--- a/skaffold.yaml
+++ b/skaffold.yaml
@@ -31,7 +31,7 @@ deploy:
         namespace: monitoring
         createNamespace: true
         setValues:
-          otel.metrics.prometheus.url: monitoring-prometheus-server.monitoring.svc.cluster.local:80
+          prometheus.enabled: true
           otel.metrics.swi_endpoint_check: false
           otel.metrics.prometheus_check: false
           otel.endpoint: timeseries-mock-service:9082
@@ -47,17 +47,6 @@ deploy:
           cluster.name: cluster name
           cluster.uid: cluster-uid-123456789
         upgradeOnChange: true
-      
-      - name: monitoring
-        remoteChart: prometheus
-        namespace: monitoring
-        createNamespace: true
-        repo: https://prometheus-community.github.io/helm-charts
-        version: 19.0.1
-        setValues:
-          alertmanager.enabled: false
-          prometheus-node-exporter.enabled: false
-          prometheus-pushgateway.enabled: false
   kubeContext: docker-desktop
 portForward:
 - resourceType: service
@@ -65,7 +54,7 @@ portForward:
   namespace: monitoring
   port: 8088
 - resourceType: service
-  resourceName: monitoring-prometheus-server
+  resourceName: swi-k8s-opentelemetry-collector-prometheus-server
   namespace: monitoring
   port: 80
   localPort: 8080
@@ -84,21 +73,23 @@ profiles:
   # Useful to develop integration tests - environment is configured to use mocked prometheus metrics
   - name: only-mock
     patches:
-    - op: replace
+    - op: add
       path: /deploy/helm/releases/0/setValues/otel.metrics.prometheus.url
       value: wiremock.monitoring.svc.cluster.local:8080
-    - op: remove
-      path: /deploy/helm/releases/1
+    - op: replace
+      path: /deploy/helm/releases/0/setValues/prometheus.enabled
+      value: false
     - op: remove
       path: /portForward/1
   # Useful to develop against remote prometheus instance (mounted locally on host.docker.internal:9090)
   - name: remote-prometheus
     patches:
-    - op: replace
+    - op: add
       path: /deploy/helm/releases/0/setValues/otel.metrics.prometheus.url
       value: host.docker.internal:9090
-    - op: remove
-      path: /deploy/helm/releases/1
+    - op: replace
+      path: /deploy/helm/releases/0/setValues/prometheus.enabled
+      value: false
     - op: remove
       path: /portForward/1
   - name: ci
@@ -114,11 +105,12 @@ profiles:
         structureTests:
           - './build/docker/structure-test.yaml'
     patches:
-    - op: replace
+    - op: add
       path: /deploy/helm/releases/0/setValues/otel.metrics.prometheus.url
       value: wiremock.monitoring.svc.cluster.local:8080
-    - op: remove
-      path: /deploy/helm/releases/1
+    - op: replace
+      path: /deploy/helm/releases/0/setValues/prometheus.enabled
+      value: false
     - op: remove
       path: /portForward/1
     deploy:
@@ -131,9 +123,12 @@ profiles:
         path: /deploy/helm/releases/0/setValues/otel.image.repository
       - op: remove
         path: /deploy/helm/releases/0/setValues/otel.image.tag
-      - op: replace
+      - op: add
         path: /deploy/helm/releases/0/setValues/otel.metrics.prometheus.url
         value: wiremock.monitoring.svc.cluster.local:8080
+      - op: replace
+        path: /deploy/helm/releases/0/setValues/prometheus.enabled
+        value: false
     build:
       local:
         push: false


### PR DESCRIPTION
Add option to deploy a Prometheus as part of the k8s collector chart installation.
This is controlled by a new setting `prometheus.enabled: true`.

This PR adds the [prometheus](https://github.com/prometheus-community/helm-charts/tree/main/charts/prometheus) as a dependency.
