### PR TITLE
NH-39357 [Security][swi-k8s-opentelemetry-collector][Docker Scout] CVE-2023-28840 moby

### DIFF
--- a/build/swi-k8s-opentelemetry-collector.yaml
+++ b/build/swi-k8s-opentelemetry-collector.yaml
@@ -34,3 +34,8 @@ extensions:
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/extension/storage v0.73.0
     import: "github.com/open-telemetry/opentelemetry-collector-contrib/extension/storage/filestorage"
   - gomod: go.opentelemetry.io/collector/extension/ballastextension v0.73.0
+
+replaces:
+  - github.com/docker/docker => github.com/docker/docker v23.0.4+incompatible
+  - github.com/aws/aws-sdk-go => github.com/aws/aws-sdk-go v1.44.249
+  - github.com/prometheus/prometheus => github.com/prometheus/prometheus v0.43.0


### PR DESCRIPTION
Fixing: 
* [CVE-2023-28840⁠](https://dso.docker.com/cve/CVE-2023-28840)
* [CVE-2020-8911⁠](https://dso.docker.com/cve/CVE-2020-8911)
* [CVE-2020-8912⁠](https://dso.docker.com/cve/CVE-2020-8912)
* [CVE-2019-3826⁠](https://dso.docker.com/cve/CVE-2019-3826)

Those are fixed in OTEL 0.76.0, but that version is not yet released so patching this manually
