### PR TITLE
NH-40779 patching dependencies

### DIFF
--- a/build/swi-k8s-opentelemetry-collector.yaml
+++ b/build/swi-k8s-opentelemetry-collector.yaml
@@ -39,3 +39,4 @@ replaces:
   - github.com/docker/docker => github.com/docker/docker v23.0.4+incompatible
   - github.com/aws/aws-sdk-go => github.com/aws/aws-sdk-go v1.44.249
   - github.com/prometheus/prometheus => github.com/prometheus/prometheus v0.43.0
+  - google.golang.org/protobuf => google.golang.org/protobuf v1.29.1


### PR DESCRIPTION
increasing protobuf version because of security issue (we can also increase otel collector version, but there are breaking changes, so there is separate task for it)