### PR TITLE
NH-35087 - Invalid k8s nodes

### DIFF
--- a/deploy/helm/CHANGELOG.md
+++ b/deploy/helm/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed 
 - Fix grouping conditions for container_network_* and container_fs_* metrics to not relly on container attribute
+- Added metrics k8s.cluster.version which extract version from kubernetes_build_info. Metric kubernetes_build_info is not published
 
 ## [2.2.0-beta.1] - 2023-03-16
 

--- a/deploy/helm/metrics-collector-config.yaml
+++ b/deploy/helm/metrics-collector-config.yaml
@@ -787,15 +787,16 @@ processors:
             label_set: []
             aggregation_type: sum
       - include: k8s.kubernetes_build_info
-        action: update
+        action: insert
+        experimental_match_labels: { "exported_job": "kubernetes-apiservers" }
+        new_name: k8s.cluster.version
         operations:
-          - action: delete_label_value
-            label: exported_job
-            label_value: kubernetes-nodes
-          - action: delete_label_value
-            label: exported_job
-            label_value: kubelet
-
+          - action: aggregate_labels
+            label_set: [git_version]
+            aggregation_type: sum
+      - include: k8s.kubernetes_build_info
+        action: update 
+        new_name: k8s.kubernetes_build_info_temp
       # Prometheus metrics
       - include: apiserver_request_total
         action: insert
@@ -1045,6 +1046,8 @@ processors:
       - key: sw.k8s.cluster.version
         from_attribute: git_version
         action: insert
+      - key: git_version
+        action: delete
 
       # Node
       - key: k8s.node.name
@@ -1342,7 +1345,7 @@ receivers:
               - "kube_job_status_completion_time"
               - "kube_job_spec_completions"
               - "kube_job_spec_parallelism"
-              - "kubernetes_build_info"
+              - '{__name__="kubernetes_build_info", job="kubernetes-apiservers"}'
 {{- if .Values.otel.metrics.extra_scrape_metrics }}
 {{ toYaml .Values.otel.metrics.extra_scrape_metrics | indent 14 }}
 {{- end }}

--- a/doc/exported_metrics.md
+++ b/doc/exported_metrics.md
@@ -19,7 +19,7 @@ The following tables contain the list of all metrics exported by the swi-k8s-ope
 | k8s.cluster.pods.running | Gauge |  | The count of pods in running phase | custom |
 | k8s.cluster.spec.cpu.requests | Gauge | cores | The total number of requested CPU by all containers in a cluster | custom |
 | k8s.cluster.spec.memory.requests | Gauge | bytes | The total number of requested memory by all containers in a cluster | custom |
-| k8s.kubernetes_build_info | Gauge |  | Information about Kubernetes build  | native |
+| k8s.cluster.version | Gauge |  | Kubernetes cluster version| custom |
 
 ## Node metrics
 


### PR DESCRIPTION
kubernetes_build_info contains attribute instance and this isn't Node, but also endpoint and it introduced a lot of fake nodes in SWO