### PR TITLE
NH-35637: k8s.kube_pod_status_phase is send with value 0

### DIFF
--- a/.github/workflows/buildAndDeploy.yml
+++ b/.github/workflows/buildAndDeploy.yml
@@ -212,6 +212,10 @@ jobs:
         run: |
           kubectl create job --from=cronjob/helm-autoupdate helm-autoupdate-manual-trigger -n swo-k8s-collector
           kubectl wait --for=condition=complete --timeout=300s job/helm-autoupdate-manual-trigger -n swo-k8s-collector
+
+      - name: Trigger helm-autoupdate CronJob logs
+        if: ${{ always() }}
+        run: |
           kubectl logs jobs/helm-autoupdate-manual-trigger -n swo-k8s-collector --all-containers=true
 
   deploy_dockerhub:

--- a/.github/workflows/buildAndDeploy.yml
+++ b/.github/workflows/buildAndDeploy.yml
@@ -199,7 +199,10 @@ jobs:
             --set autoupdate.enabled=true \
             --set autoupdate.devel=true \
             --set otel.metrics.swi_endpoint_check=false \
-            --set otel.metrics.prometheus_check=false
+            --set otel.metrics.prometheus_check=false \
+            --set otel.metrics.resources.requests.memory=100Mi \
+            --set otel.events.resources.requests.memory=100Mi \
+            --set otel.logs.resources.requests.memory=100Mi
 
       - name: Update AutoUpdate ConfigMap to use local Helm repository
         run: |

--- a/src/processor/swmetricstransformprocessor/metrics_testcase_builder_test.go
+++ b/src/processor/swmetricstransformprocessor/metrics_testcase_builder_test.go
@@ -52,6 +52,12 @@ func metricBuilder(metricType pmetric.MetricType, name string, attrs ...string) 
 	}
 }
 
+func (b builder) addFlagDatapoint(start, ts pcommon.Timestamp, val pmetric.DataPointFlags, attrValues ...string) builder {
+	dp := b.addNumberDatapoint(start, ts, attrValues)
+	dp.SetFlags(val)
+	return b
+}
+
 func (b builder) addIntDatapoint(start, ts pcommon.Timestamp, val int64, attrValues ...string) builder {
 	dp := b.addNumberDatapoint(start, ts, attrValues)
 	dp.SetIntValue(val)

--- a/src/processor/swmetricstransformprocessor/operation_filter_datapoints.go
+++ b/src/processor/swmetricstransformprocessor/operation_filter_datapoints.go
@@ -39,7 +39,8 @@ func filterDataPoints(metric pmetric.Metric, mtpOp internalOperation) {
 				return !includeDataPoint(dp.DoubleValue(), mtpOp.configOperation.DataPointValue, action)
 			}
 
-			return false
+			// if double or int value is not found, consider value to be zero
+			return !includeDataPoint(0, mtpOp.configOperation.DataPointValue, action)
 		})
 	}
 }

--- a/src/processor/swmetricstransformprocessor/processor_testcases_test.go
+++ b/src/processor/swmetricstransformprocessor/processor_testcases_test.go
@@ -742,6 +742,29 @@ var (
 			},
 		},
 		{
+			name: "filter_datapoints_include_flag_datapoints",
+			transforms: []internalTransform{
+				{
+					MetricIncludeFilter: internalFilterStrict{include: "metric"},
+					Action:              Update,
+					Operations: []internalOperation{
+						{
+							configOperation: Operation{
+								Action:               FilterDataPoints,
+								DataPointValue:       1,
+								DataPointValueAction: Include,
+							},
+						},
+					},
+				},
+			},
+			in: []pmetric.Metric{
+				metricBuilder(pmetric.MetricTypeGauge, "metric", "label1", "label2").
+					addFlagDatapoint(1, 2, 1, "label1value2", "label2value").build(),
+			},
+			out: []pmetric.Metric{},
+		},
+		{
 			name: "filter_datapoints_exclude",
 			transforms: []internalTransform{
 				{
@@ -766,6 +789,32 @@ var (
 			out: []pmetric.Metric{
 				metricBuilder(pmetric.MetricTypeGauge, "metric", "label1", "label2").
 					addIntDatapoint(1, 2, 0, "label1value2", "label2value").build(),
+			},
+		},
+		{
+			name: "filter_datapoints_exclude_flag_datapoints",
+			transforms: []internalTransform{
+				{
+					MetricIncludeFilter: internalFilterStrict{include: "metric"},
+					Action:              Update,
+					Operations: []internalOperation{
+						{
+							configOperation: Operation{
+								Action:               FilterDataPoints,
+								DataPointValue:       1,
+								DataPointValueAction: Exclude,
+							},
+						},
+					},
+				},
+			},
+			in: []pmetric.Metric{
+				metricBuilder(pmetric.MetricTypeGauge, "metric", "label1", "label2").
+					addFlagDatapoint(1, 2, 1, "label1value2", "label2value").build(),
+			},
+			out: []pmetric.Metric{
+				metricBuilder(pmetric.MetricTypeGauge, "metric", "label1", "label2").
+					addFlagDatapoint(1, 2, 1, "label1value2", "label2value").build(),
 			},
 		},
 	}


### PR DESCRIPTION
https://swicloud.atlassian.net/browse/NH-35637

sometimes the datapoint does not have any value, but just flag. Something like this:
```
"dataPoints": [
    { "timeUnixNano": "1683187000677000000", "flags": 1 }
]
```
where flag=1 just indicates that there is no value. Our filterDatapoints didn't count with datapoints without value.