### PR TITLE
NH-34014: Updating Helm chart, using latest image and scraping labels/annotations from all supported kubernetes services

### DIFF
--- a/deploy/helm/CHANGELOG.md
+++ b/deploy/helm/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Added
+- Added automatic extraction of Kubernetes labels and annotations from additional resources (Deployment, StatefulSet, ReplicaSet, DaemonSet, Job, CronJob, Node) and sent using resource attributes with metric
+
 ## [2.3.0-alpha.4] - 2023-03-29
 
 ### Added

--- a/deploy/helm/CHANGELOG.md
+++ b/deploy/helm/CHANGELOG.md
@@ -7,8 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## [2.3.0-alpha.6] - 2023-04-06
+
 ### Added
 - Added automatic extraction of Kubernetes labels and annotations from additional resources (Deployment, StatefulSet, ReplicaSet, DaemonSet, Job, CronJob, Node) and sent using resource attributes with metric
+
+## [2.3.0-alpha.5] - 2023-04-06
 
 ### Changed
 - Enabled honor_labels option to keep scraped data over server-side labels

--- a/deploy/helm/Chart.yaml
+++ b/deploy/helm/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: swo-k8s-collector
 version: 2.3.0-alpha.4
-appVersion: "0.4.1"
+appVersion: "0.5.0"
 description: SolarWinds Kubernetes Integration
 keywords:
   - monitoring

--- a/deploy/helm/Chart.yaml
+++ b/deploy/helm/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: swo-k8s-collector
-version: 2.3.0-alpha.5
+version: 2.3.0-alpha.6
 appVersion: "0.5.0"
 description: SolarWinds Kubernetes Integration
 keywords:

--- a/deploy/helm/metrics-collector-config.yaml
+++ b/deploy/helm/metrics-collector-config.yaml
@@ -46,6 +46,158 @@ processors:
             name: k8s.pod.name
           - from: resource_attribute
             name: k8s.namespace.name
+    deployment:
+      extract:
+        metadata:
+          - k8s.deployment.uid
+{{- if .Values.otel.metrics.k8s_instrumentation.annotations.enabled }}
+        annotations:
+          - key_regex: (.*)
+            tag_name: k8s.deployment.annotations.$$1
+            from: deployment
+{{- end }}
+{{- if .Values.otel.metrics.k8s_instrumentation.labels.enabled }}
+        labels:
+          - key_regex: (.*)
+            tag_name: k8s.deployment.labels.$$1
+            from: deployment
+{{- end }}
+      association:
+      - sources:
+          - from: resource_attribute
+            name: k8s.deployment.name
+          - from: resource_attribute
+            name: k8s.namespace.name
+    statefulset:
+      extract:
+        metadata:
+          - k8s.statefulset.uid
+{{- if .Values.otel.metrics.k8s_instrumentation.annotations.enabled }}
+        annotations:
+          - key_regex: (.*)
+            tag_name: k8s.statefulset.annotations.$$1
+            from: statefulset
+{{- end }}
+{{- if .Values.otel.metrics.k8s_instrumentation.labels.enabled }}
+        labels:
+          - key_regex: (.*)
+            tag_name: k8s.statefulset.labels.$$1
+            from: statefulset
+{{- end }}
+      association:
+      - sources:
+          - from: resource_attribute
+            name: k8s.statefulset.name
+          - from: resource_attribute
+            name: k8s.namespace.name
+    replicaset:
+      extract:
+        metadata:
+          - k8s.replicaset.uid
+{{- if .Values.otel.metrics.k8s_instrumentation.annotations.enabled }}
+        annotations:
+          - key_regex: (.*)
+            tag_name: k8s.replicaset.annotations.$$1
+            from: replicaset
+{{- end }}
+{{- if .Values.otel.metrics.k8s_instrumentation.labels.enabled }}
+        labels:
+          - key_regex: (.*)
+            tag_name: k8s.replicaset.labels.$$1
+            from: replicaset
+{{- end }}
+      association:
+      - sources:
+          - from: resource_attribute
+            name: k8s.replicaset.name
+          - from: resource_attribute
+            name: k8s.namespace.name
+    daemonset:
+      extract:
+        metadata:
+          - k8s.daemonset.uid
+{{- if .Values.otel.metrics.k8s_instrumentation.annotations.enabled }}
+        annotations:
+          - key_regex: (.*)
+            tag_name: k8s.daemonset.annotations.$$1
+            from: daemonset
+{{- end }}
+{{- if .Values.otel.metrics.k8s_instrumentation.labels.enabled }}
+        labels:
+          - key_regex: (.*)
+            tag_name: k8s.daemonset.labels.$$1
+            from: daemonset
+{{- end }}
+      association:
+      - sources:
+          - from: resource_attribute
+            name: k8s.daemonset.name
+          - from: resource_attribute
+            name: k8s.namespace.name
+    job:
+      extract:
+        metadata:
+          - k8s.job.uid
+{{- if .Values.otel.metrics.k8s_instrumentation.annotations.enabled }}
+        annotations:
+          - key_regex: (.*)
+            tag_name: k8s.job.annotations.$$1
+            from: job
+{{- end }}
+{{- if .Values.otel.metrics.k8s_instrumentation.labels.enabled }}
+        labels:
+          - key_regex: (.*)
+            tag_name: k8s.job.labels.$$1
+            from: job
+{{- end }}
+      association:
+      - sources:
+          - from: resource_attribute
+            name: k8s.job.name
+          - from: resource_attribute
+            name: k8s.namespace.name
+    cronjob:
+      extract:
+        metadata:
+          - k8s.cronjob.uid
+{{- if .Values.otel.metrics.k8s_instrumentation.annotations.enabled }}
+        annotations:
+          - key_regex: (.*)
+            tag_name: k8s.cronjob.annotations.$$1
+            from: cronjob
+{{- end }}
+{{- if .Values.otel.metrics.k8s_instrumentation.labels.enabled }}
+        labels:
+          - key_regex: (.*)
+            tag_name: k8s.cronjob.labels.$$1
+            from: cronjob
+{{- end }}
+      association:
+      - sources:
+          - from: resource_attribute
+            name: k8s.cronjob.name
+          - from: resource_attribute
+            name: k8s.namespace.name
+    node:
+      extract:
+        metadata:
+          - k8s.node.uid
+{{- if .Values.otel.metrics.k8s_instrumentation.annotations.enabled }}
+        annotations:
+          - key_regex: (.*)
+            tag_name: k8s.node.annotations.$$1
+            from: node
+{{- end }}
+{{- if .Values.otel.metrics.k8s_instrumentation.labels.enabled }}
+        labels:
+          - key_regex: (.*)
+            tag_name: k8s.node.labels.$$1
+            from: node
+{{- end }}
+      association:
+      - sources:
+          - from: resource_attribute
+            name: k8s.node.name
 {{- if not (empty .Values.otel.metrics.k8s_instrumentation.labels.excludePattern) }}
   resource/k8sattributes_labels_filter:
     attributes:

--- a/deploy/helm/metrics-collector-config.yaml
+++ b/deploy/helm/metrics-collector-config.yaml
@@ -48,8 +48,6 @@ processors:
             name: k8s.namespace.name
     deployment:
       extract:
-        metadata:
-          - k8s.deployment.uid
 {{- if .Values.otel.metrics.k8s_instrumentation.annotations.enabled }}
         annotations:
           - key_regex: (.*)
@@ -70,8 +68,6 @@ processors:
             name: k8s.namespace.name
     statefulset:
       extract:
-        metadata:
-          - k8s.statefulset.uid
 {{- if .Values.otel.metrics.k8s_instrumentation.annotations.enabled }}
         annotations:
           - key_regex: (.*)
@@ -92,8 +88,6 @@ processors:
             name: k8s.namespace.name
     replicaset:
       extract:
-        metadata:
-          - k8s.replicaset.uid
 {{- if .Values.otel.metrics.k8s_instrumentation.annotations.enabled }}
         annotations:
           - key_regex: (.*)
@@ -114,8 +108,6 @@ processors:
             name: k8s.namespace.name
     daemonset:
       extract:
-        metadata:
-          - k8s.daemonset.uid
 {{- if .Values.otel.metrics.k8s_instrumentation.annotations.enabled }}
         annotations:
           - key_regex: (.*)
@@ -136,8 +128,6 @@ processors:
             name: k8s.namespace.name
     job:
       extract:
-        metadata:
-          - k8s.job.uid
 {{- if .Values.otel.metrics.k8s_instrumentation.annotations.enabled }}
         annotations:
           - key_regex: (.*)
@@ -158,8 +148,6 @@ processors:
             name: k8s.namespace.name
     cronjob:
       extract:
-        metadata:
-          - k8s.cronjob.uid
 {{- if .Values.otel.metrics.k8s_instrumentation.annotations.enabled }}
         annotations:
           - key_regex: (.*)
@@ -180,8 +168,6 @@ processors:
             name: k8s.namespace.name
     node:
       extract:
-        metadata:
-          - k8s.node.uid
 {{- if .Values.otel.metrics.k8s_instrumentation.annotations.enabled }}
         annotations:
           - key_regex: (.*)

--- a/skaffold.yaml
+++ b/skaffold.yaml
@@ -49,7 +49,7 @@ deploy:
           # excluded annotations:
           # * kubectl.kubernetes.io/last-applied-configuration - deployed by kubectl, contains full config for each resource
           # * cni.projectcalico.org/ - deployed in CI system (k3s)
-          otel.metrics.k8s_instrumentation.annotations.excludePattern: "(kubectl\\.kubernetes\\.io/last-applied-configuration)|(cni\\.projectcalico\\.org/.*)"
+          otel.metrics.k8s_instrumentation.annotations.excludePattern: "(kubectl\\.kubernetes\\.io/last-applied-configuration)|(cni\\.projectcalico\\.org/.*)|(deployment\\.kubernetes\\.io/revision)|(deprecated\\.daemonset\\.template\\.generation)"
           # excluded labels:
           # * skaffold.dev/ - deployed by skaffold, contains unique ids so it must be excluded
           otel.metrics.k8s_instrumentation.labels.excludePattern: "skaffold\\.dev/.*"

--- a/tests/deploy/tests/test_metric_manifest.yaml
+++ b/tests/deploy/tests/test_metric_manifest.yaml
@@ -22,3 +22,133 @@ spec:
   - name: test-container
     image: busybox
     command: ["sh", "-c", "sleep infinity"]
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: test-deployment
+  namespace: test-namespace
+  labels:
+    app: test-deployment
+  annotations:
+    test-annotation: "test-value"
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: test-deployment
+  template:
+    metadata:
+      labels:
+        app: test-deployment
+      annotations:
+        test-annotation: "test-value"
+    spec:
+      containers:
+      - name: test-container
+        image: busybox
+        command: ["sh", "-c", "sleep infinity"]
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: test-statefulset
+  namespace: test-namespace
+  labels:
+    app: test-statefulset
+  annotations:
+    test-annotation: "test-value"
+spec:
+  serviceName: "test-service"
+  replicas: 1
+  selector:
+    matchLabels:
+      app: test-statefulset
+  template:
+    metadata:
+      labels:
+        app: test-statefulset
+      annotations:
+        test-annotation: "test-value"
+    spec:
+      containers:
+      - name: test-container
+        image: busybox
+        command: ["sh", "-c", "sleep infinity"]
+---
+apiVersion: apps/v1
+kind: ReplicaSet
+metadata:
+  name: test-replicaset
+  namespace: test-namespace
+  labels:
+    app: test-replicaset
+  annotations:
+    test-annotation: "test-value"
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: test-replicaset
+  template:
+    metadata:
+      labels:
+        app: test-replicaset
+      annotations:
+        test-annotation: "test-value"
+    spec:
+      containers:
+      - name: test-container
+        image: busybox
+        command: ["sh", "-c", "sleep infinity"]
+---
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: test-daemonset
+  namespace: test-namespace
+  labels:
+    app: test-daemonset
+  annotations:
+    test-annotation: "test-value"
+spec:
+  selector:
+    matchLabels:
+      app: test-daemonset
+  template:
+    metadata:
+      labels:
+        app: test-daemonset
+      annotations:
+        test-annotation: "test-value"
+    spec:
+      containers:
+      - name: test-container
+        image: busybox
+        command: ["sh", "-c", "sleep infinity"]
+---
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: test-cronjob
+  namespace: test-namespace
+  labels:
+    app: test-cronjob
+  annotations:
+    test-annotation: "test-value"
+spec:
+  schedule: "*/1 * * * *"
+  jobTemplate:
+    spec:
+      template:
+        metadata:
+          labels:
+            app: test-cronjob
+          annotations:
+            test-annotation: "test-value"
+        spec:
+          containers:
+          - name: test-container
+            image: busybox
+            command: ["sh", "-c", "sleep 10"]
+          restartPolicy: Never

--- a/tests/integration/expected_output.json
+++ b/tests/integration/expected_output.json
@@ -126,7 +126,7 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "2.3.0-alpha.5"
+              "stringValue": "2.3.0-alpha.6"
             }
           },
           {
@@ -302,7 +302,7 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "2.3.0-alpha.5"
+              "stringValue": "2.3.0-alpha.6"
             }
           },
           {
@@ -460,7 +460,7 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "2.3.0-alpha.5"
+              "stringValue": "2.3.0-alpha.6"
             }
           },
           {
@@ -642,7 +642,7 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "2.3.0-alpha.5"
+              "stringValue": "2.3.0-alpha.6"
             }
           },
           {
@@ -824,7 +824,7 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "2.3.0-alpha.5"
+              "stringValue": "2.3.0-alpha.6"
             }
           },
           {
@@ -1381,7 +1381,7 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "2.3.0-alpha.5"
+              "stringValue": "2.3.0-alpha.6"
             }
           },
           {
@@ -1675,7 +1675,7 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "2.3.0-alpha.5"
+              "stringValue": "2.3.0-alpha.6"
             }
           },
           {
@@ -1865,7 +1865,7 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "2.3.0-alpha.5"
+              "stringValue": "2.3.0-alpha.6"
             }
           },
           {
@@ -2049,7 +2049,7 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "2.3.0-alpha.5"
+              "stringValue": "2.3.0-alpha.6"
             }
           },
           {
@@ -2653,7 +2653,7 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "2.3.0-alpha.5"
+              "stringValue": "2.3.0-alpha.6"
             }
           },
           {
@@ -2909,7 +2909,7 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "2.3.0-alpha.5"
+              "stringValue": "2.3.0-alpha.6"
             }
           },
           {
@@ -3159,7 +3159,7 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "2.3.0-alpha.5"
+              "stringValue": "2.3.0-alpha.6"
             }
           },
           {
@@ -3406,7 +3406,7 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "2.3.0-alpha.5"
+              "stringValue": "2.3.0-alpha.6"
             }
           },
           {
@@ -3715,159 +3715,7 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "2.3.0-alpha.5"
-            }
-          },
-          {
-            "key": "sw.k8s.cluster.uid",
-            "value": {
-              "stringValue": "cluster-uid-123456789"
-            }
-          }
-        ]
-      },
-      "scopeMetrics": [
-        {
-          "metrics": [
-            {
-              "gauge": {
-                "dataPoints": [
-                  {
-                    "asDouble": 1,
-                    "attributes": [
-                      {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "http"
-                        }
-                      },
-                      {
-                        "key": "prometheus",
-                        "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
-                        }
-                      },
-                      {
-                        "key": "prometheus_replica",
-                        "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
-                        }
-                      }
-                    ],
-                    "timeUnixNano": "0"
-                  }
-                ]
-              },
-              "name": "k8s.kube_pod_container_status_ready"
-            }
-          ],
-          "scope": {}
-        }
-      ]
-    },
-    {
-      "resource": {
-        "attributes": [
-          {
-            "key": "http.scheme",
-            "value": {
-              "stringValue": "http"
-            }
-          },
-          {
-            "key": "k8s.cluster.name",
-            "value": {
-              "stringValue": "cluster name"
-            }
-          },
-          {
-            "key": "k8s.container.name",
-            "value": {
-              "stringValue": "test-container"
-            }
-          },
-          {
-            "key": "k8s.namespace.annotations.description",
-            "value": {
-              "stringValue": "This is a test namespace."
-            }
-          },
-          {
-            "key": "k8s.namespace.labels.app",
-            "value": {
-              "stringValue": "test-app"
-            }
-          },
-          {
-            "key": "k8s.namespace.labels.kubernetes.io/metadata.name",
-            "value": {
-              "stringValue": "test-namespace"
-            }
-          },
-          {
-            "key": "k8s.namespace.labels.purpose",
-            "value": {
-              "stringValue": "testing"
-            }
-          },
-          {
-            "key": "k8s.namespace.name",
-            "value": {
-              "stringValue": "test-namespace"
-            }
-          },
-          {
-            "key": "k8s.pod.annotations.test-annotation",
-            "value": {
-              "stringValue": "test-value"
-            }
-          },
-          {
-            "key": "k8s.pod.labels.app",
-            "value": {
-              "stringValue": "test-pod"
-            }
-          },
-          {
-            "key": "k8s.pod.name",
-            "value": {
-              "stringValue": "test-pod"
-            }
-          },
-          {
-            "key": "k8s.pod.uid",
-            "value": {
-              "stringValue": "00000000-0000-0000-0000-000000000000"
-            }
-          },
-          {
-            "key": "net.host.name",
-            "value": {
-              "stringValue": "test-node"
-            }
-          },
-          {
-            "key": "net.host.port",
-            "value": {
-              "stringValue": ""
-            }
-          },
-          {
-            "key": "service.instance.id",
-            "value": {
-              "stringValue": "test-node"
-            }
-          },
-          {
-            "key": "sw.k8s.agent.app.version",
-            "value": {
-              "stringValue": "0.5.0"
-            }
-          },
-          {
-            "key": "sw.k8s.agent.manifest.version",
-            "value": {
-              "stringValue": "2.3.0-alpha.5"
+              "stringValue": "2.3.0-alpha.6"
             }
           },
           {
@@ -4025,159 +3873,7 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "2.3.0-alpha.5"
-            }
-          },
-          {
-            "key": "sw.k8s.cluster.uid",
-            "value": {
-              "stringValue": "cluster-uid-123456789"
-            }
-          }
-        ]
-      },
-      "scopeMetrics": [
-        {
-          "metrics": [
-            {
-              "gauge": {
-                "dataPoints": [
-                  {
-                    "asDouble": 0,
-                    "attributes": [
-                      {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "http"
-                        }
-                      },
-                      {
-                        "key": "prometheus",
-                        "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
-                        }
-                      },
-                      {
-                        "key": "prometheus_replica",
-                        "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
-                        }
-                      }
-                    ],
-                    "timeUnixNano": "0"
-                  }
-                ]
-              },
-              "name": "k8s.kube_pod_container_status_waiting"
-            }
-          ],
-          "scope": {}
-        }
-      ]
-    },
-    {
-      "resource": {
-        "attributes": [
-          {
-            "key": "http.scheme",
-            "value": {
-              "stringValue": "http"
-            }
-          },
-          {
-            "key": "k8s.cluster.name",
-            "value": {
-              "stringValue": "cluster name"
-            }
-          },
-          {
-            "key": "k8s.container.name",
-            "value": {
-              "stringValue": "test-container"
-            }
-          },
-          {
-            "key": "k8s.namespace.annotations.description",
-            "value": {
-              "stringValue": "This is a test namespace."
-            }
-          },
-          {
-            "key": "k8s.namespace.labels.app",
-            "value": {
-              "stringValue": "test-app"
-            }
-          },
-          {
-            "key": "k8s.namespace.labels.kubernetes.io/metadata.name",
-            "value": {
-              "stringValue": "test-namespace"
-            }
-          },
-          {
-            "key": "k8s.namespace.labels.purpose",
-            "value": {
-              "stringValue": "testing"
-            }
-          },
-          {
-            "key": "k8s.namespace.name",
-            "value": {
-              "stringValue": "test-namespace"
-            }
-          },
-          {
-            "key": "k8s.pod.annotations.test-annotation",
-            "value": {
-              "stringValue": "test-value"
-            }
-          },
-          {
-            "key": "k8s.pod.labels.app",
-            "value": {
-              "stringValue": "test-pod"
-            }
-          },
-          {
-            "key": "k8s.pod.name",
-            "value": {
-              "stringValue": "test-pod"
-            }
-          },
-          {
-            "key": "k8s.pod.uid",
-            "value": {
-              "stringValue": "00000000-0000-0000-0000-000000000000"
-            }
-          },
-          {
-            "key": "net.host.name",
-            "value": {
-              "stringValue": "test-node"
-            }
-          },
-          {
-            "key": "net.host.port",
-            "value": {
-              "stringValue": ""
-            }
-          },
-          {
-            "key": "service.instance.id",
-            "value": {
-              "stringValue": "test-node"
-            }
-          },
-          {
-            "key": "sw.k8s.agent.app.version",
-            "value": {
-              "stringValue": "0.5.0"
-            }
-          },
-          {
-            "key": "sw.k8s.agent.manifest.version",
-            "value": {
-              "stringValue": "2.3.0-alpha.5"
+              "stringValue": "2.3.0-alpha.6"
             }
           },
           {
@@ -4335,7 +4031,311 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "2.3.0-alpha.5"
+              "stringValue": "2.3.0-alpha.6"
+            }
+          },
+          {
+            "key": "sw.k8s.cluster.uid",
+            "value": {
+              "stringValue": "cluster-uid-123456789"
+            }
+          }
+        ]
+      },
+      "scopeMetrics": [
+        {
+          "metrics": [
+            {
+              "gauge": {
+                "dataPoints": [
+                  {
+                    "asDouble": 0,
+                    "attributes": [
+                      {
+                        "key": "endpoint",
+                        "value": {
+                          "stringValue": "http"
+                        }
+                      },
+                      {
+                        "key": "prometheus",
+                        "value": {
+                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
+                        }
+                      },
+                      {
+                        "key": "prometheus_replica",
+                        "value": {
+                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
+                        }
+                      }
+                    ],
+                    "timeUnixNano": "0"
+                  }
+                ]
+              },
+              "name": "k8s.kube_pod_container_status_waiting"
+            }
+          ],
+          "scope": {}
+        }
+      ]
+    },
+    {
+      "resource": {
+        "attributes": [
+          {
+            "key": "http.scheme",
+            "value": {
+              "stringValue": "http"
+            }
+          },
+          {
+            "key": "k8s.cluster.name",
+            "value": {
+              "stringValue": "cluster name"
+            }
+          },
+          {
+            "key": "k8s.container.name",
+            "value": {
+              "stringValue": "test-container"
+            }
+          },
+          {
+            "key": "k8s.namespace.annotations.description",
+            "value": {
+              "stringValue": "This is a test namespace."
+            }
+          },
+          {
+            "key": "k8s.namespace.labels.app",
+            "value": {
+              "stringValue": "test-app"
+            }
+          },
+          {
+            "key": "k8s.namespace.labels.kubernetes.io/metadata.name",
+            "value": {
+              "stringValue": "test-namespace"
+            }
+          },
+          {
+            "key": "k8s.namespace.labels.purpose",
+            "value": {
+              "stringValue": "testing"
+            }
+          },
+          {
+            "key": "k8s.namespace.name",
+            "value": {
+              "stringValue": "test-namespace"
+            }
+          },
+          {
+            "key": "k8s.pod.annotations.test-annotation",
+            "value": {
+              "stringValue": "test-value"
+            }
+          },
+          {
+            "key": "k8s.pod.labels.app",
+            "value": {
+              "stringValue": "test-pod"
+            }
+          },
+          {
+            "key": "k8s.pod.name",
+            "value": {
+              "stringValue": "test-pod"
+            }
+          },
+          {
+            "key": "k8s.pod.uid",
+            "value": {
+              "stringValue": "00000000-0000-0000-0000-000000000000"
+            }
+          },
+          {
+            "key": "net.host.name",
+            "value": {
+              "stringValue": "test-node"
+            }
+          },
+          {
+            "key": "net.host.port",
+            "value": {
+              "stringValue": ""
+            }
+          },
+          {
+            "key": "service.instance.id",
+            "value": {
+              "stringValue": "test-node"
+            }
+          },
+          {
+            "key": "sw.k8s.agent.app.version",
+            "value": {
+              "stringValue": "0.5.0"
+            }
+          },
+          {
+            "key": "sw.k8s.agent.manifest.version",
+            "value": {
+              "stringValue": "2.3.0-alpha.6"
+            }
+          },
+          {
+            "key": "sw.k8s.cluster.uid",
+            "value": {
+              "stringValue": "cluster-uid-123456789"
+            }
+          }
+        ]
+      },
+      "scopeMetrics": [
+        {
+          "metrics": [
+            {
+              "gauge": {
+                "dataPoints": [
+                  {
+                    "asDouble": 1,
+                    "attributes": [
+                      {
+                        "key": "endpoint",
+                        "value": {
+                          "stringValue": "http"
+                        }
+                      },
+                      {
+                        "key": "prometheus",
+                        "value": {
+                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
+                        }
+                      },
+                      {
+                        "key": "prometheus_replica",
+                        "value": {
+                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
+                        }
+                      }
+                    ],
+                    "timeUnixNano": "0"
+                  }
+                ]
+              },
+              "name": "k8s.kube_pod_container_status_ready"
+            }
+          ],
+          "scope": {}
+        }
+      ]
+    },
+    {
+      "resource": {
+        "attributes": [
+          {
+            "key": "http.scheme",
+            "value": {
+              "stringValue": "http"
+            }
+          },
+          {
+            "key": "k8s.cluster.name",
+            "value": {
+              "stringValue": "cluster name"
+            }
+          },
+          {
+            "key": "k8s.container.name",
+            "value": {
+              "stringValue": "test-container"
+            }
+          },
+          {
+            "key": "k8s.namespace.annotations.description",
+            "value": {
+              "stringValue": "This is a test namespace."
+            }
+          },
+          {
+            "key": "k8s.namespace.labels.app",
+            "value": {
+              "stringValue": "test-app"
+            }
+          },
+          {
+            "key": "k8s.namespace.labels.kubernetes.io/metadata.name",
+            "value": {
+              "stringValue": "test-namespace"
+            }
+          },
+          {
+            "key": "k8s.namespace.labels.purpose",
+            "value": {
+              "stringValue": "testing"
+            }
+          },
+          {
+            "key": "k8s.namespace.name",
+            "value": {
+              "stringValue": "test-namespace"
+            }
+          },
+          {
+            "key": "k8s.pod.annotations.test-annotation",
+            "value": {
+              "stringValue": "test-value"
+            }
+          },
+          {
+            "key": "k8s.pod.labels.app",
+            "value": {
+              "stringValue": "test-pod"
+            }
+          },
+          {
+            "key": "k8s.pod.name",
+            "value": {
+              "stringValue": "test-pod"
+            }
+          },
+          {
+            "key": "k8s.pod.uid",
+            "value": {
+              "stringValue": "00000000-0000-0000-0000-000000000000"
+            }
+          },
+          {
+            "key": "net.host.name",
+            "value": {
+              "stringValue": "test-node"
+            }
+          },
+          {
+            "key": "net.host.port",
+            "value": {
+              "stringValue": ""
+            }
+          },
+          {
+            "key": "service.instance.id",
+            "value": {
+              "stringValue": "test-node"
+            }
+          },
+          {
+            "key": "sw.k8s.agent.app.version",
+            "value": {
+              "stringValue": "0.5.0"
+            }
+          },
+          {
+            "key": "sw.k8s.agent.manifest.version",
+            "value": {
+              "stringValue": "2.3.0-alpha.6"
             }
           },
           {
@@ -4493,7 +4493,7 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "2.3.0-alpha.5"
+              "stringValue": "2.3.0-alpha.6"
             }
           },
           {
@@ -4645,7 +4645,7 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "2.3.0-alpha.5"
+              "stringValue": "2.3.0-alpha.6"
             }
           },
           {
@@ -4971,140 +4971,6 @@
             }
           },
           {
-            "key": "k8s.namespace.labels.app",
-            "value": {
-              "stringValue": "test-app"
-            }
-          },
-          {
-            "key": "k8s.namespace.labels.kubernetes.io/metadata.name",
-            "value": {
-              "stringValue": "test-namespace"
-            }
-          },
-          {
-            "key": "k8s.namespace.labels.purpose",
-            "value": {
-              "stringValue": "testing"
-            }
-          },
-          {
-            "key": "k8s.namespace.name",
-            "value": {
-              "stringValue": "test-namespace"
-            }
-          },
-          {
-            "key": "k8s.replicaset.name",
-            "value": {
-              "stringValue": "test-replicaset"
-            }
-          },
-          {
-            "key": "net.host.name",
-            "value": {
-              "stringValue": "test-node"
-            }
-          },
-          {
-            "key": "net.host.port",
-            "value": {
-              "stringValue": ""
-            }
-          },
-          {
-            "key": "service.instance.id",
-            "value": {
-              "stringValue": "test-node"
-            }
-          },
-          {
-            "key": "sw.k8s.agent.app.version",
-            "value": {
-              "stringValue": "0.4.1"
-            }
-          },
-          {
-            "key": "sw.k8s.agent.manifest.version",
-            "value": {
-              "stringValue": "2.3.0-alpha.5"
-            }
-          },
-          {
-            "key": "sw.k8s.cluster.uid",
-            "value": {
-              "stringValue": "cluster-uid-123456789"
-            }
-          }
-        ]
-      },
-      "scopeMetrics": [
-        {
-          "metrics": [
-            {
-              "gauge": {
-                "dataPoints": [
-                  {
-                    "asDouble": 1,
-                    "attributes": [
-                      {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "http"
-                        }
-                      },
-                      {
-                        "key": "owner_is_controller",
-                        "value": {
-                          "stringValue": "true"
-                        }
-                      },
-                      {
-                        "key": "owner_kind",
-                        "value": {
-                          "stringValue": "Deployment"
-                        }
-                      },
-                      {
-                        "key": "prometheus",
-                        "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
-                        }
-                      },
-                      {
-                        "key": "prometheus_replica",
-                        "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
-                        }
-                      }
-                    ],
-                    "timeUnixNano": "0"
-                  }
-                ]
-              },
-              "name": "k8s.kube.replicaset.owner.deployment"
-            }
-          ],
-          "scope": {}
-        }
-      ]
-    },
-    {
-      "resource": {
-        "attributes": [
-          {
-            "key": "http.scheme",
-            "value": {
-              "stringValue": "http"
-            }
-          },
-          {
-            "key": "k8s.cluster.name",
-            "value": {
-              "stringValue": "cluster name"
-            }
-          },
-          {
             "key": "k8s.deployment.name",
             "value": {
               "stringValue": "test-deployment"
@@ -5114,146 +4980,6 @@
             "key": "k8s.deployment.uid",
             "value": {
               "stringValue": "00000000-0000-0000-0000-000000000000"
-            }
-          },
-          {
-            "key": "k8s.namespace.labels.app",
-            "value": {
-              "stringValue": "test-app"
-            }
-          },
-          {
-            "key": "k8s.namespace.labels.kubernetes.io/metadata.name",
-            "value": {
-              "stringValue": "test-namespace"
-            }
-          },
-          {
-            "key": "k8s.namespace.labels.purpose",
-            "value": {
-              "stringValue": "testing"
-            }
-          },
-          {
-            "key": "k8s.namespace.name",
-            "value": {
-              "stringValue": "test-namespace"
-            }
-          },
-          {
-            "key": "k8s.replicaset.name",
-            "value": {
-              "stringValue": "test-replicaset"
-            }
-          },
-          {
-            "key": "net.host.name",
-            "value": {
-              "stringValue": "test-node"
-            }
-          },
-          {
-            "key": "net.host.port",
-            "value": {
-              "stringValue": ""
-            }
-          },
-          {
-            "key": "service.instance.id",
-            "value": {
-              "stringValue": "test-node"
-            }
-          },
-          {
-            "key": "sw.k8s.agent.app.version",
-            "value": {
-              "stringValue": "0.4.1"
-            }
-          },
-          {
-            "key": "sw.k8s.agent.manifest.version",
-            "value": {
-              "stringValue": "2.3.0-alpha.5"
-            }
-          },
-          {
-            "key": "sw.k8s.cluster.uid",
-            "value": {
-              "stringValue": "cluster-uid-123456789"
-            }
-          }
-        ]
-      },
-      "scopeMetrics": [
-        {
-          "metrics": [
-            {
-              "gauge": {
-                "dataPoints": [
-                  {
-                    "asDouble": 1,
-                    "attributes": [
-                      {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "http"
-                        }
-                      },
-                      {
-                        "key": "owner_is_controller",
-                        "value": {
-                          "stringValue": "true"
-                        }
-                      },
-                      {
-                        "key": "owner_kind",
-                        "value": {
-                          "stringValue": "Deployment"
-                        }
-                      },
-                      {
-                        "key": "prometheus",
-                        "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
-                        }
-                      },
-                      {
-                        "key": "prometheus_replica",
-                        "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
-                        }
-                      }
-                    ],
-                    "timeUnixNano": "0"
-                  }
-                ]
-              },
-              "name": "k8s.kube.replicaset.owner.deployment"
-            }
-          ],
-          "scope": {}
-        }
-      ]
-    },
-    {
-      "resource": {
-        "attributes": [
-          {
-            "key": "http.scheme",
-            "value": {
-              "stringValue": "http"
-            }
-          },
-          {
-            "key": "k8s.cluster.name",
-            "value": {
-              "stringValue": "cluster name"
-            }
-          },
-          {
-            "key": "k8s.deployment.name",
-            "value": {
-              "stringValue": "test-deployment"
             }
           },
           {
@@ -5313,7 +5039,7 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "2.3.0-alpha.5"
+              "stringValue": "2.3.0-alpha.6"
             }
           },
           {
@@ -5998,19 +5724,19 @@
           {
             "key": "net.host.name",
             "value": {
-              "stringValue": "wiremock.monitoring.svc.cluster.local"
+              "stringValue": "test-node"
             }
           },
           {
             "key": "net.host.port",
             "value": {
-              "stringValue": "8080"
+              "stringValue": ""
             }
           },
           {
             "key": "service.instance.id",
             "value": {
-              "stringValue": "wiremock.monitoring.svc.cluster.local:8080"
+              "stringValue": "test-node"
             }
           },
           {
@@ -6022,7 +5748,7 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "2.3.0-alpha.4"
+              "stringValue": "2.3.0-alpha.6"
             }
           },
           {
@@ -6162,19 +5888,19 @@
           {
             "key": "net.host.name",
             "value": {
-              "stringValue": "wiremock.monitoring.svc.cluster.local"
+              "stringValue": "test-node"
             }
           },
           {
             "key": "net.host.port",
             "value": {
-              "stringValue": "8080"
+              "stringValue": ""
             }
           },
           {
             "key": "service.instance.id",
             "value": {
-              "stringValue": "wiremock.monitoring.svc.cluster.local:8080"
+              "stringValue": "test-node"
             }
           },
           {
@@ -6186,7 +5912,7 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "2.3.0-alpha.4"
+              "stringValue": "2.3.0-alpha.6"
             }
           },
           {
@@ -6326,7 +6052,7 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "2.3.0-alpha.5"
+              "stringValue": "2.3.0-alpha.6"
             }
           },
           {
@@ -6781,7 +6507,7 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "2.3.0-alpha.5"
+              "stringValue": "2.3.0-alpha.6"
             }
           },
           {
@@ -6963,7 +6689,7 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "2.3.0-alpha.5"
+              "stringValue": "2.3.0-alpha.6"
             }
           },
           {
@@ -7139,7 +6865,7 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "2.3.0-alpha.5"
+              "stringValue": "2.3.0-alpha.6"
             }
           },
           {
@@ -8062,7 +7788,7 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "2.3.0-alpha.5"
+              "stringValue": "2.3.0-alpha.6"
             }
           },
           {
@@ -9673,7 +9399,7 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "2.3.0-alpha.5"
+              "stringValue": "2.3.0-alpha.6"
             }
           },
           {
@@ -9849,7 +9575,7 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "2.3.0-alpha.5"
+              "stringValue": "2.3.0-alpha.6"
             }
           },
           {
@@ -10025,7 +9751,7 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "2.3.0-alpha.5"
+              "stringValue": "2.3.0-alpha.6"
             }
           },
           {
@@ -10189,7 +9915,7 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "2.3.0-alpha.5"
+              "stringValue": "2.3.0-alpha.6"
             }
           },
           {
@@ -10353,7 +10079,7 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "2.3.0-alpha.5"
+              "stringValue": "2.3.0-alpha.6"
             }
           },
           {
@@ -10511,7 +10237,153 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "2.3.0-alpha.5"
+              "stringValue": "2.3.0-alpha.6"
+            }
+          },
+          {
+            "key": "sw.k8s.cluster.uid",
+            "value": {
+              "stringValue": "cluster-uid-123456789"
+            }
+          }
+        ]
+      },
+      "scopeMetrics": [
+        {
+          "metrics": [
+            {
+              "gauge": {
+                "dataPoints": [
+                  {
+                    "asDouble": 1676013611,
+                    "attributes": [
+                      {
+                        "key": "endpoint",
+                        "value": {
+                          "stringValue": "http"
+                        }
+                      },
+                      {
+                        "key": "prometheus",
+                        "value": {
+                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
+                        }
+                      },
+                      {
+                        "key": "prometheus_replica",
+                        "value": {
+                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
+                        }
+                      }
+                    ],
+                    "timeUnixNano": "0"
+                  }
+                ]
+              },
+              "name": "k8s.kube_pod_completion_time"
+            }
+          ],
+          "scope": {}
+        }
+      ]
+    },
+    {
+      "resource": {
+        "attributes": [
+          {
+            "key": "http.scheme",
+            "value": {
+              "stringValue": "http"
+            }
+          },
+          {
+            "key": "k8s.cluster.name",
+            "value": {
+              "stringValue": "cluster name"
+            }
+          },
+          {
+            "key": "k8s.namespace.annotations.description",
+            "value": {
+              "stringValue": "This is a test namespace."
+            }
+          },
+          {
+            "key": "k8s.namespace.labels.app",
+            "value": {
+              "stringValue": "test-app"
+            }
+          },
+          {
+            "key": "k8s.namespace.labels.kubernetes.io/metadata.name",
+            "value": {
+              "stringValue": "test-namespace"
+            }
+          },
+          {
+            "key": "k8s.namespace.labels.purpose",
+            "value": {
+              "stringValue": "testing"
+            }
+          },
+          {
+            "key": "k8s.namespace.name",
+            "value": {
+              "stringValue": "test-namespace"
+            }
+          },
+          {
+            "key": "k8s.pod.annotations.test-annotation",
+            "value": {
+              "stringValue": "test-value"
+            }
+          },
+          {
+            "key": "k8s.pod.labels.app",
+            "value": {
+              "stringValue": "test-pod"
+            }
+          },
+          {
+            "key": "k8s.pod.name",
+            "value": {
+              "stringValue": "test-pod"
+            }
+          },
+          {
+            "key": "k8s.pod.uid",
+            "value": {
+              "stringValue": "00000000-0000-0000-0000-000000000000"
+            }
+          },
+          {
+            "key": "net.host.name",
+            "value": {
+              "stringValue": "test-node"
+            }
+          },
+          {
+            "key": "net.host.port",
+            "value": {
+              "stringValue": ""
+            }
+          },
+          {
+            "key": "service.instance.id",
+            "value": {
+              "stringValue": "test-node"
+            }
+          },
+          {
+            "key": "sw.k8s.agent.app.version",
+            "value": {
+              "stringValue": "0.5.0"
+            }
+          },
+          {
+            "key": "sw.k8s.agent.manifest.version",
+            "value": {
+              "stringValue": "2.3.0-alpha.6"
             }
           },
           {
@@ -10737,7 +10609,7 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "2.3.0-alpha.5"
+              "stringValue": "2.3.0-alpha.6"
             }
           },
           {
@@ -11060,7 +10932,7 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "2.3.0-alpha.5"
+              "stringValue": "2.3.0-alpha.6"
             }
           },
           {
@@ -11212,153 +11084,7 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "2.3.0-alpha.5"
-            }
-          },
-          {
-            "key": "sw.k8s.cluster.uid",
-            "value": {
-              "stringValue": "cluster-uid-123456789"
-            }
-          }
-        ]
-      },
-      "scopeMetrics": [
-        {
-          "metrics": [
-            {
-              "gauge": {
-                "dataPoints": [
-                  {
-                    "asDouble": 1676013611,
-                    "attributes": [
-                      {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "http"
-                        }
-                      },
-                      {
-                        "key": "prometheus",
-                        "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
-                        }
-                      },
-                      {
-                        "key": "prometheus_replica",
-                        "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
-                        }
-                      }
-                    ],
-                    "timeUnixNano": "0"
-                  }
-                ]
-              },
-              "name": "k8s.kube_pod_completion_time"
-            }
-          ],
-          "scope": {}
-        }
-      ]
-    },
-    {
-      "resource": {
-        "attributes": [
-          {
-            "key": "http.scheme",
-            "value": {
-              "stringValue": "http"
-            }
-          },
-          {
-            "key": "k8s.cluster.name",
-            "value": {
-              "stringValue": "cluster name"
-            }
-          },
-          {
-            "key": "k8s.namespace.annotations.description",
-            "value": {
-              "stringValue": "This is a test namespace."
-            }
-          },
-          {
-            "key": "k8s.namespace.labels.app",
-            "value": {
-              "stringValue": "test-app"
-            }
-          },
-          {
-            "key": "k8s.namespace.labels.kubernetes.io/metadata.name",
-            "value": {
-              "stringValue": "test-namespace"
-            }
-          },
-          {
-            "key": "k8s.namespace.labels.purpose",
-            "value": {
-              "stringValue": "testing"
-            }
-          },
-          {
-            "key": "k8s.namespace.name",
-            "value": {
-              "stringValue": "test-namespace"
-            }
-          },
-          {
-            "key": "k8s.pod.annotations.test-annotation",
-            "value": {
-              "stringValue": "test-value"
-            }
-          },
-          {
-            "key": "k8s.pod.labels.app",
-            "value": {
-              "stringValue": "test-pod"
-            }
-          },
-          {
-            "key": "k8s.pod.name",
-            "value": {
-              "stringValue": "test-pod"
-            }
-          },
-          {
-            "key": "k8s.pod.uid",
-            "value": {
-              "stringValue": "00000000-0000-0000-0000-000000000000"
-            }
-          },
-          {
-            "key": "net.host.name",
-            "value": {
-              "stringValue": "test-node"
-            }
-          },
-          {
-            "key": "net.host.port",
-            "value": {
-              "stringValue": ""
-            }
-          },
-          {
-            "key": "service.instance.id",
-            "value": {
-              "stringValue": "test-node"
-            }
-          },
-          {
-            "key": "sw.k8s.agent.app.version",
-            "value": {
-              "stringValue": "0.5.0"
-            }
-          },
-          {
-            "key": "sw.k8s.agent.manifest.version",
-            "value": {
-              "stringValue": "2.3.0-alpha.5"
+              "stringValue": "2.3.0-alpha.6"
             }
           },
           {
@@ -11504,7 +11230,7 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "2.3.0-alpha.5"
+              "stringValue": "2.3.0-alpha.6"
             }
           },
           {
@@ -11674,7 +11400,7 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "2.3.0-alpha.5"
+              "stringValue": "2.3.0-alpha.6"
             }
           },
           {
@@ -11911,7 +11637,7 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "2.3.0-alpha.5"
+              "stringValue": "2.3.0-alpha.6"
             }
           },
           {
@@ -12188,7 +11914,7 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "2.3.0-alpha.5"
+              "stringValue": "2.3.0-alpha.6"
             }
           },
           {
@@ -12359,7 +12085,7 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "2.3.0-alpha.5"
+              "stringValue": "2.3.0-alpha.6"
             }
           },
           {
@@ -12487,7 +12213,7 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "2.3.0-alpha.5"
+              "stringValue": "2.3.0-alpha.6"
             }
           },
           {
@@ -12591,7 +12317,7 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "2.3.0-alpha.5"
+              "stringValue": "2.3.0-alpha.6"
             }
           },
           {
@@ -24563,7 +24289,7 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "2.3.0-alpha.5"
+              "stringValue": "2.3.0-alpha.6"
             }
           },
           {

--- a/tests/integration/expected_output.json
+++ b/tests/integration/expected_output.json
@@ -96,7 +96,7 @@
           {
             "key": "k8s.pod.uid",
             "value": {
-              "stringValue": "c72bea9b-2e20-4a01-8873-902890ad6ba5"
+              "stringValue": "00000000-0000-0000-0000-000000000000"
             }
           },
           {
@@ -120,7 +120,7 @@
           {
             "key": "sw.k8s.agent.app.version",
             "value": {
-              "stringValue": "0.4.1"
+              "stringValue": "0.5.0"
             }
           },
           {
@@ -272,7 +272,7 @@
           {
             "key": "k8s.pod.uid",
             "value": {
-              "stringValue": "f97c5cef-d9f0-4455-869c-d2be4e51546f"
+              "stringValue": "00000000-0000-0000-0000-000000000000"
             }
           },
           {
@@ -296,7 +296,7 @@
           {
             "key": "sw.k8s.agent.app.version",
             "value": {
-              "stringValue": "0.4.1"
+              "stringValue": "0.5.0"
             }
           },
           {
@@ -454,7 +454,7 @@
           {
             "key": "sw.k8s.agent.app.version",
             "value": {
-              "stringValue": "0.4.1"
+              "stringValue": "0.5.0"
             }
           },
           {
@@ -642,7 +642,7 @@
           {
             "key": "sw.k8s.agent.app.version",
             "value": {
-              "stringValue": "0.4.1"
+              "stringValue": "0.5.0"
             }
           },
           {
@@ -830,7 +830,7 @@
           {
             "key": "sw.k8s.agent.app.version",
             "value": {
-              "stringValue": "0.4.1"
+              "stringValue": "0.5.0"
             }
           },
           {
@@ -1429,7 +1429,7 @@
           {
             "key": "sw.k8s.agent.app.version",
             "value": {
-              "stringValue": "0.4.1"
+              "stringValue": "0.5.0"
             }
           },
           {
@@ -1741,7 +1741,7 @@
           {
             "key": "sw.k8s.agent.app.version",
             "value": {
-              "stringValue": "0.4.1"
+              "stringValue": "0.5.0"
             }
           },
           {
@@ -1937,7 +1937,7 @@
           {
             "key": "sw.k8s.agent.app.version",
             "value": {
-              "stringValue": "0.4.1"
+              "stringValue": "0.5.0"
             }
           },
           {
@@ -2127,7 +2127,7 @@
           {
             "key": "sw.k8s.agent.app.version",
             "value": {
-              "stringValue": "0.4.1"
+              "stringValue": "0.5.0"
             }
           },
           {
@@ -2755,7 +2755,7 @@
           {
             "key": "k8s.pod.uid",
             "value": {
-              "stringValue": "c72bea9b-2e20-4a01-8873-902890ad6ba5"
+              "stringValue": "00000000-0000-0000-0000-000000000000"
             }
           },
           {
@@ -2779,263 +2779,7 @@
           {
             "key": "sw.k8s.agent.app.version",
             "value": {
-              "stringValue": "0.4.1"
-            }
-          },
-          {
-            "key": "sw.k8s.agent.manifest.version",
-            "value": {
-              "stringValue": "2.3.0-alpha.4"
-            }
-          },
-          {
-            "key": "sw.k8s.cluster.uid",
-            "value": {
-              "stringValue": "cluster-uid-123456789"
-            }
-          }
-        ]
-      },
-      "scopeMetrics": [
-        {
-          "metrics": [
-            {
-              "gauge": {
-                "dataPoints": [
-                  {
-                    "asDouble": 2684354560,
-                    "attributes": [
-                      {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "http"
-                        }
-                      },
-                      {
-                        "key": "prometheus",
-                        "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
-                        }
-                      },
-                      {
-                        "key": "prometheus_replica",
-                        "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
-                        }
-                      },
-                      {
-                        "key": "resource",
-                        "value": {
-                          "stringValue": "memory"
-                        }
-                      },
-                      {
-                        "key": "unit",
-                        "value": {
-                          "stringValue": "byte"
-                        }
-                      }
-                    ],
-                    "timeUnixNano": "0"
-                  }
-                ]
-              },
-              "name": "k8s.container.spec.memory.requests"
-            },
-            {
-              "gauge": {
-                "dataPoints": [
-                  {
-                    "asDouble": 2684354560,
-                    "attributes": [
-                      {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "http"
-                        }
-                      },
-                      {
-                        "key": "prometheus",
-                        "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
-                        }
-                      },
-                      {
-                        "key": "prometheus_replica",
-                        "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
-                        }
-                      },
-                      {
-                        "key": "resource",
-                        "value": {
-                          "stringValue": "memory"
-                        }
-                      },
-                      {
-                        "key": "unit",
-                        "value": {
-                          "stringValue": "byte"
-                        }
-                      }
-                    ],
-                    "timeUnixNano": "0"
-                  }
-                ]
-              },
-              "name": "k8s.kube_pod_container_resource_limits"
-            },
-            {
-              "gauge": {
-                "dataPoints": [
-                  {
-                    "asDouble": 2684354560,
-                    "attributes": [
-                      {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "http"
-                        }
-                      },
-                      {
-                        "key": "prometheus",
-                        "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
-                        }
-                      },
-                      {
-                        "key": "prometheus_replica",
-                        "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
-                        }
-                      },
-                      {
-                        "key": "resource",
-                        "value": {
-                          "stringValue": "memory"
-                        }
-                      },
-                      {
-                        "key": "unit",
-                        "value": {
-                          "stringValue": "byte"
-                        }
-                      }
-                    ],
-                    "timeUnixNano": "0"
-                  }
-                ]
-              },
-              "name": "k8s.kube_pod_container_resource_requests"
-            }
-          ],
-          "scope": {}
-        }
-      ]
-    },
-    {
-      "resource": {
-        "attributes": [
-          {
-            "key": "http.scheme",
-            "value": {
-              "stringValue": "http"
-            }
-          },
-          {
-            "key": "k8s.cluster.name",
-            "value": {
-              "stringValue": "cluster name"
-            }
-          },
-          {
-            "key": "k8s.container.name",
-            "value": {
-              "stringValue": "test-container"
-            }
-          },
-          {
-            "key": "k8s.namespace.annotations.description",
-            "value": {
-              "stringValue": "This is a test namespace."
-            }
-          },
-          {
-            "key": "k8s.namespace.labels.app",
-            "value": {
-              "stringValue": "test-app"
-            }
-          },
-          {
-            "key": "k8s.namespace.labels.kubernetes.io/metadata.name",
-            "value": {
-              "stringValue": "test-namespace"
-            }
-          },
-          {
-            "key": "k8s.namespace.labels.purpose",
-            "value": {
-              "stringValue": "testing"
-            }
-          },
-          {
-            "key": "k8s.namespace.name",
-            "value": {
-              "stringValue": "test-namespace"
-            }
-          },
-          {
-            "key": "k8s.node.name",
-            "value": {
-              "stringValue": "test-node"
-            }
-          },
-          {
-            "key": "k8s.pod.annotations.test-annotation",
-            "value": {
-              "stringValue": "test-value"
-            }
-          },
-          {
-            "key": "k8s.pod.labels.app",
-            "value": {
-              "stringValue": "test-pod"
-            }
-          },
-          {
-            "key": "k8s.pod.name",
-            "value": {
-              "stringValue": "test-pod"
-            }
-          },
-          {
-            "key": "k8s.pod.uid",
-            "value": {
-              "stringValue": "cb5e02c4-3b32-4d99-890c-eeff7afbb859"
-            }
-          },
-          {
-            "key": "net.host.name",
-            "value": {
-              "stringValue": "wiremock.monitoring.svc.cluster.local"
-            }
-          },
-          {
-            "key": "net.host.port",
-            "value": {
-              "stringValue": "8080"
-            }
-          },
-          {
-            "key": "service.instance.id",
-            "value": {
-              "stringValue": "wiremock.monitoring.svc.cluster.local:8080"
-            }
-          },
-          {
-            "key": "sw.k8s.agent.app.version",
-            "value": {
-              "stringValue": "0.4.1"
+              "stringValue": "0.5.0"
             }
           },
           {
@@ -3241,6 +2985,12 @@
             }
           },
           {
+            "key": "k8s.node.name",
+            "value": {
+              "stringValue": "test-node"
+            }
+          },
+          {
             "key": "k8s.pod.annotations.test-annotation",
             "value": {
               "stringValue": "test-value"
@@ -3261,7 +3011,7 @@
           {
             "key": "k8s.pod.uid",
             "value": {
-              "stringValue": "08b886d4-42ad-4310-b55f-985aa26ccda2"
+              "stringValue": "00000000-0000-0000-0000-000000000000"
             }
           },
           {
@@ -3285,7 +3035,7 @@
           {
             "key": "sw.k8s.agent.app.version",
             "value": {
-              "stringValue": "0.4.1"
+              "stringValue": "0.5.0"
             }
           },
           {
@@ -3305,6 +3055,351 @@
       "scopeMetrics": [
         {
           "metrics": [
+            {
+              "gauge": {
+                "dataPoints": [
+                  {
+                    "asDouble": 2684354560,
+                    "attributes": [
+                      {
+                        "key": "endpoint",
+                        "value": {
+                          "stringValue": "http"
+                        }
+                      },
+                      {
+                        "key": "prometheus",
+                        "value": {
+                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
+                        }
+                      },
+                      {
+                        "key": "prometheus_replica",
+                        "value": {
+                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
+                        }
+                      },
+                      {
+                        "key": "resource",
+                        "value": {
+                          "stringValue": "memory"
+                        }
+                      },
+                      {
+                        "key": "unit",
+                        "value": {
+                          "stringValue": "byte"
+                        }
+                      }
+                    ],
+                    "timeUnixNano": "0"
+                  }
+                ]
+              },
+              "name": "k8s.container.spec.memory.requests"
+            },
+            {
+              "gauge": {
+                "dataPoints": [
+                  {
+                    "asDouble": 2684354560,
+                    "attributes": [
+                      {
+                        "key": "endpoint",
+                        "value": {
+                          "stringValue": "http"
+                        }
+                      },
+                      {
+                        "key": "prometheus",
+                        "value": {
+                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
+                        }
+                      },
+                      {
+                        "key": "prometheus_replica",
+                        "value": {
+                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
+                        }
+                      },
+                      {
+                        "key": "resource",
+                        "value": {
+                          "stringValue": "memory"
+                        }
+                      },
+                      {
+                        "key": "unit",
+                        "value": {
+                          "stringValue": "byte"
+                        }
+                      }
+                    ],
+                    "timeUnixNano": "0"
+                  }
+                ]
+              },
+              "name": "k8s.kube_pod_container_resource_limits"
+            },
+            {
+              "gauge": {
+                "dataPoints": [
+                  {
+                    "asDouble": 2684354560,
+                    "attributes": [
+                      {
+                        "key": "endpoint",
+                        "value": {
+                          "stringValue": "http"
+                        }
+                      },
+                      {
+                        "key": "prometheus",
+                        "value": {
+                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
+                        }
+                      },
+                      {
+                        "key": "prometheus_replica",
+                        "value": {
+                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
+                        }
+                      },
+                      {
+                        "key": "resource",
+                        "value": {
+                          "stringValue": "memory"
+                        }
+                      },
+                      {
+                        "key": "unit",
+                        "value": {
+                          "stringValue": "byte"
+                        }
+                      }
+                    ],
+                    "timeUnixNano": "0"
+                  }
+                ]
+              },
+              "name": "k8s.kube_pod_container_resource_requests"
+            }
+          ],
+          "scope": {}
+        }
+      ]
+    },
+    {
+      "resource": {
+        "attributes": [
+          {
+            "key": "http.scheme",
+            "value": {
+              "stringValue": "http"
+            }
+          },
+          {
+            "key": "k8s.cluster.name",
+            "value": {
+              "stringValue": "cluster name"
+            }
+          },
+          {
+            "key": "k8s.container.name",
+            "value": {
+              "stringValue": "test-container"
+            }
+          },
+          {
+            "key": "k8s.namespace.annotations.description",
+            "value": {
+              "stringValue": "This is a test namespace."
+            }
+          },
+          {
+            "key": "k8s.namespace.labels.app",
+            "value": {
+              "stringValue": "test-app"
+            }
+          },
+          {
+            "key": "k8s.namespace.labels.kubernetes.io/metadata.name",
+            "value": {
+              "stringValue": "test-namespace"
+            }
+          },
+          {
+            "key": "k8s.namespace.labels.purpose",
+            "value": {
+              "stringValue": "testing"
+            }
+          },
+          {
+            "key": "k8s.namespace.name",
+            "value": {
+              "stringValue": "test-namespace"
+            }
+          },
+          {
+            "key": "k8s.pod.annotations.test-annotation",
+            "value": {
+              "stringValue": "test-value"
+            }
+          },
+          {
+            "key": "k8s.pod.labels.app",
+            "value": {
+              "stringValue": "test-pod"
+            }
+          },
+          {
+            "key": "k8s.pod.name",
+            "value": {
+              "stringValue": "test-pod"
+            }
+          },
+          {
+            "key": "k8s.pod.uid",
+            "value": {
+              "stringValue": "00000000-0000-0000-0000-000000000000"
+            }
+          },
+          {
+            "key": "net.host.name",
+            "value": {
+              "stringValue": "wiremock.monitoring.svc.cluster.local"
+            }
+          },
+          {
+            "key": "net.host.port",
+            "value": {
+              "stringValue": "8080"
+            }
+          },
+          {
+            "key": "service.instance.id",
+            "value": {
+              "stringValue": "wiremock.monitoring.svc.cluster.local:8080"
+            }
+          },
+          {
+            "key": "sw.k8s.agent.app.version",
+            "value": {
+              "stringValue": "0.5.0"
+            }
+          },
+          {
+            "key": "sw.k8s.agent.manifest.version",
+            "value": {
+              "stringValue": "2.3.0-alpha.4"
+            }
+          },
+          {
+            "key": "sw.k8s.cluster.uid",
+            "value": {
+              "stringValue": "cluster-uid-123456789"
+            }
+          }
+        ]
+      },
+      "scopeMetrics": [
+        {
+          "metrics": [
+            {
+              "gauge": {
+                "dataPoints": [
+                  {
+                    "asDouble": 1677653949,
+                    "attributes": [
+                      {
+                        "key": "endpoint",
+                        "value": {
+                          "stringValue": "http"
+                        }
+                      },
+                      {
+                        "key": "prometheus",
+                        "value": {
+                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
+                        }
+                      },
+                      {
+                        "key": "prometheus_replica",
+                        "value": {
+                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
+                        }
+                      }
+                    ],
+                    "timeUnixNano": "0"
+                  }
+                ]
+              },
+              "name": "k8s.kube_pod_container_state_started"
+            },
+            {
+              "name": "k8s.kube_pod_container_status_restarts_total",
+              "sum": {
+                "aggregationTemporality": 2,
+                "dataPoints": [
+                  {
+                    "asDouble": 0,
+                    "attributes": [
+                      {
+                        "key": "endpoint",
+                        "value": {
+                          "stringValue": "http"
+                        }
+                      },
+                      {
+                        "key": "prometheus",
+                        "value": {
+                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
+                        }
+                      },
+                      {
+                        "key": "prometheus_replica",
+                        "value": {
+                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
+                        }
+                      }
+                    ],
+                    "timeUnixNano": "0"
+                  }
+                ],
+                "isMonotonic": true
+              }
+            },
+            {
+              "gauge": {
+                "dataPoints": [
+                  {
+                    "asDouble": 1,
+                    "attributes": [
+                      {
+                        "key": "endpoint",
+                        "value": {
+                          "stringValue": "http"
+                        }
+                      },
+                      {
+                        "key": "prometheus",
+                        "value": {
+                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
+                        }
+                      },
+                      {
+                        "key": "prometheus_replica",
+                        "value": {
+                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
+                        }
+                      }
+                    ],
+                    "timeUnixNano": "0"
+                  }
+                ]
+              },
+              "name": "k8s.kube_pod_container_status_running"
+            },
             {
               "gauge": {
                 "dataPoints": [
@@ -3334,7 +3429,7 @@
                   }
                 ]
               },
-              "name": "k8s.kube_pod_container_status_waiting"
+              "name": "k8s.kube_pod_container_status_terminated"
             }
           ],
           "scope": {}
@@ -3413,7 +3508,7 @@
           {
             "key": "k8s.pod.uid",
             "value": {
-              "stringValue": "259510d0-b32f-47c3-ba07-f414c9a7e310"
+              "stringValue": "00000000-0000-0000-0000-000000000000"
             }
           },
           {
@@ -3437,323 +3532,7 @@
           {
             "key": "sw.k8s.agent.app.version",
             "value": {
-              "stringValue": "0.4.1"
-            }
-          },
-          {
-            "key": "sw.k8s.agent.manifest.version",
-            "value": {
-              "stringValue": "2.3.0-alpha.4"
-            }
-          },
-          {
-            "key": "sw.k8s.cluster.uid",
-            "value": {
-              "stringValue": "cluster-uid-123456789"
-            }
-          }
-        ]
-      },
-      "scopeMetrics": [
-        {
-          "metrics": [
-            {
-              "gauge": {
-                "dataPoints": [
-                  {
-                    "asDouble": 1,
-                    "attributes": [
-                      {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "http"
-                        }
-                      },
-                      {
-                        "key": "prometheus",
-                        "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
-                        }
-                      },
-                      {
-                        "key": "prometheus_replica",
-                        "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
-                        }
-                      },
-                      {
-                        "key": "reason",
-                        "value": {
-                          "stringValue": "Completed"
-                        }
-                      }
-                    ],
-                    "timeUnixNano": "0"
-                  }
-                ]
-              },
-              "name": "k8s.kube_pod_container_status_terminated_reason"
-            }
-          ],
-          "scope": {}
-        }
-      ]
-    },
-    {
-      "resource": {
-        "attributes": [
-          {
-            "key": "http.scheme",
-            "value": {
-              "stringValue": "http"
-            }
-          },
-          {
-            "key": "k8s.cluster.name",
-            "value": {
-              "stringValue": "cluster name"
-            }
-          },
-          {
-            "key": "k8s.container.name",
-            "value": {
-              "stringValue": "test-container"
-            }
-          },
-          {
-            "key": "k8s.namespace.annotations.description",
-            "value": {
-              "stringValue": "This is a test namespace."
-            }
-          },
-          {
-            "key": "k8s.namespace.labels.app",
-            "value": {
-              "stringValue": "test-app"
-            }
-          },
-          {
-            "key": "k8s.namespace.labels.kubernetes.io/metadata.name",
-            "value": {
-              "stringValue": "test-namespace"
-            }
-          },
-          {
-            "key": "k8s.namespace.labels.purpose",
-            "value": {
-              "stringValue": "testing"
-            }
-          },
-          {
-            "key": "k8s.namespace.name",
-            "value": {
-              "stringValue": "test-namespace"
-            }
-          },
-          {
-            "key": "k8s.pod.annotations.test-annotation",
-            "value": {
-              "stringValue": "test-value"
-            }
-          },
-          {
-            "key": "k8s.pod.labels.app",
-            "value": {
-              "stringValue": "test-pod"
-            }
-          },
-          {
-            "key": "k8s.pod.name",
-            "value": {
-              "stringValue": "test-pod"
-            }
-          },
-          {
-            "key": "k8s.pod.uid",
-            "value": {
-              "stringValue": "869004b9-9774-4681-926a-60fe664122f3"
-            }
-          },
-          {
-            "key": "net.host.name",
-            "value": {
-              "stringValue": "wiremock.monitoring.svc.cluster.local"
-            }
-          },
-          {
-            "key": "net.host.port",
-            "value": {
-              "stringValue": "8080"
-            }
-          },
-          {
-            "key": "service.instance.id",
-            "value": {
-              "stringValue": "wiremock.monitoring.svc.cluster.local:8080"
-            }
-          },
-          {
-            "key": "sw.k8s.agent.app.version",
-            "value": {
-              "stringValue": "0.4.1"
-            }
-          },
-          {
-            "key": "sw.k8s.agent.manifest.version",
-            "value": {
-              "stringValue": "2.3.0-alpha.4"
-            }
-          },
-          {
-            "key": "sw.k8s.cluster.uid",
-            "value": {
-              "stringValue": "cluster-uid-123456789"
-            }
-          }
-        ]
-      },
-      "scopeMetrics": [
-        {
-          "metrics": [
-            {
-              "gauge": {
-                "dataPoints": [
-                  {
-                    "asDouble": 1,
-                    "attributes": [
-                      {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "http"
-                        }
-                      },
-                      {
-                        "key": "prometheus",
-                        "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
-                        }
-                      },
-                      {
-                        "key": "prometheus_replica",
-                        "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
-                        }
-                      },
-                      {
-                        "key": "reason",
-                        "value": {
-                          "stringValue": "Completed"
-                        }
-                      }
-                    ],
-                    "timeUnixNano": "0"
-                  }
-                ]
-              },
-              "name": "k8s.kube_pod_container_status_last_terminated_reason"
-            }
-          ],
-          "scope": {}
-        }
-      ]
-    },
-    {
-      "resource": {
-        "attributes": [
-          {
-            "key": "http.scheme",
-            "value": {
-              "stringValue": "http"
-            }
-          },
-          {
-            "key": "k8s.cluster.name",
-            "value": {
-              "stringValue": "cluster name"
-            }
-          },
-          {
-            "key": "k8s.container.name",
-            "value": {
-              "stringValue": "test-container"
-            }
-          },
-          {
-            "key": "k8s.namespace.annotations.description",
-            "value": {
-              "stringValue": "This is a test namespace."
-            }
-          },
-          {
-            "key": "k8s.namespace.labels.app",
-            "value": {
-              "stringValue": "test-app"
-            }
-          },
-          {
-            "key": "k8s.namespace.labels.kubernetes.io/metadata.name",
-            "value": {
-              "stringValue": "test-namespace"
-            }
-          },
-          {
-            "key": "k8s.namespace.labels.purpose",
-            "value": {
-              "stringValue": "testing"
-            }
-          },
-          {
-            "key": "k8s.namespace.name",
-            "value": {
-              "stringValue": "test-namespace"
-            }
-          },
-          {
-            "key": "k8s.pod.annotations.test-annotation",
-            "value": {
-              "stringValue": "test-value"
-            }
-          },
-          {
-            "key": "k8s.pod.labels.app",
-            "value": {
-              "stringValue": "test-pod"
-            }
-          },
-          {
-            "key": "k8s.pod.name",
-            "value": {
-              "stringValue": "test-pod"
-            }
-          },
-          {
-            "key": "k8s.pod.uid",
-            "value": {
-              "stringValue": "c72bea9b-2e20-4a01-8873-902890ad6ba5"
-            }
-          },
-          {
-            "key": "net.host.name",
-            "value": {
-              "stringValue": "wiremock.monitoring.svc.cluster.local"
-            }
-          },
-          {
-            "key": "net.host.port",
-            "value": {
-              "stringValue": "8080"
-            }
-          },
-          {
-            "key": "service.instance.id",
-            "value": {
-              "stringValue": "wiremock.monitoring.svc.cluster.local:8080"
-            }
-          },
-          {
-            "key": "sw.k8s.agent.app.version",
-            "value": {
-              "stringValue": "0.4.1"
+              "stringValue": "0.5.0"
             }
           },
           {
@@ -4038,7 +3817,7 @@
           {
             "key": "k8s.pod.uid",
             "value": {
-              "stringValue": "c72bea9b-2e20-4a01-8873-902890ad6ba5"
+              "stringValue": "00000000-0000-0000-0000-000000000000"
             }
           },
           {
@@ -4062,570 +3841,7 @@
           {
             "key": "sw.k8s.agent.app.version",
             "value": {
-              "stringValue": "0.4.1"
-            }
-          },
-          {
-            "key": "sw.k8s.agent.manifest.version",
-            "value": {
-              "stringValue": "2.3.0-alpha.4"
-            }
-          },
-          {
-            "key": "sw.k8s.cluster.uid",
-            "value": {
-              "stringValue": "cluster-uid-123456789"
-            }
-          },
-          {
-            "key": "sw.k8s.container.status",
-            "value": {
-              "stringValue": "running"
-            }
-          }
-        ]
-      },
-      "scopeMetrics": [
-        {
-          "metrics": [
-            {
-              "gauge": {
-                "dataPoints": [
-                  {
-                    "asDouble": 1,
-                    "attributes": [
-                      {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "http"
-                        }
-                      },
-                      {
-                        "key": "prometheus",
-                        "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
-                        }
-                      },
-                      {
-                        "key": "prometheus_replica",
-                        "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
-                        }
-                      }
-                    ],
-                    "timeUnixNano": "0"
-                  }
-                ]
-              },
-              "name": "k8s.container.status"
-            }
-          ],
-          "scope": {}
-        }
-      ]
-    },
-    {
-      "resource": {
-        "attributes": [
-          {
-            "key": "http.scheme",
-            "value": {
-              "stringValue": "http"
-            }
-          },
-          {
-            "key": "k8s.cluster.name",
-            "value": {
-              "stringValue": "cluster name"
-            }
-          },
-          {
-            "key": "k8s.container.name",
-            "value": {
-              "stringValue": "test-container"
-            }
-          },
-          {
-            "key": "k8s.namespace.annotations.description",
-            "value": {
-              "stringValue": "This is a test namespace."
-            }
-          },
-          {
-            "key": "k8s.namespace.labels.app",
-            "value": {
-              "stringValue": "test-app"
-            }
-          },
-          {
-            "key": "k8s.namespace.labels.kubernetes.io/metadata.name",
-            "value": {
-              "stringValue": "test-namespace"
-            }
-          },
-          {
-            "key": "k8s.namespace.labels.purpose",
-            "value": {
-              "stringValue": "testing"
-            }
-          },
-          {
-            "key": "k8s.namespace.name",
-            "value": {
-              "stringValue": "test-namespace"
-            }
-          },
-          {
-            "key": "k8s.pod.annotations.test-annotation",
-            "value": {
-              "stringValue": "test-value"
-            }
-          },
-          {
-            "key": "k8s.pod.labels.app",
-            "value": {
-              "stringValue": "test-pod"
-            }
-          },
-          {
-            "key": "k8s.pod.name",
-            "value": {
-              "stringValue": "test-pod"
-            }
-          },
-          {
-            "key": "k8s.pod.uid",
-            "value": {
-              "stringValue": "cb5e02c4-3b32-4d99-890c-eeff7afbb859"
-            }
-          },
-          {
-            "key": "net.host.name",
-            "value": {
-              "stringValue": "wiremock.monitoring.svc.cluster.local"
-            }
-          },
-          {
-            "key": "net.host.port",
-            "value": {
-              "stringValue": "8080"
-            }
-          },
-          {
-            "key": "service.instance.id",
-            "value": {
-              "stringValue": "wiremock.monitoring.svc.cluster.local:8080"
-            }
-          },
-          {
-            "key": "sw.k8s.agent.app.version",
-            "value": {
-              "stringValue": "0.4.1"
-            }
-          },
-          {
-            "key": "sw.k8s.agent.manifest.version",
-            "value": {
-              "stringValue": "2.3.0-alpha.4"
-            }
-          },
-          {
-            "key": "sw.k8s.cluster.uid",
-            "value": {
-              "stringValue": "cluster-uid-123456789"
-            }
-          }
-        ]
-      },
-      "scopeMetrics": [
-        {
-          "metrics": [
-            {
-              "gauge": {
-                "dataPoints": [
-                  {
-                    "asDouble": 1677653949,
-                    "attributes": [
-                      {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "http"
-                        }
-                      },
-                      {
-                        "key": "prometheus",
-                        "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
-                        }
-                      },
-                      {
-                        "key": "prometheus_replica",
-                        "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
-                        }
-                      }
-                    ],
-                    "timeUnixNano": "0"
-                  }
-                ]
-              },
-              "name": "k8s.kube_pod_container_state_started"
-            },
-            {
-              "name": "k8s.kube_pod_container_status_restarts_total",
-              "sum": {
-                "aggregationTemporality": 2,
-                "dataPoints": [
-                  {
-                    "asDouble": 0,
-                    "attributes": [
-                      {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "http"
-                        }
-                      },
-                      {
-                        "key": "prometheus",
-                        "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
-                        }
-                      },
-                      {
-                        "key": "prometheus_replica",
-                        "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
-                        }
-                      }
-                    ],
-                    "timeUnixNano": "0"
-                  }
-                ],
-                "isMonotonic": true
-              }
-            },
-            {
-              "gauge": {
-                "dataPoints": [
-                  {
-                    "asDouble": 1,
-                    "attributes": [
-                      {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "http"
-                        }
-                      },
-                      {
-                        "key": "prometheus",
-                        "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
-                        }
-                      },
-                      {
-                        "key": "prometheus_replica",
-                        "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
-                        }
-                      }
-                    ],
-                    "timeUnixNano": "0"
-                  }
-                ]
-              },
-              "name": "k8s.kube_pod_container_status_running"
-            },
-            {
-              "gauge": {
-                "dataPoints": [
-                  {
-                    "asDouble": 0,
-                    "attributes": [
-                      {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "http"
-                        }
-                      },
-                      {
-                        "key": "prometheus",
-                        "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
-                        }
-                      },
-                      {
-                        "key": "prometheus_replica",
-                        "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
-                        }
-                      }
-                    ],
-                    "timeUnixNano": "0"
-                  }
-                ]
-              },
-              "name": "k8s.kube_pod_container_status_terminated"
-            }
-          ],
-          "scope": {}
-        }
-      ]
-    },
-    {
-      "resource": {
-        "attributes": [
-          {
-            "key": "http.scheme",
-            "value": {
-              "stringValue": "http"
-            }
-          },
-          {
-            "key": "k8s.cluster.name",
-            "value": {
-              "stringValue": "cluster name"
-            }
-          },
-          {
-            "key": "k8s.container.name",
-            "value": {
-              "stringValue": "test-container"
-            }
-          },
-          {
-            "key": "k8s.namespace.annotations.description",
-            "value": {
-              "stringValue": "This is a test namespace."
-            }
-          },
-          {
-            "key": "k8s.namespace.labels.app",
-            "value": {
-              "stringValue": "test-app"
-            }
-          },
-          {
-            "key": "k8s.namespace.labels.kubernetes.io/metadata.name",
-            "value": {
-              "stringValue": "test-namespace"
-            }
-          },
-          {
-            "key": "k8s.namespace.labels.purpose",
-            "value": {
-              "stringValue": "testing"
-            }
-          },
-          {
-            "key": "k8s.namespace.name",
-            "value": {
-              "stringValue": "test-namespace"
-            }
-          },
-          {
-            "key": "k8s.pod.annotations.test-annotation",
-            "value": {
-              "stringValue": "test-value"
-            }
-          },
-          {
-            "key": "k8s.pod.labels.app",
-            "value": {
-              "stringValue": "test-pod"
-            }
-          },
-          {
-            "key": "k8s.pod.name",
-            "value": {
-              "stringValue": "test-pod"
-            }
-          },
-          {
-            "key": "k8s.pod.uid",
-            "value": {
-              "stringValue": "cb5e02c4-3b32-4d99-890c-eeff7afbb859"
-            }
-          },
-          {
-            "key": "net.host.name",
-            "value": {
-              "stringValue": "wiremock.monitoring.svc.cluster.local"
-            }
-          },
-          {
-            "key": "net.host.port",
-            "value": {
-              "stringValue": "8080"
-            }
-          },
-          {
-            "key": "service.instance.id",
-            "value": {
-              "stringValue": "wiremock.monitoring.svc.cluster.local:8080"
-            }
-          },
-          {
-            "key": "sw.k8s.agent.app.version",
-            "value": {
-              "stringValue": "0.4.1"
-            }
-          },
-          {
-            "key": "sw.k8s.agent.manifest.version",
-            "value": {
-              "stringValue": "2.3.0-alpha.4"
-            }
-          },
-          {
-            "key": "sw.k8s.cluster.uid",
-            "value": {
-              "stringValue": "cluster-uid-123456789"
-            }
-          },
-          {
-            "key": "sw.k8s.container.status",
-            "value": {
-              "stringValue": "running"
-            }
-          }
-        ]
-      },
-      "scopeMetrics": [
-        {
-          "metrics": [
-            {
-              "gauge": {
-                "dataPoints": [
-                  {
-                    "asDouble": 1,
-                    "attributes": [
-                      {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "http"
-                        }
-                      },
-                      {
-                        "key": "prometheus",
-                        "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
-                        }
-                      },
-                      {
-                        "key": "prometheus_replica",
-                        "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
-                        }
-                      }
-                    ],
-                    "timeUnixNano": "0"
-                  }
-                ]
-              },
-              "name": "k8s.container.status"
-            }
-          ],
-          "scope": {}
-        }
-      ]
-    },
-    {
-      "resource": {
-        "attributes": [
-          {
-            "key": "http.scheme",
-            "value": {
-              "stringValue": "http"
-            }
-          },
-          {
-            "key": "k8s.cluster.name",
-            "value": {
-              "stringValue": "cluster name"
-            }
-          },
-          {
-            "key": "k8s.container.name",
-            "value": {
-              "stringValue": "test-container"
-            }
-          },
-          {
-            "key": "k8s.namespace.annotations.description",
-            "value": {
-              "stringValue": "This is a test namespace."
-            }
-          },
-          {
-            "key": "k8s.namespace.labels.app",
-            "value": {
-              "stringValue": "test-app"
-            }
-          },
-          {
-            "key": "k8s.namespace.labels.kubernetes.io/metadata.name",
-            "value": {
-              "stringValue": "test-namespace"
-            }
-          },
-          {
-            "key": "k8s.namespace.labels.purpose",
-            "value": {
-              "stringValue": "testing"
-            }
-          },
-          {
-            "key": "k8s.namespace.name",
-            "value": {
-              "stringValue": "test-namespace"
-            }
-          },
-          {
-            "key": "k8s.pod.annotations.test-annotation",
-            "value": {
-              "stringValue": "test-value"
-            }
-          },
-          {
-            "key": "k8s.pod.labels.app",
-            "value": {
-              "stringValue": "test-pod"
-            }
-          },
-          {
-            "key": "k8s.pod.name",
-            "value": {
-              "stringValue": "test-pod"
-            }
-          },
-          {
-            "key": "k8s.pod.uid",
-            "value": {
-              "stringValue": "f97c5cef-d9f0-4455-869c-d2be4e51546f"
-            }
-          },
-          {
-            "key": "net.host.name",
-            "value": {
-              "stringValue": "wiremock.monitoring.svc.cluster.local"
-            }
-          },
-          {
-            "key": "net.host.port",
-            "value": {
-              "stringValue": "8080"
-            }
-          },
-          {
-            "key": "service.instance.id",
-            "value": {
-              "stringValue": "wiremock.monitoring.svc.cluster.local:8080"
-            }
-          },
-          {
-            "key": "sw.k8s.agent.app.version",
-            "value": {
-              "stringValue": "0.4.1"
+              "stringValue": "0.5.0"
             }
           },
           {
@@ -4697,9 +3913,811 @@
             }
           },
           {
+            "key": "k8s.container.name",
+            "value": {
+              "stringValue": "test-container"
+            }
+          },
+          {
+            "key": "k8s.namespace.annotations.description",
+            "value": {
+              "stringValue": "This is a test namespace."
+            }
+          },
+          {
+            "key": "k8s.namespace.labels.app",
+            "value": {
+              "stringValue": "test-app"
+            }
+          },
+          {
+            "key": "k8s.namespace.labels.kubernetes.io/metadata.name",
+            "value": {
+              "stringValue": "test-namespace"
+            }
+          },
+          {
+            "key": "k8s.namespace.labels.purpose",
+            "value": {
+              "stringValue": "testing"
+            }
+          },
+          {
+            "key": "k8s.namespace.name",
+            "value": {
+              "stringValue": "test-namespace"
+            }
+          },
+          {
+            "key": "k8s.pod.annotations.test-annotation",
+            "value": {
+              "stringValue": "test-value"
+            }
+          },
+          {
+            "key": "k8s.pod.labels.app",
+            "value": {
+              "stringValue": "test-pod"
+            }
+          },
+          {
+            "key": "k8s.pod.name",
+            "value": {
+              "stringValue": "test-pod"
+            }
+          },
+          {
+            "key": "k8s.pod.uid",
+            "value": {
+              "stringValue": "00000000-0000-0000-0000-000000000000"
+            }
+          },
+          {
+            "key": "net.host.name",
+            "value": {
+              "stringValue": "wiremock.monitoring.svc.cluster.local"
+            }
+          },
+          {
+            "key": "net.host.port",
+            "value": {
+              "stringValue": "8080"
+            }
+          },
+          {
+            "key": "service.instance.id",
+            "value": {
+              "stringValue": "wiremock.monitoring.svc.cluster.local:8080"
+            }
+          },
+          {
+            "key": "sw.k8s.agent.app.version",
+            "value": {
+              "stringValue": "0.5.0"
+            }
+          },
+          {
+            "key": "sw.k8s.agent.manifest.version",
+            "value": {
+              "stringValue": "2.3.0-alpha.4"
+            }
+          },
+          {
+            "key": "sw.k8s.cluster.uid",
+            "value": {
+              "stringValue": "cluster-uid-123456789"
+            }
+          }
+        ]
+      },
+      "scopeMetrics": [
+        {
+          "metrics": [
+            {
+              "gauge": {
+                "dataPoints": [
+                  {
+                    "asDouble": 1,
+                    "attributes": [
+                      {
+                        "key": "endpoint",
+                        "value": {
+                          "stringValue": "http"
+                        }
+                      },
+                      {
+                        "key": "prometheus",
+                        "value": {
+                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
+                        }
+                      },
+                      {
+                        "key": "prometheus_replica",
+                        "value": {
+                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
+                        }
+                      },
+                      {
+                        "key": "reason",
+                        "value": {
+                          "stringValue": "Completed"
+                        }
+                      }
+                    ],
+                    "timeUnixNano": "0"
+                  }
+                ]
+              },
+              "name": "k8s.kube_pod_container_status_terminated_reason"
+            }
+          ],
+          "scope": {}
+        }
+      ]
+    },
+    {
+      "resource": {
+        "attributes": [
+          {
+            "key": "http.scheme",
+            "value": {
+              "stringValue": "http"
+            }
+          },
+          {
+            "key": "k8s.cluster.name",
+            "value": {
+              "stringValue": "cluster name"
+            }
+          },
+          {
+            "key": "k8s.container.name",
+            "value": {
+              "stringValue": "test-container"
+            }
+          },
+          {
+            "key": "k8s.namespace.annotations.description",
+            "value": {
+              "stringValue": "This is a test namespace."
+            }
+          },
+          {
+            "key": "k8s.namespace.labels.app",
+            "value": {
+              "stringValue": "test-app"
+            }
+          },
+          {
+            "key": "k8s.namespace.labels.kubernetes.io/metadata.name",
+            "value": {
+              "stringValue": "test-namespace"
+            }
+          },
+          {
+            "key": "k8s.namespace.labels.purpose",
+            "value": {
+              "stringValue": "testing"
+            }
+          },
+          {
+            "key": "k8s.namespace.name",
+            "value": {
+              "stringValue": "test-namespace"
+            }
+          },
+          {
+            "key": "k8s.pod.annotations.test-annotation",
+            "value": {
+              "stringValue": "test-value"
+            }
+          },
+          {
+            "key": "k8s.pod.labels.app",
+            "value": {
+              "stringValue": "test-pod"
+            }
+          },
+          {
+            "key": "k8s.pod.name",
+            "value": {
+              "stringValue": "test-pod"
+            }
+          },
+          {
+            "key": "k8s.pod.uid",
+            "value": {
+              "stringValue": "00000000-0000-0000-0000-000000000000"
+            }
+          },
+          {
+            "key": "net.host.name",
+            "value": {
+              "stringValue": "wiremock.monitoring.svc.cluster.local"
+            }
+          },
+          {
+            "key": "net.host.port",
+            "value": {
+              "stringValue": "8080"
+            }
+          },
+          {
+            "key": "service.instance.id",
+            "value": {
+              "stringValue": "wiremock.monitoring.svc.cluster.local:8080"
+            }
+          },
+          {
+            "key": "sw.k8s.agent.app.version",
+            "value": {
+              "stringValue": "0.5.0"
+            }
+          },
+          {
+            "key": "sw.k8s.agent.manifest.version",
+            "value": {
+              "stringValue": "2.3.0-alpha.4"
+            }
+          },
+          {
+            "key": "sw.k8s.cluster.uid",
+            "value": {
+              "stringValue": "cluster-uid-123456789"
+            }
+          }
+        ]
+      },
+      "scopeMetrics": [
+        {
+          "metrics": [
+            {
+              "gauge": {
+                "dataPoints": [
+                  {
+                    "asDouble": 0,
+                    "attributes": [
+                      {
+                        "key": "endpoint",
+                        "value": {
+                          "stringValue": "http"
+                        }
+                      },
+                      {
+                        "key": "prometheus",
+                        "value": {
+                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
+                        }
+                      },
+                      {
+                        "key": "prometheus_replica",
+                        "value": {
+                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
+                        }
+                      }
+                    ],
+                    "timeUnixNano": "0"
+                  }
+                ]
+              },
+              "name": "k8s.kube_pod_container_status_waiting"
+            }
+          ],
+          "scope": {}
+        }
+      ]
+    },
+    {
+      "resource": {
+        "attributes": [
+          {
+            "key": "http.scheme",
+            "value": {
+              "stringValue": "http"
+            }
+          },
+          {
+            "key": "k8s.cluster.name",
+            "value": {
+              "stringValue": "cluster name"
+            }
+          },
+          {
+            "key": "k8s.container.name",
+            "value": {
+              "stringValue": "test-container"
+            }
+          },
+          {
+            "key": "k8s.namespace.annotations.description",
+            "value": {
+              "stringValue": "This is a test namespace."
+            }
+          },
+          {
+            "key": "k8s.namespace.labels.app",
+            "value": {
+              "stringValue": "test-app"
+            }
+          },
+          {
+            "key": "k8s.namespace.labels.kubernetes.io/metadata.name",
+            "value": {
+              "stringValue": "test-namespace"
+            }
+          },
+          {
+            "key": "k8s.namespace.labels.purpose",
+            "value": {
+              "stringValue": "testing"
+            }
+          },
+          {
+            "key": "k8s.namespace.name",
+            "value": {
+              "stringValue": "test-namespace"
+            }
+          },
+          {
+            "key": "k8s.pod.annotations.test-annotation",
+            "value": {
+              "stringValue": "test-value"
+            }
+          },
+          {
+            "key": "k8s.pod.labels.app",
+            "value": {
+              "stringValue": "test-pod"
+            }
+          },
+          {
+            "key": "k8s.pod.name",
+            "value": {
+              "stringValue": "test-pod"
+            }
+          },
+          {
+            "key": "k8s.pod.uid",
+            "value": {
+              "stringValue": "00000000-0000-0000-0000-000000000000"
+            }
+          },
+          {
+            "key": "net.host.name",
+            "value": {
+              "stringValue": "wiremock.monitoring.svc.cluster.local"
+            }
+          },
+          {
+            "key": "net.host.port",
+            "value": {
+              "stringValue": "8080"
+            }
+          },
+          {
+            "key": "service.instance.id",
+            "value": {
+              "stringValue": "wiremock.monitoring.svc.cluster.local:8080"
+            }
+          },
+          {
+            "key": "sw.k8s.agent.app.version",
+            "value": {
+              "stringValue": "0.5.0"
+            }
+          },
+          {
+            "key": "sw.k8s.agent.manifest.version",
+            "value": {
+              "stringValue": "2.3.0-alpha.4"
+            }
+          },
+          {
+            "key": "sw.k8s.cluster.uid",
+            "value": {
+              "stringValue": "cluster-uid-123456789"
+            }
+          }
+        ]
+      },
+      "scopeMetrics": [
+        {
+          "metrics": [
+            {
+              "gauge": {
+                "dataPoints": [
+                  {
+                    "asDouble": 1,
+                    "attributes": [
+                      {
+                        "key": "endpoint",
+                        "value": {
+                          "stringValue": "http"
+                        }
+                      },
+                      {
+                        "key": "prometheus",
+                        "value": {
+                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
+                        }
+                      },
+                      {
+                        "key": "prometheus_replica",
+                        "value": {
+                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
+                        }
+                      },
+                      {
+                        "key": "reason",
+                        "value": {
+                          "stringValue": "Completed"
+                        }
+                      }
+                    ],
+                    "timeUnixNano": "0"
+                  }
+                ]
+              },
+              "name": "k8s.kube_pod_container_status_last_terminated_reason"
+            }
+          ],
+          "scope": {}
+        }
+      ]
+    },
+    {
+      "resource": {
+        "attributes": [
+          {
+            "key": "http.scheme",
+            "value": {
+              "stringValue": "http"
+            }
+          },
+          {
+            "key": "k8s.cluster.name",
+            "value": {
+              "stringValue": "cluster name"
+            }
+          },
+          {
+            "key": "k8s.container.name",
+            "value": {
+              "stringValue": "test-container"
+            }
+          },
+          {
+            "key": "k8s.namespace.annotations.description",
+            "value": {
+              "stringValue": "This is a test namespace."
+            }
+          },
+          {
+            "key": "k8s.namespace.labels.app",
+            "value": {
+              "stringValue": "test-app"
+            }
+          },
+          {
+            "key": "k8s.namespace.labels.kubernetes.io/metadata.name",
+            "value": {
+              "stringValue": "test-namespace"
+            }
+          },
+          {
+            "key": "k8s.namespace.labels.purpose",
+            "value": {
+              "stringValue": "testing"
+            }
+          },
+          {
+            "key": "k8s.namespace.name",
+            "value": {
+              "stringValue": "test-namespace"
+            }
+          },
+          {
+            "key": "k8s.pod.annotations.test-annotation",
+            "value": {
+              "stringValue": "test-value"
+            }
+          },
+          {
+            "key": "k8s.pod.labels.app",
+            "value": {
+              "stringValue": "test-pod"
+            }
+          },
+          {
+            "key": "k8s.pod.name",
+            "value": {
+              "stringValue": "test-pod"
+            }
+          },
+          {
+            "key": "k8s.pod.uid",
+            "value": {
+              "stringValue": "00000000-0000-0000-0000-000000000000"
+            }
+          },
+          {
+            "key": "net.host.name",
+            "value": {
+              "stringValue": "wiremock.monitoring.svc.cluster.local"
+            }
+          },
+          {
+            "key": "net.host.port",
+            "value": {
+              "stringValue": "8080"
+            }
+          },
+          {
+            "key": "service.instance.id",
+            "value": {
+              "stringValue": "wiremock.monitoring.svc.cluster.local:8080"
+            }
+          },
+          {
+            "key": "sw.k8s.agent.app.version",
+            "value": {
+              "stringValue": "0.5.0"
+            }
+          },
+          {
+            "key": "sw.k8s.agent.manifest.version",
+            "value": {
+              "stringValue": "2.3.0-alpha.4"
+            }
+          },
+          {
+            "key": "sw.k8s.cluster.uid",
+            "value": {
+              "stringValue": "cluster-uid-123456789"
+            }
+          },
+          {
+            "key": "sw.k8s.container.status",
+            "value": {
+              "stringValue": "running"
+            }
+          }
+        ]
+      },
+      "scopeMetrics": [
+        {
+          "metrics": [
+            {
+              "gauge": {
+                "dataPoints": [
+                  {
+                    "asDouble": 1,
+                    "attributes": [
+                      {
+                        "key": "endpoint",
+                        "value": {
+                          "stringValue": "http"
+                        }
+                      },
+                      {
+                        "key": "prometheus",
+                        "value": {
+                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
+                        }
+                      },
+                      {
+                        "key": "prometheus_replica",
+                        "value": {
+                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
+                        }
+                      }
+                    ],
+                    "timeUnixNano": "0"
+                  }
+                ]
+              },
+              "name": "k8s.container.status"
+            }
+          ],
+          "scope": {}
+        }
+      ]
+    },
+    {
+      "resource": {
+        "attributes": [
+          {
+            "key": "http.scheme",
+            "value": {
+              "stringValue": "http"
+            }
+          },
+          {
+            "key": "k8s.cluster.name",
+            "value": {
+              "stringValue": "cluster name"
+            }
+          },
+          {
+            "key": "k8s.container.name",
+            "value": {
+              "stringValue": "test-container"
+            }
+          },
+          {
+            "key": "k8s.namespace.annotations.description",
+            "value": {
+              "stringValue": "This is a test namespace."
+            }
+          },
+          {
+            "key": "k8s.namespace.labels.app",
+            "value": {
+              "stringValue": "test-app"
+            }
+          },
+          {
+            "key": "k8s.namespace.labels.kubernetes.io/metadata.name",
+            "value": {
+              "stringValue": "test-namespace"
+            }
+          },
+          {
+            "key": "k8s.namespace.labels.purpose",
+            "value": {
+              "stringValue": "testing"
+            }
+          },
+          {
+            "key": "k8s.namespace.name",
+            "value": {
+              "stringValue": "test-namespace"
+            }
+          },
+          {
+            "key": "k8s.pod.annotations.test-annotation",
+            "value": {
+              "stringValue": "test-value"
+            }
+          },
+          {
+            "key": "k8s.pod.labels.app",
+            "value": {
+              "stringValue": "test-pod"
+            }
+          },
+          {
+            "key": "k8s.pod.name",
+            "value": {
+              "stringValue": "test-pod"
+            }
+          },
+          {
+            "key": "k8s.pod.uid",
+            "value": {
+              "stringValue": "00000000-0000-0000-0000-000000000000"
+            }
+          },
+          {
+            "key": "net.host.name",
+            "value": {
+              "stringValue": "wiremock.monitoring.svc.cluster.local"
+            }
+          },
+          {
+            "key": "net.host.port",
+            "value": {
+              "stringValue": "8080"
+            }
+          },
+          {
+            "key": "service.instance.id",
+            "value": {
+              "stringValue": "wiremock.monitoring.svc.cluster.local:8080"
+            }
+          },
+          {
+            "key": "sw.k8s.agent.app.version",
+            "value": {
+              "stringValue": "0.5.0"
+            }
+          },
+          {
+            "key": "sw.k8s.agent.manifest.version",
+            "value": {
+              "stringValue": "2.3.0-alpha.4"
+            }
+          },
+          {
+            "key": "sw.k8s.cluster.uid",
+            "value": {
+              "stringValue": "cluster-uid-123456789"
+            }
+          },
+          {
+            "key": "sw.k8s.container.status",
+            "value": {
+              "stringValue": "running"
+            }
+          }
+        ]
+      },
+      "scopeMetrics": [
+        {
+          "metrics": [
+            {
+              "gauge": {
+                "dataPoints": [
+                  {
+                    "asDouble": 1,
+                    "attributes": [
+                      {
+                        "key": "endpoint",
+                        "value": {
+                          "stringValue": "http"
+                        }
+                      },
+                      {
+                        "key": "prometheus",
+                        "value": {
+                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
+                        }
+                      },
+                      {
+                        "key": "prometheus_replica",
+                        "value": {
+                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
+                        }
+                      }
+                    ],
+                    "timeUnixNano": "0"
+                  }
+                ]
+              },
+              "name": "k8s.container.status"
+            }
+          ],
+          "scope": {}
+        }
+      ]
+    },
+    {
+      "resource": {
+        "attributes": [
+          {
+            "key": "http.scheme",
+            "value": {
+              "stringValue": "http"
+            }
+          },
+          {
+            "key": "k8s.cluster.name",
+            "value": {
+              "stringValue": "cluster name"
+            }
+          },
+          {
+            "key": "k8s.daemonset.annotations.test-annotation",
+            "value": {
+              "stringValue": "test-value"
+            }
+          },
+          {
+            "key": "k8s.daemonset.labels.app",
+            "value": {
+              "stringValue": "test-daemonset"
+            }
+          },
+          {
             "key": "k8s.daemonset.name",
             "value": {
               "stringValue": "test-daemonset"
+            }
+          },
+          {
+            "key": "k8s.daemonset.uid",
+            "value": {
+              "stringValue": "00000000-0000-0000-0000-000000000000"
             }
           },
           {
@@ -4753,7 +4771,7 @@
           {
             "key": "sw.k8s.agent.app.version",
             "value": {
-              "stringValue": "0.4.1"
+              "stringValue": "0.5.0"
             }
           },
           {
@@ -5073,295 +5091,15 @@
             }
           },
           {
-            "key": "k8s.deployment.name",
+            "key": "k8s.deployment.annotations.test-annotation",
             "value": {
-              "stringValue": "istiod"
+              "stringValue": "test-value"
             }
           },
           {
-            "key": "k8s.namespace.annotations.description",
+            "key": "k8s.deployment.labels.app",
             "value": {
-              "stringValue": "This is a test namespace."
-            }
-          },
-          {
-            "key": "k8s.namespace.labels.app",
-            "value": {
-              "stringValue": "test-app"
-            }
-          },
-          {
-            "key": "k8s.namespace.labels.kubernetes.io/metadata.name",
-            "value": {
-              "stringValue": "test-namespace"
-            }
-          },
-          {
-            "key": "k8s.namespace.labels.purpose",
-            "value": {
-              "stringValue": "testing"
-            }
-          },
-          {
-            "key": "k8s.namespace.name",
-            "value": {
-              "stringValue": "test-namespace"
-            }
-          },
-          {
-            "key": "k8s.replicaset.name",
-            "value": {
-              "stringValue": "test-replicaset"
-            }
-          },
-          {
-            "key": "net.host.name",
-            "value": {
-              "stringValue": "wiremock.monitoring.svc.cluster.local"
-            }
-          },
-          {
-            "key": "net.host.port",
-            "value": {
-              "stringValue": "8080"
-            }
-          },
-          {
-            "key": "service.instance.id",
-            "value": {
-              "stringValue": "wiremock.monitoring.svc.cluster.local:8080"
-            }
-          },
-          {
-            "key": "sw.k8s.agent.app.version",
-            "value": {
-              "stringValue": "0.4.1"
-            }
-          },
-          {
-            "key": "sw.k8s.agent.manifest.version",
-            "value": {
-              "stringValue": "2.3.0-alpha.4"
-            }
-          },
-          {
-            "key": "sw.k8s.cluster.uid",
-            "value": {
-              "stringValue": "cluster-uid-123456789"
-            }
-          }
-        ]
-      },
-      "scopeMetrics": [
-        {
-          "metrics": [
-            {
-              "gauge": {
-                "dataPoints": [
-                  {
-                    "asDouble": 1,
-                    "attributes": [
-                      {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "http"
-                        }
-                      },
-                      {
-                        "key": "owner_is_controller",
-                        "value": {
-                          "stringValue": "true"
-                        }
-                      },
-                      {
-                        "key": "owner_kind",
-                        "value": {
-                          "stringValue": "Deployment"
-                        }
-                      },
-                      {
-                        "key": "prometheus",
-                        "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
-                        }
-                      },
-                      {
-                        "key": "prometheus_replica",
-                        "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
-                        }
-                      }
-                    ],
-                    "timeUnixNano": "0"
-                  }
-                ]
-              },
-              "name": "k8s.kube.replicaset.owner.deployment"
-            }
-          ],
-          "scope": {}
-        }
-      ]
-    },
-    {
-      "resource": {
-        "attributes": [
-          {
-            "key": "http.scheme",
-            "value": {
-              "stringValue": "http"
-            }
-          },
-          {
-            "key": "k8s.cluster.name",
-            "value": {
-              "stringValue": "cluster name"
-            }
-          },
-          {
-            "key": "k8s.deployment.name",
-            "value": {
-              "stringValue": "swi-k8s-otel-collector-swo-k8s-collector-metrics"
-            }
-          },
-          {
-            "key": "k8s.namespace.annotations.description",
-            "value": {
-              "stringValue": "This is a test namespace."
-            }
-          },
-          {
-            "key": "k8s.namespace.labels.app",
-            "value": {
-              "stringValue": "test-app"
-            }
-          },
-          {
-            "key": "k8s.namespace.labels.kubernetes.io/metadata.name",
-            "value": {
-              "stringValue": "test-namespace"
-            }
-          },
-          {
-            "key": "k8s.namespace.labels.purpose",
-            "value": {
-              "stringValue": "testing"
-            }
-          },
-          {
-            "key": "k8s.namespace.name",
-            "value": {
-              "stringValue": "test-namespace"
-            }
-          },
-          {
-            "key": "k8s.replicaset.name",
-            "value": {
-              "stringValue": "test-replicaset"
-            }
-          },
-          {
-            "key": "net.host.name",
-            "value": {
-              "stringValue": "wiremock.monitoring.svc.cluster.local"
-            }
-          },
-          {
-            "key": "net.host.port",
-            "value": {
-              "stringValue": "8080"
-            }
-          },
-          {
-            "key": "service.instance.id",
-            "value": {
-              "stringValue": "wiremock.monitoring.svc.cluster.local:8080"
-            }
-          },
-          {
-            "key": "sw.k8s.agent.app.version",
-            "value": {
-              "stringValue": "0.4.1"
-            }
-          },
-          {
-            "key": "sw.k8s.agent.manifest.version",
-            "value": {
-              "stringValue": "2.3.0-alpha.4"
-            }
-          },
-          {
-            "key": "sw.k8s.cluster.uid",
-            "value": {
-              "stringValue": "cluster-uid-123456789"
-            }
-          }
-        ]
-      },
-      "scopeMetrics": [
-        {
-          "metrics": [
-            {
-              "gauge": {
-                "dataPoints": [
-                  {
-                    "asDouble": 1,
-                    "attributes": [
-                      {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "http"
-                        }
-                      },
-                      {
-                        "key": "owner_is_controller",
-                        "value": {
-                          "stringValue": "true"
-                        }
-                      },
-                      {
-                        "key": "owner_kind",
-                        "value": {
-                          "stringValue": "Deployment"
-                        }
-                      },
-                      {
-                        "key": "prometheus",
-                        "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
-                        }
-                      },
-                      {
-                        "key": "prometheus_replica",
-                        "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
-                        }
-                      }
-                    ],
-                    "timeUnixNano": "0"
-                  }
-                ]
-              },
-              "name": "k8s.kube.replicaset.owner.deployment"
-            }
-          ],
-          "scope": {}
-        }
-      ]
-    },
-    {
-      "resource": {
-        "attributes": [
-          {
-            "key": "http.scheme",
-            "value": {
-              "stringValue": "http"
-            }
-          },
-          {
-            "key": "k8s.cluster.name",
-            "value": {
-              "stringValue": "cluster name"
+              "stringValue": "test-deployment"
             }
           },
           {
@@ -5371,6 +5109,12 @@
             }
           },
           {
+            "key": "k8s.deployment.uid",
+            "value": {
+              "stringValue": "00000000-0000-0000-0000-000000000000"
+            }
+          },
+          {
             "key": "k8s.namespace.annotations.description",
             "value": {
               "stringValue": "This is a test namespace."
@@ -5421,7 +5165,7 @@
           {
             "key": "sw.k8s.agent.app.version",
             "value": {
-              "stringValue": "0.4.1"
+              "stringValue": "0.5.0"
             }
           },
           {
@@ -6050,6 +5794,334 @@
             }
           },
           {
+            "key": "k8s.deployment.name",
+            "value": {
+              "stringValue": "istiod"
+            }
+          },
+          {
+            "key": "k8s.namespace.annotations.description",
+            "value": {
+              "stringValue": "This is a test namespace."
+            }
+          },
+          {
+            "key": "k8s.namespace.labels.app",
+            "value": {
+              "stringValue": "test-app"
+            }
+          },
+          {
+            "key": "k8s.namespace.labels.kubernetes.io/metadata.name",
+            "value": {
+              "stringValue": "test-namespace"
+            }
+          },
+          {
+            "key": "k8s.namespace.labels.purpose",
+            "value": {
+              "stringValue": "testing"
+            }
+          },
+          {
+            "key": "k8s.namespace.name",
+            "value": {
+              "stringValue": "test-namespace"
+            }
+          },
+          {
+            "key": "k8s.replicaset.annotations.test-annotation",
+            "value": {
+              "stringValue": "test-value"
+            }
+          },
+          {
+            "key": "k8s.replicaset.labels.app",
+            "value": {
+              "stringValue": "test-replicaset"
+            }
+          },
+          {
+            "key": "k8s.replicaset.name",
+            "value": {
+              "stringValue": "test-replicaset"
+            }
+          },
+          {
+            "key": "k8s.replicaset.uid",
+            "value": {
+              "stringValue": "00000000-0000-0000-0000-000000000000"
+            }
+          },
+          {
+            "key": "net.host.name",
+            "value": {
+              "stringValue": "wiremock.monitoring.svc.cluster.local"
+            }
+          },
+          {
+            "key": "net.host.port",
+            "value": {
+              "stringValue": "8080"
+            }
+          },
+          {
+            "key": "service.instance.id",
+            "value": {
+              "stringValue": "wiremock.monitoring.svc.cluster.local:8080"
+            }
+          },
+          {
+            "key": "sw.k8s.agent.app.version",
+            "value": {
+              "stringValue": "0.5.0"
+            }
+          },
+          {
+            "key": "sw.k8s.agent.manifest.version",
+            "value": {
+              "stringValue": "2.3.0-alpha.4"
+            }
+          },
+          {
+            "key": "sw.k8s.cluster.uid",
+            "value": {
+              "stringValue": "cluster-uid-123456789"
+            }
+          }
+        ]
+      },
+      "scopeMetrics": [
+        {
+          "metrics": [
+            {
+              "gauge": {
+                "dataPoints": [
+                  {
+                    "asDouble": 1,
+                    "attributes": [
+                      {
+                        "key": "endpoint",
+                        "value": {
+                          "stringValue": "http"
+                        }
+                      },
+                      {
+                        "key": "owner_is_controller",
+                        "value": {
+                          "stringValue": "true"
+                        }
+                      },
+                      {
+                        "key": "owner_kind",
+                        "value": {
+                          "stringValue": "Deployment"
+                        }
+                      },
+                      {
+                        "key": "prometheus",
+                        "value": {
+                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
+                        }
+                      },
+                      {
+                        "key": "prometheus_replica",
+                        "value": {
+                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
+                        }
+                      }
+                    ],
+                    "timeUnixNano": "0"
+                  }
+                ]
+              },
+              "name": "k8s.kube.replicaset.owner.deployment"
+            }
+          ],
+          "scope": {}
+        }
+      ]
+    },
+    {
+      "resource": {
+        "attributes": [
+          {
+            "key": "http.scheme",
+            "value": {
+              "stringValue": "http"
+            }
+          },
+          {
+            "key": "k8s.cluster.name",
+            "value": {
+              "stringValue": "cluster name"
+            }
+          },
+          {
+            "key": "k8s.deployment.name",
+            "value": {
+              "stringValue": "swi-k8s-otel-collector-swo-k8s-collector-metrics"
+            }
+          },
+          {
+            "key": "k8s.namespace.annotations.description",
+            "value": {
+              "stringValue": "This is a test namespace."
+            }
+          },
+          {
+            "key": "k8s.namespace.labels.app",
+            "value": {
+              "stringValue": "test-app"
+            }
+          },
+          {
+            "key": "k8s.namespace.labels.kubernetes.io/metadata.name",
+            "value": {
+              "stringValue": "test-namespace"
+            }
+          },
+          {
+            "key": "k8s.namespace.labels.purpose",
+            "value": {
+              "stringValue": "testing"
+            }
+          },
+          {
+            "key": "k8s.namespace.name",
+            "value": {
+              "stringValue": "test-namespace"
+            }
+          },
+          {
+            "key": "k8s.replicaset.annotations.test-annotation",
+            "value": {
+              "stringValue": "test-value"
+            }
+          },
+          {
+            "key": "k8s.replicaset.labels.app",
+            "value": {
+              "stringValue": "test-replicaset"
+            }
+          },
+          {
+            "key": "k8s.replicaset.name",
+            "value": {
+              "stringValue": "test-replicaset"
+            }
+          },
+          {
+            "key": "k8s.replicaset.uid",
+            "value": {
+              "stringValue": "00000000-0000-0000-0000-000000000000"
+            }
+          },
+          {
+            "key": "net.host.name",
+            "value": {
+              "stringValue": "wiremock.monitoring.svc.cluster.local"
+            }
+          },
+          {
+            "key": "net.host.port",
+            "value": {
+              "stringValue": "8080"
+            }
+          },
+          {
+            "key": "service.instance.id",
+            "value": {
+              "stringValue": "wiremock.monitoring.svc.cluster.local:8080"
+            }
+          },
+          {
+            "key": "sw.k8s.agent.app.version",
+            "value": {
+              "stringValue": "0.5.0"
+            }
+          },
+          {
+            "key": "sw.k8s.agent.manifest.version",
+            "value": {
+              "stringValue": "2.3.0-alpha.4"
+            }
+          },
+          {
+            "key": "sw.k8s.cluster.uid",
+            "value": {
+              "stringValue": "cluster-uid-123456789"
+            }
+          }
+        ]
+      },
+      "scopeMetrics": [
+        {
+          "metrics": [
+            {
+              "gauge": {
+                "dataPoints": [
+                  {
+                    "asDouble": 1,
+                    "attributes": [
+                      {
+                        "key": "endpoint",
+                        "value": {
+                          "stringValue": "http"
+                        }
+                      },
+                      {
+                        "key": "owner_is_controller",
+                        "value": {
+                          "stringValue": "true"
+                        }
+                      },
+                      {
+                        "key": "owner_kind",
+                        "value": {
+                          "stringValue": "Deployment"
+                        }
+                      },
+                      {
+                        "key": "prometheus",
+                        "value": {
+                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
+                        }
+                      },
+                      {
+                        "key": "prometheus_replica",
+                        "value": {
+                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
+                        }
+                      }
+                    ],
+                    "timeUnixNano": "0"
+                  }
+                ]
+              },
+              "name": "k8s.kube.replicaset.owner.deployment"
+            }
+          ],
+          "scope": {}
+        }
+      ]
+    },
+    {
+      "resource": {
+        "attributes": [
+          {
+            "key": "http.scheme",
+            "value": {
+              "stringValue": "http"
+            }
+          },
+          {
+            "key": "k8s.cluster.name",
+            "value": {
+              "stringValue": "cluster name"
+            }
+          },
+          {
             "key": "k8s.job.name",
             "value": {
               "stringValue": "test-job-name"
@@ -6106,7 +6178,7 @@
           {
             "key": "sw.k8s.agent.app.version",
             "value": {
-              "stringValue": "0.4.1"
+              "stringValue": "0.5.0"
             }
           },
           {
@@ -6537,7 +6609,7 @@
           {
             "key": "k8s.pod.uid",
             "value": {
-              "stringValue": "c72bea9b-2e20-4a01-8873-902890ad6ba5"
+              "stringValue": "00000000-0000-0000-0000-000000000000"
             }
           },
           {
@@ -6561,7 +6633,7 @@
           {
             "key": "sw.k8s.agent.app.version",
             "value": {
-              "stringValue": "0.4.1"
+              "stringValue": "0.5.0"
             }
           },
           {
@@ -6719,7 +6791,7 @@
           {
             "key": "k8s.pod.uid",
             "value": {
-              "stringValue": "f97c5cef-d9f0-4455-869c-d2be4e51546f"
+              "stringValue": "00000000-0000-0000-0000-000000000000"
             }
           },
           {
@@ -6743,7 +6815,7 @@
           {
             "key": "sw.k8s.agent.app.version",
             "value": {
-              "stringValue": "0.4.1"
+              "stringValue": "0.5.0"
             }
           },
           {
@@ -6919,7 +6991,7 @@
           {
             "key": "sw.k8s.agent.app.version",
             "value": {
-              "stringValue": "0.4.1"
+              "stringValue": "0.5.0"
             }
           },
           {
@@ -7920,7 +7992,7 @@
           {
             "key": "sw.k8s.agent.app.version",
             "value": {
-              "stringValue": "0.4.1"
+              "stringValue": "0.5.0"
             }
           },
           {
@@ -9531,7 +9603,7 @@
           {
             "key": "sw.k8s.agent.app.version",
             "value": {
-              "stringValue": "0.4.1"
+              "stringValue": "0.5.0"
             }
           },
           {
@@ -9707,7 +9779,7 @@
           {
             "key": "sw.k8s.agent.app.version",
             "value": {
-              "stringValue": "0.4.1"
+              "stringValue": "0.5.0"
             }
           },
           {
@@ -9883,7 +9955,7 @@
           {
             "key": "sw.k8s.agent.app.version",
             "value": {
-              "stringValue": "0.4.1"
+              "stringValue": "0.5.0"
             }
           },
           {
@@ -10017,159 +10089,13 @@
           {
             "key": "k8s.pod.uid",
             "value": {
-              "stringValue": "52694956-5803-4d4b-9397-c6e928dbc61e"
-            }
-          },
-          {
-            "key": "net.host.name",
-            "value": {
-              "stringValue": "wiremock.monitoring.svc.cluster.local"
-            }
-          },
-          {
-            "key": "net.host.port",
-            "value": {
-              "stringValue": "8080"
-            }
-          },
-          {
-            "key": "service.instance.id",
-            "value": {
-              "stringValue": "wiremock.monitoring.svc.cluster.local:8080"
-            }
-          },
-          {
-            "key": "sw.k8s.agent.app.version",
-            "value": {
-              "stringValue": "0.4.1"
-            }
-          },
-          {
-            "key": "sw.k8s.agent.manifest.version",
-            "value": {
-              "stringValue": "2.3.0-alpha.4"
-            }
-          },
-          {
-            "key": "sw.k8s.cluster.uid",
-            "value": {
-              "stringValue": "cluster-uid-123456789"
-            }
-          }
-        ]
-      },
-      "scopeMetrics": [
-        {
-          "metrics": [
-            {
-              "gauge": {
-                "dataPoints": [
-                  {
-                    "asDouble": 1676013611,
-                    "attributes": [
-                      {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "http"
-                        }
-                      },
-                      {
-                        "key": "prometheus",
-                        "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
-                        }
-                      },
-                      {
-                        "key": "prometheus_replica",
-                        "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
-                        }
-                      }
-                    ],
-                    "timeUnixNano": "0"
-                  }
-                ]
-              },
-              "name": "k8s.kube_pod_completion_time"
-            }
-          ],
-          "scope": {}
-        }
-      ]
-    },
-    {
-      "resource": {
-        "attributes": [
-          {
-            "key": "http.scheme",
-            "value": {
-              "stringValue": "http"
-            }
-          },
-          {
-            "key": "k8s.cluster.name",
-            "value": {
-              "stringValue": "cluster name"
-            }
-          },
-          {
-            "key": "k8s.namespace.annotations.description",
-            "value": {
-              "stringValue": "This is a test namespace."
-            }
-          },
-          {
-            "key": "k8s.namespace.labels.app",
-            "value": {
-              "stringValue": "test-app"
-            }
-          },
-          {
-            "key": "k8s.namespace.labels.kubernetes.io/metadata.name",
-            "value": {
-              "stringValue": "test-namespace"
-            }
-          },
-          {
-            "key": "k8s.namespace.labels.purpose",
-            "value": {
-              "stringValue": "testing"
-            }
-          },
-          {
-            "key": "k8s.namespace.name",
-            "value": {
-              "stringValue": "test-namespace"
-            }
-          },
-          {
-            "key": "k8s.pod.annotations.test-annotation",
-            "value": {
-              "stringValue": "test-value"
-            }
-          },
-          {
-            "key": "k8s.pod.labels.app",
-            "value": {
-              "stringValue": "test-pod"
-            }
-          },
-          {
-            "key": "k8s.pod.name",
-            "value": {
-              "stringValue": "test-pod"
-            }
-          },
-          {
-            "key": "k8s.pod.uid",
-            "value": {
-              "stringValue": "c72bea9b-2e20-4a01-8873-902890ad6ba5"
+              "stringValue": "00000000-0000-0000-0000-000000000000"
             }
           },
           {
             "key": "k8s.replicaset.name",
             "value": {
-              "stringValue": "swi-k8s-otel-collector-swo-k8s-collector-metrics-85fc84c847"
+              "stringValue": "calico-apiserver-54689b9f68"
             }
           },
           {
@@ -10193,7 +10119,7 @@
           {
             "key": "sw.k8s.agent.app.version",
             "value": {
-              "stringValue": "0.4.1"
+              "stringValue": "0.5.0"
             }
           },
           {
@@ -10327,7 +10253,13 @@
           {
             "key": "k8s.pod.uid",
             "value": {
-              "stringValue": "c72bea9b-2e20-4a01-8873-902890ad6ba5"
+              "stringValue": "00000000-0000-0000-0000-000000000000"
+            }
+          },
+          {
+            "key": "k8s.replicaset.name",
+            "value": {
+              "stringValue": "swi-k8s-otel-collector-swo-k8s-collector-metrics-85fc84c847"
             }
           },
           {
@@ -10351,7 +10283,391 @@
           {
             "key": "sw.k8s.agent.app.version",
             "value": {
-              "stringValue": "0.4.1"
+              "stringValue": "0.5.0"
+            }
+          },
+          {
+            "key": "sw.k8s.agent.manifest.version",
+            "value": {
+              "stringValue": "2.3.0-alpha.4"
+            }
+          },
+          {
+            "key": "sw.k8s.cluster.uid",
+            "value": {
+              "stringValue": "cluster-uid-123456789"
+            }
+          }
+        ]
+      },
+      "scopeMetrics": [
+        {
+          "metrics": [
+            {
+              "gauge": {
+                "dataPoints": [
+                  {
+                    "asDouble": 1,
+                    "attributes": [
+                      {
+                        "key": "endpoint",
+                        "value": {
+                          "stringValue": "http"
+                        }
+                      },
+                      {
+                        "key": "owner_is_controller",
+                        "value": {
+                          "stringValue": "true"
+                        }
+                      },
+                      {
+                        "key": "owner_kind",
+                        "value": {
+                          "stringValue": "ReplicaSet"
+                        }
+                      },
+                      {
+                        "key": "prometheus",
+                        "value": {
+                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
+                        }
+                      },
+                      {
+                        "key": "prometheus_replica",
+                        "value": {
+                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
+                        }
+                      }
+                    ],
+                    "timeUnixNano": "0"
+                  }
+                ]
+              },
+              "name": "k8s.kube.pod.owner.replicaset"
+            }
+          ],
+          "scope": {}
+        }
+      ]
+    },
+    {
+      "resource": {
+        "attributes": [
+          {
+            "key": "http.scheme",
+            "value": {
+              "stringValue": "http"
+            }
+          },
+          {
+            "key": "k8s.cluster.name",
+            "value": {
+              "stringValue": "cluster name"
+            }
+          },
+          {
+            "key": "k8s.namespace.annotations.description",
+            "value": {
+              "stringValue": "This is a test namespace."
+            }
+          },
+          {
+            "key": "k8s.namespace.labels.app",
+            "value": {
+              "stringValue": "test-app"
+            }
+          },
+          {
+            "key": "k8s.namespace.labels.kubernetes.io/metadata.name",
+            "value": {
+              "stringValue": "test-namespace"
+            }
+          },
+          {
+            "key": "k8s.namespace.labels.purpose",
+            "value": {
+              "stringValue": "testing"
+            }
+          },
+          {
+            "key": "k8s.namespace.name",
+            "value": {
+              "stringValue": "test-namespace"
+            }
+          },
+          {
+            "key": "k8s.pod.annotations.test-annotation",
+            "value": {
+              "stringValue": "test-value"
+            }
+          },
+          {
+            "key": "k8s.pod.labels.app",
+            "value": {
+              "stringValue": "test-pod"
+            }
+          },
+          {
+            "key": "k8s.pod.name",
+            "value": {
+              "stringValue": "test-pod"
+            }
+          },
+          {
+            "key": "k8s.pod.uid",
+            "value": {
+              "stringValue": "00000000-0000-0000-0000-000000000000"
+            }
+          },
+          {
+            "key": "net.host.name",
+            "value": {
+              "stringValue": "wiremock.monitoring.svc.cluster.local"
+            }
+          },
+          {
+            "key": "net.host.port",
+            "value": {
+              "stringValue": "8080"
+            }
+          },
+          {
+            "key": "service.instance.id",
+            "value": {
+              "stringValue": "wiremock.monitoring.svc.cluster.local:8080"
+            }
+          },
+          {
+            "key": "sw.k8s.agent.app.version",
+            "value": {
+              "stringValue": "0.5.0"
+            }
+          },
+          {
+            "key": "sw.k8s.agent.manifest.version",
+            "value": {
+              "stringValue": "2.3.0-alpha.4"
+            }
+          },
+          {
+            "key": "sw.k8s.cluster.uid",
+            "value": {
+              "stringValue": "cluster-uid-123456789"
+            }
+          }
+        ]
+      },
+      "scopeMetrics": [
+        {
+          "metrics": [
+            {
+              "gauge": {
+                "dataPoints": [
+                  {
+                    "asDouble": 1675771430,
+                    "attributes": [
+                      {
+                        "key": "endpoint",
+                        "value": {
+                          "stringValue": "http"
+                        }
+                      },
+                      {
+                        "key": "prometheus",
+                        "value": {
+                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
+                        }
+                      },
+                      {
+                        "key": "prometheus_replica",
+                        "value": {
+                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
+                        }
+                      }
+                    ],
+                    "timeUnixNano": "0"
+                  }
+                ]
+              },
+              "name": "k8s.kube_pod_created"
+            },
+            {
+              "gauge": {
+                "dataPoints": [
+                  {
+                    "asDouble": 1,
+                    "attributes": [
+                      {
+                        "key": "endpoint",
+                        "value": {
+                          "stringValue": "http"
+                        }
+                      },
+                      {
+                        "key": "owner_is_controller",
+                        "value": {
+                          "stringValue": "true"
+                        }
+                      },
+                      {
+                        "key": "owner_kind",
+                        "value": {
+                          "stringValue": "ReplicaSet"
+                        }
+                      },
+                      {
+                        "key": "owner_name",
+                        "value": {
+                          "stringValue": "calico-apiserver-54689b9f68"
+                        }
+                      },
+                      {
+                        "key": "prometheus",
+                        "value": {
+                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
+                        }
+                      },
+                      {
+                        "key": "prometheus_replica",
+                        "value": {
+                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
+                        }
+                      }
+                    ],
+                    "timeUnixNano": "0"
+                  }
+                ]
+              },
+              "name": "k8s.kube_pod_owner"
+            },
+            {
+              "gauge": {
+                "dataPoints": [
+                  {
+                    "asDouble": 1675771430,
+                    "attributes": [
+                      {
+                        "key": "endpoint",
+                        "value": {
+                          "stringValue": "http"
+                        }
+                      },
+                      {
+                        "key": "prometheus",
+                        "value": {
+                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
+                        }
+                      },
+                      {
+                        "key": "prometheus_replica",
+                        "value": {
+                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
+                        }
+                      }
+                    ],
+                    "timeUnixNano": "0"
+                  }
+                ]
+              },
+              "name": "k8s.kube_pod_start_time"
+            }
+          ],
+          "scope": {}
+        }
+      ]
+    },
+    {
+      "resource": {
+        "attributes": [
+          {
+            "key": "http.scheme",
+            "value": {
+              "stringValue": "http"
+            }
+          },
+          {
+            "key": "k8s.cluster.name",
+            "value": {
+              "stringValue": "cluster name"
+            }
+          },
+          {
+            "key": "k8s.namespace.annotations.description",
+            "value": {
+              "stringValue": "This is a test namespace."
+            }
+          },
+          {
+            "key": "k8s.namespace.labels.app",
+            "value": {
+              "stringValue": "test-app"
+            }
+          },
+          {
+            "key": "k8s.namespace.labels.kubernetes.io/metadata.name",
+            "value": {
+              "stringValue": "test-namespace"
+            }
+          },
+          {
+            "key": "k8s.namespace.labels.purpose",
+            "value": {
+              "stringValue": "testing"
+            }
+          },
+          {
+            "key": "k8s.namespace.name",
+            "value": {
+              "stringValue": "test-namespace"
+            }
+          },
+          {
+            "key": "k8s.pod.annotations.test-annotation",
+            "value": {
+              "stringValue": "test-value"
+            }
+          },
+          {
+            "key": "k8s.pod.labels.app",
+            "value": {
+              "stringValue": "test-pod"
+            }
+          },
+          {
+            "key": "k8s.pod.name",
+            "value": {
+              "stringValue": "test-pod"
+            }
+          },
+          {
+            "key": "k8s.pod.uid",
+            "value": {
+              "stringValue": "00000000-0000-0000-0000-000000000000"
+            }
+          },
+          {
+            "key": "net.host.name",
+            "value": {
+              "stringValue": "wiremock.monitoring.svc.cluster.local"
+            }
+          },
+          {
+            "key": "net.host.port",
+            "value": {
+              "stringValue": "8080"
+            }
+          },
+          {
+            "key": "service.instance.id",
+            "value": {
+              "stringValue": "wiremock.monitoring.svc.cluster.local:8080"
+            }
+          },
+          {
+            "key": "sw.k8s.agent.app.version",
+            "value": {
+              "stringValue": "0.5.0"
             }
           },
           {
@@ -10650,7 +10966,7 @@
           {
             "key": "k8s.pod.uid",
             "value": {
-              "stringValue": "c72bea9b-2e20-4a01-8873-902890ad6ba5"
+              "stringValue": "00000000-0000-0000-0000-000000000000"
             }
           },
           {
@@ -10674,549 +10990,7 @@
           {
             "key": "sw.k8s.agent.app.version",
             "value": {
-              "stringValue": "0.4.1"
-            }
-          },
-          {
-            "key": "sw.k8s.agent.manifest.version",
-            "value": {
-              "stringValue": "2.3.0-alpha.4"
-            }
-          },
-          {
-            "key": "sw.k8s.cluster.uid",
-            "value": {
-              "stringValue": "cluster-uid-123456789"
-            }
-          },
-          {
-            "key": "sw.k8s.pod.status",
-            "value": {
-              "stringValue": "Running"
-            }
-          }
-        ]
-      },
-      "scopeMetrics": [
-        {
-          "metrics": [
-            {
-              "gauge": {
-                "dataPoints": [
-                  {
-                    "asDouble": 1,
-                    "attributes": [
-                      {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "http"
-                        }
-                      },
-                      {
-                        "key": "prometheus",
-                        "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
-                        }
-                      },
-                      {
-                        "key": "prometheus_replica",
-                        "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
-                        }
-                      }
-                    ],
-                    "timeUnixNano": "0"
-                  }
-                ]
-              },
-              "name": "k8s.kube_pod_status_phase"
-            }
-          ],
-          "scope": {}
-        }
-      ]
-    },
-    {
-      "resource": {
-        "attributes": [
-          {
-            "key": "http.scheme",
-            "value": {
-              "stringValue": "http"
-            }
-          },
-          {
-            "key": "k8s.cluster.name",
-            "value": {
-              "stringValue": "cluster name"
-            }
-          },
-          {
-            "key": "k8s.namespace.annotations.description",
-            "value": {
-              "stringValue": "This is a test namespace."
-            }
-          },
-          {
-            "key": "k8s.namespace.labels.app",
-            "value": {
-              "stringValue": "test-app"
-            }
-          },
-          {
-            "key": "k8s.namespace.labels.kubernetes.io/metadata.name",
-            "value": {
-              "stringValue": "test-namespace"
-            }
-          },
-          {
-            "key": "k8s.namespace.labels.purpose",
-            "value": {
-              "stringValue": "testing"
-            }
-          },
-          {
-            "key": "k8s.namespace.name",
-            "value": {
-              "stringValue": "test-namespace"
-            }
-          },
-          {
-            "key": "k8s.pod.annotations.test-annotation",
-            "value": {
-              "stringValue": "test-value"
-            }
-          },
-          {
-            "key": "k8s.pod.labels.app",
-            "value": {
-              "stringValue": "test-pod"
-            }
-          },
-          {
-            "key": "k8s.pod.name",
-            "value": {
-              "stringValue": "test-pod"
-            }
-          },
-          {
-            "key": "k8s.pod.uid",
-            "value": {
-              "stringValue": "cfac3fff-7602-4a02-86c2-73c6a6316db5"
-            }
-          },
-          {
-            "key": "k8s.replicaset.name",
-            "value": {
-              "stringValue": "calico-apiserver-54689b9f68"
-            }
-          },
-          {
-            "key": "net.host.name",
-            "value": {
-              "stringValue": "wiremock.monitoring.svc.cluster.local"
-            }
-          },
-          {
-            "key": "net.host.port",
-            "value": {
-              "stringValue": "8080"
-            }
-          },
-          {
-            "key": "service.instance.id",
-            "value": {
-              "stringValue": "wiremock.monitoring.svc.cluster.local:8080"
-            }
-          },
-          {
-            "key": "sw.k8s.agent.app.version",
-            "value": {
-              "stringValue": "0.4.1"
-            }
-          },
-          {
-            "key": "sw.k8s.agent.manifest.version",
-            "value": {
-              "stringValue": "2.3.0-alpha.4"
-            }
-          },
-          {
-            "key": "sw.k8s.cluster.uid",
-            "value": {
-              "stringValue": "cluster-uid-123456789"
-            }
-          }
-        ]
-      },
-      "scopeMetrics": [
-        {
-          "metrics": [
-            {
-              "gauge": {
-                "dataPoints": [
-                  {
-                    "asDouble": 1,
-                    "attributes": [
-                      {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "http"
-                        }
-                      },
-                      {
-                        "key": "owner_is_controller",
-                        "value": {
-                          "stringValue": "true"
-                        }
-                      },
-                      {
-                        "key": "owner_kind",
-                        "value": {
-                          "stringValue": "ReplicaSet"
-                        }
-                      },
-                      {
-                        "key": "prometheus",
-                        "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
-                        }
-                      },
-                      {
-                        "key": "prometheus_replica",
-                        "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
-                        }
-                      }
-                    ],
-                    "timeUnixNano": "0"
-                  }
-                ]
-              },
-              "name": "k8s.kube.pod.owner.replicaset"
-            }
-          ],
-          "scope": {}
-        }
-      ]
-    },
-    {
-      "resource": {
-        "attributes": [
-          {
-            "key": "http.scheme",
-            "value": {
-              "stringValue": "http"
-            }
-          },
-          {
-            "key": "k8s.cluster.name",
-            "value": {
-              "stringValue": "cluster name"
-            }
-          },
-          {
-            "key": "k8s.namespace.annotations.description",
-            "value": {
-              "stringValue": "This is a test namespace."
-            }
-          },
-          {
-            "key": "k8s.namespace.labels.app",
-            "value": {
-              "stringValue": "test-app"
-            }
-          },
-          {
-            "key": "k8s.namespace.labels.kubernetes.io/metadata.name",
-            "value": {
-              "stringValue": "test-namespace"
-            }
-          },
-          {
-            "key": "k8s.namespace.labels.purpose",
-            "value": {
-              "stringValue": "testing"
-            }
-          },
-          {
-            "key": "k8s.namespace.name",
-            "value": {
-              "stringValue": "test-namespace"
-            }
-          },
-          {
-            "key": "k8s.pod.annotations.test-annotation",
-            "value": {
-              "stringValue": "test-value"
-            }
-          },
-          {
-            "key": "k8s.pod.labels.app",
-            "value": {
-              "stringValue": "test-pod"
-            }
-          },
-          {
-            "key": "k8s.pod.name",
-            "value": {
-              "stringValue": "test-pod"
-            }
-          },
-          {
-            "key": "k8s.pod.uid",
-            "value": {
-              "stringValue": "cfac3fff-7602-4a02-86c2-73c6a6316db5"
-            }
-          },
-          {
-            "key": "net.host.name",
-            "value": {
-              "stringValue": "wiremock.monitoring.svc.cluster.local"
-            }
-          },
-          {
-            "key": "net.host.port",
-            "value": {
-              "stringValue": "8080"
-            }
-          },
-          {
-            "key": "service.instance.id",
-            "value": {
-              "stringValue": "wiremock.monitoring.svc.cluster.local:8080"
-            }
-          },
-          {
-            "key": "sw.k8s.agent.app.version",
-            "value": {
-              "stringValue": "0.4.1"
-            }
-          },
-          {
-            "key": "sw.k8s.agent.manifest.version",
-            "value": {
-              "stringValue": "2.3.0-alpha.4"
-            }
-          },
-          {
-            "key": "sw.k8s.cluster.uid",
-            "value": {
-              "stringValue": "cluster-uid-123456789"
-            }
-          }
-        ]
-      },
-      "scopeMetrics": [
-        {
-          "metrics": [
-            {
-              "gauge": {
-                "dataPoints": [
-                  {
-                    "asDouble": 1675771430,
-                    "attributes": [
-                      {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "http"
-                        }
-                      },
-                      {
-                        "key": "prometheus",
-                        "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
-                        }
-                      },
-                      {
-                        "key": "prometheus_replica",
-                        "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
-                        }
-                      }
-                    ],
-                    "timeUnixNano": "0"
-                  }
-                ]
-              },
-              "name": "k8s.kube_pod_created"
-            },
-            {
-              "gauge": {
-                "dataPoints": [
-                  {
-                    "asDouble": 1,
-                    "attributes": [
-                      {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "http"
-                        }
-                      },
-                      {
-                        "key": "owner_is_controller",
-                        "value": {
-                          "stringValue": "true"
-                        }
-                      },
-                      {
-                        "key": "owner_kind",
-                        "value": {
-                          "stringValue": "ReplicaSet"
-                        }
-                      },
-                      {
-                        "key": "owner_name",
-                        "value": {
-                          "stringValue": "calico-apiserver-54689b9f68"
-                        }
-                      },
-                      {
-                        "key": "prometheus",
-                        "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
-                        }
-                      },
-                      {
-                        "key": "prometheus_replica",
-                        "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
-                        }
-                      }
-                    ],
-                    "timeUnixNano": "0"
-                  }
-                ]
-              },
-              "name": "k8s.kube_pod_owner"
-            },
-            {
-              "gauge": {
-                "dataPoints": [
-                  {
-                    "asDouble": 1675771430,
-                    "attributes": [
-                      {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "http"
-                        }
-                      },
-                      {
-                        "key": "prometheus",
-                        "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
-                        }
-                      },
-                      {
-                        "key": "prometheus_replica",
-                        "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
-                        }
-                      }
-                    ],
-                    "timeUnixNano": "0"
-                  }
-                ]
-              },
-              "name": "k8s.kube_pod_start_time"
-            }
-          ],
-          "scope": {}
-        }
-      ]
-    },
-    {
-      "resource": {
-        "attributes": [
-          {
-            "key": "http.scheme",
-            "value": {
-              "stringValue": "http"
-            }
-          },
-          {
-            "key": "k8s.cluster.name",
-            "value": {
-              "stringValue": "cluster name"
-            }
-          },
-          {
-            "key": "k8s.namespace.annotations.description",
-            "value": {
-              "stringValue": "This is a test namespace."
-            }
-          },
-          {
-            "key": "k8s.namespace.labels.app",
-            "value": {
-              "stringValue": "test-app"
-            }
-          },
-          {
-            "key": "k8s.namespace.labels.kubernetes.io/metadata.name",
-            "value": {
-              "stringValue": "test-namespace"
-            }
-          },
-          {
-            "key": "k8s.namespace.labels.purpose",
-            "value": {
-              "stringValue": "testing"
-            }
-          },
-          {
-            "key": "k8s.namespace.name",
-            "value": {
-              "stringValue": "test-namespace"
-            }
-          },
-          {
-            "key": "k8s.pod.annotations.test-annotation",
-            "value": {
-              "stringValue": "test-value"
-            }
-          },
-          {
-            "key": "k8s.pod.labels.app",
-            "value": {
-              "stringValue": "test-pod"
-            }
-          },
-          {
-            "key": "k8s.pod.name",
-            "value": {
-              "stringValue": "test-pod"
-            }
-          },
-          {
-            "key": "k8s.pod.uid",
-            "value": {
-              "stringValue": "f97c5cef-d9f0-4455-869c-d2be4e51546f"
-            }
-          },
-          {
-            "key": "net.host.name",
-            "value": {
-              "stringValue": "wiremock.monitoring.svc.cluster.local"
-            }
-          },
-          {
-            "key": "net.host.port",
-            "value": {
-              "stringValue": "8080"
-            }
-          },
-          {
-            "key": "service.instance.id",
-            "value": {
-              "stringValue": "wiremock.monitoring.svc.cluster.local:8080"
-            }
-          },
-          {
-            "key": "sw.k8s.agent.app.version",
-            "value": {
-              "stringValue": "0.4.1"
+              "stringValue": "0.5.0"
             }
           },
           {
@@ -11342,6 +11116,12 @@
             }
           },
           {
+            "key": "k8s.pod.uid",
+            "value": {
+              "stringValue": "00000000-0000-0000-0000-000000000000"
+            }
+          },
+          {
             "key": "net.host.name",
             "value": {
               "stringValue": "wiremock.monitoring.svc.cluster.local"
@@ -11362,7 +11142,299 @@
           {
             "key": "sw.k8s.agent.app.version",
             "value": {
-              "stringValue": "0.4.1"
+              "stringValue": "0.5.0"
+            }
+          },
+          {
+            "key": "sw.k8s.agent.manifest.version",
+            "value": {
+              "stringValue": "2.3.0-alpha.4"
+            }
+          },
+          {
+            "key": "sw.k8s.cluster.uid",
+            "value": {
+              "stringValue": "cluster-uid-123456789"
+            }
+          }
+        ]
+      },
+      "scopeMetrics": [
+        {
+          "metrics": [
+            {
+              "gauge": {
+                "dataPoints": [
+                  {
+                    "asDouble": 1676013611,
+                    "attributes": [
+                      {
+                        "key": "endpoint",
+                        "value": {
+                          "stringValue": "http"
+                        }
+                      },
+                      {
+                        "key": "prometheus",
+                        "value": {
+                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
+                        }
+                      },
+                      {
+                        "key": "prometheus_replica",
+                        "value": {
+                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
+                        }
+                      }
+                    ],
+                    "timeUnixNano": "0"
+                  }
+                ]
+              },
+              "name": "k8s.kube_pod_completion_time"
+            }
+          ],
+          "scope": {}
+        }
+      ]
+    },
+    {
+      "resource": {
+        "attributes": [
+          {
+            "key": "http.scheme",
+            "value": {
+              "stringValue": "http"
+            }
+          },
+          {
+            "key": "k8s.cluster.name",
+            "value": {
+              "stringValue": "cluster name"
+            }
+          },
+          {
+            "key": "k8s.namespace.annotations.description",
+            "value": {
+              "stringValue": "This is a test namespace."
+            }
+          },
+          {
+            "key": "k8s.namespace.labels.app",
+            "value": {
+              "stringValue": "test-app"
+            }
+          },
+          {
+            "key": "k8s.namespace.labels.kubernetes.io/metadata.name",
+            "value": {
+              "stringValue": "test-namespace"
+            }
+          },
+          {
+            "key": "k8s.namespace.labels.purpose",
+            "value": {
+              "stringValue": "testing"
+            }
+          },
+          {
+            "key": "k8s.namespace.name",
+            "value": {
+              "stringValue": "test-namespace"
+            }
+          },
+          {
+            "key": "k8s.pod.annotations.test-annotation",
+            "value": {
+              "stringValue": "test-value"
+            }
+          },
+          {
+            "key": "k8s.pod.labels.app",
+            "value": {
+              "stringValue": "test-pod"
+            }
+          },
+          {
+            "key": "k8s.pod.name",
+            "value": {
+              "stringValue": "test-pod"
+            }
+          },
+          {
+            "key": "k8s.pod.uid",
+            "value": {
+              "stringValue": "00000000-0000-0000-0000-000000000000"
+            }
+          },
+          {
+            "key": "net.host.name",
+            "value": {
+              "stringValue": "wiremock.monitoring.svc.cluster.local"
+            }
+          },
+          {
+            "key": "net.host.port",
+            "value": {
+              "stringValue": "8080"
+            }
+          },
+          {
+            "key": "service.instance.id",
+            "value": {
+              "stringValue": "wiremock.monitoring.svc.cluster.local:8080"
+            }
+          },
+          {
+            "key": "sw.k8s.agent.app.version",
+            "value": {
+              "stringValue": "0.5.0"
+            }
+          },
+          {
+            "key": "sw.k8s.agent.manifest.version",
+            "value": {
+              "stringValue": "2.3.0-alpha.4"
+            }
+          },
+          {
+            "key": "sw.k8s.cluster.uid",
+            "value": {
+              "stringValue": "cluster-uid-123456789"
+            }
+          },
+          {
+            "key": "sw.k8s.pod.status",
+            "value": {
+              "stringValue": "Running"
+            }
+          }
+        ]
+      },
+      "scopeMetrics": [
+        {
+          "metrics": [
+            {
+              "gauge": {
+                "dataPoints": [
+                  {
+                    "asDouble": 1,
+                    "attributes": [
+                      {
+                        "key": "endpoint",
+                        "value": {
+                          "stringValue": "http"
+                        }
+                      },
+                      {
+                        "key": "prometheus",
+                        "value": {
+                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
+                        }
+                      },
+                      {
+                        "key": "prometheus_replica",
+                        "value": {
+                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
+                        }
+                      }
+                    ],
+                    "timeUnixNano": "0"
+                  }
+                ]
+              },
+              "name": "k8s.kube_pod_status_phase"
+            }
+          ],
+          "scope": {}
+        }
+      ]
+    },
+    {
+      "resource": {
+        "attributes": [
+          {
+            "key": "http.scheme",
+            "value": {
+              "stringValue": "http"
+            }
+          },
+          {
+            "key": "k8s.cluster.name",
+            "value": {
+              "stringValue": "cluster name"
+            }
+          },
+          {
+            "key": "k8s.namespace.annotations.description",
+            "value": {
+              "stringValue": "This is a test namespace."
+            }
+          },
+          {
+            "key": "k8s.namespace.labels.app",
+            "value": {
+              "stringValue": "test-app"
+            }
+          },
+          {
+            "key": "k8s.namespace.labels.kubernetes.io/metadata.name",
+            "value": {
+              "stringValue": "test-namespace"
+            }
+          },
+          {
+            "key": "k8s.namespace.labels.purpose",
+            "value": {
+              "stringValue": "testing"
+            }
+          },
+          {
+            "key": "k8s.namespace.name",
+            "value": {
+              "stringValue": "test-namespace"
+            }
+          },
+          {
+            "key": "k8s.pod.annotations.test-annotation",
+            "value": {
+              "stringValue": "test-value"
+            }
+          },
+          {
+            "key": "k8s.pod.labels.app",
+            "value": {
+              "stringValue": "test-pod"
+            }
+          },
+          {
+            "key": "k8s.pod.name",
+            "value": {
+              "stringValue": "test-pod"
+            }
+          },
+          {
+            "key": "net.host.name",
+            "value": {
+              "stringValue": "wiremock.monitoring.svc.cluster.local"
+            }
+          },
+          {
+            "key": "net.host.port",
+            "value": {
+              "stringValue": "8080"
+            }
+          },
+          {
+            "key": "service.instance.id",
+            "value": {
+              "stringValue": "wiremock.monitoring.svc.cluster.local:8080"
+            }
+          },
+          {
+            "key": "sw.k8s.agent.app.version",
+            "value": {
+              "stringValue": "0.5.0"
             }
           },
           {
@@ -11488,9 +11560,27 @@
             }
           },
           {
+            "key": "k8s.replicaset.annotations.test-annotation",
+            "value": {
+              "stringValue": "test-value"
+            }
+          },
+          {
+            "key": "k8s.replicaset.labels.app",
+            "value": {
+              "stringValue": "test-replicaset"
+            }
+          },
+          {
             "key": "k8s.replicaset.name",
             "value": {
               "stringValue": "test-replicaset"
+            }
+          },
+          {
+            "key": "k8s.replicaset.uid",
+            "value": {
+              "stringValue": "00000000-0000-0000-0000-000000000000"
             }
           },
           {
@@ -11514,7 +11604,7 @@
           {
             "key": "sw.k8s.agent.app.version",
             "value": {
-              "stringValue": "0.4.1"
+              "stringValue": "0.5.0"
             }
           },
           {
@@ -11707,9 +11797,27 @@
             }
           },
           {
+            "key": "k8s.statefulset.annotations.test-annotation",
+            "value": {
+              "stringValue": "test-value"
+            }
+          },
+          {
+            "key": "k8s.statefulset.labels.app",
+            "value": {
+              "stringValue": "test-statefulset"
+            }
+          },
+          {
             "key": "k8s.statefulset.name",
             "value": {
               "stringValue": "test-statefulset"
+            }
+          },
+          {
+            "key": "k8s.statefulset.uid",
+            "value": {
+              "stringValue": "00000000-0000-0000-0000-000000000000"
             }
           },
           {
@@ -11733,7 +11841,7 @@
           {
             "key": "sw.k8s.agent.app.version",
             "value": {
-              "stringValue": "0.4.1"
+              "stringValue": "0.5.0"
             }
           },
           {
@@ -12010,7 +12118,7 @@
           {
             "key": "sw.k8s.agent.app.version",
             "value": {
-              "stringValue": "0.4.1"
+              "stringValue": "0.5.0"
             }
           },
           {
@@ -12181,7 +12289,7 @@
           {
             "key": "sw.k8s.agent.app.version",
             "value": {
-              "stringValue": "0.4.1"
+              "stringValue": "0.5.0"
             }
           },
           {
@@ -12309,7 +12417,7 @@
           {
             "key": "sw.k8s.agent.app.version",
             "value": {
-              "stringValue": "0.4.1"
+              "stringValue": "0.5.0"
             }
           },
           {
@@ -12413,7 +12521,7 @@
           {
             "key": "sw.k8s.agent.app.version",
             "value": {
-              "stringValue": "0.4.1"
+              "stringValue": "0.5.0"
             }
           },
           {
@@ -25849,7 +25957,7 @@
           {
             "key": "sw.k8s.agent.app.version",
             "value": {
-              "stringValue": "0.4.1"
+              "stringValue": "0.5.0"
             }
           },
           {

--- a/tests/integration/expected_output.json
+++ b/tests/integration/expected_output.json
@@ -4583,12 +4583,6 @@
             }
           },
           {
-            "key": "k8s.daemonset.uid",
-            "value": {
-              "stringValue": "00000000-0000-0000-0000-000000000000"
-            }
-          },
-          {
             "key": "k8s.namespace.annotations.description",
             "value": {
               "stringValue": "This is a test namespace."
@@ -4974,12 +4968,6 @@
             "key": "k8s.deployment.name",
             "value": {
               "stringValue": "test-deployment"
-            }
-          },
-          {
-            "key": "k8s.deployment.uid",
-            "value": {
-              "stringValue": "00000000-0000-0000-0000-000000000000"
             }
           },
           {
@@ -5716,12 +5704,6 @@
             }
           },
           {
-            "key": "k8s.replicaset.uid",
-            "value": {
-              "stringValue": "00000000-0000-0000-0000-000000000000"
-            }
-          },
-          {
             "key": "net.host.name",
             "value": {
               "stringValue": "test-node"
@@ -5877,12 +5859,6 @@
             "key": "k8s.replicaset.name",
             "value": {
               "stringValue": "test-replicaset"
-            }
-          },
-          {
-            "key": "k8s.replicaset.uid",
-            "value": {
-              "stringValue": "00000000-0000-0000-0000-000000000000"
             }
           },
           {
@@ -11368,12 +11344,6 @@
             }
           },
           {
-            "key": "k8s.replicaset.uid",
-            "value": {
-              "stringValue": "00000000-0000-0000-0000-000000000000"
-            }
-          },
-          {
             "key": "net.host.name",
             "value": {
               "stringValue": "test-node"
@@ -11602,12 +11572,6 @@
             "key": "k8s.statefulset.name",
             "value": {
               "stringValue": "test-statefulset"
-            }
-          },
-          {
-            "key": "k8s.statefulset.uid",
-            "value": {
-              "stringValue": "00000000-0000-0000-0000-000000000000"
             }
           },
           {

--- a/tests/integration/expected_output.json
+++ b/tests/integration/expected_output.json
@@ -96,7 +96,7 @@
           {
             "key": "k8s.pod.uid",
             "value": {
-              "stringValue": "00000000-0000-0000-0000-000000000000"
+              "stringValue": "c72bea9b-2e20-4a01-8873-902890ad6ba5"
             }
           },
           {
@@ -272,7 +272,7 @@
           {
             "key": "k8s.pod.uid",
             "value": {
-              "stringValue": "00000000-0000-0000-0000-000000000000"
+              "stringValue": "f97c5cef-d9f0-4455-869c-d2be4e51546f"
             }
           },
           {
@@ -2623,263 +2623,7 @@
           {
             "key": "k8s.pod.uid",
             "value": {
-              "stringValue": "00000000-0000-0000-0000-000000000000"
-            }
-          },
-          {
-            "key": "net.host.name",
-            "value": {
-              "stringValue": "test-node"
-            }
-          },
-          {
-            "key": "net.host.port",
-            "value": {
-              "stringValue": ""
-            }
-          },
-          {
-            "key": "service.instance.id",
-            "value": {
-              "stringValue": "test-node"
-            }
-          },
-          {
-            "key": "sw.k8s.agent.app.version",
-            "value": {
-              "stringValue": "0.5.0"
-            }
-          },
-          {
-            "key": "sw.k8s.agent.manifest.version",
-            "value": {
-              "stringValue": "2.3.0-alpha.6"
-            }
-          },
-          {
-            "key": "sw.k8s.cluster.uid",
-            "value": {
-              "stringValue": "cluster-uid-123456789"
-            }
-          }
-        ]
-      },
-      "scopeMetrics": [
-        {
-          "metrics": [
-            {
-              "gauge": {
-                "dataPoints": [
-                  {
-                    "asDouble": 0.25,
-                    "attributes": [
-                      {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "http"
-                        }
-                      },
-                      {
-                        "key": "prometheus",
-                        "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
-                        }
-                      },
-                      {
-                        "key": "prometheus_replica",
-                        "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
-                        }
-                      },
-                      {
-                        "key": "resource",
-                        "value": {
-                          "stringValue": "cpu"
-                        }
-                      },
-                      {
-                        "key": "unit",
-                        "value": {
-                          "stringValue": "core"
-                        }
-                      }
-                    ],
-                    "timeUnixNano": "0"
-                  }
-                ]
-              },
-              "name": "k8s.container.spec.cpu.requests"
-            },
-            {
-              "gauge": {
-                "dataPoints": [
-                  {
-                    "asDouble": 268435456,
-                    "attributes": [
-                      {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "http"
-                        }
-                      },
-                      {
-                        "key": "prometheus",
-                        "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
-                        }
-                      },
-                      {
-                        "key": "prometheus_replica",
-                        "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
-                        }
-                      },
-                      {
-                        "key": "resource",
-                        "value": {
-                          "stringValue": "memory"
-                        }
-                      },
-                      {
-                        "key": "unit",
-                        "value": {
-                          "stringValue": "byte"
-                        }
-                      }
-                    ],
-                    "timeUnixNano": "0"
-                  }
-                ]
-              },
-              "name": "k8s.kube_pod_container_resource_limits"
-            },
-            {
-              "gauge": {
-                "dataPoints": [
-                  {
-                    "asDouble": 0.25,
-                    "attributes": [
-                      {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "http"
-                        }
-                      },
-                      {
-                        "key": "prometheus",
-                        "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
-                        }
-                      },
-                      {
-                        "key": "prometheus_replica",
-                        "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
-                        }
-                      },
-                      {
-                        "key": "resource",
-                        "value": {
-                          "stringValue": "cpu"
-                        }
-                      },
-                      {
-                        "key": "unit",
-                        "value": {
-                          "stringValue": "core"
-                        }
-                      }
-                    ],
-                    "timeUnixNano": "0"
-                  }
-                ]
-              },
-              "name": "k8s.kube_pod_container_resource_requests"
-            }
-          ],
-          "scope": {}
-        }
-      ]
-    },
-    {
-      "resource": {
-        "attributes": [
-          {
-            "key": "http.scheme",
-            "value": {
-              "stringValue": "http"
-            }
-          },
-          {
-            "key": "k8s.cluster.name",
-            "value": {
-              "stringValue": "cluster name"
-            }
-          },
-          {
-            "key": "k8s.container.name",
-            "value": {
-              "stringValue": "test-container"
-            }
-          },
-          {
-            "key": "k8s.namespace.annotations.description",
-            "value": {
-              "stringValue": "This is a test namespace."
-            }
-          },
-          {
-            "key": "k8s.namespace.labels.app",
-            "value": {
-              "stringValue": "test-app"
-            }
-          },
-          {
-            "key": "k8s.namespace.labels.kubernetes.io/metadata.name",
-            "value": {
-              "stringValue": "test-namespace"
-            }
-          },
-          {
-            "key": "k8s.namespace.labels.purpose",
-            "value": {
-              "stringValue": "testing"
-            }
-          },
-          {
-            "key": "k8s.namespace.name",
-            "value": {
-              "stringValue": "test-namespace"
-            }
-          },
-          {
-            "key": "k8s.node.name",
-            "value": {
-              "stringValue": "test-node"
-            }
-          },
-          {
-            "key": "k8s.pod.annotations.test-annotation",
-            "value": {
-              "stringValue": "test-value"
-            }
-          },
-          {
-            "key": "k8s.pod.labels.app",
-            "value": {
-              "stringValue": "test-pod"
-            }
-          },
-          {
-            "key": "k8s.pod.name",
-            "value": {
-              "stringValue": "test-pod"
-            }
-          },
-          {
-            "key": "k8s.pod.uid",
-            "value": {
-              "stringValue": "00000000-0000-0000-0000-000000000000"
+              "stringValue": "c72bea9b-2e20-4a01-8873-902890ad6ba5"
             }
           },
           {
@@ -3109,6 +2853,12 @@
             }
           },
           {
+            "key": "k8s.node.name",
+            "value": {
+              "stringValue": "test-node"
+            }
+          },
+          {
             "key": "k8s.pod.annotations.test-annotation",
             "value": {
               "stringValue": "test-value"
@@ -3129,7 +2879,7 @@
           {
             "key": "k8s.pod.uid",
             "value": {
-              "stringValue": "00000000-0000-0000-0000-000000000000"
+              "stringValue": "cb5e02c4-3b32-4d99-890c-eeff7afbb859"
             }
           },
           {
@@ -3177,7 +2927,7 @@
               "gauge": {
                 "dataPoints": [
                   {
-                    "asDouble": 1677653949,
+                    "asDouble": 0.25,
                     "attributes": [
                       {
                         "key": "endpoint",
@@ -3195,6 +2945,18 @@
                         "key": "prometheus_replica",
                         "value": {
                           "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
+                        }
+                      },
+                      {
+                        "key": "resource",
+                        "value": {
+                          "stringValue": "cpu"
+                        }
+                      },
+                      {
+                        "key": "unit",
+                        "value": {
+                          "stringValue": "core"
                         }
                       }
                     ],
@@ -3202,46 +2964,13 @@
                   }
                 ]
               },
-              "name": "k8s.kube_pod_container_state_started"
-            },
-            {
-              "name": "k8s.kube_pod_container_status_restarts_total",
-              "sum": {
-                "aggregationTemporality": 2,
-                "dataPoints": [
-                  {
-                    "asDouble": 0,
-                    "attributes": [
-                      {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "http"
-                        }
-                      },
-                      {
-                        "key": "prometheus",
-                        "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
-                        }
-                      },
-                      {
-                        "key": "prometheus_replica",
-                        "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
-                        }
-                      }
-                    ],
-                    "timeUnixNano": "0"
-                  }
-                ],
-                "isMonotonic": true
-              }
+              "name": "k8s.container.spec.cpu.requests"
             },
             {
               "gauge": {
                 "dataPoints": [
                   {
-                    "asDouble": 1,
+                    "asDouble": 268435456,
                     "attributes": [
                       {
                         "key": "endpoint",
@@ -3260,19 +2989,31 @@
                         "value": {
                           "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
                         }
+                      },
+                      {
+                        "key": "resource",
+                        "value": {
+                          "stringValue": "memory"
+                        }
+                      },
+                      {
+                        "key": "unit",
+                        "value": {
+                          "stringValue": "byte"
+                        }
                       }
                     ],
                     "timeUnixNano": "0"
                   }
                 ]
               },
-              "name": "k8s.kube_pod_container_status_running"
+              "name": "k8s.kube_pod_container_resource_limits"
             },
             {
               "gauge": {
                 "dataPoints": [
                   {
-                    "asDouble": 0,
+                    "asDouble": 0.25,
                     "attributes": [
                       {
                         "key": "endpoint",
@@ -3291,13 +3032,25 @@
                         "value": {
                           "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
                         }
+                      },
+                      {
+                        "key": "resource",
+                        "value": {
+                          "stringValue": "cpu"
+                        }
+                      },
+                      {
+                        "key": "unit",
+                        "value": {
+                          "stringValue": "core"
+                        }
                       }
                     ],
                     "timeUnixNano": "0"
                   }
                 ]
               },
-              "name": "k8s.kube_pod_container_status_terminated"
+              "name": "k8s.kube_pod_container_resource_requests"
             }
           ],
           "scope": {}
@@ -3376,7 +3129,475 @@
           {
             "key": "k8s.pod.uid",
             "value": {
-              "stringValue": "00000000-0000-0000-0000-000000000000"
+              "stringValue": "08b886d4-42ad-4310-b55f-985aa26ccda2"
+            }
+          },
+          {
+            "key": "net.host.name",
+            "value": {
+              "stringValue": "test-node"
+            }
+          },
+          {
+            "key": "net.host.port",
+            "value": {
+              "stringValue": ""
+            }
+          },
+          {
+            "key": "service.instance.id",
+            "value": {
+              "stringValue": "test-node"
+            }
+          },
+          {
+            "key": "sw.k8s.agent.app.version",
+            "value": {
+              "stringValue": "0.5.0"
+            }
+          },
+          {
+            "key": "sw.k8s.agent.manifest.version",
+            "value": {
+              "stringValue": "2.3.0-alpha.6"
+            }
+          },
+          {
+            "key": "sw.k8s.cluster.uid",
+            "value": {
+              "stringValue": "cluster-uid-123456789"
+            }
+          }
+        ]
+      },
+      "scopeMetrics": [
+        {
+          "metrics": [
+            {
+              "gauge": {
+                "dataPoints": [
+                  {
+                    "asDouble": 0,
+                    "attributes": [
+                      {
+                        "key": "endpoint",
+                        "value": {
+                          "stringValue": "http"
+                        }
+                      },
+                      {
+                        "key": "prometheus",
+                        "value": {
+                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
+                        }
+                      },
+                      {
+                        "key": "prometheus_replica",
+                        "value": {
+                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
+                        }
+                      }
+                    ],
+                    "timeUnixNano": "0"
+                  }
+                ]
+              },
+              "name": "k8s.kube_pod_container_status_waiting"
+            }
+          ],
+          "scope": {}
+        }
+      ]
+    },
+    {
+      "resource": {
+        "attributes": [
+          {
+            "key": "http.scheme",
+            "value": {
+              "stringValue": "http"
+            }
+          },
+          {
+            "key": "k8s.cluster.name",
+            "value": {
+              "stringValue": "cluster name"
+            }
+          },
+          {
+            "key": "k8s.container.name",
+            "value": {
+              "stringValue": "test-container"
+            }
+          },
+          {
+            "key": "k8s.namespace.annotations.description",
+            "value": {
+              "stringValue": "This is a test namespace."
+            }
+          },
+          {
+            "key": "k8s.namespace.labels.app",
+            "value": {
+              "stringValue": "test-app"
+            }
+          },
+          {
+            "key": "k8s.namespace.labels.kubernetes.io/metadata.name",
+            "value": {
+              "stringValue": "test-namespace"
+            }
+          },
+          {
+            "key": "k8s.namespace.labels.purpose",
+            "value": {
+              "stringValue": "testing"
+            }
+          },
+          {
+            "key": "k8s.namespace.name",
+            "value": {
+              "stringValue": "test-namespace"
+            }
+          },
+          {
+            "key": "k8s.pod.annotations.test-annotation",
+            "value": {
+              "stringValue": "test-value"
+            }
+          },
+          {
+            "key": "k8s.pod.labels.app",
+            "value": {
+              "stringValue": "test-pod"
+            }
+          },
+          {
+            "key": "k8s.pod.name",
+            "value": {
+              "stringValue": "test-pod"
+            }
+          },
+          {
+            "key": "k8s.pod.uid",
+            "value": {
+              "stringValue": "259510d0-b32f-47c3-ba07-f414c9a7e310"
+            }
+          },
+          {
+            "key": "net.host.name",
+            "value": {
+              "stringValue": "test-node"
+            }
+          },
+          {
+            "key": "net.host.port",
+            "value": {
+              "stringValue": ""
+            }
+          },
+          {
+            "key": "service.instance.id",
+            "value": {
+              "stringValue": "test-node"
+            }
+          },
+          {
+            "key": "sw.k8s.agent.app.version",
+            "value": {
+              "stringValue": "0.5.0"
+            }
+          },
+          {
+            "key": "sw.k8s.agent.manifest.version",
+            "value": {
+              "stringValue": "2.3.0-alpha.6"
+            }
+          },
+          {
+            "key": "sw.k8s.cluster.uid",
+            "value": {
+              "stringValue": "cluster-uid-123456789"
+            }
+          }
+        ]
+      },
+      "scopeMetrics": [
+        {
+          "metrics": [
+            {
+              "gauge": {
+                "dataPoints": [
+                  {
+                    "asDouble": 1,
+                    "attributes": [
+                      {
+                        "key": "endpoint",
+                        "value": {
+                          "stringValue": "http"
+                        }
+                      },
+                      {
+                        "key": "prometheus",
+                        "value": {
+                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
+                        }
+                      },
+                      {
+                        "key": "prometheus_replica",
+                        "value": {
+                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
+                        }
+                      },
+                      {
+                        "key": "reason",
+                        "value": {
+                          "stringValue": "Completed"
+                        }
+                      }
+                    ],
+                    "timeUnixNano": "0"
+                  }
+                ]
+              },
+              "name": "k8s.kube_pod_container_status_terminated_reason"
+            }
+          ],
+          "scope": {}
+        }
+      ]
+    },
+    {
+      "resource": {
+        "attributes": [
+          {
+            "key": "http.scheme",
+            "value": {
+              "stringValue": "http"
+            }
+          },
+          {
+            "key": "k8s.cluster.name",
+            "value": {
+              "stringValue": "cluster name"
+            }
+          },
+          {
+            "key": "k8s.container.name",
+            "value": {
+              "stringValue": "test-container"
+            }
+          },
+          {
+            "key": "k8s.namespace.annotations.description",
+            "value": {
+              "stringValue": "This is a test namespace."
+            }
+          },
+          {
+            "key": "k8s.namespace.labels.app",
+            "value": {
+              "stringValue": "test-app"
+            }
+          },
+          {
+            "key": "k8s.namespace.labels.kubernetes.io/metadata.name",
+            "value": {
+              "stringValue": "test-namespace"
+            }
+          },
+          {
+            "key": "k8s.namespace.labels.purpose",
+            "value": {
+              "stringValue": "testing"
+            }
+          },
+          {
+            "key": "k8s.namespace.name",
+            "value": {
+              "stringValue": "test-namespace"
+            }
+          },
+          {
+            "key": "k8s.pod.annotations.test-annotation",
+            "value": {
+              "stringValue": "test-value"
+            }
+          },
+          {
+            "key": "k8s.pod.labels.app",
+            "value": {
+              "stringValue": "test-pod"
+            }
+          },
+          {
+            "key": "k8s.pod.name",
+            "value": {
+              "stringValue": "test-pod"
+            }
+          },
+          {
+            "key": "k8s.pod.uid",
+            "value": {
+              "stringValue": "869004b9-9774-4681-926a-60fe664122f3"
+            }
+          },
+          {
+            "key": "net.host.name",
+            "value": {
+              "stringValue": "test-node"
+            }
+          },
+          {
+            "key": "net.host.port",
+            "value": {
+              "stringValue": ""
+            }
+          },
+          {
+            "key": "service.instance.id",
+            "value": {
+              "stringValue": "test-node"
+            }
+          },
+          {
+            "key": "sw.k8s.agent.app.version",
+            "value": {
+              "stringValue": "0.5.0"
+            }
+          },
+          {
+            "key": "sw.k8s.agent.manifest.version",
+            "value": {
+              "stringValue": "2.3.0-alpha.6"
+            }
+          },
+          {
+            "key": "sw.k8s.cluster.uid",
+            "value": {
+              "stringValue": "cluster-uid-123456789"
+            }
+          }
+        ]
+      },
+      "scopeMetrics": [
+        {
+          "metrics": [
+            {
+              "gauge": {
+                "dataPoints": [
+                  {
+                    "asDouble": 1,
+                    "attributes": [
+                      {
+                        "key": "endpoint",
+                        "value": {
+                          "stringValue": "http"
+                        }
+                      },
+                      {
+                        "key": "prometheus",
+                        "value": {
+                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
+                        }
+                      },
+                      {
+                        "key": "prometheus_replica",
+                        "value": {
+                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
+                        }
+                      },
+                      {
+                        "key": "reason",
+                        "value": {
+                          "stringValue": "Completed"
+                        }
+                      }
+                    ],
+                    "timeUnixNano": "0"
+                  }
+                ]
+              },
+              "name": "k8s.kube_pod_container_status_last_terminated_reason"
+            }
+          ],
+          "scope": {}
+        }
+      ]
+    },
+    {
+      "resource": {
+        "attributes": [
+          {
+            "key": "http.scheme",
+            "value": {
+              "stringValue": "http"
+            }
+          },
+          {
+            "key": "k8s.cluster.name",
+            "value": {
+              "stringValue": "cluster name"
+            }
+          },
+          {
+            "key": "k8s.container.name",
+            "value": {
+              "stringValue": "test-container"
+            }
+          },
+          {
+            "key": "k8s.namespace.annotations.description",
+            "value": {
+              "stringValue": "This is a test namespace."
+            }
+          },
+          {
+            "key": "k8s.namespace.labels.app",
+            "value": {
+              "stringValue": "test-app"
+            }
+          },
+          {
+            "key": "k8s.namespace.labels.kubernetes.io/metadata.name",
+            "value": {
+              "stringValue": "test-namespace"
+            }
+          },
+          {
+            "key": "k8s.namespace.labels.purpose",
+            "value": {
+              "stringValue": "testing"
+            }
+          },
+          {
+            "key": "k8s.namespace.name",
+            "value": {
+              "stringValue": "test-namespace"
+            }
+          },
+          {
+            "key": "k8s.pod.annotations.test-annotation",
+            "value": {
+              "stringValue": "test-value"
+            }
+          },
+          {
+            "key": "k8s.pod.labels.app",
+            "value": {
+              "stringValue": "test-pod"
+            }
+          },
+          {
+            "key": "k8s.pod.name",
+            "value": {
+              "stringValue": "test-pod"
+            }
+          },
+          {
+            "key": "k8s.pod.uid",
+            "value": {
+              "stringValue": "c72bea9b-2e20-4a01-8873-902890ad6ba5"
             }
           },
           {
@@ -3685,7 +3906,7 @@
           {
             "key": "k8s.pod.uid",
             "value": {
-              "stringValue": "00000000-0000-0000-0000-000000000000"
+              "stringValue": "c72bea9b-2e20-4a01-8873-902890ad6ba5"
             }
           },
           {
@@ -3723,6 +3944,12 @@
             "value": {
               "stringValue": "cluster-uid-123456789"
             }
+          },
+          {
+            "key": "sw.k8s.container.status",
+            "value": {
+              "stringValue": "running"
+            }
           }
         ]
       },
@@ -3752,19 +3979,13 @@
                         "value": {
                           "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
                         }
-                      },
-                      {
-                        "key": "reason",
-                        "value": {
-                          "stringValue": "Completed"
-                        }
                       }
                     ],
                     "timeUnixNano": "0"
                   }
                 ]
               },
-              "name": "k8s.kube_pod_container_status_terminated_reason"
+              "name": "k8s.container.status"
             }
           ],
           "scope": {}
@@ -3843,7 +4064,7 @@
           {
             "key": "k8s.pod.uid",
             "value": {
-              "stringValue": "00000000-0000-0000-0000-000000000000"
+              "stringValue": "cb5e02c4-3b32-4d99-890c-eeff7afbb859"
             }
           },
           {
@@ -3891,6 +4112,70 @@
               "gauge": {
                 "dataPoints": [
                   {
+                    "asDouble": 1677653949,
+                    "attributes": [
+                      {
+                        "key": "endpoint",
+                        "value": {
+                          "stringValue": "http"
+                        }
+                      },
+                      {
+                        "key": "prometheus",
+                        "value": {
+                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
+                        }
+                      },
+                      {
+                        "key": "prometheus_replica",
+                        "value": {
+                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
+                        }
+                      }
+                    ],
+                    "timeUnixNano": "0"
+                  }
+                ]
+              },
+              "name": "k8s.kube_pod_container_state_started"
+            },
+            {
+              "name": "k8s.kube_pod_container_status_restarts_total",
+              "sum": {
+                "aggregationTemporality": 2,
+                "dataPoints": [
+                  {
+                    "asDouble": 0,
+                    "attributes": [
+                      {
+                        "key": "endpoint",
+                        "value": {
+                          "stringValue": "http"
+                        }
+                      },
+                      {
+                        "key": "prometheus",
+                        "value": {
+                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
+                        }
+                      },
+                      {
+                        "key": "prometheus_replica",
+                        "value": {
+                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
+                        }
+                      }
+                    ],
+                    "timeUnixNano": "0"
+                  }
+                ],
+                "isMonotonic": true
+              }
+            },
+            {
+              "gauge": {
+                "dataPoints": [
+                  {
                     "asDouble": 1,
                     "attributes": [
                       {
@@ -3910,141 +4195,14 @@
                         "value": {
                           "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
                         }
-                      },
-                      {
-                        "key": "reason",
-                        "value": {
-                          "stringValue": "Completed"
-                        }
                       }
                     ],
                     "timeUnixNano": "0"
                   }
                 ]
               },
-              "name": "k8s.kube_pod_container_status_last_terminated_reason"
-            }
-          ],
-          "scope": {}
-        }
-      ]
-    },
-    {
-      "resource": {
-        "attributes": [
-          {
-            "key": "http.scheme",
-            "value": {
-              "stringValue": "http"
-            }
-          },
-          {
-            "key": "k8s.cluster.name",
-            "value": {
-              "stringValue": "cluster name"
-            }
-          },
-          {
-            "key": "k8s.container.name",
-            "value": {
-              "stringValue": "test-container"
-            }
-          },
-          {
-            "key": "k8s.namespace.annotations.description",
-            "value": {
-              "stringValue": "This is a test namespace."
-            }
-          },
-          {
-            "key": "k8s.namespace.labels.app",
-            "value": {
-              "stringValue": "test-app"
-            }
-          },
-          {
-            "key": "k8s.namespace.labels.kubernetes.io/metadata.name",
-            "value": {
-              "stringValue": "test-namespace"
-            }
-          },
-          {
-            "key": "k8s.namespace.labels.purpose",
-            "value": {
-              "stringValue": "testing"
-            }
-          },
-          {
-            "key": "k8s.namespace.name",
-            "value": {
-              "stringValue": "test-namespace"
-            }
-          },
-          {
-            "key": "k8s.pod.annotations.test-annotation",
-            "value": {
-              "stringValue": "test-value"
-            }
-          },
-          {
-            "key": "k8s.pod.labels.app",
-            "value": {
-              "stringValue": "test-pod"
-            }
-          },
-          {
-            "key": "k8s.pod.name",
-            "value": {
-              "stringValue": "test-pod"
-            }
-          },
-          {
-            "key": "k8s.pod.uid",
-            "value": {
-              "stringValue": "00000000-0000-0000-0000-000000000000"
-            }
-          },
-          {
-            "key": "net.host.name",
-            "value": {
-              "stringValue": "test-node"
-            }
-          },
-          {
-            "key": "net.host.port",
-            "value": {
-              "stringValue": ""
-            }
-          },
-          {
-            "key": "service.instance.id",
-            "value": {
-              "stringValue": "test-node"
-            }
-          },
-          {
-            "key": "sw.k8s.agent.app.version",
-            "value": {
-              "stringValue": "0.5.0"
-            }
-          },
-          {
-            "key": "sw.k8s.agent.manifest.version",
-            "value": {
-              "stringValue": "2.3.0-alpha.6"
-            }
-          },
-          {
-            "key": "sw.k8s.cluster.uid",
-            "value": {
-              "stringValue": "cluster-uid-123456789"
-            }
-          }
-        ]
-      },
-      "scopeMetrics": [
-        {
-          "metrics": [
+              "name": "k8s.kube_pod_container_status_running"
+            },
             {
               "gauge": {
                 "dataPoints": [
@@ -4074,7 +4232,7 @@
                   }
                 ]
               },
-              "name": "k8s.kube_pod_container_status_waiting"
+              "name": "k8s.kube_pod_container_status_terminated"
             }
           ],
           "scope": {}
@@ -4153,7 +4311,165 @@
           {
             "key": "k8s.pod.uid",
             "value": {
-              "stringValue": "00000000-0000-0000-0000-000000000000"
+              "stringValue": "cb5e02c4-3b32-4d99-890c-eeff7afbb859"
+            }
+          },
+          {
+            "key": "net.host.name",
+            "value": {
+              "stringValue": "test-node"
+            }
+          },
+          {
+            "key": "net.host.port",
+            "value": {
+              "stringValue": ""
+            }
+          },
+          {
+            "key": "service.instance.id",
+            "value": {
+              "stringValue": "test-node"
+            }
+          },
+          {
+            "key": "sw.k8s.agent.app.version",
+            "value": {
+              "stringValue": "0.5.0"
+            }
+          },
+          {
+            "key": "sw.k8s.agent.manifest.version",
+            "value": {
+              "stringValue": "2.3.0-alpha.6"
+            }
+          },
+          {
+            "key": "sw.k8s.cluster.uid",
+            "value": {
+              "stringValue": "cluster-uid-123456789"
+            }
+          },
+          {
+            "key": "sw.k8s.container.status",
+            "value": {
+              "stringValue": "running"
+            }
+          }
+        ]
+      },
+      "scopeMetrics": [
+        {
+          "metrics": [
+            {
+              "gauge": {
+                "dataPoints": [
+                  {
+                    "asDouble": 1,
+                    "attributes": [
+                      {
+                        "key": "endpoint",
+                        "value": {
+                          "stringValue": "http"
+                        }
+                      },
+                      {
+                        "key": "prometheus",
+                        "value": {
+                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
+                        }
+                      },
+                      {
+                        "key": "prometheus_replica",
+                        "value": {
+                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
+                        }
+                      }
+                    ],
+                    "timeUnixNano": "0"
+                  }
+                ]
+              },
+              "name": "k8s.container.status"
+            }
+          ],
+          "scope": {}
+        }
+      ]
+    },
+    {
+      "resource": {
+        "attributes": [
+          {
+            "key": "http.scheme",
+            "value": {
+              "stringValue": "http"
+            }
+          },
+          {
+            "key": "k8s.cluster.name",
+            "value": {
+              "stringValue": "cluster name"
+            }
+          },
+          {
+            "key": "k8s.container.name",
+            "value": {
+              "stringValue": "test-container"
+            }
+          },
+          {
+            "key": "k8s.namespace.annotations.description",
+            "value": {
+              "stringValue": "This is a test namespace."
+            }
+          },
+          {
+            "key": "k8s.namespace.labels.app",
+            "value": {
+              "stringValue": "test-app"
+            }
+          },
+          {
+            "key": "k8s.namespace.labels.kubernetes.io/metadata.name",
+            "value": {
+              "stringValue": "test-namespace"
+            }
+          },
+          {
+            "key": "k8s.namespace.labels.purpose",
+            "value": {
+              "stringValue": "testing"
+            }
+          },
+          {
+            "key": "k8s.namespace.name",
+            "value": {
+              "stringValue": "test-namespace"
+            }
+          },
+          {
+            "key": "k8s.pod.annotations.test-annotation",
+            "value": {
+              "stringValue": "test-value"
+            }
+          },
+          {
+            "key": "k8s.pod.labels.app",
+            "value": {
+              "stringValue": "test-pod"
+            }
+          },
+          {
+            "key": "k8s.pod.name",
+            "value": {
+              "stringValue": "test-pod"
+            }
+          },
+          {
+            "key": "k8s.pod.uid",
+            "value": {
+              "stringValue": "f97c5cef-d9f0-4455-869c-d2be4e51546f"
             }
           },
           {
@@ -4227,322 +4543,6 @@
                 ]
               },
               "name": "k8s.kube_pod_container_status_ready"
-            }
-          ],
-          "scope": {}
-        }
-      ]
-    },
-    {
-      "resource": {
-        "attributes": [
-          {
-            "key": "http.scheme",
-            "value": {
-              "stringValue": "http"
-            }
-          },
-          {
-            "key": "k8s.cluster.name",
-            "value": {
-              "stringValue": "cluster name"
-            }
-          },
-          {
-            "key": "k8s.container.name",
-            "value": {
-              "stringValue": "test-container"
-            }
-          },
-          {
-            "key": "k8s.namespace.annotations.description",
-            "value": {
-              "stringValue": "This is a test namespace."
-            }
-          },
-          {
-            "key": "k8s.namespace.labels.app",
-            "value": {
-              "stringValue": "test-app"
-            }
-          },
-          {
-            "key": "k8s.namespace.labels.kubernetes.io/metadata.name",
-            "value": {
-              "stringValue": "test-namespace"
-            }
-          },
-          {
-            "key": "k8s.namespace.labels.purpose",
-            "value": {
-              "stringValue": "testing"
-            }
-          },
-          {
-            "key": "k8s.namespace.name",
-            "value": {
-              "stringValue": "test-namespace"
-            }
-          },
-          {
-            "key": "k8s.pod.annotations.test-annotation",
-            "value": {
-              "stringValue": "test-value"
-            }
-          },
-          {
-            "key": "k8s.pod.labels.app",
-            "value": {
-              "stringValue": "test-pod"
-            }
-          },
-          {
-            "key": "k8s.pod.name",
-            "value": {
-              "stringValue": "test-pod"
-            }
-          },
-          {
-            "key": "k8s.pod.uid",
-            "value": {
-              "stringValue": "00000000-0000-0000-0000-000000000000"
-            }
-          },
-          {
-            "key": "net.host.name",
-            "value": {
-              "stringValue": "test-node"
-            }
-          },
-          {
-            "key": "net.host.port",
-            "value": {
-              "stringValue": ""
-            }
-          },
-          {
-            "key": "service.instance.id",
-            "value": {
-              "stringValue": "test-node"
-            }
-          },
-          {
-            "key": "sw.k8s.agent.app.version",
-            "value": {
-              "stringValue": "0.5.0"
-            }
-          },
-          {
-            "key": "sw.k8s.agent.manifest.version",
-            "value": {
-              "stringValue": "2.3.0-alpha.6"
-            }
-          },
-          {
-            "key": "sw.k8s.cluster.uid",
-            "value": {
-              "stringValue": "cluster-uid-123456789"
-            }
-          },
-          {
-            "key": "sw.k8s.container.status",
-            "value": {
-              "stringValue": "running"
-            }
-          }
-        ]
-      },
-      "scopeMetrics": [
-        {
-          "metrics": [
-            {
-              "gauge": {
-                "dataPoints": [
-                  {
-                    "asDouble": 1,
-                    "attributes": [
-                      {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "http"
-                        }
-                      },
-                      {
-                        "key": "prometheus",
-                        "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
-                        }
-                      },
-                      {
-                        "key": "prometheus_replica",
-                        "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
-                        }
-                      }
-                    ],
-                    "timeUnixNano": "0"
-                  }
-                ]
-              },
-              "name": "k8s.container.status"
-            }
-          ],
-          "scope": {}
-        }
-      ]
-    },
-    {
-      "resource": {
-        "attributes": [
-          {
-            "key": "http.scheme",
-            "value": {
-              "stringValue": "http"
-            }
-          },
-          {
-            "key": "k8s.cluster.name",
-            "value": {
-              "stringValue": "cluster name"
-            }
-          },
-          {
-            "key": "k8s.container.name",
-            "value": {
-              "stringValue": "test-container"
-            }
-          },
-          {
-            "key": "k8s.namespace.annotations.description",
-            "value": {
-              "stringValue": "This is a test namespace."
-            }
-          },
-          {
-            "key": "k8s.namespace.labels.app",
-            "value": {
-              "stringValue": "test-app"
-            }
-          },
-          {
-            "key": "k8s.namespace.labels.kubernetes.io/metadata.name",
-            "value": {
-              "stringValue": "test-namespace"
-            }
-          },
-          {
-            "key": "k8s.namespace.labels.purpose",
-            "value": {
-              "stringValue": "testing"
-            }
-          },
-          {
-            "key": "k8s.namespace.name",
-            "value": {
-              "stringValue": "test-namespace"
-            }
-          },
-          {
-            "key": "k8s.pod.annotations.test-annotation",
-            "value": {
-              "stringValue": "test-value"
-            }
-          },
-          {
-            "key": "k8s.pod.labels.app",
-            "value": {
-              "stringValue": "test-pod"
-            }
-          },
-          {
-            "key": "k8s.pod.name",
-            "value": {
-              "stringValue": "test-pod"
-            }
-          },
-          {
-            "key": "k8s.pod.uid",
-            "value": {
-              "stringValue": "00000000-0000-0000-0000-000000000000"
-            }
-          },
-          {
-            "key": "net.host.name",
-            "value": {
-              "stringValue": "test-node"
-            }
-          },
-          {
-            "key": "net.host.port",
-            "value": {
-              "stringValue": ""
-            }
-          },
-          {
-            "key": "service.instance.id",
-            "value": {
-              "stringValue": "test-node"
-            }
-          },
-          {
-            "key": "sw.k8s.agent.app.version",
-            "value": {
-              "stringValue": "0.5.0"
-            }
-          },
-          {
-            "key": "sw.k8s.agent.manifest.version",
-            "value": {
-              "stringValue": "2.3.0-alpha.6"
-            }
-          },
-          {
-            "key": "sw.k8s.cluster.uid",
-            "value": {
-              "stringValue": "cluster-uid-123456789"
-            }
-          },
-          {
-            "key": "sw.k8s.container.status",
-            "value": {
-              "stringValue": "running"
-            }
-          }
-        ]
-      },
-      "scopeMetrics": [
-        {
-          "metrics": [
-            {
-              "gauge": {
-                "dataPoints": [
-                  {
-                    "asDouble": 1,
-                    "attributes": [
-                      {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "http"
-                        }
-                      },
-                      {
-                        "key": "prometheus",
-                        "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
-                        }
-                      },
-                      {
-                        "key": "prometheus_replica",
-                        "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
-                        }
-                      }
-                    ],
-                    "timeUnixNano": "0"
-                  }
-                ]
-              },
-              "name": "k8s.container.status"
             }
           ],
           "scope": {}
@@ -6477,7 +6477,7 @@
           {
             "key": "k8s.pod.uid",
             "value": {
-              "stringValue": "00000000-0000-0000-0000-000000000000"
+              "stringValue": "c72bea9b-2e20-4a01-8873-902890ad6ba5"
             }
           },
           {
@@ -6659,7 +6659,7 @@
           {
             "key": "k8s.pod.uid",
             "value": {
-              "stringValue": "00000000-0000-0000-0000-000000000000"
+              "stringValue": "f97c5cef-d9f0-4455-869c-d2be4e51546f"
             }
           },
           {
@@ -9879,13 +9879,7 @@
           {
             "key": "k8s.pod.uid",
             "value": {
-              "stringValue": "00000000-0000-0000-0000-000000000000"
-            }
-          },
-          {
-            "key": "k8s.replicaset.name",
-            "value": {
-              "stringValue": "calico-apiserver-54689b9f68"
+              "stringValue": "52694956-5803-4d4b-9397-c6e928dbc61e"
             }
           },
           {
@@ -9933,24 +9927,12 @@
               "gauge": {
                 "dataPoints": [
                   {
-                    "asDouble": 1,
+                    "asDouble": 1676013611,
                     "attributes": [
                       {
                         "key": "endpoint",
                         "value": {
                           "stringValue": "http"
-                        }
-                      },
-                      {
-                        "key": "owner_is_controller",
-                        "value": {
-                          "stringValue": "true"
-                        }
-                      },
-                      {
-                        "key": "owner_kind",
-                        "value": {
-                          "stringValue": "ReplicaSet"
                         }
                       },
                       {
@@ -9970,7 +9952,7 @@
                   }
                 ]
               },
-              "name": "k8s.kube.pod.owner.replicaset"
+              "name": "k8s.kube_pod_completion_time"
             }
           ],
           "scope": {}
@@ -10043,7 +10025,7 @@
           {
             "key": "k8s.pod.uid",
             "value": {
-              "stringValue": "00000000-0000-0000-0000-000000000000"
+              "stringValue": "c72bea9b-2e20-4a01-8873-902890ad6ba5"
             }
           },
           {
@@ -10207,379 +10189,7 @@
           {
             "key": "k8s.pod.uid",
             "value": {
-              "stringValue": "00000000-0000-0000-0000-000000000000"
-            }
-          },
-          {
-            "key": "net.host.name",
-            "value": {
-              "stringValue": "test-node"
-            }
-          },
-          {
-            "key": "net.host.port",
-            "value": {
-              "stringValue": ""
-            }
-          },
-          {
-            "key": "service.instance.id",
-            "value": {
-              "stringValue": "test-node"
-            }
-          },
-          {
-            "key": "sw.k8s.agent.app.version",
-            "value": {
-              "stringValue": "0.5.0"
-            }
-          },
-          {
-            "key": "sw.k8s.agent.manifest.version",
-            "value": {
-              "stringValue": "2.3.0-alpha.6"
-            }
-          },
-          {
-            "key": "sw.k8s.cluster.uid",
-            "value": {
-              "stringValue": "cluster-uid-123456789"
-            }
-          }
-        ]
-      },
-      "scopeMetrics": [
-        {
-          "metrics": [
-            {
-              "gauge": {
-                "dataPoints": [
-                  {
-                    "asDouble": 1676013611,
-                    "attributes": [
-                      {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "http"
-                        }
-                      },
-                      {
-                        "key": "prometheus",
-                        "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
-                        }
-                      },
-                      {
-                        "key": "prometheus_replica",
-                        "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
-                        }
-                      }
-                    ],
-                    "timeUnixNano": "0"
-                  }
-                ]
-              },
-              "name": "k8s.kube_pod_completion_time"
-            }
-          ],
-          "scope": {}
-        }
-      ]
-    },
-    {
-      "resource": {
-        "attributes": [
-          {
-            "key": "http.scheme",
-            "value": {
-              "stringValue": "http"
-            }
-          },
-          {
-            "key": "k8s.cluster.name",
-            "value": {
-              "stringValue": "cluster name"
-            }
-          },
-          {
-            "key": "k8s.namespace.annotations.description",
-            "value": {
-              "stringValue": "This is a test namespace."
-            }
-          },
-          {
-            "key": "k8s.namespace.labels.app",
-            "value": {
-              "stringValue": "test-app"
-            }
-          },
-          {
-            "key": "k8s.namespace.labels.kubernetes.io/metadata.name",
-            "value": {
-              "stringValue": "test-namespace"
-            }
-          },
-          {
-            "key": "k8s.namespace.labels.purpose",
-            "value": {
-              "stringValue": "testing"
-            }
-          },
-          {
-            "key": "k8s.namespace.name",
-            "value": {
-              "stringValue": "test-namespace"
-            }
-          },
-          {
-            "key": "k8s.pod.annotations.test-annotation",
-            "value": {
-              "stringValue": "test-value"
-            }
-          },
-          {
-            "key": "k8s.pod.labels.app",
-            "value": {
-              "stringValue": "test-pod"
-            }
-          },
-          {
-            "key": "k8s.pod.name",
-            "value": {
-              "stringValue": "test-pod"
-            }
-          },
-          {
-            "key": "k8s.pod.uid",
-            "value": {
-              "stringValue": "00000000-0000-0000-0000-000000000000"
-            }
-          },
-          {
-            "key": "net.host.name",
-            "value": {
-              "stringValue": "test-node"
-            }
-          },
-          {
-            "key": "net.host.port",
-            "value": {
-              "stringValue": ""
-            }
-          },
-          {
-            "key": "service.instance.id",
-            "value": {
-              "stringValue": "test-node"
-            }
-          },
-          {
-            "key": "sw.k8s.agent.app.version",
-            "value": {
-              "stringValue": "0.5.0"
-            }
-          },
-          {
-            "key": "sw.k8s.agent.manifest.version",
-            "value": {
-              "stringValue": "2.3.0-alpha.6"
-            }
-          },
-          {
-            "key": "sw.k8s.cluster.uid",
-            "value": {
-              "stringValue": "cluster-uid-123456789"
-            }
-          }
-        ]
-      },
-      "scopeMetrics": [
-        {
-          "metrics": [
-            {
-              "gauge": {
-                "dataPoints": [
-                  {
-                    "asDouble": 1675771430,
-                    "attributes": [
-                      {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "http"
-                        }
-                      },
-                      {
-                        "key": "prometheus",
-                        "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
-                        }
-                      },
-                      {
-                        "key": "prometheus_replica",
-                        "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
-                        }
-                      }
-                    ],
-                    "timeUnixNano": "0"
-                  }
-                ]
-              },
-              "name": "k8s.kube_pod_created"
-            },
-            {
-              "gauge": {
-                "dataPoints": [
-                  {
-                    "asDouble": 1,
-                    "attributes": [
-                      {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "http"
-                        }
-                      },
-                      {
-                        "key": "owner_is_controller",
-                        "value": {
-                          "stringValue": "true"
-                        }
-                      },
-                      {
-                        "key": "owner_kind",
-                        "value": {
-                          "stringValue": "ReplicaSet"
-                        }
-                      },
-                      {
-                        "key": "owner_name",
-                        "value": {
-                          "stringValue": "calico-apiserver-54689b9f68"
-                        }
-                      },
-                      {
-                        "key": "prometheus",
-                        "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
-                        }
-                      },
-                      {
-                        "key": "prometheus_replica",
-                        "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
-                        }
-                      }
-                    ],
-                    "timeUnixNano": "0"
-                  }
-                ]
-              },
-              "name": "k8s.kube_pod_owner"
-            },
-            {
-              "gauge": {
-                "dataPoints": [
-                  {
-                    "asDouble": 1675771430,
-                    "attributes": [
-                      {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "http"
-                        }
-                      },
-                      {
-                        "key": "prometheus",
-                        "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
-                        }
-                      },
-                      {
-                        "key": "prometheus_replica",
-                        "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
-                        }
-                      }
-                    ],
-                    "timeUnixNano": "0"
-                  }
-                ]
-              },
-              "name": "k8s.kube_pod_start_time"
-            }
-          ],
-          "scope": {}
-        }
-      ]
-    },
-    {
-      "resource": {
-        "attributes": [
-          {
-            "key": "http.scheme",
-            "value": {
-              "stringValue": "http"
-            }
-          },
-          {
-            "key": "k8s.cluster.name",
-            "value": {
-              "stringValue": "cluster name"
-            }
-          },
-          {
-            "key": "k8s.namespace.annotations.description",
-            "value": {
-              "stringValue": "This is a test namespace."
-            }
-          },
-          {
-            "key": "k8s.namespace.labels.app",
-            "value": {
-              "stringValue": "test-app"
-            }
-          },
-          {
-            "key": "k8s.namespace.labels.kubernetes.io/metadata.name",
-            "value": {
-              "stringValue": "test-namespace"
-            }
-          },
-          {
-            "key": "k8s.namespace.labels.purpose",
-            "value": {
-              "stringValue": "testing"
-            }
-          },
-          {
-            "key": "k8s.namespace.name",
-            "value": {
-              "stringValue": "test-namespace"
-            }
-          },
-          {
-            "key": "k8s.pod.annotations.test-annotation",
-            "value": {
-              "stringValue": "test-value"
-            }
-          },
-          {
-            "key": "k8s.pod.labels.app",
-            "value": {
-              "stringValue": "test-pod"
-            }
-          },
-          {
-            "key": "k8s.pod.name",
-            "value": {
-              "stringValue": "test-pod"
-            }
-          },
-          {
-            "key": "k8s.pod.uid",
-            "value": {
-              "stringValue": "00000000-0000-0000-0000-000000000000"
+              "stringValue": "c72bea9b-2e20-4a01-8873-902890ad6ba5"
             }
           },
           {
@@ -10902,159 +10512,7 @@
           {
             "key": "k8s.pod.uid",
             "value": {
-              "stringValue": "00000000-0000-0000-0000-000000000000"
-            }
-          },
-          {
-            "key": "net.host.name",
-            "value": {
-              "stringValue": "test-node"
-            }
-          },
-          {
-            "key": "net.host.port",
-            "value": {
-              "stringValue": ""
-            }
-          },
-          {
-            "key": "service.instance.id",
-            "value": {
-              "stringValue": "test-node"
-            }
-          },
-          {
-            "key": "sw.k8s.agent.app.version",
-            "value": {
-              "stringValue": "0.5.0"
-            }
-          },
-          {
-            "key": "sw.k8s.agent.manifest.version",
-            "value": {
-              "stringValue": "2.3.0-alpha.6"
-            }
-          },
-          {
-            "key": "sw.k8s.cluster.uid",
-            "value": {
-              "stringValue": "cluster-uid-123456789"
-            }
-          }
-        ]
-      },
-      "scopeMetrics": [
-        {
-          "metrics": [
-            {
-              "gauge": {
-                "dataPoints": [
-                  {
-                    "asDouble": 0,
-                    "attributes": [
-                      {
-                        "key": "condition",
-                        "value": {
-                          "stringValue": "unknown"
-                        }
-                      },
-                      {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "http"
-                        }
-                      },
-                      {
-                        "key": "prometheus",
-                        "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
-                        }
-                      },
-                      {
-                        "key": "prometheus_replica",
-                        "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
-                        }
-                      }
-                    ],
-                    "timeUnixNano": "0"
-                  }
-                ]
-              },
-              "name": "k8s.kube_pod_status_ready"
-            }
-          ],
-          "scope": {}
-        }
-      ]
-    },
-    {
-      "resource": {
-        "attributes": [
-          {
-            "key": "http.scheme",
-            "value": {
-              "stringValue": "http"
-            }
-          },
-          {
-            "key": "k8s.cluster.name",
-            "value": {
-              "stringValue": "cluster name"
-            }
-          },
-          {
-            "key": "k8s.namespace.annotations.description",
-            "value": {
-              "stringValue": "This is a test namespace."
-            }
-          },
-          {
-            "key": "k8s.namespace.labels.app",
-            "value": {
-              "stringValue": "test-app"
-            }
-          },
-          {
-            "key": "k8s.namespace.labels.kubernetes.io/metadata.name",
-            "value": {
-              "stringValue": "test-namespace"
-            }
-          },
-          {
-            "key": "k8s.namespace.labels.purpose",
-            "value": {
-              "stringValue": "testing"
-            }
-          },
-          {
-            "key": "k8s.namespace.name",
-            "value": {
-              "stringValue": "test-namespace"
-            }
-          },
-          {
-            "key": "k8s.pod.annotations.test-annotation",
-            "value": {
-              "stringValue": "test-value"
-            }
-          },
-          {
-            "key": "k8s.pod.labels.app",
-            "value": {
-              "stringValue": "test-pod"
-            }
-          },
-          {
-            "key": "k8s.pod.name",
-            "value": {
-              "stringValue": "test-pod"
-            }
-          },
-          {
-            "key": "k8s.pod.uid",
-            "value": {
-              "stringValue": "00000000-0000-0000-0000-000000000000"
+              "stringValue": "c72bea9b-2e20-4a01-8873-902890ad6ba5"
             }
           },
           {
@@ -11134,6 +10592,548 @@
                 ]
               },
               "name": "k8s.kube_pod_status_phase"
+            }
+          ],
+          "scope": {}
+        }
+      ]
+    },
+    {
+      "resource": {
+        "attributes": [
+          {
+            "key": "http.scheme",
+            "value": {
+              "stringValue": "http"
+            }
+          },
+          {
+            "key": "k8s.cluster.name",
+            "value": {
+              "stringValue": "cluster name"
+            }
+          },
+          {
+            "key": "k8s.namespace.annotations.description",
+            "value": {
+              "stringValue": "This is a test namespace."
+            }
+          },
+          {
+            "key": "k8s.namespace.labels.app",
+            "value": {
+              "stringValue": "test-app"
+            }
+          },
+          {
+            "key": "k8s.namespace.labels.kubernetes.io/metadata.name",
+            "value": {
+              "stringValue": "test-namespace"
+            }
+          },
+          {
+            "key": "k8s.namespace.labels.purpose",
+            "value": {
+              "stringValue": "testing"
+            }
+          },
+          {
+            "key": "k8s.namespace.name",
+            "value": {
+              "stringValue": "test-namespace"
+            }
+          },
+          {
+            "key": "k8s.pod.annotations.test-annotation",
+            "value": {
+              "stringValue": "test-value"
+            }
+          },
+          {
+            "key": "k8s.pod.labels.app",
+            "value": {
+              "stringValue": "test-pod"
+            }
+          },
+          {
+            "key": "k8s.pod.name",
+            "value": {
+              "stringValue": "test-pod"
+            }
+          },
+          {
+            "key": "k8s.pod.uid",
+            "value": {
+              "stringValue": "cfac3fff-7602-4a02-86c2-73c6a6316db5"
+            }
+          },
+          {
+            "key": "k8s.replicaset.name",
+            "value": {
+              "stringValue": "calico-apiserver-54689b9f68"
+            }
+          },
+          {
+            "key": "net.host.name",
+            "value": {
+              "stringValue": "test-node"
+            }
+          },
+          {
+            "key": "net.host.port",
+            "value": {
+              "stringValue": ""
+            }
+          },
+          {
+            "key": "service.instance.id",
+            "value": {
+              "stringValue": "test-node"
+            }
+          },
+          {
+            "key": "sw.k8s.agent.app.version",
+            "value": {
+              "stringValue": "0.5.0"
+            }
+          },
+          {
+            "key": "sw.k8s.agent.manifest.version",
+            "value": {
+              "stringValue": "2.3.0-alpha.6"
+            }
+          },
+          {
+            "key": "sw.k8s.cluster.uid",
+            "value": {
+              "stringValue": "cluster-uid-123456789"
+            }
+          }
+        ]
+      },
+      "scopeMetrics": [
+        {
+          "metrics": [
+            {
+              "gauge": {
+                "dataPoints": [
+                  {
+                    "asDouble": 1,
+                    "attributes": [
+                      {
+                        "key": "endpoint",
+                        "value": {
+                          "stringValue": "http"
+                        }
+                      },
+                      {
+                        "key": "owner_is_controller",
+                        "value": {
+                          "stringValue": "true"
+                        }
+                      },
+                      {
+                        "key": "owner_kind",
+                        "value": {
+                          "stringValue": "ReplicaSet"
+                        }
+                      },
+                      {
+                        "key": "prometheus",
+                        "value": {
+                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
+                        }
+                      },
+                      {
+                        "key": "prometheus_replica",
+                        "value": {
+                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
+                        }
+                      }
+                    ],
+                    "timeUnixNano": "0"
+                  }
+                ]
+              },
+              "name": "k8s.kube.pod.owner.replicaset"
+            }
+          ],
+          "scope": {}
+        }
+      ]
+    },
+    {
+      "resource": {
+        "attributes": [
+          {
+            "key": "http.scheme",
+            "value": {
+              "stringValue": "http"
+            }
+          },
+          {
+            "key": "k8s.cluster.name",
+            "value": {
+              "stringValue": "cluster name"
+            }
+          },
+          {
+            "key": "k8s.namespace.annotations.description",
+            "value": {
+              "stringValue": "This is a test namespace."
+            }
+          },
+          {
+            "key": "k8s.namespace.labels.app",
+            "value": {
+              "stringValue": "test-app"
+            }
+          },
+          {
+            "key": "k8s.namespace.labels.kubernetes.io/metadata.name",
+            "value": {
+              "stringValue": "test-namespace"
+            }
+          },
+          {
+            "key": "k8s.namespace.labels.purpose",
+            "value": {
+              "stringValue": "testing"
+            }
+          },
+          {
+            "key": "k8s.namespace.name",
+            "value": {
+              "stringValue": "test-namespace"
+            }
+          },
+          {
+            "key": "k8s.pod.annotations.test-annotation",
+            "value": {
+              "stringValue": "test-value"
+            }
+          },
+          {
+            "key": "k8s.pod.labels.app",
+            "value": {
+              "stringValue": "test-pod"
+            }
+          },
+          {
+            "key": "k8s.pod.name",
+            "value": {
+              "stringValue": "test-pod"
+            }
+          },
+          {
+            "key": "k8s.pod.uid",
+            "value": {
+              "stringValue": "cfac3fff-7602-4a02-86c2-73c6a6316db5"
+            }
+          },
+          {
+            "key": "net.host.name",
+            "value": {
+              "stringValue": "test-node"
+            }
+          },
+          {
+            "key": "net.host.port",
+            "value": {
+              "stringValue": ""
+            }
+          },
+          {
+            "key": "service.instance.id",
+            "value": {
+              "stringValue": "test-node"
+            }
+          },
+          {
+            "key": "sw.k8s.agent.app.version",
+            "value": {
+              "stringValue": "0.5.0"
+            }
+          },
+          {
+            "key": "sw.k8s.agent.manifest.version",
+            "value": {
+              "stringValue": "2.3.0-alpha.6"
+            }
+          },
+          {
+            "key": "sw.k8s.cluster.uid",
+            "value": {
+              "stringValue": "cluster-uid-123456789"
+            }
+          }
+        ]
+      },
+      "scopeMetrics": [
+        {
+          "metrics": [
+            {
+              "gauge": {
+                "dataPoints": [
+                  {
+                    "asDouble": 1675771430,
+                    "attributes": [
+                      {
+                        "key": "endpoint",
+                        "value": {
+                          "stringValue": "http"
+                        }
+                      },
+                      {
+                        "key": "prometheus",
+                        "value": {
+                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
+                        }
+                      },
+                      {
+                        "key": "prometheus_replica",
+                        "value": {
+                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
+                        }
+                      }
+                    ],
+                    "timeUnixNano": "0"
+                  }
+                ]
+              },
+              "name": "k8s.kube_pod_created"
+            },
+            {
+              "gauge": {
+                "dataPoints": [
+                  {
+                    "asDouble": 1,
+                    "attributes": [
+                      {
+                        "key": "endpoint",
+                        "value": {
+                          "stringValue": "http"
+                        }
+                      },
+                      {
+                        "key": "owner_is_controller",
+                        "value": {
+                          "stringValue": "true"
+                        }
+                      },
+                      {
+                        "key": "owner_kind",
+                        "value": {
+                          "stringValue": "ReplicaSet"
+                        }
+                      },
+                      {
+                        "key": "owner_name",
+                        "value": {
+                          "stringValue": "calico-apiserver-54689b9f68"
+                        }
+                      },
+                      {
+                        "key": "prometheus",
+                        "value": {
+                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
+                        }
+                      },
+                      {
+                        "key": "prometheus_replica",
+                        "value": {
+                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
+                        }
+                      }
+                    ],
+                    "timeUnixNano": "0"
+                  }
+                ]
+              },
+              "name": "k8s.kube_pod_owner"
+            },
+            {
+              "gauge": {
+                "dataPoints": [
+                  {
+                    "asDouble": 1675771430,
+                    "attributes": [
+                      {
+                        "key": "endpoint",
+                        "value": {
+                          "stringValue": "http"
+                        }
+                      },
+                      {
+                        "key": "prometheus",
+                        "value": {
+                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
+                        }
+                      },
+                      {
+                        "key": "prometheus_replica",
+                        "value": {
+                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
+                        }
+                      }
+                    ],
+                    "timeUnixNano": "0"
+                  }
+                ]
+              },
+              "name": "k8s.kube_pod_start_time"
+            }
+          ],
+          "scope": {}
+        }
+      ]
+    },
+    {
+      "resource": {
+        "attributes": [
+          {
+            "key": "http.scheme",
+            "value": {
+              "stringValue": "http"
+            }
+          },
+          {
+            "key": "k8s.cluster.name",
+            "value": {
+              "stringValue": "cluster name"
+            }
+          },
+          {
+            "key": "k8s.namespace.annotations.description",
+            "value": {
+              "stringValue": "This is a test namespace."
+            }
+          },
+          {
+            "key": "k8s.namespace.labels.app",
+            "value": {
+              "stringValue": "test-app"
+            }
+          },
+          {
+            "key": "k8s.namespace.labels.kubernetes.io/metadata.name",
+            "value": {
+              "stringValue": "test-namespace"
+            }
+          },
+          {
+            "key": "k8s.namespace.labels.purpose",
+            "value": {
+              "stringValue": "testing"
+            }
+          },
+          {
+            "key": "k8s.namespace.name",
+            "value": {
+              "stringValue": "test-namespace"
+            }
+          },
+          {
+            "key": "k8s.pod.annotations.test-annotation",
+            "value": {
+              "stringValue": "test-value"
+            }
+          },
+          {
+            "key": "k8s.pod.labels.app",
+            "value": {
+              "stringValue": "test-pod"
+            }
+          },
+          {
+            "key": "k8s.pod.name",
+            "value": {
+              "stringValue": "test-pod"
+            }
+          },
+          {
+            "key": "k8s.pod.uid",
+            "value": {
+              "stringValue": "f97c5cef-d9f0-4455-869c-d2be4e51546f"
+            }
+          },
+          {
+            "key": "net.host.name",
+            "value": {
+              "stringValue": "test-node"
+            }
+          },
+          {
+            "key": "net.host.port",
+            "value": {
+              "stringValue": ""
+            }
+          },
+          {
+            "key": "service.instance.id",
+            "value": {
+              "stringValue": "test-node"
+            }
+          },
+          {
+            "key": "sw.k8s.agent.app.version",
+            "value": {
+              "stringValue": "0.5.0"
+            }
+          },
+          {
+            "key": "sw.k8s.agent.manifest.version",
+            "value": {
+              "stringValue": "2.3.0-alpha.6"
+            }
+          },
+          {
+            "key": "sw.k8s.cluster.uid",
+            "value": {
+              "stringValue": "cluster-uid-123456789"
+            }
+          }
+        ]
+      },
+      "scopeMetrics": [
+        {
+          "metrics": [
+            {
+              "gauge": {
+                "dataPoints": [
+                  {
+                    "asDouble": 0,
+                    "attributes": [
+                      {
+                        "key": "condition",
+                        "value": {
+                          "stringValue": "unknown"
+                        }
+                      },
+                      {
+                        "key": "endpoint",
+                        "value": {
+                          "stringValue": "http"
+                        }
+                      },
+                      {
+                        "key": "prometheus",
+                        "value": {
+                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
+                        }
+                      },
+                      {
+                        "key": "prometheus_replica",
+                        "value": {
+                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
+                        }
+                      }
+                    ],
+                    "timeUnixNano": "0"
+                  }
+                ]
+              },
+              "name": "k8s.kube_pod_status_ready"
             }
           ],
           "scope": {}

--- a/tests/integration/test_utils.py
+++ b/tests/integration/test_utils.py
@@ -79,7 +79,7 @@ def sort_attributes(element):
 def replace_uid_attributes(element):
     if "attributes" in element:
         for attribute in element["attributes"]:
-            if re.match(r"^.*(pod|deployment|statefulset|replicaset|daemonset|job|cronjob|node)\.uid$", attribute["key"]):
+            if re.match(r"^.*(deployment|statefulset|replicaset|daemonset|job|cronjob|node)\.uid$", attribute["key"]):
                 attribute["value"]["stringValue"] = "00000000-0000-0000-0000-000000000000"
 
 def sort_datapoints(metric):
@@ -114,8 +114,8 @@ def get_merged_json(content):
 
     # Sort the result and set timeStamps to 0 to make it easier to compare
     for resource in result["resourceMetrics"]:
-        sort_attributes(resource["resource"])
         replace_uid_attributes(resource["resource"])
+        sort_attributes(resource["resource"])
         for scope in resource["scopeMetrics"]:
             scope["metrics"] = sorted(
                 scope["metrics"], key=lambda m: m["name"])

--- a/tests/integration/test_utils.py
+++ b/tests/integration/test_utils.py
@@ -76,12 +76,6 @@ def sort_attributes(element):
         element["attributes"] = sorted(
             element["attributes"], key=lambda a: a["key"])
 
-def replace_uid_attributes(element):
-    if "attributes" in element:
-        for attribute in element["attributes"]:
-            if re.match(r"^.*(deployment|statefulset|replicaset|daemonset|job|cronjob|node)\.uid$", attribute["key"]):
-                attribute["value"]["stringValue"] = "00000000-0000-0000-0000-000000000000"
-
 def sort_datapoints(metric):
     def datapoint_sorting_key(datapoint):
         if "attributes" in datapoint:
@@ -114,7 +108,6 @@ def get_merged_json(content):
 
     # Sort the result and set timeStamps to 0 to make it easier to compare
     for resource in result["resourceMetrics"]:
-        replace_uid_attributes(resource["resource"])
         sort_attributes(resource["resource"])
         for scope in resource["scopeMetrics"]:
             scope["metrics"] = sorted(

--- a/tests/integration/test_utils.py
+++ b/tests/integration/test_utils.py
@@ -3,6 +3,7 @@ import time
 import requests
 import traceback
 from jsonmerge import merge
+import re
 
 def get_all_bodies(log_bulk):
     result = [records["body"]["stringValue"]
@@ -75,6 +76,11 @@ def sort_attributes(element):
         element["attributes"] = sorted(
             element["attributes"], key=lambda a: a["key"])
 
+def replace_uid_attributes(element):
+    if "attributes" in element:
+        for attribute in element["attributes"]:
+            if re.match(r"^.*(pod|deployment|statefulset|replicaset|daemonset|job|cronjob|node)\.uid$", attribute["key"]):
+                attribute["value"]["stringValue"] = "00000000-0000-0000-0000-000000000000"
 
 def sort_datapoints(metric):
     def datapoint_sorting_key(datapoint):
@@ -109,6 +115,7 @@ def get_merged_json(content):
     # Sort the result and set timeStamps to 0 to make it easier to compare
     for resource in result["resourceMetrics"]:
         sort_attributes(resource["resource"])
+        replace_uid_attributes(resource["resource"])
         for scope in resource["scopeMetrics"]:
             scope["metrics"] = sorted(
                 scope["metrics"], key=lambda m: m["name"])


### PR DESCRIPTION
Dependent on https://github.com/solarwinds/swi-k8s-opentelemetry-collector/pull/243 as the image will be released after its merging.

* UID attributes are removed from expected outcome of integration test, as they are extracted from real resource and they will be different in each environment
* releasing `2.3.0-alpha.6` as part of this
