### PR TITLE
NH-41723: Updating image with forwardconnector

### DIFF
--- a/build/docker/structure-test.yaml
+++ b/build/docker/structure-test.yaml
@@ -18,4 +18,4 @@ commandTests:
   - name: "swi-otelcol is working in the image"
     command: "/swi-otelcol"
     args: ["-v"]
-    expectedOutput: ["swi-k8s-opentelemetry-collector version 0.5.1"]
+    expectedOutput: ["swi-k8s-opentelemetry-collector version 0.6.0"]

--- a/build/swi-k8s-opentelemetry-collector.yaml
+++ b/build/swi-k8s-opentelemetry-collector.yaml
@@ -2,9 +2,12 @@ dist:
   name: swi-k8s-opentelemetry-collector
   description: "SolarWinds distribution for OpenTelemetry"
   otelcol_version: "0.73.0"
-  version: "0.5.1"
+  version: "0.6.0"
 exporters:
   - gomod: go.opentelemetry.io/collector/exporter/otlpexporter v0.73.0
+
+connectors:
+  - gomod: go.opentelemetry.io/collector/connector/forwardconnector v0.73.0
 
 receivers:
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver v0.73.0


### PR DESCRIPTION
this is needed to connect two pipelines. This is required for https://github.com/solarwinds/swi-k8s-opentelemetry-collector/pull/292
