### PR TITLE
NH-40558: Adding PV and PVC labels/annotations instrumentation

### DIFF
--- a/build/docker/structure-test.yaml
+++ b/build/docker/structure-test.yaml
@@ -18,4 +18,4 @@ commandTests:
   - name: "swi-otelcol is working in the image"
     command: "/swi-otelcol"
     args: ["-v"]
-    expectedOutput: ["swi-k8s-opentelemetry-collector version 0.6.0"]
+    expectedOutput: ["swi-k8s-opentelemetry-collector version 0.7.0"]

--- a/build/swi-k8s-opentelemetry-collector.yaml
+++ b/build/swi-k8s-opentelemetry-collector.yaml
@@ -2,7 +2,7 @@ dist:
   name: swi-k8s-opentelemetry-collector
   description: "SolarWinds distribution for OpenTelemetry"
   otelcol_version: "0.73.0"
-  version: "0.6.0"
+  version: "0.7.0"
 exporters:
   - gomod: go.opentelemetry.io/collector/exporter/otlpexporter v0.73.0
 

--- a/src/processor/k8sattributesprocessor/config.go
+++ b/src/processor/k8sattributesprocessor/config.go
@@ -70,6 +70,12 @@ type Config struct {
 
 	// Section allows to define rules for extracting annotations and labels from Node
 	Node NodeConfig `mapstructure:"node"`
+
+	// Section allows to define rules for extracting annotations and labels from Persistent Volumes
+	PersistentVolume PersistentVolumeConfig `mapstructure:"persistentvolume"`
+
+	// Section allows to define rules for extracting annotations and labels from Persistent Volume Claims
+	PersistentVolumeClaim PersistentVolumeClaimConfig `mapstructure:"persistentvolumeclaim"`
 }
 
 func (cfg *Config) Validate() error {
@@ -108,6 +114,14 @@ func (cfg *Config) Validate() error {
 	}
 
 	if err := cfg.Node.Validate(); err != nil {
+		return err
+	}
+
+	if err := cfg.PersistentVolume.Validate(); err != nil {
+		return err
+	}
+
+	if err := cfg.PersistentVolumeClaim.Validate(); err != nil {
 		return err
 	}
 
@@ -209,6 +223,30 @@ type NodeConfig struct {
 }
 
 func (cfg *NodeConfig) Validate() error {
+	return validateAssociation(cfg.Association)
+}
+
+// PersistentVolumeConfig defines configuration for Persistent Volume.
+type PersistentVolumeConfig struct {
+	Extract     ExtractConfig                 `mapstructure:"extract"`
+	Filter      FilterConfig                  `mapstructure:"filter"`
+	Exclude     ExcludePersistentVolumeConfig `mapstructure:"exclude"`
+	Association []AssociationConfig           `mapstructure:"association"`
+}
+
+func (cfg *PersistentVolumeConfig) Validate() error {
+	return validateAssociation(cfg.Association)
+}
+
+// PersistentVolumeClaimConfig defines configuration for Persistent Volume Claim.
+type PersistentVolumeClaimConfig struct {
+	Extract     ExtractConfig                      `mapstructure:"extract"`
+	Filter      FilterConfig                       `mapstructure:"filter"`
+	Exclude     ExcludePersistentVolumeClaimConfig `mapstructure:"exclude"`
+	Association []AssociationConfig                `mapstructure:"association"`
+}
+
+func (cfg *PersistentVolumeClaimConfig) Validate() error {
 	return validateAssociation(cfg.Association)
 }
 
@@ -456,6 +494,14 @@ type ExcludeCronJobConfig struct {
 // ExcludeNodeConfig represent a list of Node to exclude
 type ExcludeNodeConfig struct {
 	Nodes []ExcludePodConfig `mapstructure:"nodes"`
+}
+
+type ExcludePersistentVolumeConfig struct {
+	PVs []ExcludePodConfig `mapstructure:"pvs"`
+}
+
+type ExcludePersistentVolumeClaimConfig struct {
+	PVCs []ExcludePodConfig `mapstructure:"pvcs"`
 }
 
 // ExcludePodConfig represent a Pod name to ignore

--- a/src/processor/k8sattributesprocessor/config_test.go
+++ b/src/processor/k8sattributesprocessor/config_test.go
@@ -284,6 +284,52 @@ func TestLoadConfig(t *testing.T) {
 						},
 					},
 				},
+				PersistentVolume: PersistentVolumeConfig{
+					Extract: ExtractConfig{
+						Metadata: []string{"k8s.persistentvolume.uid"},
+						Annotations: []FieldExtractConfig{
+							{TagName: "k8s.persistentvolume.annotations.$$1", KeyRegex: "(.*)", From: kube.MetadataFromPersistentVolume},
+						},
+						Labels: []FieldExtractConfig{
+							{TagName: "k8s.persistentvolume.labels.$$1", KeyRegex: "(.*)", From: kube.MetadataFromPersistentVolume},
+						},
+					},
+					Association: []AssociationConfig{
+						{
+							Sources: []AssociationSourceConfig{
+								{
+									From: "resource_attribute",
+									Name: "k8s.persistentvolume.name",
+								},
+							},
+						},
+					},
+				},
+				PersistentVolumeClaim: PersistentVolumeClaimConfig{
+					Extract: ExtractConfig{
+						Metadata: []string{"k8s.persistentvolumeclaim.uid"},
+						Annotations: []FieldExtractConfig{
+							{TagName: "k8s.persistentvolumeclaim.annotations.$$1", KeyRegex: "(.*)", From: kube.MetadataFromPersistentVolumeClaim},
+						},
+						Labels: []FieldExtractConfig{
+							{TagName: "k8s.persistentvolumeclaim.labels.$$1", KeyRegex: "(.*)", From: kube.MetadataFromPersistentVolumeClaim},
+						},
+					},
+					Association: []AssociationConfig{
+						{
+							Sources: []AssociationSourceConfig{
+								{
+									From: "resource_attribute",
+									Name: "k8s.persistentvolumeclaim.name",
+								},
+								{
+									From: "resource_attribute",
+									Name: "k8s.namespace.name",
+								},
+							},
+						},
+					},
+				},
 				Exclude: ExcludeConfig{
 					Pods: []ExcludePodConfig{
 						{Name: "jaeger-agent"},

--- a/src/processor/k8sattributesprocessor/factory.go
+++ b/src/processor/k8sattributesprocessor/factory.go
@@ -223,6 +223,8 @@ func createProcessorOpts(cfg component.Config) []option {
 	opts = append(opts, createJobProcessorOpts(oCfg.Job)...)
 	opts = append(opts, createCronJobProcessorOpts(oCfg.CronJob)...)
 	opts = append(opts, createNodeProcessorOpts(oCfg.Node)...)
+	opts = append(opts, createPersistentVolumeProcessorOpts(oCfg.PersistentVolume)...)
+	opts = append(opts, createPersistentVolumeClaimProcessorOpts(oCfg.PersistentVolumeClaim)...)
 	return opts
 }
 

--- a/src/processor/k8sattributesprocessor/factory_resource.go
+++ b/src/processor/k8sattributesprocessor/factory_resource.go
@@ -127,3 +127,35 @@ func createNodeProcessorOpts(nodeConfig NodeConfig) []option {
 
 	return opts
 }
+
+func createPersistentVolumeProcessorOpts(persistentVolumeConfig PersistentVolumeConfig) []option {
+	var opts []option
+
+	opts = append(opts, withResource(kube.MetadataFromPersistentVolume))
+	opts = append(opts, withExtractMetadataPersistentVolumes(persistentVolumeConfig.Extract.Metadata...))
+	opts = append(opts, withExtractLabelsGeneric(kube.MetadataFromPersistentVolume, persistentVolumeConfig.Extract.Labels...))
+	opts = append(opts, withExtractAnnotationsGeneric(kube.MetadataFromPersistentVolume, persistentVolumeConfig.Extract.Annotations...))
+	opts = append(opts, withFilterNamespaceGeneric(kube.MetadataFromPersistentVolume, persistentVolumeConfig.Filter.Namespace))
+	opts = append(opts, withFilterLabelsGeneric(kube.MetadataFromPersistentVolume, persistentVolumeConfig.Filter.Labels...))
+	opts = append(opts, withFilterFieldsGeneric(kube.MetadataFromPersistentVolume, persistentVolumeConfig.Filter.Fields...))
+	opts = append(opts, withExtractAssociationsGeneric(kube.MetadataFromPersistentVolume, persistentVolumeConfig.Association...))
+	opts = append(opts, withExcludesResource(kube.MetadataFromPersistentVolume, persistentVolumeConfig.Exclude.PVs))
+
+	return opts
+}
+
+func createPersistentVolumeClaimProcessorOpts(persistentVolumeClaimConfig PersistentVolumeClaimConfig) []option {
+	var opts []option
+
+	opts = append(opts, withResource(kube.MetadataFromPersistentVolumeClaim))
+	opts = append(opts, withExtractMetadataPersistentVolumeClaims(persistentVolumeClaimConfig.Extract.Metadata...))
+	opts = append(opts, withExtractLabelsGeneric(kube.MetadataFromPersistentVolumeClaim, persistentVolumeClaimConfig.Extract.Labels...))
+	opts = append(opts, withExtractAnnotationsGeneric(kube.MetadataFromPersistentVolumeClaim, persistentVolumeClaimConfig.Extract.Annotations...))
+	opts = append(opts, withFilterNamespaceGeneric(kube.MetadataFromPersistentVolumeClaim, persistentVolumeClaimConfig.Filter.Namespace))
+	opts = append(opts, withFilterLabelsGeneric(kube.MetadataFromPersistentVolumeClaim, persistentVolumeClaimConfig.Filter.Labels...))
+	opts = append(opts, withFilterFieldsGeneric(kube.MetadataFromPersistentVolumeClaim, persistentVolumeClaimConfig.Filter.Fields...))
+	opts = append(opts, withExtractAssociationsGeneric(kube.MetadataFromPersistentVolumeClaim, persistentVolumeClaimConfig.Association...))
+	opts = append(opts, withExcludesResource(kube.MetadataFromPersistentVolumeClaim, persistentVolumeClaimConfig.Exclude.PVCs))
+
+	return opts
+}

--- a/src/processor/k8sattributesprocessor/internal/kube/client_resource.go
+++ b/src/processor/k8sattributesprocessor/internal/kube/client_resource.go
@@ -167,6 +167,40 @@ func NewWatchNodeClient(
 	)
 }
 
+func NewWatchPersistentVolumeClient(
+	client *WatchClient,
+	clientResource *ClientResource) (*WatchResourceClient[KubernetesResource], error) {
+	return NewWatchResourceClient[KubernetesResource](
+		client,
+		clientResource,
+		MetadataFromPersistentVolume,
+		"k8s.persistentvolume.name",
+		"k8s.persistentvolume.uid",
+		observability.RecordPersistentVolumeTableSize,
+		observability.RecordPersistentVolumeAdded,
+		observability.RecordPersistentVolumeUpdated,
+		observability.RecordPersistentVolumeDeleted,
+		newPersistentVolumeSharedInformer,
+	)
+}
+
+func NewWatchPersistentVolumeClaimClient(
+	client *WatchClient,
+	clientResource *ClientResource) (*WatchResourceClient[KubernetesResource], error) {
+	return NewWatchResourceClient[KubernetesResource](
+		client,
+		clientResource,
+		MetadataFromPersistentVolumeClaim,
+		"k8s.persistentvolumeclaim.name",
+		"k8s.persistentvolumeclaim.uid",
+		observability.RecordPersistentVolumeClaimTableSize,
+		observability.RecordPersistentVolumeClaimAdded,
+		observability.RecordPersistentVolumeClaimUpdated,
+		observability.RecordPersistentVolumeClaimDeleted,
+		newPersistentVolumeClaimSharedInformer,
+	)
+}
+
 // New initializes a new k8s Client.
 func NewWatchResourceClient[T KubernetesResource](
 	client *WatchClient,

--- a/src/processor/k8sattributesprocessor/internal/kube/client_test.go
+++ b/src/processor/k8sattributesprocessor/internal/kube/client_test.go
@@ -1385,13 +1385,15 @@ func newTestClientWithRulesAndFilters(t *testing.T, e ExtractionRules, f Filters
 		NewFakeInformer,
 		NewFakeNamespaceInformer,
 		map[string]*ClientResource{
-			MetadataFromDeployment:  newClientResource("k8s.deployment.uid"),
-			MetadataFromStatefulSet: newClientResource("k8s.statefulset.uid"),
-			MetadataFromReplicaSet:  newClientResource("k8s.replicaset.uid"),
-			MetadataFromDaemonSet:   newClientResource("k8s.daemonset.uid"),
-			MetadataFromJob:         newClientResource("k8s.job.uid"),
-			MetadataFromCronJob:     newClientResource("k8s.cronjob.uid"),
-			MetadataFromNode:        newClientResource("k8s.node.uid"),
+			MetadataFromDeployment:            newClientResource("k8s.deployment.uid"),
+			MetadataFromStatefulSet:           newClientResource("k8s.statefulset.uid"),
+			MetadataFromReplicaSet:            newClientResource("k8s.replicaset.uid"),
+			MetadataFromDaemonSet:             newClientResource("k8s.daemonset.uid"),
+			MetadataFromJob:                   newClientResource("k8s.job.uid"),
+			MetadataFromCronJob:               newClientResource("k8s.cronjob.uid"),
+			MetadataFromNode:                  newClientResource("k8s.node.uid"),
+			MetadataFromPersistentVolume:      newClientResource("k8s.persistentvolume.uid"),
+			MetadataFromPersistentVolumeClaim: newClientResource("k8s.persistentvolumeclaim.uid"),
 		})
 	require.NoError(t, err)
 	return c.(*WatchClient), logs

--- a/src/processor/k8sattributesprocessor/internal/kube/informer_resource.go
+++ b/src/processor/k8sattributesprocessor/internal/kube/informer_resource.go
@@ -271,3 +271,71 @@ func nodeInformerWatchFuncWithSelectors(client kubernetes.Interface, ls labels.S
 		return client.CoreV1().Nodes().Watch(context.Background(), opts)
 	}
 }
+
+// Add this new function for Persistent volume
+func newPersistentVolumeSharedInformer(
+	client kubernetes.Interface,
+	namespace string,
+	ls labels.Selector,
+	fs fields.Selector,
+) cache.SharedInformer {
+	informer := cache.NewSharedInformer(
+		&cache.ListWatch{
+			ListFunc:  persistentVolumeInformerListFuncWithSelectors(client, ls, fs),
+			WatchFunc: persistentVolumeInformerWatchFuncWithSelectors(client, ls, fs),
+		},
+		&corev1.PersistentVolume{},
+		watchSyncPeriod,
+	)
+	return informer
+}
+
+func persistentVolumeInformerListFuncWithSelectors(client kubernetes.Interface, ls labels.Selector, fs fields.Selector) cache.ListFunc {
+	return func(opts metav1.ListOptions) (runtime.Object, error) {
+		opts.LabelSelector = ls.String()
+		opts.FieldSelector = fs.String()
+		return client.CoreV1().PersistentVolumes().List(context.Background(), opts)
+	}
+}
+
+func persistentVolumeInformerWatchFuncWithSelectors(client kubernetes.Interface, ls labels.Selector, fs fields.Selector) cache.WatchFunc {
+	return func(opts metav1.ListOptions) (watch.Interface, error) {
+		opts.LabelSelector = ls.String()
+		opts.FieldSelector = fs.String()
+		return client.CoreV1().PersistentVolumes().Watch(context.Background(), opts)
+	}
+}
+
+// Add this new function for Persistent volume
+func newPersistentVolumeClaimSharedInformer(
+	client kubernetes.Interface,
+	namespace string,
+	ls labels.Selector,
+	fs fields.Selector,
+) cache.SharedInformer {
+	informer := cache.NewSharedInformer(
+		&cache.ListWatch{
+			ListFunc:  persistentVolumeClaimInformerListFuncWithSelectors(client, namespace, ls, fs),
+			WatchFunc: persistentVolumeClaimInformerWatchFuncWithSelectors(client, namespace, ls, fs),
+		},
+		&corev1.PersistentVolumeClaim{},
+		watchSyncPeriod,
+	)
+	return informer
+}
+
+func persistentVolumeClaimInformerListFuncWithSelectors(client kubernetes.Interface, namespace string, ls labels.Selector, fs fields.Selector) cache.ListFunc {
+	return func(opts metav1.ListOptions) (runtime.Object, error) {
+		opts.LabelSelector = ls.String()
+		opts.FieldSelector = fs.String()
+		return client.CoreV1().PersistentVolumeClaims(namespace).List(context.Background(), opts)
+	}
+}
+
+func persistentVolumeClaimInformerWatchFuncWithSelectors(client kubernetes.Interface, namespace string, ls labels.Selector, fs fields.Selector) cache.WatchFunc {
+	return func(opts metav1.ListOptions) (watch.Interface, error) {
+		opts.LabelSelector = ls.String()
+		opts.FieldSelector = fs.String()
+		return client.CoreV1().PersistentVolumeClaims(namespace).Watch(context.Background(), opts)
+	}
+}

--- a/src/processor/k8sattributesprocessor/internal/kube/informer_resource_test.go
+++ b/src/processor/k8sattributesprocessor/internal/kube/informer_resource_test.go
@@ -274,6 +274,72 @@ func Test_NodeInformerWatchFuncWithSelectors(t *testing.T) {
 	assert.NotNil(t, obj)
 }
 
+func Test_newPersistentVolumeSharedInformer(t *testing.T) {
+	labelSelector, fieldSelector, err := selectorsFromFilters(Filters{})
+	require.NoError(t, err)
+	client, err := newFakeAPIClientset(k8sconfig.APIConfig{})
+	require.NoError(t, err)
+	informer := newPersistentVolumeSharedInformer(client, "testns", labelSelector, fieldSelector)
+	assert.NotNil(t, informer)
+}
+
+func Test_PersistentVolumeInformerListFuncWithSelectors(t *testing.T) {
+	ls, fs, err := newTestSelectors()
+	assert.NoError(t, err)
+	c, err := newFakeAPIClientset(k8sconfig.APIConfig{})
+	assert.NoError(t, err)
+	listFunc := persistentVolumeInformerListFuncWithSelectors(c, ls, fs)
+	opts := metav1.ListOptions{}
+	obj, err := listFunc(opts)
+	assert.NoError(t, err)
+	assert.NotNil(t, obj)
+}
+
+func Test_PersistentVolumeInformerWatchFuncWithSelectors(t *testing.T) {
+	ls, fs, err := newTestSelectors()
+	assert.NoError(t, err)
+	c, err := newFakeAPIClientset(k8sconfig.APIConfig{})
+	assert.NoError(t, err)
+	watchFunc := persistentVolumeInformerWatchFuncWithSelectors(c, ls, fs)
+	opts := metav1.ListOptions{}
+	obj, err := watchFunc(opts)
+	assert.NoError(t, err)
+	assert.NotNil(t, obj)
+}
+
+func Test_newPersistentVolumeClaimSharedInformer(t *testing.T) {
+	labelSelector, fieldSelector, err := selectorsFromFilters(Filters{})
+	require.NoError(t, err)
+	client, err := newFakeAPIClientset(k8sconfig.APIConfig{})
+	require.NoError(t, err)
+	informer := newPersistentVolumeClaimSharedInformer(client, "testns", labelSelector, fieldSelector)
+	assert.NotNil(t, informer)
+}
+
+func Test_PersistentVolumeClaimInformerListFuncWithSelectors(t *testing.T) {
+	ls, fs, err := newTestSelectors()
+	assert.NoError(t, err)
+	c, err := newFakeAPIClientset(k8sconfig.APIConfig{})
+	assert.NoError(t, err)
+	listFunc := persistentVolumeClaimInformerListFuncWithSelectors(c, "testns", ls, fs)
+	opts := metav1.ListOptions{}
+	obj, err := listFunc(opts)
+	assert.NoError(t, err)
+	assert.NotNil(t, obj)
+}
+
+func Test_PersistentVolumeClaimInformerWatchFuncWithSelectors(t *testing.T) {
+	ls, fs, err := newTestSelectors()
+	assert.NoError(t, err)
+	c, err := newFakeAPIClientset(k8sconfig.APIConfig{})
+	assert.NoError(t, err)
+	watchFunc := persistentVolumeClaimInformerWatchFuncWithSelectors(c, "testns", ls, fs)
+	opts := metav1.ListOptions{}
+	obj, err := watchFunc(opts)
+	assert.NoError(t, err)
+	assert.NotNil(t, obj)
+}
+
 func newTestSelectors() (labels.Selector, fields.Selector, error) {
 	ls, fs, err := selectorsFromFilters(Filters{
 		Fields: []FieldFilter{

--- a/src/processor/k8sattributesprocessor/internal/kube/kube_resource.go
+++ b/src/processor/k8sattributesprocessor/internal/kube/kube_resource.go
@@ -36,6 +36,10 @@ const (
 	MetadataFromCronJob = "cronjob"
 	// MetadataFromNode is used to specify to extract metadata/labels/annotations from node
 	MetadataFromNode = "node"
+	// MetadataFromPersistentVolume is used to specify to extract metadata/labels/annotations from persistent volume
+	MetadataFromPersistentVolume = "persistentvolume"
+	// MetadataFromPersistentVolumeClaim is used to specify to extract metadata/labels/annotations from persistent volume claim
+	MetadataFromPersistentVolumeClaim = "persistentvolumeclaim"
 )
 
 // ClientResource is a generic client for Kubernetes resources

--- a/src/processor/k8sattributesprocessor/internal/observability/observability.go
+++ b/src/processor/k8sattributesprocessor/internal/observability/observability.go
@@ -45,6 +45,41 @@ func init() {
 		viewStatefulSetsAdded,
 		viewStatefulSetsDeleted,
 		viewStatefulSetTableSize,
+
+		viewReplicaSetsUpdated,
+		viewReplicaSetsAdded,
+		viewReplicaSetsDeleted,
+		viewReplicaSetTableSize,
+
+		viewDaemonSetsUpdated,
+		viewDaemonSetsAdded,
+		viewDaemonSetsDeleted,
+		viewDaemonSetTableSize,
+
+		viewJobsUpdated,
+		viewJobsAdded,
+		viewJobsDeleted,
+		viewJobTableSize,
+
+		viewCronJobsUpdated,
+		viewCronJobsAdded,
+		viewCronJobsDeleted,
+		viewCronJobTableSize,
+
+		viewNodesUpdated,
+		viewNodesAdded,
+		viewNodesDeleted,
+		viewNodeTableSize,
+
+		viewPersistentVolumesUpdated,
+		viewPersistentVolumesAdded,
+		viewPersistentVolumesDeleted,
+		viewPersistentVolumeTableSize,
+
+		viewPersistentVolumeClaimsUpdated,
+		viewPersistentVolumeClaimsAdded,
+		viewPersistentVolumeClaimsDeleted,
+		viewPersistentVolumeClaimTableSize,
 	)
 }
 

--- a/src/processor/k8sattributesprocessor/internal/observability/observability_resource.go
+++ b/src/processor/k8sattributesprocessor/internal/observability/observability_resource.go
@@ -63,6 +63,18 @@ var (
 	mNodesAdded    = stats.Int64("otelsvc/k8s/node_added", "Number of node add events received", "1")
 	mNodesDeleted  = stats.Int64("otelsvc/k8s/node_deleted", "Number of node delete events received", "1")
 	mNodeTableSize = stats.Int64("otelsvc/k8s/node_table_size", "Size of table containing node info", "1")
+
+	// Persistent volume metrics
+	mPersistentVolumesUpdated  = stats.Int64("otelsvc/k8s/persistentvolume_updated", "Number of persistentvolume update events received", "1")
+	mPersistentVolumesAdded    = stats.Int64("otelsvc/k8s/persistentvolume_added", "Number of persistentvolume add events received", "1")
+	mPersistentVolumesDeleted  = stats.Int64("otelsvc/k8s/persistentvolume_deleted", "Number of persistentvolume delete events received", "1")
+	mPersistentVolumeTableSize = stats.Int64("otelsvc/k8s/persistentvolume_table_size", "Size of table containing persistentvolume info", "1")
+
+	// Persistent volume claim metrics
+	mPersistentVolumeClaimsUpdated  = stats.Int64("otelsvc/k8s/persistentvolumeclaim_updated", "Number of persistentvolumeclaim update events received", "1")
+	mPersistentVolumeClaimsAdded    = stats.Int64("otelsvc/k8s/persistentvolumeclaim_added", "Number of persistentvolumeclaim add events received", "1")
+	mPersistentVolumeClaimsDeleted  = stats.Int64("otelsvc/k8s/persistentvolumeclaim_deleted", "Number of persistentvolumeclaim delete events received", "1")
+	mPersistentVolumeClaimTableSize = stats.Int64("otelsvc/k8s/persistentvolumeclaim_table_size", "Size of table containing persistentvolumeclaim info", "1")
 )
 
 // RecordDeploymentUpdated increments the metric that records deployment update events received.
@@ -203,6 +215,46 @@ func RecordNodeDeleted() {
 // RecordNodeTableSize stores the size of the node table field in WatchClient
 func RecordNodeTableSize(nodeTableSize int64) {
 	stats.Record(context.Background(), mNodeTableSize.M(nodeTableSize))
+}
+
+// RecordPersistentVolumeUpdated increments the metric that records persistent volume update events received.
+func RecordPersistentVolumeUpdated() {
+	stats.Record(context.Background(), mPersistentVolumesUpdated.M(int64(1)))
+}
+
+// RecordPersistentVolumeAdded increments the metric that records persistent volume add events received.
+func RecordPersistentVolumeAdded() {
+	stats.Record(context.Background(), mPersistentVolumesAdded.M(int64(1)))
+}
+
+// RecordPersistentVolumeDeleted increments the metric that records persistent volume delete events received.
+func RecordPersistentVolumeDeleted() {
+	stats.Record(context.Background(), mPersistentVolumesDeleted.M(int64(1)))
+}
+
+// RecordPersistentVolumeTableSize stores the size of the persistent volume table field in WatchClient
+func RecordPersistentVolumeTableSize(persistentVolumeTableSize int64) {
+	stats.Record(context.Background(), mPersistentVolumeTableSize.M(persistentVolumeTableSize))
+}
+
+// RecordPersistentVolumeClaimUpdated increments the metric that records persistent volume update events received.
+func RecordPersistentVolumeClaimUpdated() {
+	stats.Record(context.Background(), mPersistentVolumeClaimsUpdated.M(int64(1)))
+}
+
+// RecordPersistentVolumeClaimAdded increments the metric that records persistent volume add events received.
+func RecordPersistentVolumeClaimAdded() {
+	stats.Record(context.Background(), mPersistentVolumeClaimsAdded.M(int64(1)))
+}
+
+// RecordPersistentVolumeClaimDeleted increments the metric that records persistent volume delete events received.
+func RecordPersistentVolumeClaimDeleted() {
+	stats.Record(context.Background(), mPersistentVolumeClaimsDeleted.M(int64(1)))
+}
+
+// RecordPersistentVolumeClaimTableSize stores the size of the persistent volume table field in WatchClient
+func RecordPersistentVolumeClaimTableSize(persistentVolumeClaimTableSize int64) {
+	stats.Record(context.Background(), mPersistentVolumeTableSize.M(persistentVolumeClaimTableSize))
 }
 
 // Create views for each metric
@@ -399,5 +451,61 @@ var viewNodeTableSize = &view.View{
 	Name:        mNodeTableSize.Name(),
 	Description: mNodeTableSize.Description(),
 	Measure:     mNodeTableSize,
+	Aggregation: view.LastValue(),
+}
+
+var viewPersistentVolumesUpdated = &view.View{
+	Name:        mPersistentVolumesUpdated.Name(),
+	Description: mPersistentVolumesUpdated.Description(),
+	Measure:     mPersistentVolumesUpdated,
+	Aggregation: view.Sum(),
+}
+
+var viewPersistentVolumesAdded = &view.View{
+	Name:        mPersistentVolumesAdded.Name(),
+	Description: mPersistentVolumesAdded.Description(),
+	Measure:     mPersistentVolumesAdded,
+	Aggregation: view.Sum(),
+}
+
+var viewPersistentVolumesDeleted = &view.View{
+	Name:        mPersistentVolumesDeleted.Name(),
+	Description: mPersistentVolumesDeleted.Description(),
+	Measure:     mPersistentVolumesDeleted,
+	Aggregation: view.Sum(),
+}
+
+var viewPersistentVolumeTableSize = &view.View{
+	Name:        mPersistentVolumeTableSize.Name(),
+	Description: mPersistentVolumeTableSize.Description(),
+	Measure:     mPersistentVolumeTableSize,
+	Aggregation: view.LastValue(),
+}
+
+var viewPersistentVolumeClaimsUpdated = &view.View{
+	Name:        mPersistentVolumeClaimsUpdated.Name(),
+	Description: mPersistentVolumeClaimsUpdated.Description(),
+	Measure:     mPersistentVolumeClaimsUpdated,
+	Aggregation: view.Sum(),
+}
+
+var viewPersistentVolumeClaimsAdded = &view.View{
+	Name:        mPersistentVolumeClaimsAdded.Name(),
+	Description: mPersistentVolumeClaimsAdded.Description(),
+	Measure:     mPersistentVolumeClaimsAdded,
+	Aggregation: view.Sum(),
+}
+
+var viewPersistentVolumeClaimsDeleted = &view.View{
+	Name:        mPersistentVolumeClaimsDeleted.Name(),
+	Description: mPersistentVolumeClaimsDeleted.Description(),
+	Measure:     mPersistentVolumeClaimsDeleted,
+	Aggregation: view.Sum(),
+}
+
+var viewPersistentVolumeClaimTableSize = &view.View{
+	Name:        mPersistentVolumeClaimTableSize.Name(),
+	Description: mPersistentVolumeClaimTableSize.Description(),
+	Measure:     mPersistentVolumeClaimTableSize,
 	Aggregation: view.LastValue(),
 }

--- a/src/processor/k8sattributesprocessor/options.go
+++ b/src/processor/k8sattributesprocessor/options.go
@@ -188,8 +188,12 @@ func extractFieldRules(fieldType string, fields ...FieldExtractConfig) ([]kube.F
 			a.From = kube.MetadataFromCronJob
 		case kube.MetadataFromNode:
 			a.From = kube.MetadataFromNode
+		case kube.MetadataFromPersistentVolume:
+			a.From = kube.MetadataFromPersistentVolume
+		case kube.MetadataFromPersistentVolumeClaim:
+			a.From = kube.MetadataFromPersistentVolumeClaim
 		default:
-			return rules, fmt.Errorf("%s is not a valid choice for From. Must be one of: pod, deployment, statefulset, replicaset, daemonset, job, cronjob, node, namespace", a.From)
+			return rules, fmt.Errorf("%s is not a valid choice for From. Must be one of: pod, deployment, statefulset, replicaset, daemonset, job, cronjob, node, namespace, persistentvolume, persistentvolumeclaim", a.From)
 		}
 
 		if name == "" && a.Key != "" {
@@ -212,6 +216,10 @@ func extractFieldRules(fieldType string, fields ...FieldExtractConfig) ([]kube.F
 				name = fmt.Sprintf("k8s.cronjob.%s.%s", fieldType, a.Key)
 			} else if a.From == kube.MetadataFromNode {
 				name = fmt.Sprintf("k8s.node.%s.%s", fieldType, a.Key)
+			} else if a.From == kube.MetadataFromPersistentVolume {
+				name = fmt.Sprintf("k8s.persistentvolume.%s.%s", fieldType, a.Key)
+			} else if a.From == kube.MetadataFromPersistentVolumeClaim {
+				name = fmt.Sprintf("k8s.persistentvolumeclaim.%s.%s", fieldType, a.Key)
 			}
 		}
 

--- a/src/processor/k8sattributesprocessor/options_resource.go
+++ b/src/processor/k8sattributesprocessor/options_resource.go
@@ -157,6 +157,44 @@ func withExtractMetadataNode(fields ...string) option {
 	}
 }
 
+// withExtractMetadataPersistentVolumes allows specifying options to control extraction of persistent volume metadata.
+// If no fields explicitly provided, all metadata extracted by default.
+func withExtractMetadataPersistentVolumes(fields ...string) option {
+	return func(p *kubernetesprocessor) error {
+		if len(fields) == 0 {
+			fields = []string{}
+		}
+		for _, field := range fields {
+			switch field {
+			case "k8s.persistentvolume.uid":
+				p.resources[kube.MetadataFromPersistentVolume].rules.UID = true
+			default:
+				return fmt.Errorf("\"%s\" is not a supported metadata field", field)
+			}
+		}
+		return nil
+	}
+}
+
+// withExtractMetadataPersistentVolumeClaims allows specifying options to control extraction of persistent volume claim metadata.
+// If no fields explicitly provided, all metadata extracted by default.
+func withExtractMetadataPersistentVolumeClaims(fields ...string) option {
+	return func(p *kubernetesprocessor) error {
+		if len(fields) == 0 {
+			fields = []string{}
+		}
+		for _, field := range fields {
+			switch field {
+			case "k8s.persistentvolumeclaim.uid":
+				p.resources[kube.MetadataFromPersistentVolumeClaim].rules.UID = true
+			default:
+				return fmt.Errorf("\"%s\" is not a supported metadata field", field)
+			}
+		}
+		return nil
+	}
+}
+
 // withExtractResourceAssociations allows specifying options to associate pod metadata with incoming resource
 func withExtractResourceAssociations(resourceType string, resourceAssociations ...AssociationConfig) option {
 	return func(p *kubernetesprocessor) error {

--- a/src/processor/k8sattributesprocessor/processor.go
+++ b/src/processor/k8sattributesprocessor/processor.go
@@ -67,13 +67,15 @@ func (kp *kubernetesprocessor) initKubeClient(logger *zap.Logger, kubeClient kub
 			nil,
 			nil,
 			map[string]*kube.ClientResource{
-				kube.MetadataFromDeployment:  kp.getClientResource(kp.resources[kube.MetadataFromDeployment]),
-				kube.MetadataFromStatefulSet: kp.getClientResource(kp.resources[kube.MetadataFromStatefulSet]),
-				kube.MetadataFromReplicaSet:  kp.getClientResource(kp.resources[kube.MetadataFromReplicaSet]),
-				kube.MetadataFromDaemonSet:   kp.getClientResource(kp.resources[kube.MetadataFromDaemonSet]),
-				kube.MetadataFromJob:         kp.getClientResource(kp.resources[kube.MetadataFromJob]),
-				kube.MetadataFromCronJob:     kp.getClientResource(kp.resources[kube.MetadataFromCronJob]),
-				kube.MetadataFromNode:        kp.getClientResource(kp.resources[kube.MetadataFromNode]),
+				kube.MetadataFromDeployment:            kp.getClientResource(kp.resources[kube.MetadataFromDeployment]),
+				kube.MetadataFromStatefulSet:           kp.getClientResource(kp.resources[kube.MetadataFromStatefulSet]),
+				kube.MetadataFromReplicaSet:            kp.getClientResource(kp.resources[kube.MetadataFromReplicaSet]),
+				kube.MetadataFromDaemonSet:             kp.getClientResource(kp.resources[kube.MetadataFromDaemonSet]),
+				kube.MetadataFromJob:                   kp.getClientResource(kp.resources[kube.MetadataFromJob]),
+				kube.MetadataFromCronJob:               kp.getClientResource(kp.resources[kube.MetadataFromCronJob]),
+				kube.MetadataFromNode:                  kp.getClientResource(kp.resources[kube.MetadataFromNode]),
+				kube.MetadataFromPersistentVolume:      kp.getClientResource(kp.resources[kube.MetadataFromPersistentVolume]),
+				kube.MetadataFromPersistentVolumeClaim: kp.getClientResource(kp.resources[kube.MetadataFromPersistentVolumeClaim]),
 			})
 		if err != nil {
 			return err

--- a/src/processor/k8sattributesprocessor/testdata/config.yaml
+++ b/src/processor/k8sattributesprocessor/testdata/config.yaml
@@ -196,6 +196,42 @@ k8sattributes/2:
       - sources:
           - from: resource_attribute
             name: k8s.node.name
+  
+  persistentvolume:
+      extract:
+        metadata:
+          - k8s.persistentvolume.uid
+        annotations:
+          - key_regex: (.*)
+            tag_name: k8s.persistentvolume.annotations.$$1
+            from: persistentvolume
+        labels:
+          - key_regex: (.*)
+            tag_name: k8s.persistentvolume.labels.$$1
+            from: persistentvolume
+      association:
+      - sources:
+          - from: resource_attribute
+            name: k8s.persistentvolume.name
+
+  persistentvolumeclaim:
+      extract:
+        metadata:
+          - k8s.persistentvolumeclaim.uid
+        annotations:
+          - key_regex: (.*)
+            tag_name: k8s.persistentvolumeclaim.annotations.$$1
+            from: persistentvolumeclaim
+        labels:
+          - key_regex: (.*)
+            tag_name: k8s.persistentvolumeclaim.labels.$$1
+            from: persistentvolumeclaim
+      association:
+      - sources:
+          - from: resource_attribute
+            name: k8s.persistentvolumeclaim.name
+          - from: resource_attribute
+            name: k8s.namespace.name
 
   exclude:
     pods:


### PR DESCRIPTION
* this will be published to Docker hub as 0.7.0 version
* adding `persistentvolume` and `persistentvolumeclaim` sections to k8sattributes processor and adding labels/annotations extractions
* there were forgotten observability metrics so I added them for some other resources