### PR TITLE
NH-36860: Fixing calculation of `k8s.pod.spec.memory.limit`

### DIFF
--- a/deploy/helm/CHANGELOG.md
+++ b/deploy/helm/CHANGELOG.md
@@ -11,6 +11,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Enabled honor_labels option to keep scraped data over server-side labels
 
+### Fixed
+- Fixed calculation of `k8s.pod.spec.memory.limit` on newer container runtime (no longer use `container_spec_memory_limit_bytes`, but `kube_pod_container_resource_limits`)
+
 ## [2.3.0-alpha.4] - 2023-03-29
 
 ### Added

--- a/deploy/helm/metrics-collector-config.yaml
+++ b/deploy/helm/metrics-collector-config.yaml
@@ -335,11 +335,10 @@ processors:
         experimental_match_labels: { "resource": "cpu" }
         action: insert
         new_name: k8s.container.spec.cpu.requests
-      - include: k8s.container_spec_memory_limit_bytes
+      - include: k8s.kube_pod_container_resource_limits
         action: insert
         match_type: regexp
-        # take datapoints with non-empty container label
-        experimental_match_labels: { "container": "\\S+" }
+        experimental_match_labels: { "resource": "memory" }
         new_name: k8s.container.spec.memory.limit_temp
 
       # Pod resource metrics

--- a/tests/integration/expected_output.json
+++ b/tests/integration/expected_output.json
@@ -11209,7 +11209,7 @@
               "gauge": {
                 "dataPoints": [
                   {
-                    "asDouble": 2684354560,
+                    "asDouble": 2952790016,
                     "timeUnixNano": "0"
                   }
                 ]


### PR DESCRIPTION
no longer use `container_spec_memory_limit_bytes` provided by container runtime, but `kube_pod_container_resource_limits` which use KubeAPI