### PR TITLE
NH-39591: Fixing CPU/Memory usage Pod metrics on latest cAdvisor/containerd

### DIFF
--- a/deploy/helm/CHANGELOG.md
+++ b/deploy/helm/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## [2.5.0-alpha.4] - 2023-06-05
+### Fixed
+- Fixed CPU/Memory usage Pod metrics on latest cAdvisor/containerd (not relying on Pod level datapoints, but doing SUM of container datapoints)
+
 ## [2.5.0-alpha.3] - 2023-06-02
 ### Added
 - Added `k8s.kube_pod_spec_volumes_persistentvolumeclaims_info` metric to connect Pod and PVC

--- a/deploy/helm/Chart.yaml
+++ b/deploy/helm/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: swo-k8s-collector
-version: 2.5.0-alpha.3
+version: 2.5.0-alpha.4
 appVersion: "0.7.0"
 description: SolarWinds Kubernetes Integration
 keywords:

--- a/deploy/helm/metrics-collector-config.yaml
+++ b/deploy/helm/metrics-collector-config.yaml
@@ -531,28 +531,36 @@ processors:
       - include: k8s.container_cpu_usage_seconds_total
         action: insert
         match_type: regexp
-        # empty `image` label and non-empty `pod` and `namespace` are datapoints of Pod's CPU usage
-        experimental_match_labels: { "image": "^$", "pod": "\\S+", "namespace": "\\S+" }
+        experimental_match_labels: { "container": "\\S+", "pod": "\\S+", "namespace": "\\S+" }
         new_name: k8s.pod.cpu.usage.seconds.rate
+        operations:
+          - action: aggregate_labels
+            label_set: [pod, namespace, k8s.node.name]
+            aggregation_type: sum
       - include: k8s.container_cpu_usage_seconds_total
         action: insert
         new_name: k8s.container.cpu.usage.seconds.rate
       - include: k8s.container_memory_working_set_bytes
         action: insert
         match_type: regexp
-        # empty `image` label and non-empty `pod` and `namespace` are datapoints of Pod's Memory usage
-        experimental_match_labels: { "image": "^$", "pod": "\\S+", "namespace": "\\S+" }
+        experimental_match_labels: { "container": "\\S+", "pod": "\\S+", "namespace": "\\S+" }
         new_name: k8s.pod.memory.working_set
+        operations:
+          - action: aggregate_labels
+            label_set: [pod, namespace, k8s.node.name]
+            aggregation_type: sum
       - include: k8s.container_spec_cpu_quota
         action: insert
         match_type: regexp
-        # empty `image` label and non-empty `pod` and `namespace` are datapoints of Pod's CPU quota
-        experimental_match_labels: { "image": "^$", "pod": "\\S+", "namespace": "\\S+" }
+        experimental_match_labels: { "container": "\\S+", "pod": "\\S+", "namespace": "\\S+" }
         new_name: k8s.pod.spec.cpu.quota_temp
+        operations:
+          - action: aggregate_labels
+            label_set: [pod, namespace, k8s.node.name]
+            aggregation_type: sum
       - include: k8s.container_spec_cpu_period
         action: insert
         match_type: regexp
-        # empty `image` label and non-empty `pod` and `namespace` are datapoints of Pod's CPU period
         experimental_match_labels: { "image": "^$", "pod": "\\S+", "namespace": "\\S+" }
         new_name: k8s.pod.spec.cpu.period_temp
       - include: k8s.container_network_receive_bytes_total

--- a/tests/integration/expected_output.json
+++ b/tests/integration/expected_output.json
@@ -108,7 +108,7 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "2.5.0-alpha.3"
+              "stringValue": "2.5.0-alpha.4"
             }
           },
           {
@@ -284,7 +284,177 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "2.5.0-alpha.3"
+              "stringValue": "2.5.0-alpha.4"
+            }
+          },
+          {
+            "key": "sw.k8s.cluster.uid",
+            "value": {
+              "stringValue": "cluster-uid-123456789"
+            }
+          },
+          {
+            "key": "sw.k8s.container.init",
+            "value": {
+              "stringValue": "false"
+            }
+          }
+        ]
+      },
+      "scopeMetrics": [
+        {
+          "metrics": [
+            {
+              "gauge": {
+                "dataPoints": [
+                  {
+                    "asDouble": 1,
+                    "attributes": [
+                      {
+                        "key": "endpoint",
+                        "value": {
+                          "stringValue": "http"
+                        }
+                      },
+                      {
+                        "key": "prometheus",
+                        "value": {
+                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
+                        }
+                      },
+                      {
+                        "key": "prometheus_replica",
+                        "value": {
+                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
+                        }
+                      }
+                    ],
+                    "timeUnixNano": "0"
+                  }
+                ]
+              },
+              "name": "k8s.kube_pod_container_info"
+            }
+          ],
+          "scope": {}
+        }
+      ]
+    },
+    {
+      "resource": {
+        "attributes": [
+          {
+            "key": "container.id",
+            "value": {
+              "stringValue": "4e62576bf25921598bb22da4ddc01595c0b3f7c75313b4aa00a701d0c9ef0121"
+            }
+          },
+          {
+            "key": "container.runtime",
+            "value": {
+              "stringValue": "docker"
+            }
+          },
+          {
+            "key": "http.scheme",
+            "value": {
+              "stringValue": "http"
+            }
+          },
+          {
+            "key": "k8s.cluster.name",
+            "value": {
+              "stringValue": "cluster name"
+            }
+          },
+          {
+            "key": "k8s.container.image.id",
+            "value": {
+              "stringValue": "docker-pullable://registry.k8s.io/sig-storage/csi-node-driver-registrar@sha256:a13bff2ed69af0cf4270f0cf47bdedf75a56c095cd95b91195ae6c713a9b1845"
+            }
+          },
+          {
+            "key": "k8s.container.image.name",
+            "value": {
+              "stringValue": "registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.6.2"
+            }
+          },
+          {
+            "key": "k8s.container.name",
+            "value": {
+              "stringValue": "test-container"
+            }
+          },
+          {
+            "key": "k8s.namespace.annotations.description",
+            "value": {
+              "stringValue": "This is a test namespace."
+            }
+          },
+          {
+            "key": "k8s.namespace.labels.app",
+            "value": {
+              "stringValue": "test-app"
+            }
+          },
+          {
+            "key": "k8s.namespace.labels.kubernetes.io/metadata.name",
+            "value": {
+              "stringValue": "test-namespace"
+            }
+          },
+          {
+            "key": "k8s.namespace.labels.purpose",
+            "value": {
+              "stringValue": "testing"
+            }
+          },
+          {
+            "key": "k8s.namespace.name",
+            "value": {
+              "stringValue": "test-namespace"
+            }
+          },
+          {
+            "key": "k8s.pod.name",
+            "value": {
+              "stringValue": "test-pod"
+            }
+          },
+          {
+            "key": "k8s.pod.uid",
+            "value": {
+              "stringValue": "ce71b442-44d6-4e24-a6f9-f234f55929f9"
+            }
+          },
+          {
+            "key": "net.host.name",
+            "value": {
+              "stringValue": "test-node"
+            }
+          },
+          {
+            "key": "net.host.port",
+            "value": {
+              "stringValue": ""
+            }
+          },
+          {
+            "key": "service.instance.id",
+            "value": {
+              "stringValue": "test-node"
+            }
+          },
+          {
+            "key": "sw.k8s.agent.app.version",
+            "value": {
+              "stringValue": "0.7.0"
+            }
+          },
+          {
+            "key": "sw.k8s.agent.manifest.version",
+            "value": {
+              "stringValue": "2.5.0-alpha.4"
             }
           },
           {
@@ -466,7 +636,177 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "2.5.0-alpha.3"
+              "stringValue": "2.5.0-alpha.4"
+            }
+          },
+          {
+            "key": "sw.k8s.cluster.uid",
+            "value": {
+              "stringValue": "cluster-uid-123456789"
+            }
+          },
+          {
+            "key": "sw.k8s.container.init",
+            "value": {
+              "stringValue": "true"
+            }
+          }
+        ]
+      },
+      "scopeMetrics": [
+        {
+          "metrics": [
+            {
+              "gauge": {
+                "dataPoints": [
+                  {
+                    "asDouble": 1,
+                    "attributes": [
+                      {
+                        "key": "endpoint",
+                        "value": {
+                          "stringValue": "http"
+                        }
+                      },
+                      {
+                        "key": "prometheus",
+                        "value": {
+                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
+                        }
+                      },
+                      {
+                        "key": "prometheus_replica",
+                        "value": {
+                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
+                        }
+                      }
+                    ],
+                    "timeUnixNano": "0"
+                  }
+                ]
+              },
+              "name": "k8s.kube_pod_init_container_info"
+            }
+          ],
+          "scope": {}
+        }
+      ]
+    },
+    {
+      "resource": {
+        "attributes": [
+          {
+            "key": "container.id",
+            "value": {
+              "stringValue": "6fb07210b86971939dbfb16ae47f98afdb8214a52a21dd5fc26f21ae35c09d9e"
+            }
+          },
+          {
+            "key": "container.runtime",
+            "value": {
+              "stringValue": "docker"
+            }
+          },
+          {
+            "key": "http.scheme",
+            "value": {
+              "stringValue": "http"
+            }
+          },
+          {
+            "key": "k8s.cluster.name",
+            "value": {
+              "stringValue": "cluster name"
+            }
+          },
+          {
+            "key": "k8s.container.image.id",
+            "value": {
+              "stringValue": "docker-pullable://busybox@sha256:b5d6fe0712636ceb7430189de28819e195e8966372edfc2d9409d79402a0dc16"
+            }
+          },
+          {
+            "key": "k8s.container.image.name",
+            "value": {
+              "stringValue": "busybox:latest"
+            }
+          },
+          {
+            "key": "k8s.container.name",
+            "value": {
+              "stringValue": "test-container"
+            }
+          },
+          {
+            "key": "k8s.namespace.annotations.description",
+            "value": {
+              "stringValue": "This is a test namespace."
+            }
+          },
+          {
+            "key": "k8s.namespace.labels.app",
+            "value": {
+              "stringValue": "test-app"
+            }
+          },
+          {
+            "key": "k8s.namespace.labels.kubernetes.io/metadata.name",
+            "value": {
+              "stringValue": "test-namespace"
+            }
+          },
+          {
+            "key": "k8s.namespace.labels.purpose",
+            "value": {
+              "stringValue": "testing"
+            }
+          },
+          {
+            "key": "k8s.namespace.name",
+            "value": {
+              "stringValue": "test-namespace"
+            }
+          },
+          {
+            "key": "k8s.pod.name",
+            "value": {
+              "stringValue": "test-pod"
+            }
+          },
+          {
+            "key": "k8s.pod.uid",
+            "value": {
+              "stringValue": "bafeef2c-1292-4a5e-a92c-d709480b04b6"
+            }
+          },
+          {
+            "key": "net.host.name",
+            "value": {
+              "stringValue": "test-node"
+            }
+          },
+          {
+            "key": "net.host.port",
+            "value": {
+              "stringValue": ""
+            }
+          },
+          {
+            "key": "service.instance.id",
+            "value": {
+              "stringValue": "test-node"
+            }
+          },
+          {
+            "key": "sw.k8s.agent.app.version",
+            "value": {
+              "stringValue": "0.7.0"
+            }
+          },
+          {
+            "key": "sw.k8s.agent.manifest.version",
+            "value": {
+              "stringValue": "2.5.0-alpha.4"
             }
           },
           {
@@ -648,7 +988,177 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "2.5.0-alpha.3"
+              "stringValue": "2.5.0-alpha.4"
+            }
+          },
+          {
+            "key": "sw.k8s.cluster.uid",
+            "value": {
+              "stringValue": "cluster-uid-123456789"
+            }
+          },
+          {
+            "key": "sw.k8s.container.init",
+            "value": {
+              "stringValue": "false"
+            }
+          }
+        ]
+      },
+      "scopeMetrics": [
+        {
+          "metrics": [
+            {
+              "gauge": {
+                "dataPoints": [
+                  {
+                    "asDouble": 1,
+                    "attributes": [
+                      {
+                        "key": "endpoint",
+                        "value": {
+                          "stringValue": "http"
+                        }
+                      },
+                      {
+                        "key": "prometheus",
+                        "value": {
+                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
+                        }
+                      },
+                      {
+                        "key": "prometheus_replica",
+                        "value": {
+                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
+                        }
+                      }
+                    ],
+                    "timeUnixNano": "0"
+                  }
+                ]
+              },
+              "name": "k8s.kube_pod_container_info"
+            }
+          ],
+          "scope": {}
+        }
+      ]
+    },
+    {
+      "resource": {
+        "attributes": [
+          {
+            "key": "container.id",
+            "value": {
+              "stringValue": "86a84e64dded58918633fc9d1dd89a3f769d25143dd2da4273516d013df5862a"
+            }
+          },
+          {
+            "key": "container.runtime",
+            "value": {
+              "stringValue": "docker"
+            }
+          },
+          {
+            "key": "http.scheme",
+            "value": {
+              "stringValue": "http"
+            }
+          },
+          {
+            "key": "k8s.cluster.name",
+            "value": {
+              "stringValue": "cluster name"
+            }
+          },
+          {
+            "key": "k8s.container.image.id",
+            "value": {
+              "stringValue": "docker-pullable://solarwinds/swi-opentelemetry-collector@sha256:481b2907feabeadd46d4b26048f3f164e20b55c46d12d487b559ace212b287bc"
+            }
+          },
+          {
+            "key": "k8s.container.image.name",
+            "value": {
+              "stringValue": "solarwinds/swi-opentelemetry-collector:0.5.0"
+            }
+          },
+          {
+            "key": "k8s.container.name",
+            "value": {
+              "stringValue": "test-container"
+            }
+          },
+          {
+            "key": "k8s.namespace.annotations.description",
+            "value": {
+              "stringValue": "This is a test namespace."
+            }
+          },
+          {
+            "key": "k8s.namespace.labels.app",
+            "value": {
+              "stringValue": "test-app"
+            }
+          },
+          {
+            "key": "k8s.namespace.labels.kubernetes.io/metadata.name",
+            "value": {
+              "stringValue": "test-namespace"
+            }
+          },
+          {
+            "key": "k8s.namespace.labels.purpose",
+            "value": {
+              "stringValue": "testing"
+            }
+          },
+          {
+            "key": "k8s.namespace.name",
+            "value": {
+              "stringValue": "test-namespace"
+            }
+          },
+          {
+            "key": "k8s.pod.name",
+            "value": {
+              "stringValue": "test-pod"
+            }
+          },
+          {
+            "key": "k8s.pod.uid",
+            "value": {
+              "stringValue": "bafeef2c-1292-4a5e-a92c-d709480b04b6"
+            }
+          },
+          {
+            "key": "net.host.name",
+            "value": {
+              "stringValue": "test-node"
+            }
+          },
+          {
+            "key": "net.host.port",
+            "value": {
+              "stringValue": ""
+            }
+          },
+          {
+            "key": "service.instance.id",
+            "value": {
+              "stringValue": "test-node"
+            }
+          },
+          {
+            "key": "sw.k8s.agent.app.version",
+            "value": {
+              "stringValue": "0.7.0"
+            }
+          },
+          {
+            "key": "sw.k8s.agent.manifest.version",
+            "value": {
+              "stringValue": "2.5.0-alpha.4"
             }
           },
           {
@@ -830,7 +1340,177 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "2.5.0-alpha.3"
+              "stringValue": "2.5.0-alpha.4"
+            }
+          },
+          {
+            "key": "sw.k8s.cluster.uid",
+            "value": {
+              "stringValue": "cluster-uid-123456789"
+            }
+          },
+          {
+            "key": "sw.k8s.container.init",
+            "value": {
+              "stringValue": "true"
+            }
+          }
+        ]
+      },
+      "scopeMetrics": [
+        {
+          "metrics": [
+            {
+              "gauge": {
+                "dataPoints": [
+                  {
+                    "asDouble": 1,
+                    "attributes": [
+                      {
+                        "key": "endpoint",
+                        "value": {
+                          "stringValue": "http"
+                        }
+                      },
+                      {
+                        "key": "prometheus",
+                        "value": {
+                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
+                        }
+                      },
+                      {
+                        "key": "prometheus_replica",
+                        "value": {
+                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
+                        }
+                      }
+                    ],
+                    "timeUnixNano": "0"
+                  }
+                ]
+              },
+              "name": "k8s.kube_pod_init_container_info"
+            }
+          ],
+          "scope": {}
+        }
+      ]
+    },
+    {
+      "resource": {
+        "attributes": [
+          {
+            "key": "container.id",
+            "value": {
+              "stringValue": "f1c98663d614379552d6c9aae831b4eb3e149c469d4d589b62ea077cf3dad807"
+            }
+          },
+          {
+            "key": "container.runtime",
+            "value": {
+              "stringValue": "docker"
+            }
+          },
+          {
+            "key": "http.scheme",
+            "value": {
+              "stringValue": "http"
+            }
+          },
+          {
+            "key": "k8s.cluster.name",
+            "value": {
+              "stringValue": "cluster name"
+            }
+          },
+          {
+            "key": "k8s.container.image.id",
+            "value": {
+              "stringValue": "docker-pullable://busybox@sha256:cb63aa0641a885f54de20f61d152187419e8f6b159ed11a251a09d115fdff9bd"
+            }
+          },
+          {
+            "key": "k8s.container.image.name",
+            "value": {
+              "stringValue": "busybox:1.29.2"
+            }
+          },
+          {
+            "key": "k8s.container.name",
+            "value": {
+              "stringValue": "test-container"
+            }
+          },
+          {
+            "key": "k8s.namespace.annotations.description",
+            "value": {
+              "stringValue": "This is a test namespace."
+            }
+          },
+          {
+            "key": "k8s.namespace.labels.app",
+            "value": {
+              "stringValue": "test-app"
+            }
+          },
+          {
+            "key": "k8s.namespace.labels.kubernetes.io/metadata.name",
+            "value": {
+              "stringValue": "test-namespace"
+            }
+          },
+          {
+            "key": "k8s.namespace.labels.purpose",
+            "value": {
+              "stringValue": "testing"
+            }
+          },
+          {
+            "key": "k8s.namespace.name",
+            "value": {
+              "stringValue": "test-namespace"
+            }
+          },
+          {
+            "key": "k8s.pod.name",
+            "value": {
+              "stringValue": "test-pod"
+            }
+          },
+          {
+            "key": "k8s.pod.uid",
+            "value": {
+              "stringValue": "9cab81cb-9da1-4029-ac51-c7c3024c6fbf"
+            }
+          },
+          {
+            "key": "net.host.name",
+            "value": {
+              "stringValue": "test-node"
+            }
+          },
+          {
+            "key": "net.host.port",
+            "value": {
+              "stringValue": ""
+            }
+          },
+          {
+            "key": "service.instance.id",
+            "value": {
+              "stringValue": "test-node"
+            }
+          },
+          {
+            "key": "sw.k8s.agent.app.version",
+            "value": {
+              "stringValue": "0.7.0"
+            }
+          },
+          {
+            "key": "sw.k8s.agent.manifest.version",
+            "value": {
+              "stringValue": "2.5.0-alpha.4"
             }
           },
           {
@@ -1012,7 +1692,177 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "2.5.0-alpha.3"
+              "stringValue": "2.5.0-alpha.4"
+            }
+          },
+          {
+            "key": "sw.k8s.cluster.uid",
+            "value": {
+              "stringValue": "cluster-uid-123456789"
+            }
+          },
+          {
+            "key": "sw.k8s.container.init",
+            "value": {
+              "stringValue": "true"
+            }
+          }
+        ]
+      },
+      "scopeMetrics": [
+        {
+          "metrics": [
+            {
+              "gauge": {
+                "dataPoints": [
+                  {
+                    "asDouble": 1,
+                    "attributes": [
+                      {
+                        "key": "endpoint",
+                        "value": {
+                          "stringValue": "http"
+                        }
+                      },
+                      {
+                        "key": "prometheus",
+                        "value": {
+                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
+                        }
+                      },
+                      {
+                        "key": "prometheus_replica",
+                        "value": {
+                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
+                        }
+                      }
+                    ],
+                    "timeUnixNano": "0"
+                  }
+                ]
+              },
+              "name": "k8s.kube_pod_init_container_info"
+            }
+          ],
+          "scope": {}
+        }
+      ]
+    },
+    {
+      "resource": {
+        "attributes": [
+          {
+            "key": "container.id",
+            "value": {
+              "stringValue": "f55a97f615b1a90f15f114def871a7d4f0ed8a32d9a329cc7e2f94a24d4780c1"
+            }
+          },
+          {
+            "key": "container.runtime",
+            "value": {
+              "stringValue": "docker"
+            }
+          },
+          {
+            "key": "http.scheme",
+            "value": {
+              "stringValue": "http"
+            }
+          },
+          {
+            "key": "k8s.cluster.name",
+            "value": {
+              "stringValue": "cluster name"
+            }
+          },
+          {
+            "key": "k8s.container.image.id",
+            "value": {
+              "stringValue": "docker-pullable://fullstorydev/grpcurl@sha256:d42ef512419560776bee5bb51e338a1734a0edb99f450b6d98fd98bcc93796f3"
+            }
+          },
+          {
+            "key": "k8s.container.image.name",
+            "value": {
+              "stringValue": "fullstorydev/grpcurl:latest"
+            }
+          },
+          {
+            "key": "k8s.container.name",
+            "value": {
+              "stringValue": "test-container"
+            }
+          },
+          {
+            "key": "k8s.namespace.annotations.description",
+            "value": {
+              "stringValue": "This is a test namespace."
+            }
+          },
+          {
+            "key": "k8s.namespace.labels.app",
+            "value": {
+              "stringValue": "test-app"
+            }
+          },
+          {
+            "key": "k8s.namespace.labels.kubernetes.io/metadata.name",
+            "value": {
+              "stringValue": "test-namespace"
+            }
+          },
+          {
+            "key": "k8s.namespace.labels.purpose",
+            "value": {
+              "stringValue": "testing"
+            }
+          },
+          {
+            "key": "k8s.namespace.name",
+            "value": {
+              "stringValue": "test-namespace"
+            }
+          },
+          {
+            "key": "k8s.pod.name",
+            "value": {
+              "stringValue": "test-pod"
+            }
+          },
+          {
+            "key": "k8s.pod.uid",
+            "value": {
+              "stringValue": "bafeef2c-1292-4a5e-a92c-d709480b04b6"
+            }
+          },
+          {
+            "key": "net.host.name",
+            "value": {
+              "stringValue": "test-node"
+            }
+          },
+          {
+            "key": "net.host.port",
+            "value": {
+              "stringValue": ""
+            }
+          },
+          {
+            "key": "service.instance.id",
+            "value": {
+              "stringValue": "test-node"
+            }
+          },
+          {
+            "key": "sw.k8s.agent.app.version",
+            "value": {
+              "stringValue": "0.7.0"
+            }
+          },
+          {
+            "key": "sw.k8s.agent.manifest.version",
+            "value": {
+              "stringValue": "2.5.0-alpha.4"
             }
           },
           {
@@ -1176,7 +2026,426 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "2.5.0-alpha.3"
+              "stringValue": "2.5.0-alpha.4"
+            }
+          },
+          {
+            "key": "sw.k8s.cluster.uid",
+            "value": {
+              "stringValue": "cluster-uid-123456789"
+            }
+          }
+        ]
+      },
+      "scopeMetrics": [
+        {
+          "metrics": [
+            {
+              "gauge": {
+                "dataPoints": [
+                  {
+                    "asDouble": 0,
+                    "attributes": [
+                      {
+                        "key": "cpu",
+                        "value": {
+                          "stringValue": "total"
+                        }
+                      },
+                      {
+                        "key": "endpoint",
+                        "value": {
+                          "stringValue": "https-metrics"
+                        }
+                      },
+                      {
+                        "key": "id",
+                        "value": {
+                          "stringValue": "/kubepods/burstable/pod03d2b55c-b225-476b-9178-c74f8e5eaba2/b569246357457b8e4212a8e1a655442561648908c07e6343be2df710f0b4b067"
+                        }
+                      },
+                      {
+                        "key": "metrics_path",
+                        "value": {
+                          "stringValue": "/metrics/cadvisor"
+                        }
+                      },
+                      {
+                        "key": "name",
+                        "value": {
+                          "stringValue": "k8s_admin-tools_temporal-admintools-9f5d799c8-7t7jv_temporal-system_03d2b55c-b225-476b-9178-c74f8e5eaba2_0"
+                        }
+                      },
+                      {
+                        "key": "prometheus",
+                        "value": {
+                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
+                        }
+                      },
+                      {
+                        "key": "prometheus_replica",
+                        "value": {
+                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
+                        }
+                      },
+                      {
+                        "key": "service",
+                        "value": {
+                          "stringValue": "test-service"
+                        }
+                      }
+                    ],
+                    "startTimeUnixNano": "0",
+                    "timeUnixNano": "0"
+                  }
+                ]
+              },
+              "name": "k8s.container.cpu.usage.seconds.rate"
+            },
+            {
+              "name": "k8s.container_cpu_usage_seconds_total",
+              "sum": {
+                "aggregationTemporality": 2,
+                "dataPoints": [
+                  {
+                    "asDouble": 430.63580538,
+                    "attributes": [
+                      {
+                        "key": "cpu",
+                        "value": {
+                          "stringValue": "total"
+                        }
+                      },
+                      {
+                        "key": "endpoint",
+                        "value": {
+                          "stringValue": "https-metrics"
+                        }
+                      },
+                      {
+                        "key": "id",
+                        "value": {
+                          "stringValue": "/kubepods/burstable/pod03d2b55c-b225-476b-9178-c74f8e5eaba2/b569246357457b8e4212a8e1a655442561648908c07e6343be2df710f0b4b067"
+                        }
+                      },
+                      {
+                        "key": "metrics_path",
+                        "value": {
+                          "stringValue": "/metrics/cadvisor"
+                        }
+                      },
+                      {
+                        "key": "name",
+                        "value": {
+                          "stringValue": "k8s_admin-tools_temporal-admintools-9f5d799c8-7t7jv_temporal-system_03d2b55c-b225-476b-9178-c74f8e5eaba2_0"
+                        }
+                      },
+                      {
+                        "key": "prometheus",
+                        "value": {
+                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
+                        }
+                      },
+                      {
+                        "key": "prometheus_replica",
+                        "value": {
+                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
+                        }
+                      },
+                      {
+                        "key": "service",
+                        "value": {
+                          "stringValue": "test-service"
+                        }
+                      }
+                    ],
+                    "timeUnixNano": "0"
+                  }
+                ],
+                "isMonotonic": true
+              }
+            },
+            {
+              "gauge": {
+                "dataPoints": [
+                  {
+                    "asDouble": 12288,
+                    "attributes": [
+                      {
+                        "key": "device",
+                        "value": {
+                          "stringValue": "/dev/nvme0n1p1"
+                        }
+                      },
+                      {
+                        "key": "endpoint",
+                        "value": {
+                          "stringValue": "https-metrics"
+                        }
+                      },
+                      {
+                        "key": "id",
+                        "value": {
+                          "stringValue": "/kubepods/burstable/pod03d2b55c-b225-476b-9178-c74f8e5eaba2/b569246357457b8e4212a8e1a655442561648908c07e6343be2df710f0b4b067"
+                        }
+                      },
+                      {
+                        "key": "metrics_path",
+                        "value": {
+                          "stringValue": "/metrics/cadvisor"
+                        }
+                      },
+                      {
+                        "key": "name",
+                        "value": {
+                          "stringValue": "k8s_admin-tools_temporal-admintools-9f5d799c8-7t7jv_temporal-system_03d2b55c-b225-476b-9178-c74f8e5eaba2_0"
+                        }
+                      },
+                      {
+                        "key": "prometheus",
+                        "value": {
+                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
+                        }
+                      },
+                      {
+                        "key": "prometheus_replica",
+                        "value": {
+                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
+                        }
+                      },
+                      {
+                        "key": "service",
+                        "value": {
+                          "stringValue": "test-service"
+                        }
+                      }
+                    ],
+                    "timeUnixNano": "0"
+                  }
+                ]
+              },
+              "name": "k8s.container_fs_usage_bytes"
+            },
+            {
+              "name": "k8s.container_fs_writes_total",
+              "sum": {
+                "aggregationTemporality": 2,
+                "dataPoints": [
+                  {
+                    "asDouble": 0,
+                    "attributes": [
+                      {
+                        "key": "device",
+                        "value": {
+                          "stringValue": "/dev/nvme0n1p1"
+                        }
+                      },
+                      {
+                        "key": "endpoint",
+                        "value": {
+                          "stringValue": "https-metrics"
+                        }
+                      },
+                      {
+                        "key": "id",
+                        "value": {
+                          "stringValue": "/kubepods/burstable/pod03d2b55c-b225-476b-9178-c74f8e5eaba2/b569246357457b8e4212a8e1a655442561648908c07e6343be2df710f0b4b067"
+                        }
+                      },
+                      {
+                        "key": "metrics_path",
+                        "value": {
+                          "stringValue": "/metrics/cadvisor"
+                        }
+                      },
+                      {
+                        "key": "name",
+                        "value": {
+                          "stringValue": "k8s_admin-tools_temporal-admintools-9f5d799c8-7t7jv_temporal-system_03d2b55c-b225-476b-9178-c74f8e5eaba2_0"
+                        }
+                      },
+                      {
+                        "key": "prometheus",
+                        "value": {
+                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
+                        }
+                      },
+                      {
+                        "key": "prometheus_replica",
+                        "value": {
+                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
+                        }
+                      },
+                      {
+                        "key": "service",
+                        "value": {
+                          "stringValue": "test-service"
+                        }
+                      }
+                    ],
+                    "timeUnixNano": "0"
+                  }
+                ],
+                "isMonotonic": true
+              }
+            },
+            {
+              "gauge": {
+                "dataPoints": [
+                  {
+                    "asDouble": 100000,
+                    "attributes": [
+                      {
+                        "key": "endpoint",
+                        "value": {
+                          "stringValue": "https-metrics"
+                        }
+                      },
+                      {
+                        "key": "id",
+                        "value": {
+                          "stringValue": "/kubepods/burstable/pod03d2b55c-b225-476b-9178-c74f8e5eaba2/b569246357457b8e4212a8e1a655442561648908c07e6343be2df710f0b4b067"
+                        }
+                      },
+                      {
+                        "key": "metrics_path",
+                        "value": {
+                          "stringValue": "/metrics/cadvisor"
+                        }
+                      },
+                      {
+                        "key": "name",
+                        "value": {
+                          "stringValue": "k8s_admin-tools_temporal-admintools-9f5d799c8-7t7jv_temporal-system_03d2b55c-b225-476b-9178-c74f8e5eaba2_0"
+                        }
+                      },
+                      {
+                        "key": "prometheus",
+                        "value": {
+                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
+                        }
+                      },
+                      {
+                        "key": "prometheus_replica",
+                        "value": {
+                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
+                        }
+                      },
+                      {
+                        "key": "service",
+                        "value": {
+                          "stringValue": "test-service"
+                        }
+                      }
+                    ],
+                    "timeUnixNano": "0"
+                  }
+                ]
+              },
+              "name": "k8s.container_spec_cpu_period"
+            }
+          ],
+          "scope": {}
+        }
+      ]
+    },
+    {
+      "resource": {
+        "attributes": [
+          {
+            "key": "http.scheme",
+            "value": {
+              "stringValue": "http"
+            }
+          },
+          {
+            "key": "k8s.cluster.name",
+            "value": {
+              "stringValue": "cluster name"
+            }
+          },
+          {
+            "key": "k8s.container.image.name",
+            "value": {
+              "stringValue": "915014598477.dkr.ecr.us-east-1.amazonaws.com/external/docker.io/temporalio/admin-tools@sha256:69e9f218ec37d8ef0ed793e2cc1a73dedbb62f545c9e1b858afffedba36fdd66"
+            }
+          },
+          {
+            "key": "k8s.container.name",
+            "value": {
+              "stringValue": "test-container"
+            }
+          },
+          {
+            "key": "k8s.namespace.annotations.description",
+            "value": {
+              "stringValue": "This is a test namespace."
+            }
+          },
+          {
+            "key": "k8s.namespace.labels.app",
+            "value": {
+              "stringValue": "test-app"
+            }
+          },
+          {
+            "key": "k8s.namespace.labels.kubernetes.io/metadata.name",
+            "value": {
+              "stringValue": "test-namespace"
+            }
+          },
+          {
+            "key": "k8s.namespace.labels.purpose",
+            "value": {
+              "stringValue": "testing"
+            }
+          },
+          {
+            "key": "k8s.namespace.name",
+            "value": {
+              "stringValue": "test-namespace"
+            }
+          },
+          {
+            "key": "k8s.node.name",
+            "value": {
+              "stringValue": "test-node"
+            }
+          },
+          {
+            "key": "k8s.pod.name",
+            "value": {
+              "stringValue": "test-pod"
+            }
+          },
+          {
+            "key": "net.host.name",
+            "value": {
+              "stringValue": "test-node"
+            }
+          },
+          {
+            "key": "net.host.port",
+            "value": {
+              "stringValue": ""
+            }
+          },
+          {
+            "key": "service.instance.id",
+            "value": {
+              "stringValue": "test-node"
+            }
+          },
+          {
+            "key": "sw.k8s.agent.app.version",
+            "value": {
+              "stringValue": "0.7.0"
+            }
+          },
+          {
+            "key": "sw.k8s.agent.manifest.version",
+            "value": {
+              "stringValue": "2.5.0-alpha.4"
             }
           },
           {
@@ -1607,7 +2876,177 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "2.5.0-alpha.3"
+              "stringValue": "2.5.0-alpha.4"
+            }
+          },
+          {
+            "key": "sw.k8s.cluster.uid",
+            "value": {
+              "stringValue": "cluster-uid-123456789"
+            }
+          }
+        ]
+      },
+      "scopeMetrics": [
+        {
+          "metrics": [
+            {
+              "gauge": {
+                "dataPoints": [
+                  {
+                    "asDouble": 42266624,
+                    "attributes": [
+                      {
+                        "key": "endpoint",
+                        "value": {
+                          "stringValue": "https-metrics"
+                        }
+                      },
+                      {
+                        "key": "id",
+                        "value": {
+                          "stringValue": "/kubepods/burstable/podda98d120-3439-4c96-a0ff-a67749a268b5/162dda5dbbea3eb335679b99848024f3e6ce6766709f8724b2128c4c11824d5b"
+                        }
+                      },
+                      {
+                        "key": "metrics_path",
+                        "value": {
+                          "stringValue": "/metrics/cadvisor"
+                        }
+                      },
+                      {
+                        "key": "name",
+                        "value": {
+                          "stringValue": "k8s_temporal-worker_temporal-worker-5f8c4f4b56-w58zb_temporal-system_da98d120-3439-4c96-a0ff-a67749a268b5_0"
+                        }
+                      },
+                      {
+                        "key": "prometheus",
+                        "value": {
+                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
+                        }
+                      },
+                      {
+                        "key": "prometheus_replica",
+                        "value": {
+                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
+                        }
+                      },
+                      {
+                        "key": "service",
+                        "value": {
+                          "stringValue": "test-service"
+                        }
+                      }
+                    ],
+                    "timeUnixNano": "0"
+                  }
+                ]
+              },
+              "name": "k8s.container_memory_working_set_bytes"
+            }
+          ],
+          "scope": {}
+        }
+      ]
+    },
+    {
+      "resource": {
+        "attributes": [
+          {
+            "key": "http.scheme",
+            "value": {
+              "stringValue": "http"
+            }
+          },
+          {
+            "key": "k8s.cluster.name",
+            "value": {
+              "stringValue": "cluster name"
+            }
+          },
+          {
+            "key": "k8s.container.image.name",
+            "value": {
+              "stringValue": "915014598477.dkr.ecr.us-east-1.amazonaws.com/external/docker.io/temporalio/server@sha256:1ecfc4b2cb425b93c1f74ab7288ac190982f039ac65789da3a97377bed706348"
+            }
+          },
+          {
+            "key": "k8s.container.name",
+            "value": {
+              "stringValue": "test-container"
+            }
+          },
+          {
+            "key": "k8s.namespace.annotations.description",
+            "value": {
+              "stringValue": "This is a test namespace."
+            }
+          },
+          {
+            "key": "k8s.namespace.labels.app",
+            "value": {
+              "stringValue": "test-app"
+            }
+          },
+          {
+            "key": "k8s.namespace.labels.kubernetes.io/metadata.name",
+            "value": {
+              "stringValue": "test-namespace"
+            }
+          },
+          {
+            "key": "k8s.namespace.labels.purpose",
+            "value": {
+              "stringValue": "testing"
+            }
+          },
+          {
+            "key": "k8s.namespace.name",
+            "value": {
+              "stringValue": "test-namespace"
+            }
+          },
+          {
+            "key": "k8s.node.name",
+            "value": {
+              "stringValue": "test-node"
+            }
+          },
+          {
+            "key": "k8s.pod.name",
+            "value": {
+              "stringValue": "test-pod"
+            }
+          },
+          {
+            "key": "net.host.name",
+            "value": {
+              "stringValue": "test-node"
+            }
+          },
+          {
+            "key": "net.host.port",
+            "value": {
+              "stringValue": ""
+            }
+          },
+          {
+            "key": "service.instance.id",
+            "value": {
+              "stringValue": "test-node"
+            }
+          },
+          {
+            "key": "sw.k8s.agent.app.version",
+            "value": {
+              "stringValue": "0.7.0"
+            }
+          },
+          {
+            "key": "sw.k8s.agent.manifest.version",
+            "value": {
+              "stringValue": "2.5.0-alpha.4"
             }
           },
           {
@@ -1789,7 +3228,291 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "2.5.0-alpha.3"
+              "stringValue": "2.5.0-alpha.4"
+            }
+          },
+          {
+            "key": "sw.k8s.cluster.uid",
+            "value": {
+              "stringValue": "cluster-uid-123456789"
+            }
+          }
+        ]
+      },
+      "scopeMetrics": [
+        {
+          "metrics": [
+            {
+              "name": "k8s.container_cpu_cfs_periods_total",
+              "sum": {
+                "aggregationTemporality": 2,
+                "dataPoints": [
+                  {
+                    "asDouble": 550377,
+                    "attributes": [
+                      {
+                        "key": "endpoint",
+                        "value": {
+                          "stringValue": "https-metrics"
+                        }
+                      },
+                      {
+                        "key": "id",
+                        "value": {
+                          "stringValue": "/kubepods/burstable/pod7590868f-fb43-40c5-b750-9306fa11571e/1e14a072d677f6b31ac2a09a68d14ac5c788663a660979980da066a919fe7e84"
+                        }
+                      },
+                      {
+                        "key": "metrics_path",
+                        "value": {
+                          "stringValue": "/metrics/cadvisor"
+                        }
+                      },
+                      {
+                        "key": "name",
+                        "value": {
+                          "stringValue": "k8s_alerting-management_alerting-management-internal-5546c9b5c6-jgvm6_o11y-platform_7590868f-fb43-40c5-b750-9306fa11571e_0"
+                        }
+                      },
+                      {
+                        "key": "prometheus",
+                        "value": {
+                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
+                        }
+                      },
+                      {
+                        "key": "prometheus_replica",
+                        "value": {
+                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
+                        }
+                      },
+                      {
+                        "key": "service",
+                        "value": {
+                          "stringValue": "test-service"
+                        }
+                      }
+                    ],
+                    "timeUnixNano": "0"
+                  }
+                ],
+                "isMonotonic": true
+              }
+            },
+            {
+              "name": "k8s.container_cpu_cfs_throttled_periods_total",
+              "sum": {
+                "aggregationTemporality": 2,
+                "dataPoints": [
+                  {
+                    "asDouble": 20702,
+                    "attributes": [
+                      {
+                        "key": "endpoint",
+                        "value": {
+                          "stringValue": "https-metrics"
+                        }
+                      },
+                      {
+                        "key": "id",
+                        "value": {
+                          "stringValue": "/kubepods/burstable/pod7590868f-fb43-40c5-b750-9306fa11571e/1e14a072d677f6b31ac2a09a68d14ac5c788663a660979980da066a919fe7e84"
+                        }
+                      },
+                      {
+                        "key": "metrics_path",
+                        "value": {
+                          "stringValue": "/metrics/cadvisor"
+                        }
+                      },
+                      {
+                        "key": "name",
+                        "value": {
+                          "stringValue": "k8s_alerting-management_alerting-management-internal-5546c9b5c6-jgvm6_o11y-platform_7590868f-fb43-40c5-b750-9306fa11571e_0"
+                        }
+                      },
+                      {
+                        "key": "prometheus",
+                        "value": {
+                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
+                        }
+                      },
+                      {
+                        "key": "prometheus_replica",
+                        "value": {
+                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
+                        }
+                      },
+                      {
+                        "key": "service",
+                        "value": {
+                          "stringValue": "test-service"
+                        }
+                      }
+                    ],
+                    "timeUnixNano": "0"
+                  }
+                ],
+                "isMonotonic": true
+              }
+            },
+            {
+              "gauge": {
+                "dataPoints": [
+                  {
+                    "asDouble": 100000,
+                    "attributes": [
+                      {
+                        "key": "endpoint",
+                        "value": {
+                          "stringValue": "https-metrics"
+                        }
+                      },
+                      {
+                        "key": "id",
+                        "value": {
+                          "stringValue": "/kubepods/burstable/pod7590868f-fb43-40c5-b750-9306fa11571e/1e14a072d677f6b31ac2a09a68d14ac5c788663a660979980da066a919fe7e84"
+                        }
+                      },
+                      {
+                        "key": "metrics_path",
+                        "value": {
+                          "stringValue": "/metrics/cadvisor"
+                        }
+                      },
+                      {
+                        "key": "name",
+                        "value": {
+                          "stringValue": "k8s_alerting-management_alerting-management-internal-5546c9b5c6-jgvm6_o11y-platform_7590868f-fb43-40c5-b750-9306fa11571e_0"
+                        }
+                      },
+                      {
+                        "key": "prometheus",
+                        "value": {
+                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
+                        }
+                      },
+                      {
+                        "key": "prometheus_replica",
+                        "value": {
+                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
+                        }
+                      },
+                      {
+                        "key": "service",
+                        "value": {
+                          "stringValue": "test-service"
+                        }
+                      }
+                    ],
+                    "timeUnixNano": "0"
+                  }
+                ]
+              },
+              "name": "k8s.container_spec_cpu_quota"
+            }
+          ],
+          "scope": {}
+        }
+      ]
+    },
+    {
+      "resource": {
+        "attributes": [
+          {
+            "key": "http.scheme",
+            "value": {
+              "stringValue": "http"
+            }
+          },
+          {
+            "key": "k8s.cluster.name",
+            "value": {
+              "stringValue": "cluster name"
+            }
+          },
+          {
+            "key": "k8s.container.image.name",
+            "value": {
+              "stringValue": "915014598477.dkr.ecr.us-east-1.amazonaws.com/nighthawk/alerting_management@sha256:11138b16b634ffbc60ceb1c9c99a93faab82d0b74c1204157c2ee2068f3395b8"
+            }
+          },
+          {
+            "key": "k8s.container.name",
+            "value": {
+              "stringValue": "test-container"
+            }
+          },
+          {
+            "key": "k8s.namespace.annotations.description",
+            "value": {
+              "stringValue": "This is a test namespace."
+            }
+          },
+          {
+            "key": "k8s.namespace.labels.app",
+            "value": {
+              "stringValue": "test-app"
+            }
+          },
+          {
+            "key": "k8s.namespace.labels.kubernetes.io/metadata.name",
+            "value": {
+              "stringValue": "test-namespace"
+            }
+          },
+          {
+            "key": "k8s.namespace.labels.purpose",
+            "value": {
+              "stringValue": "testing"
+            }
+          },
+          {
+            "key": "k8s.namespace.name",
+            "value": {
+              "stringValue": "test-namespace"
+            }
+          },
+          {
+            "key": "k8s.node.name",
+            "value": {
+              "stringValue": "test-node"
+            }
+          },
+          {
+            "key": "k8s.pod.name",
+            "value": {
+              "stringValue": "test-pod"
+            }
+          },
+          {
+            "key": "net.host.name",
+            "value": {
+              "stringValue": "test-node"
+            }
+          },
+          {
+            "key": "net.host.port",
+            "value": {
+              "stringValue": ""
+            }
+          },
+          {
+            "key": "service.instance.id",
+            "value": {
+              "stringValue": "test-node"
+            }
+          },
+          {
+            "key": "sw.k8s.agent.app.version",
+            "value": {
+              "stringValue": "0.7.0"
+            }
+          },
+          {
+            "key": "sw.k8s.agent.manifest.version",
+            "value": {
+              "stringValue": "2.5.0-alpha.4"
             }
           },
           {
@@ -2085,7 +3808,248 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "2.5.0-alpha.3"
+              "stringValue": "2.5.0-alpha.4"
+            }
+          },
+          {
+            "key": "sw.k8s.cluster.uid",
+            "value": {
+              "stringValue": "cluster-uid-123456789"
+            }
+          }
+        ]
+      },
+      "scopeMetrics": [
+        {
+          "metrics": [
+            {
+              "name": "k8s.container_fs_reads_bytes_total",
+              "sum": {
+                "aggregationTemporality": 2,
+                "dataPoints": [
+                  {
+                    "asDouble": 6209536,
+                    "attributes": [
+                      {
+                        "key": "device",
+                        "value": {
+                          "stringValue": "/dev/nvme0n1"
+                        }
+                      },
+                      {
+                        "key": "endpoint",
+                        "value": {
+                          "stringValue": "https-metrics"
+                        }
+                      },
+                      {
+                        "key": "id",
+                        "value": {
+                          "stringValue": "/kubepods/burstable/pod86586cab-5b42-4084-a56e-b1520bd171a9/c6bdd9e7503d57f9b171a8a4174834aa9a58ece0a00015a7d9c24a75fe525e3c"
+                        }
+                      },
+                      {
+                        "key": "metrics_path",
+                        "value": {
+                          "stringValue": "/metrics/cadvisor"
+                        }
+                      },
+                      {
+                        "key": "name",
+                        "value": {
+                          "stringValue": "k8s_alerting-state-manager_alerting-state-manager-6874584f7b-n8hfc_o11y-platform_86586cab-5b42-4084-a56e-b1520bd171a9_0"
+                        }
+                      },
+                      {
+                        "key": "prometheus",
+                        "value": {
+                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
+                        }
+                      },
+                      {
+                        "key": "prometheus_replica",
+                        "value": {
+                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
+                        }
+                      },
+                      {
+                        "key": "service",
+                        "value": {
+                          "stringValue": "test-service"
+                        }
+                      }
+                    ],
+                    "timeUnixNano": "0"
+                  }
+                ],
+                "isMonotonic": true
+              }
+            },
+            {
+              "name": "k8s.container_fs_writes_bytes_total",
+              "sum": {
+                "aggregationTemporality": 2,
+                "dataPoints": [
+                  {
+                    "asDouble": 0,
+                    "attributes": [
+                      {
+                        "key": "device",
+                        "value": {
+                          "stringValue": "/dev/nvme0n1"
+                        }
+                      },
+                      {
+                        "key": "endpoint",
+                        "value": {
+                          "stringValue": "https-metrics"
+                        }
+                      },
+                      {
+                        "key": "id",
+                        "value": {
+                          "stringValue": "/kubepods/burstable/pod86586cab-5b42-4084-a56e-b1520bd171a9/c6bdd9e7503d57f9b171a8a4174834aa9a58ece0a00015a7d9c24a75fe525e3c"
+                        }
+                      },
+                      {
+                        "key": "metrics_path",
+                        "value": {
+                          "stringValue": "/metrics/cadvisor"
+                        }
+                      },
+                      {
+                        "key": "name",
+                        "value": {
+                          "stringValue": "k8s_alerting-state-manager_alerting-state-manager-6874584f7b-n8hfc_o11y-platform_86586cab-5b42-4084-a56e-b1520bd171a9_0"
+                        }
+                      },
+                      {
+                        "key": "prometheus",
+                        "value": {
+                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
+                        }
+                      },
+                      {
+                        "key": "prometheus_replica",
+                        "value": {
+                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
+                        }
+                      },
+                      {
+                        "key": "service",
+                        "value": {
+                          "stringValue": "test-service"
+                        }
+                      }
+                    ],
+                    "timeUnixNano": "0"
+                  }
+                ],
+                "isMonotonic": true
+              }
+            }
+          ],
+          "scope": {}
+        }
+      ]
+    },
+    {
+      "resource": {
+        "attributes": [
+          {
+            "key": "http.scheme",
+            "value": {
+              "stringValue": "http"
+            }
+          },
+          {
+            "key": "k8s.cluster.name",
+            "value": {
+              "stringValue": "cluster name"
+            }
+          },
+          {
+            "key": "k8s.container.image.name",
+            "value": {
+              "stringValue": "915014598477.dkr.ecr.us-east-1.amazonaws.com/nighthawk/alerting_state_manager@sha256:aa7e6b9e69e8acceb8e6754832324ddf6d6f339101493816e0311ccfeae2c3dd"
+            }
+          },
+          {
+            "key": "k8s.container.name",
+            "value": {
+              "stringValue": "test-container"
+            }
+          },
+          {
+            "key": "k8s.namespace.annotations.description",
+            "value": {
+              "stringValue": "This is a test namespace."
+            }
+          },
+          {
+            "key": "k8s.namespace.labels.app",
+            "value": {
+              "stringValue": "test-app"
+            }
+          },
+          {
+            "key": "k8s.namespace.labels.kubernetes.io/metadata.name",
+            "value": {
+              "stringValue": "test-namespace"
+            }
+          },
+          {
+            "key": "k8s.namespace.labels.purpose",
+            "value": {
+              "stringValue": "testing"
+            }
+          },
+          {
+            "key": "k8s.namespace.name",
+            "value": {
+              "stringValue": "test-namespace"
+            }
+          },
+          {
+            "key": "k8s.node.name",
+            "value": {
+              "stringValue": "test-node"
+            }
+          },
+          {
+            "key": "k8s.pod.name",
+            "value": {
+              "stringValue": "test-pod"
+            }
+          },
+          {
+            "key": "net.host.name",
+            "value": {
+              "stringValue": "test-node"
+            }
+          },
+          {
+            "key": "net.host.port",
+            "value": {
+              "stringValue": ""
+            }
+          },
+          {
+            "key": "service.instance.id",
+            "value": {
+              "stringValue": "test-node"
+            }
+          },
+          {
+            "key": "sw.k8s.agent.app.version",
+            "value": {
+              "stringValue": "0.7.0"
+            }
+          },
+          {
+            "key": "sw.k8s.agent.manifest.version",
+            "value": {
+              "stringValue": "2.5.0-alpha.4"
             }
           },
           {
@@ -2338,7 +4302,833 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "2.5.0-alpha.3"
+              "stringValue": "2.5.0-alpha.4"
+            }
+          },
+          {
+            "key": "sw.k8s.cluster.uid",
+            "value": {
+              "stringValue": "cluster-uid-123456789"
+            }
+          }
+        ]
+      },
+      "scopeMetrics": [
+        {
+          "metrics": [
+            {
+              "gauge": {
+                "dataPoints": [
+                  {
+                    "asDouble": 0,
+                    "attributes": [
+                      {
+                        "key": "cpu",
+                        "value": {
+                          "stringValue": "total"
+                        }
+                      },
+                      {
+                        "key": "endpoint",
+                        "value": {
+                          "stringValue": "https-metrics"
+                        }
+                      },
+                      {
+                        "key": "id",
+                        "value": {
+                          "stringValue": "/kubepods/burstable/podbafeef2c-1292-4a5e-a92c-d709480b04b6/86a84e64dded58918633fc9d1dd89a3f769d25143dd2da4273516d013df5862a"
+                        }
+                      },
+                      {
+                        "key": "metrics_path",
+                        "value": {
+                          "stringValue": "/metrics/cadvisor"
+                        }
+                      },
+                      {
+                        "key": "name",
+                        "value": {
+                          "stringValue": "k8s_swi-opentelemetry-collector_swi-k8s-otel-collector-swo-k8s-collector-metrics-cf8f6886bwt88g_prometheus-system_bafeef2c-1292-4a5e-a92c-d709480b04b6_0"
+                        }
+                      },
+                      {
+                        "key": "prometheus",
+                        "value": {
+                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
+                        }
+                      },
+                      {
+                        "key": "prometheus_replica",
+                        "value": {
+                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
+                        }
+                      },
+                      {
+                        "key": "service",
+                        "value": {
+                          "stringValue": "test-service"
+                        }
+                      }
+                    ],
+                    "startTimeUnixNano": "0",
+                    "timeUnixNano": "0"
+                  }
+                ]
+              },
+              "name": "k8s.container.cpu.usage.seconds.rate"
+            },
+            {
+              "name": "k8s.container_cpu_usage_seconds_total",
+              "sum": {
+                "aggregationTemporality": 2,
+                "dataPoints": [
+                  {
+                    "asDouble": 7940.745108638,
+                    "attributes": [
+                      {
+                        "key": "cpu",
+                        "value": {
+                          "stringValue": "total"
+                        }
+                      },
+                      {
+                        "key": "endpoint",
+                        "value": {
+                          "stringValue": "https-metrics"
+                        }
+                      },
+                      {
+                        "key": "id",
+                        "value": {
+                          "stringValue": "/kubepods/burstable/podbafeef2c-1292-4a5e-a92c-d709480b04b6/86a84e64dded58918633fc9d1dd89a3f769d25143dd2da4273516d013df5862a"
+                        }
+                      },
+                      {
+                        "key": "metrics_path",
+                        "value": {
+                          "stringValue": "/metrics/cadvisor"
+                        }
+                      },
+                      {
+                        "key": "name",
+                        "value": {
+                          "stringValue": "k8s_swi-opentelemetry-collector_swi-k8s-otel-collector-swo-k8s-collector-metrics-cf8f6886bwt88g_prometheus-system_bafeef2c-1292-4a5e-a92c-d709480b04b6_0"
+                        }
+                      },
+                      {
+                        "key": "prometheus",
+                        "value": {
+                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
+                        }
+                      },
+                      {
+                        "key": "prometheus_replica",
+                        "value": {
+                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
+                        }
+                      },
+                      {
+                        "key": "service",
+                        "value": {
+                          "stringValue": "test-service"
+                        }
+                      }
+                    ],
+                    "timeUnixNano": "0"
+                  }
+                ],
+                "isMonotonic": true
+              }
+            },
+            {
+              "name": "k8s.container_fs_reads_bytes_total",
+              "sum": {
+                "aggregationTemporality": 2,
+                "dataPoints": [
+                  {
+                    "asDouble": 0,
+                    "attributes": [
+                      {
+                        "key": "device",
+                        "value": {
+                          "stringValue": "/dev/nvme0n1"
+                        }
+                      },
+                      {
+                        "key": "endpoint",
+                        "value": {
+                          "stringValue": "https-metrics"
+                        }
+                      },
+                      {
+                        "key": "id",
+                        "value": {
+                          "stringValue": "/kubepods/burstable/podbafeef2c-1292-4a5e-a92c-d709480b04b6/86a84e64dded58918633fc9d1dd89a3f769d25143dd2da4273516d013df5862a"
+                        }
+                      },
+                      {
+                        "key": "metrics_path",
+                        "value": {
+                          "stringValue": "/metrics/cadvisor"
+                        }
+                      },
+                      {
+                        "key": "name",
+                        "value": {
+                          "stringValue": "k8s_swi-opentelemetry-collector_swi-k8s-otel-collector-swo-k8s-collector-metrics-cf8f6886bwt88g_prometheus-system_bafeef2c-1292-4a5e-a92c-d709480b04b6_0"
+                        }
+                      },
+                      {
+                        "key": "prometheus",
+                        "value": {
+                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
+                        }
+                      },
+                      {
+                        "key": "prometheus_replica",
+                        "value": {
+                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
+                        }
+                      },
+                      {
+                        "key": "service",
+                        "value": {
+                          "stringValue": "test-service"
+                        }
+                      }
+                    ],
+                    "timeUnixNano": "0"
+                  }
+                ],
+                "isMonotonic": true
+              }
+            },
+            {
+              "name": "k8s.container_fs_reads_total",
+              "sum": {
+                "aggregationTemporality": 2,
+                "dataPoints": [
+                  {
+                    "asDouble": 0,
+                    "attributes": [
+                      {
+                        "key": "device",
+                        "value": {
+                          "stringValue": "/dev/nvme0n1"
+                        }
+                      },
+                      {
+                        "key": "endpoint",
+                        "value": {
+                          "stringValue": "https-metrics"
+                        }
+                      },
+                      {
+                        "key": "id",
+                        "value": {
+                          "stringValue": "/kubepods/burstable/podbafeef2c-1292-4a5e-a92c-d709480b04b6/86a84e64dded58918633fc9d1dd89a3f769d25143dd2da4273516d013df5862a"
+                        }
+                      },
+                      {
+                        "key": "metrics_path",
+                        "value": {
+                          "stringValue": "/metrics/cadvisor"
+                        }
+                      },
+                      {
+                        "key": "name",
+                        "value": {
+                          "stringValue": "k8s_swi-opentelemetry-collector_swi-k8s-otel-collector-swo-k8s-collector-metrics-cf8f6886bwt88g_prometheus-system_bafeef2c-1292-4a5e-a92c-d709480b04b6_0"
+                        }
+                      },
+                      {
+                        "key": "prometheus",
+                        "value": {
+                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
+                        }
+                      },
+                      {
+                        "key": "prometheus_replica",
+                        "value": {
+                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
+                        }
+                      },
+                      {
+                        "key": "service",
+                        "value": {
+                          "stringValue": "test-service"
+                        }
+                      }
+                    ],
+                    "timeUnixNano": "0"
+                  },
+                  {
+                    "asDouble": 0,
+                    "attributes": [
+                      {
+                        "key": "device",
+                        "value": {
+                          "stringValue": "/dev/nvme0n1p1"
+                        }
+                      },
+                      {
+                        "key": "endpoint",
+                        "value": {
+                          "stringValue": "https-metrics"
+                        }
+                      },
+                      {
+                        "key": "id",
+                        "value": {
+                          "stringValue": "/kubepods/burstable/podbafeef2c-1292-4a5e-a92c-d709480b04b6/86a84e64dded58918633fc9d1dd89a3f769d25143dd2da4273516d013df5862a"
+                        }
+                      },
+                      {
+                        "key": "metrics_path",
+                        "value": {
+                          "stringValue": "/metrics/cadvisor"
+                        }
+                      },
+                      {
+                        "key": "name",
+                        "value": {
+                          "stringValue": "k8s_swi-opentelemetry-collector_swi-k8s-otel-collector-swo-k8s-collector-metrics-cf8f6886bwt88g_prometheus-system_bafeef2c-1292-4a5e-a92c-d709480b04b6_0"
+                        }
+                      },
+                      {
+                        "key": "prometheus",
+                        "value": {
+                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
+                        }
+                      },
+                      {
+                        "key": "prometheus_replica",
+                        "value": {
+                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
+                        }
+                      },
+                      {
+                        "key": "service",
+                        "value": {
+                          "stringValue": "test-service"
+                        }
+                      }
+                    ],
+                    "timeUnixNano": "0"
+                  }
+                ],
+                "isMonotonic": true
+              }
+            },
+            {
+              "gauge": {
+                "dataPoints": [
+                  {
+                    "asDouble": 540672,
+                    "attributes": [
+                      {
+                        "key": "device",
+                        "value": {
+                          "stringValue": "/dev/nvme0n1p1"
+                        }
+                      },
+                      {
+                        "key": "endpoint",
+                        "value": {
+                          "stringValue": "https-metrics"
+                        }
+                      },
+                      {
+                        "key": "id",
+                        "value": {
+                          "stringValue": "/kubepods/burstable/podbafeef2c-1292-4a5e-a92c-d709480b04b6/86a84e64dded58918633fc9d1dd89a3f769d25143dd2da4273516d013df5862a"
+                        }
+                      },
+                      {
+                        "key": "metrics_path",
+                        "value": {
+                          "stringValue": "/metrics/cadvisor"
+                        }
+                      },
+                      {
+                        "key": "name",
+                        "value": {
+                          "stringValue": "k8s_swi-opentelemetry-collector_swi-k8s-otel-collector-swo-k8s-collector-metrics-cf8f6886bwt88g_prometheus-system_bafeef2c-1292-4a5e-a92c-d709480b04b6_0"
+                        }
+                      },
+                      {
+                        "key": "prometheus",
+                        "value": {
+                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
+                        }
+                      },
+                      {
+                        "key": "prometheus_replica",
+                        "value": {
+                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
+                        }
+                      },
+                      {
+                        "key": "service",
+                        "value": {
+                          "stringValue": "test-service"
+                        }
+                      }
+                    ],
+                    "timeUnixNano": "0"
+                  }
+                ]
+              },
+              "name": "k8s.container_fs_usage_bytes"
+            },
+            {
+              "name": "k8s.container_fs_writes_bytes_total",
+              "sum": {
+                "aggregationTemporality": 2,
+                "dataPoints": [
+                  {
+                    "asDouble": 31744,
+                    "attributes": [
+                      {
+                        "key": "device",
+                        "value": {
+                          "stringValue": "/dev/nvme0n1"
+                        }
+                      },
+                      {
+                        "key": "endpoint",
+                        "value": {
+                          "stringValue": "https-metrics"
+                        }
+                      },
+                      {
+                        "key": "id",
+                        "value": {
+                          "stringValue": "/kubepods/burstable/podbafeef2c-1292-4a5e-a92c-d709480b04b6/86a84e64dded58918633fc9d1dd89a3f769d25143dd2da4273516d013df5862a"
+                        }
+                      },
+                      {
+                        "key": "metrics_path",
+                        "value": {
+                          "stringValue": "/metrics/cadvisor"
+                        }
+                      },
+                      {
+                        "key": "name",
+                        "value": {
+                          "stringValue": "k8s_swi-opentelemetry-collector_swi-k8s-otel-collector-swo-k8s-collector-metrics-cf8f6886bwt88g_prometheus-system_bafeef2c-1292-4a5e-a92c-d709480b04b6_0"
+                        }
+                      },
+                      {
+                        "key": "prometheus",
+                        "value": {
+                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
+                        }
+                      },
+                      {
+                        "key": "prometheus_replica",
+                        "value": {
+                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
+                        }
+                      },
+                      {
+                        "key": "service",
+                        "value": {
+                          "stringValue": "test-service"
+                        }
+                      }
+                    ],
+                    "timeUnixNano": "0"
+                  }
+                ],
+                "isMonotonic": true
+              }
+            },
+            {
+              "name": "k8s.container_fs_writes_total",
+              "sum": {
+                "aggregationTemporality": 2,
+                "dataPoints": [
+                  {
+                    "asDouble": 2,
+                    "attributes": [
+                      {
+                        "key": "device",
+                        "value": {
+                          "stringValue": "/dev/nvme0n1"
+                        }
+                      },
+                      {
+                        "key": "endpoint",
+                        "value": {
+                          "stringValue": "https-metrics"
+                        }
+                      },
+                      {
+                        "key": "id",
+                        "value": {
+                          "stringValue": "/kubepods/burstable/podbafeef2c-1292-4a5e-a92c-d709480b04b6/86a84e64dded58918633fc9d1dd89a3f769d25143dd2da4273516d013df5862a"
+                        }
+                      },
+                      {
+                        "key": "metrics_path",
+                        "value": {
+                          "stringValue": "/metrics/cadvisor"
+                        }
+                      },
+                      {
+                        "key": "name",
+                        "value": {
+                          "stringValue": "k8s_swi-opentelemetry-collector_swi-k8s-otel-collector-swo-k8s-collector-metrics-cf8f6886bwt88g_prometheus-system_bafeef2c-1292-4a5e-a92c-d709480b04b6_0"
+                        }
+                      },
+                      {
+                        "key": "prometheus",
+                        "value": {
+                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
+                        }
+                      },
+                      {
+                        "key": "prometheus_replica",
+                        "value": {
+                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
+                        }
+                      },
+                      {
+                        "key": "service",
+                        "value": {
+                          "stringValue": "test-service"
+                        }
+                      }
+                    ],
+                    "timeUnixNano": "0"
+                  },
+                  {
+                    "asDouble": 0,
+                    "attributes": [
+                      {
+                        "key": "device",
+                        "value": {
+                          "stringValue": "/dev/nvme0n1p1"
+                        }
+                      },
+                      {
+                        "key": "endpoint",
+                        "value": {
+                          "stringValue": "https-metrics"
+                        }
+                      },
+                      {
+                        "key": "id",
+                        "value": {
+                          "stringValue": "/kubepods/burstable/podbafeef2c-1292-4a5e-a92c-d709480b04b6/86a84e64dded58918633fc9d1dd89a3f769d25143dd2da4273516d013df5862a"
+                        }
+                      },
+                      {
+                        "key": "metrics_path",
+                        "value": {
+                          "stringValue": "/metrics/cadvisor"
+                        }
+                      },
+                      {
+                        "key": "name",
+                        "value": {
+                          "stringValue": "k8s_swi-opentelemetry-collector_swi-k8s-otel-collector-swo-k8s-collector-metrics-cf8f6886bwt88g_prometheus-system_bafeef2c-1292-4a5e-a92c-d709480b04b6_0"
+                        }
+                      },
+                      {
+                        "key": "prometheus",
+                        "value": {
+                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
+                        }
+                      },
+                      {
+                        "key": "prometheus_replica",
+                        "value": {
+                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
+                        }
+                      },
+                      {
+                        "key": "service",
+                        "value": {
+                          "stringValue": "test-service"
+                        }
+                      }
+                    ],
+                    "timeUnixNano": "0"
+                  }
+                ],
+                "isMonotonic": true
+              }
+            },
+            {
+              "gauge": {
+                "dataPoints": [
+                  {
+                    "asDouble": 2036076544,
+                    "attributes": [
+                      {
+                        "key": "endpoint",
+                        "value": {
+                          "stringValue": "https-metrics"
+                        }
+                      },
+                      {
+                        "key": "id",
+                        "value": {
+                          "stringValue": "/kubepods/burstable/podbafeef2c-1292-4a5e-a92c-d709480b04b6/86a84e64dded58918633fc9d1dd89a3f769d25143dd2da4273516d013df5862a"
+                        }
+                      },
+                      {
+                        "key": "metrics_path",
+                        "value": {
+                          "stringValue": "/metrics/cadvisor"
+                        }
+                      },
+                      {
+                        "key": "name",
+                        "value": {
+                          "stringValue": "k8s_swi-opentelemetry-collector_swi-k8s-otel-collector-swo-k8s-collector-metrics-cf8f6886bwt88g_prometheus-system_bafeef2c-1292-4a5e-a92c-d709480b04b6_0"
+                        }
+                      },
+                      {
+                        "key": "prometheus",
+                        "value": {
+                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
+                        }
+                      },
+                      {
+                        "key": "prometheus_replica",
+                        "value": {
+                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
+                        }
+                      },
+                      {
+                        "key": "service",
+                        "value": {
+                          "stringValue": "test-service"
+                        }
+                      }
+                    ],
+                    "timeUnixNano": "0"
+                  }
+                ]
+              },
+              "name": "k8s.container_memory_working_set_bytes"
+            },
+            {
+              "gauge": {
+                "dataPoints": [
+                  {
+                    "asDouble": 100000,
+                    "attributes": [
+                      {
+                        "key": "endpoint",
+                        "value": {
+                          "stringValue": "https-metrics"
+                        }
+                      },
+                      {
+                        "key": "id",
+                        "value": {
+                          "stringValue": "/kubepods/burstable/podbafeef2c-1292-4a5e-a92c-d709480b04b6/86a84e64dded58918633fc9d1dd89a3f769d25143dd2da4273516d013df5862a"
+                        }
+                      },
+                      {
+                        "key": "metrics_path",
+                        "value": {
+                          "stringValue": "/metrics/cadvisor"
+                        }
+                      },
+                      {
+                        "key": "name",
+                        "value": {
+                          "stringValue": "k8s_swi-opentelemetry-collector_swi-k8s-otel-collector-swo-k8s-collector-metrics-cf8f6886bwt88g_prometheus-system_bafeef2c-1292-4a5e-a92c-d709480b04b6_0"
+                        }
+                      },
+                      {
+                        "key": "prometheus",
+                        "value": {
+                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
+                        }
+                      },
+                      {
+                        "key": "prometheus_replica",
+                        "value": {
+                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
+                        }
+                      },
+                      {
+                        "key": "service",
+                        "value": {
+                          "stringValue": "test-service"
+                        }
+                      }
+                    ],
+                    "timeUnixNano": "0"
+                  }
+                ]
+              },
+              "name": "k8s.container_spec_cpu_period"
+            },
+            {
+              "gauge": {
+                "dataPoints": [
+                  {
+                    "asDouble": 3221225472,
+                    "attributes": [
+                      {
+                        "key": "endpoint",
+                        "value": {
+                          "stringValue": "https-metrics"
+                        }
+                      },
+                      {
+                        "key": "id",
+                        "value": {
+                          "stringValue": "/kubepods/burstable/podbafeef2c-1292-4a5e-a92c-d709480b04b6/86a84e64dded58918633fc9d1dd89a3f769d25143dd2da4273516d013df5862a"
+                        }
+                      },
+                      {
+                        "key": "metrics_path",
+                        "value": {
+                          "stringValue": "/metrics/cadvisor"
+                        }
+                      },
+                      {
+                        "key": "name",
+                        "value": {
+                          "stringValue": "k8s_swi-opentelemetry-collector_swi-k8s-otel-collector-swo-k8s-collector-metrics-cf8f6886bwt88g_prometheus-system_bafeef2c-1292-4a5e-a92c-d709480b04b6_0"
+                        }
+                      },
+                      {
+                        "key": "prometheus",
+                        "value": {
+                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
+                        }
+                      },
+                      {
+                        "key": "prometheus_replica",
+                        "value": {
+                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
+                        }
+                      },
+                      {
+                        "key": "service",
+                        "value": {
+                          "stringValue": "test-service"
+                        }
+                      }
+                    ],
+                    "timeUnixNano": "0"
+                  }
+                ]
+              },
+              "name": "k8s.container_spec_memory_limit_bytes"
+            }
+          ],
+          "scope": {}
+        }
+      ]
+    },
+    {
+      "resource": {
+        "attributes": [
+          {
+            "key": "http.scheme",
+            "value": {
+              "stringValue": "http"
+            }
+          },
+          {
+            "key": "k8s.cluster.name",
+            "value": {
+              "stringValue": "cluster name"
+            }
+          },
+          {
+            "key": "k8s.container.image.name",
+            "value": {
+              "stringValue": "sha256:8423d5a81606084300d223d734589c7264ca789ff6908875cf62178ead6a6154"
+            }
+          },
+          {
+            "key": "k8s.container.name",
+            "value": {
+              "stringValue": "test-container"
+            }
+          },
+          {
+            "key": "k8s.namespace.annotations.description",
+            "value": {
+              "stringValue": "This is a test namespace."
+            }
+          },
+          {
+            "key": "k8s.namespace.labels.app",
+            "value": {
+              "stringValue": "test-app"
+            }
+          },
+          {
+            "key": "k8s.namespace.labels.kubernetes.io/metadata.name",
+            "value": {
+              "stringValue": "test-namespace"
+            }
+          },
+          {
+            "key": "k8s.namespace.labels.purpose",
+            "value": {
+              "stringValue": "testing"
+            }
+          },
+          {
+            "key": "k8s.namespace.name",
+            "value": {
+              "stringValue": "test-namespace"
+            }
+          },
+          {
+            "key": "k8s.node.name",
+            "value": {
+              "stringValue": "test-node"
+            }
+          },
+          {
+            "key": "k8s.pod.name",
+            "value": {
+              "stringValue": "test-pod"
+            }
+          },
+          {
+            "key": "net.host.name",
+            "value": {
+              "stringValue": "test-node"
+            }
+          },
+          {
+            "key": "net.host.port",
+            "value": {
+              "stringValue": ""
+            }
+          },
+          {
+            "key": "service.instance.id",
+            "value": {
+              "stringValue": "test-node"
+            }
+          },
+          {
+            "key": "sw.k8s.agent.app.version",
+            "value": {
+              "stringValue": "0.7.0"
+            }
+          },
+          {
+            "key": "sw.k8s.agent.manifest.version",
+            "value": {
+              "stringValue": "2.5.0-alpha.4"
             }
           },
           {
@@ -3176,7 +5966,185 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "2.5.0-alpha.3"
+              "stringValue": "2.5.0-alpha.4"
+            }
+          },
+          {
+            "key": "sw.k8s.cluster.uid",
+            "value": {
+              "stringValue": "cluster-uid-123456789"
+            }
+          }
+        ]
+      },
+      "scopeMetrics": [
+        {
+          "metrics": [
+            {
+              "name": "k8s.container_fs_reads_total",
+              "sum": {
+                "aggregationTemporality": 2,
+                "dataPoints": [
+                  {
+                    "asDouble": 50,
+                    "attributes": [
+                      {
+                        "key": "device",
+                        "value": {
+                          "stringValue": "/dev/nvme0n1"
+                        }
+                      },
+                      {
+                        "key": "endpoint",
+                        "value": {
+                          "stringValue": "https-metrics"
+                        }
+                      },
+                      {
+                        "key": "id",
+                        "value": {
+                          "stringValue": "/kubepods/burstable/pode7c539fd-351f-4f2e-a2d9-9a5c6fe69b78/d10b04fe42ee52263efe5b77a3764ac1d775afd100f5b7e52f995a8e00cd9665"
+                        }
+                      },
+                      {
+                        "key": "metrics_path",
+                        "value": {
+                          "stringValue": "/metrics/cadvisor"
+                        }
+                      },
+                      {
+                        "key": "name",
+                        "value": {
+                          "stringValue": "k8s_clickhouse-backup_chi-ch-chainsaw-1-2-0_o11y-clickhouse_e7c539fd-351f-4f2e-a2d9-9a5c6fe69b78_0"
+                        }
+                      },
+                      {
+                        "key": "prometheus",
+                        "value": {
+                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
+                        }
+                      },
+                      {
+                        "key": "prometheus_replica",
+                        "value": {
+                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
+                        }
+                      },
+                      {
+                        "key": "service",
+                        "value": {
+                          "stringValue": "test-service"
+                        }
+                      }
+                    ],
+                    "timeUnixNano": "0"
+                  }
+                ],
+                "isMonotonic": true
+              }
+            }
+          ],
+          "scope": {}
+        }
+      ]
+    },
+    {
+      "resource": {
+        "attributes": [
+          {
+            "key": "http.scheme",
+            "value": {
+              "stringValue": "http"
+            }
+          },
+          {
+            "key": "k8s.cluster.name",
+            "value": {
+              "stringValue": "cluster name"
+            }
+          },
+          {
+            "key": "k8s.container.image.name",
+            "value": {
+              "stringValue": "sha256:90c7349d6e210794df9fb6a022050325400daae2fa23b833be91293aae2e4e78"
+            }
+          },
+          {
+            "key": "k8s.container.name",
+            "value": {
+              "stringValue": "test-container"
+            }
+          },
+          {
+            "key": "k8s.namespace.annotations.description",
+            "value": {
+              "stringValue": "This is a test namespace."
+            }
+          },
+          {
+            "key": "k8s.namespace.labels.app",
+            "value": {
+              "stringValue": "test-app"
+            }
+          },
+          {
+            "key": "k8s.namespace.labels.kubernetes.io/metadata.name",
+            "value": {
+              "stringValue": "test-namespace"
+            }
+          },
+          {
+            "key": "k8s.namespace.labels.purpose",
+            "value": {
+              "stringValue": "testing"
+            }
+          },
+          {
+            "key": "k8s.namespace.name",
+            "value": {
+              "stringValue": "test-namespace"
+            }
+          },
+          {
+            "key": "k8s.node.name",
+            "value": {
+              "stringValue": "test-node"
+            }
+          },
+          {
+            "key": "k8s.pod.name",
+            "value": {
+              "stringValue": "test-pod"
+            }
+          },
+          {
+            "key": "net.host.name",
+            "value": {
+              "stringValue": "test-node"
+            }
+          },
+          {
+            "key": "net.host.port",
+            "value": {
+              "stringValue": ""
+            }
+          },
+          {
+            "key": "service.instance.id",
+            "value": {
+              "stringValue": "test-node"
+            }
+          },
+          {
+            "key": "sw.k8s.agent.app.version",
+            "value": {
+              "stringValue": "0.7.0"
+            }
+          },
+          {
+            "key": "sw.k8s.agent.manifest.version",
+            "value": {
+              "stringValue": "2.5.0-alpha.4"
             }
           },
           {
@@ -3366,7 +6334,177 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "2.5.0-alpha.3"
+              "stringValue": "2.5.0-alpha.4"
+            }
+          },
+          {
+            "key": "sw.k8s.cluster.uid",
+            "value": {
+              "stringValue": "cluster-uid-123456789"
+            }
+          }
+        ]
+      },
+      "scopeMetrics": [
+        {
+          "metrics": [
+            {
+              "gauge": {
+                "dataPoints": [
+                  {
+                    "asDouble": 1073741824,
+                    "attributes": [
+                      {
+                        "key": "endpoint",
+                        "value": {
+                          "stringValue": "https-metrics"
+                        }
+                      },
+                      {
+                        "key": "id",
+                        "value": {
+                          "stringValue": "/kubepods/burstable/pod1f59980a-6857-4530-9da3-ce5981261e5f/ba11f8492c5cf24d35dc6a96f9dde23f72e62691ef63cc725ba7738af38c2d5b"
+                        }
+                      },
+                      {
+                        "key": "metrics_path",
+                        "value": {
+                          "stringValue": "/metrics/cadvisor"
+                        }
+                      },
+                      {
+                        "key": "name",
+                        "value": {
+                          "stringValue": "k8s_istio-proxy_alerting-detector-5fd7bd944-ntrnv_o11y-platform_1f59980a-6857-4530-9da3-ce5981261e5f_0"
+                        }
+                      },
+                      {
+                        "key": "prometheus",
+                        "value": {
+                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
+                        }
+                      },
+                      {
+                        "key": "prometheus_replica",
+                        "value": {
+                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
+                        }
+                      },
+                      {
+                        "key": "service",
+                        "value": {
+                          "stringValue": "test-service"
+                        }
+                      }
+                    ],
+                    "timeUnixNano": "0"
+                  }
+                ]
+              },
+              "name": "k8s.container_spec_memory_limit_bytes"
+            }
+          ],
+          "scope": {}
+        }
+      ]
+    },
+    {
+      "resource": {
+        "attributes": [
+          {
+            "key": "http.scheme",
+            "value": {
+              "stringValue": "http"
+            }
+          },
+          {
+            "key": "k8s.cluster.name",
+            "value": {
+              "stringValue": "cluster name"
+            }
+          },
+          {
+            "key": "k8s.container.image.name",
+            "value": {
+              "stringValue": "sha256:971d0489e081e4422f45606ed2b08506243c46c47305f2476fd6b8cd92fd9a49"
+            }
+          },
+          {
+            "key": "k8s.container.name",
+            "value": {
+              "stringValue": "test-container"
+            }
+          },
+          {
+            "key": "k8s.namespace.annotations.description",
+            "value": {
+              "stringValue": "This is a test namespace."
+            }
+          },
+          {
+            "key": "k8s.namespace.labels.app",
+            "value": {
+              "stringValue": "test-app"
+            }
+          },
+          {
+            "key": "k8s.namespace.labels.kubernetes.io/metadata.name",
+            "value": {
+              "stringValue": "test-namespace"
+            }
+          },
+          {
+            "key": "k8s.namespace.labels.purpose",
+            "value": {
+              "stringValue": "testing"
+            }
+          },
+          {
+            "key": "k8s.namespace.name",
+            "value": {
+              "stringValue": "test-namespace"
+            }
+          },
+          {
+            "key": "k8s.node.name",
+            "value": {
+              "stringValue": "test-node"
+            }
+          },
+          {
+            "key": "k8s.pod.name",
+            "value": {
+              "stringValue": "test-pod"
+            }
+          },
+          {
+            "key": "net.host.name",
+            "value": {
+              "stringValue": "test-node"
+            }
+          },
+          {
+            "key": "net.host.port",
+            "value": {
+              "stringValue": ""
+            }
+          },
+          {
+            "key": "service.instance.id",
+            "value": {
+              "stringValue": "test-node"
+            }
+          },
+          {
+            "key": "sw.k8s.agent.app.version",
+            "value": {
+              "stringValue": "0.7.0"
+            }
+          },
+          {
+            "key": "sw.k8s.agent.manifest.version",
+            "value": {
+              "stringValue": "2.5.0-alpha.4"
             }
           },
           {
@@ -3548,7 +6686,7 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "2.5.0-alpha.3"
+              "stringValue": "2.5.0-alpha.4"
             }
           },
           {
@@ -3712,7 +6850,7 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "2.5.0-alpha.3"
+              "stringValue": "2.5.0-alpha.4"
             }
           },
           {
@@ -3876,7 +7014,7 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "2.5.0-alpha.3"
+              "stringValue": "2.5.0-alpha.4"
             }
           },
           {
@@ -4356,7 +7494,7 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "2.5.0-alpha.3"
+              "stringValue": "2.5.0-alpha.4"
             }
           },
           {
@@ -4575,7 +7713,1193 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "2.5.0-alpha.3"
+              "stringValue": "2.5.0-alpha.4"
+            }
+          },
+          {
+            "key": "sw.k8s.cluster.uid",
+            "value": {
+              "stringValue": "cluster-uid-123456789"
+            }
+          },
+          {
+            "key": "sw.k8s.container.init",
+            "value": {
+              "stringValue": "false"
+            }
+          }
+        ]
+      },
+      "scopeMetrics": [
+        {
+          "metrics": [
+            {
+              "gauge": {
+                "dataPoints": [
+                  {
+                    "asDouble": 5368709120,
+                    "attributes": [
+                      {
+                        "key": "endpoint",
+                        "value": {
+                          "stringValue": "http"
+                        }
+                      },
+                      {
+                        "key": "prometheus",
+                        "value": {
+                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
+                        }
+                      },
+                      {
+                        "key": "prometheus_replica",
+                        "value": {
+                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
+                        }
+                      },
+                      {
+                        "key": "resource",
+                        "value": {
+                          "stringValue": "memory"
+                        }
+                      },
+                      {
+                        "key": "unit",
+                        "value": {
+                          "stringValue": "byte"
+                        }
+                      }
+                    ],
+                    "timeUnixNano": "0"
+                  }
+                ]
+              },
+              "name": "k8s.container.spec.memory.limit"
+            },
+            {
+              "gauge": {
+                "dataPoints": [
+                  {
+                    "asDouble": 5368709120,
+                    "attributes": [
+                      {
+                        "key": "endpoint",
+                        "value": {
+                          "stringValue": "http"
+                        }
+                      },
+                      {
+                        "key": "prometheus",
+                        "value": {
+                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
+                        }
+                      },
+                      {
+                        "key": "prometheus_replica",
+                        "value": {
+                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
+                        }
+                      },
+                      {
+                        "key": "resource",
+                        "value": {
+                          "stringValue": "memory"
+                        }
+                      },
+                      {
+                        "key": "unit",
+                        "value": {
+                          "stringValue": "byte"
+                        }
+                      }
+                    ],
+                    "timeUnixNano": "0"
+                  }
+                ]
+              },
+              "name": "k8s.kube_pod_container_resource_limits"
+            }
+          ],
+          "scope": {}
+        }
+      ]
+    },
+    {
+      "resource": {
+        "attributes": [
+          {
+            "key": "http.scheme",
+            "value": {
+              "stringValue": "http"
+            }
+          },
+          {
+            "key": "k8s.cluster.name",
+            "value": {
+              "stringValue": "cluster name"
+            }
+          },
+          {
+            "key": "k8s.container.name",
+            "value": {
+              "stringValue": "test-container"
+            }
+          },
+          {
+            "key": "k8s.namespace.annotations.description",
+            "value": {
+              "stringValue": "This is a test namespace."
+            }
+          },
+          {
+            "key": "k8s.namespace.labels.app",
+            "value": {
+              "stringValue": "test-app"
+            }
+          },
+          {
+            "key": "k8s.namespace.labels.kubernetes.io/metadata.name",
+            "value": {
+              "stringValue": "test-namespace"
+            }
+          },
+          {
+            "key": "k8s.namespace.labels.purpose",
+            "value": {
+              "stringValue": "testing"
+            }
+          },
+          {
+            "key": "k8s.namespace.name",
+            "value": {
+              "stringValue": "test-namespace"
+            }
+          },
+          {
+            "key": "k8s.node.name",
+            "value": {
+              "stringValue": "test-node"
+            }
+          },
+          {
+            "key": "k8s.pod.name",
+            "value": {
+              "stringValue": "test-pod"
+            }
+          },
+          {
+            "key": "k8s.pod.uid",
+            "value": {
+              "stringValue": "03d2b55c-b225-476b-9178-c74f8e5eaba2"
+            }
+          },
+          {
+            "key": "net.host.name",
+            "value": {
+              "stringValue": "test-node"
+            }
+          },
+          {
+            "key": "net.host.port",
+            "value": {
+              "stringValue": ""
+            }
+          },
+          {
+            "key": "service.instance.id",
+            "value": {
+              "stringValue": "test-node"
+            }
+          },
+          {
+            "key": "sw.k8s.agent.app.version",
+            "value": {
+              "stringValue": "0.7.0"
+            }
+          },
+          {
+            "key": "sw.k8s.agent.manifest.version",
+            "value": {
+              "stringValue": "2.5.0-alpha.4"
+            }
+          },
+          {
+            "key": "sw.k8s.cluster.uid",
+            "value": {
+              "stringValue": "cluster-uid-123456789"
+            }
+          },
+          {
+            "key": "sw.k8s.container.init",
+            "value": {
+              "stringValue": "false"
+            }
+          }
+        ]
+      },
+      "scopeMetrics": [
+        {
+          "metrics": [
+            {
+              "gauge": {
+                "dataPoints": [
+                  {
+                    "asDouble": 268435456,
+                    "attributes": [
+                      {
+                        "key": "endpoint",
+                        "value": {
+                          "stringValue": "tcp-model"
+                        }
+                      },
+                      {
+                        "key": "prometheus",
+                        "value": {
+                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
+                        }
+                      },
+                      {
+                        "key": "prometheus_replica",
+                        "value": {
+                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
+                        }
+                      }
+                    ],
+                    "timeUnixNano": "0"
+                  }
+                ]
+              },
+              "name": "k8s.kube_pod_container_resource_limits_memory_bytes"
+            }
+          ],
+          "scope": {}
+        }
+      ]
+    },
+    {
+      "resource": {
+        "attributes": [
+          {
+            "key": "http.scheme",
+            "value": {
+              "stringValue": "http"
+            }
+          },
+          {
+            "key": "k8s.cluster.name",
+            "value": {
+              "stringValue": "cluster name"
+            }
+          },
+          {
+            "key": "k8s.container.name",
+            "value": {
+              "stringValue": "test-container"
+            }
+          },
+          {
+            "key": "k8s.namespace.annotations.description",
+            "value": {
+              "stringValue": "This is a test namespace."
+            }
+          },
+          {
+            "key": "k8s.namespace.labels.app",
+            "value": {
+              "stringValue": "test-app"
+            }
+          },
+          {
+            "key": "k8s.namespace.labels.kubernetes.io/metadata.name",
+            "value": {
+              "stringValue": "test-namespace"
+            }
+          },
+          {
+            "key": "k8s.namespace.labels.purpose",
+            "value": {
+              "stringValue": "testing"
+            }
+          },
+          {
+            "key": "k8s.namespace.name",
+            "value": {
+              "stringValue": "test-namespace"
+            }
+          },
+          {
+            "key": "k8s.node.name",
+            "value": {
+              "stringValue": "test-node"
+            }
+          },
+          {
+            "key": "k8s.pod.name",
+            "value": {
+              "stringValue": "test-pod"
+            }
+          },
+          {
+            "key": "k8s.pod.uid",
+            "value": {
+              "stringValue": "71057e83-7723-4db5-a7ca-52ad7904e34d"
+            }
+          },
+          {
+            "key": "net.host.name",
+            "value": {
+              "stringValue": "test-node"
+            }
+          },
+          {
+            "key": "net.host.port",
+            "value": {
+              "stringValue": ""
+            }
+          },
+          {
+            "key": "service.instance.id",
+            "value": {
+              "stringValue": "test-node"
+            }
+          },
+          {
+            "key": "sw.k8s.agent.app.version",
+            "value": {
+              "stringValue": "0.7.0"
+            }
+          },
+          {
+            "key": "sw.k8s.agent.manifest.version",
+            "value": {
+              "stringValue": "2.5.0-alpha.4"
+            }
+          },
+          {
+            "key": "sw.k8s.cluster.uid",
+            "value": {
+              "stringValue": "cluster-uid-123456789"
+            }
+          },
+          {
+            "key": "sw.k8s.container.init",
+            "value": {
+              "stringValue": "false"
+            }
+          }
+        ]
+      },
+      "scopeMetrics": [
+        {
+          "metrics": [
+            {
+              "gauge": {
+                "dataPoints": [
+                  {
+                    "asDouble": 1,
+                    "attributes": [
+                      {
+                        "key": "endpoint",
+                        "value": {
+                          "stringValue": "tcp-model"
+                        }
+                      },
+                      {
+                        "key": "prometheus",
+                        "value": {
+                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
+                        }
+                      },
+                      {
+                        "key": "prometheus_replica",
+                        "value": {
+                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
+                        }
+                      }
+                    ],
+                    "timeUnixNano": "0"
+                  }
+                ]
+              },
+              "name": "k8s.kube_pod_container_resource_limits_cpu_cores"
+            }
+          ],
+          "scope": {}
+        }
+      ]
+    },
+    {
+      "resource": {
+        "attributes": [
+          {
+            "key": "http.scheme",
+            "value": {
+              "stringValue": "http"
+            }
+          },
+          {
+            "key": "k8s.cluster.name",
+            "value": {
+              "stringValue": "cluster name"
+            }
+          },
+          {
+            "key": "k8s.container.name",
+            "value": {
+              "stringValue": "test-container"
+            }
+          },
+          {
+            "key": "k8s.namespace.annotations.description",
+            "value": {
+              "stringValue": "This is a test namespace."
+            }
+          },
+          {
+            "key": "k8s.namespace.labels.app",
+            "value": {
+              "stringValue": "test-app"
+            }
+          },
+          {
+            "key": "k8s.namespace.labels.kubernetes.io/metadata.name",
+            "value": {
+              "stringValue": "test-namespace"
+            }
+          },
+          {
+            "key": "k8s.namespace.labels.purpose",
+            "value": {
+              "stringValue": "testing"
+            }
+          },
+          {
+            "key": "k8s.namespace.name",
+            "value": {
+              "stringValue": "test-namespace"
+            }
+          },
+          {
+            "key": "k8s.node.name",
+            "value": {
+              "stringValue": "test-node"
+            }
+          },
+          {
+            "key": "k8s.pod.name",
+            "value": {
+              "stringValue": "test-pod"
+            }
+          },
+          {
+            "key": "k8s.pod.uid",
+            "value": {
+              "stringValue": "bafeef2c-1292-4a5e-a92c-d709480b04b6"
+            }
+          },
+          {
+            "key": "net.host.name",
+            "value": {
+              "stringValue": "test-node"
+            }
+          },
+          {
+            "key": "net.host.port",
+            "value": {
+              "stringValue": ""
+            }
+          },
+          {
+            "key": "service.instance.id",
+            "value": {
+              "stringValue": "test-node"
+            }
+          },
+          {
+            "key": "sw.k8s.agent.app.version",
+            "value": {
+              "stringValue": "0.7.0"
+            }
+          },
+          {
+            "key": "sw.k8s.agent.manifest.version",
+            "value": {
+              "stringValue": "2.5.0-alpha.4"
+            }
+          },
+          {
+            "key": "sw.k8s.cluster.uid",
+            "value": {
+              "stringValue": "cluster-uid-123456789"
+            }
+          },
+          {
+            "key": "sw.k8s.container.init",
+            "value": {
+              "stringValue": "false"
+            }
+          }
+        ]
+      },
+      "scopeMetrics": [
+        {
+          "metrics": [
+            {
+              "gauge": {
+                "dataPoints": [
+                  {
+                    "asDouble": 3221225472,
+                    "attributes": [
+                      {
+                        "key": "endpoint",
+                        "value": {
+                          "stringValue": "http"
+                        }
+                      },
+                      {
+                        "key": "prometheus",
+                        "value": {
+                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
+                        }
+                      },
+                      {
+                        "key": "prometheus_replica",
+                        "value": {
+                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
+                        }
+                      },
+                      {
+                        "key": "resource",
+                        "value": {
+                          "stringValue": "memory"
+                        }
+                      },
+                      {
+                        "key": "unit",
+                        "value": {
+                          "stringValue": "byte"
+                        }
+                      }
+                    ],
+                    "timeUnixNano": "0"
+                  },
+                  {
+                    "asDouble": 3221225472,
+                    "attributes": [
+                      {
+                        "key": "endpoint",
+                        "value": {
+                          "stringValue": "tcp-model"
+                        }
+                      },
+                      {
+                        "key": "prometheus",
+                        "value": {
+                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
+                        }
+                      },
+                      {
+                        "key": "prometheus_replica",
+                        "value": {
+                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
+                        }
+                      },
+                      {
+                        "key": "resource",
+                        "value": {
+                          "stringValue": "memory"
+                        }
+                      },
+                      {
+                        "key": "unit",
+                        "value": {
+                          "stringValue": "byte"
+                        }
+                      }
+                    ],
+                    "timeUnixNano": "0"
+                  }
+                ]
+              },
+              "name": "k8s.container.spec.memory.limit"
+            },
+            {
+              "gauge": {
+                "dataPoints": [
+                  {
+                    "asDouble": 3221225472,
+                    "attributes": [
+                      {
+                        "key": "endpoint",
+                        "value": {
+                          "stringValue": "http"
+                        }
+                      },
+                      {
+                        "key": "prometheus",
+                        "value": {
+                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
+                        }
+                      },
+                      {
+                        "key": "prometheus_replica",
+                        "value": {
+                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
+                        }
+                      },
+                      {
+                        "key": "resource",
+                        "value": {
+                          "stringValue": "memory"
+                        }
+                      },
+                      {
+                        "key": "unit",
+                        "value": {
+                          "stringValue": "byte"
+                        }
+                      }
+                    ],
+                    "timeUnixNano": "0"
+                  },
+                  {
+                    "asDouble": 3221225472,
+                    "attributes": [
+                      {
+                        "key": "endpoint",
+                        "value": {
+                          "stringValue": "tcp-model"
+                        }
+                      },
+                      {
+                        "key": "prometheus",
+                        "value": {
+                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
+                        }
+                      },
+                      {
+                        "key": "prometheus_replica",
+                        "value": {
+                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
+                        }
+                      },
+                      {
+                        "key": "resource",
+                        "value": {
+                          "stringValue": "memory"
+                        }
+                      },
+                      {
+                        "key": "unit",
+                        "value": {
+                          "stringValue": "byte"
+                        }
+                      }
+                    ],
+                    "timeUnixNano": "0"
+                  }
+                ]
+              },
+              "name": "k8s.container.spec.memory.requests"
+            },
+            {
+              "gauge": {
+                "dataPoints": [
+                  {
+                    "asDouble": 3221225472,
+                    "attributes": [
+                      {
+                        "key": "endpoint",
+                        "value": {
+                          "stringValue": "http"
+                        }
+                      },
+                      {
+                        "key": "prometheus",
+                        "value": {
+                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
+                        }
+                      },
+                      {
+                        "key": "prometheus_replica",
+                        "value": {
+                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
+                        }
+                      },
+                      {
+                        "key": "resource",
+                        "value": {
+                          "stringValue": "memory"
+                        }
+                      },
+                      {
+                        "key": "unit",
+                        "value": {
+                          "stringValue": "byte"
+                        }
+                      }
+                    ],
+                    "timeUnixNano": "0"
+                  },
+                  {
+                    "asDouble": 3221225472,
+                    "attributes": [
+                      {
+                        "key": "endpoint",
+                        "value": {
+                          "stringValue": "tcp-model"
+                        }
+                      },
+                      {
+                        "key": "prometheus",
+                        "value": {
+                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
+                        }
+                      },
+                      {
+                        "key": "prometheus_replica",
+                        "value": {
+                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
+                        }
+                      },
+                      {
+                        "key": "resource",
+                        "value": {
+                          "stringValue": "memory"
+                        }
+                      },
+                      {
+                        "key": "unit",
+                        "value": {
+                          "stringValue": "byte"
+                        }
+                      }
+                    ],
+                    "timeUnixNano": "0"
+                  }
+                ]
+              },
+              "name": "k8s.kube_pod_container_resource_limits"
+            },
+            {
+              "gauge": {
+                "dataPoints": [
+                  {
+                    "asDouble": 3221225472,
+                    "attributes": [
+                      {
+                        "key": "endpoint",
+                        "value": {
+                          "stringValue": "tcp-model"
+                        }
+                      },
+                      {
+                        "key": "prometheus",
+                        "value": {
+                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
+                        }
+                      },
+                      {
+                        "key": "prometheus_replica",
+                        "value": {
+                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
+                        }
+                      }
+                    ],
+                    "timeUnixNano": "0"
+                  }
+                ]
+              },
+              "name": "k8s.kube_pod_container_resource_limits_memory_bytes"
+            },
+            {
+              "gauge": {
+                "dataPoints": [
+                  {
+                    "asDouble": 3221225472,
+                    "attributes": [
+                      {
+                        "key": "endpoint",
+                        "value": {
+                          "stringValue": "http"
+                        }
+                      },
+                      {
+                        "key": "prometheus",
+                        "value": {
+                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
+                        }
+                      },
+                      {
+                        "key": "prometheus_replica",
+                        "value": {
+                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
+                        }
+                      },
+                      {
+                        "key": "resource",
+                        "value": {
+                          "stringValue": "memory"
+                        }
+                      },
+                      {
+                        "key": "unit",
+                        "value": {
+                          "stringValue": "byte"
+                        }
+                      }
+                    ],
+                    "timeUnixNano": "0"
+                  },
+                  {
+                    "asDouble": 3221225472,
+                    "attributes": [
+                      {
+                        "key": "endpoint",
+                        "value": {
+                          "stringValue": "tcp-model"
+                        }
+                      },
+                      {
+                        "key": "prometheus",
+                        "value": {
+                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
+                        }
+                      },
+                      {
+                        "key": "prometheus_replica",
+                        "value": {
+                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
+                        }
+                      },
+                      {
+                        "key": "resource",
+                        "value": {
+                          "stringValue": "memory"
+                        }
+                      },
+                      {
+                        "key": "unit",
+                        "value": {
+                          "stringValue": "byte"
+                        }
+                      }
+                    ],
+                    "timeUnixNano": "0"
+                  }
+                ]
+              },
+              "name": "k8s.kube_pod_container_resource_requests"
+            }
+          ],
+          "scope": {}
+        }
+      ]
+    },
+    {
+      "resource": {
+        "attributes": [
+          {
+            "key": "http.scheme",
+            "value": {
+              "stringValue": "http"
+            }
+          },
+          {
+            "key": "k8s.cluster.name",
+            "value": {
+              "stringValue": "cluster name"
+            }
+          },
+          {
+            "key": "k8s.container.name",
+            "value": {
+              "stringValue": "test-container"
+            }
+          },
+          {
+            "key": "k8s.namespace.annotations.description",
+            "value": {
+              "stringValue": "This is a test namespace."
+            }
+          },
+          {
+            "key": "k8s.namespace.labels.app",
+            "value": {
+              "stringValue": "test-app"
+            }
+          },
+          {
+            "key": "k8s.namespace.labels.kubernetes.io/metadata.name",
+            "value": {
+              "stringValue": "test-namespace"
+            }
+          },
+          {
+            "key": "k8s.namespace.labels.purpose",
+            "value": {
+              "stringValue": "testing"
+            }
+          },
+          {
+            "key": "k8s.namespace.name",
+            "value": {
+              "stringValue": "test-namespace"
+            }
+          },
+          {
+            "key": "k8s.node.name",
+            "value": {
+              "stringValue": "test-node"
+            }
+          },
+          {
+            "key": "k8s.pod.name",
+            "value": {
+              "stringValue": "test-pod"
+            }
+          },
+          {
+            "key": "k8s.pod.uid",
+            "value": {
+              "stringValue": "f15ca7ca-af33-4f43-a793-ec3176b31842"
+            }
+          },
+          {
+            "key": "net.host.name",
+            "value": {
+              "stringValue": "test-node"
+            }
+          },
+          {
+            "key": "net.host.port",
+            "value": {
+              "stringValue": ""
+            }
+          },
+          {
+            "key": "service.instance.id",
+            "value": {
+              "stringValue": "test-node"
+            }
+          },
+          {
+            "key": "sw.k8s.agent.app.version",
+            "value": {
+              "stringValue": "0.7.0"
+            }
+          },
+          {
+            "key": "sw.k8s.agent.manifest.version",
+            "value": {
+              "stringValue": "2.5.0-alpha.4"
+            }
+          },
+          {
+            "key": "sw.k8s.cluster.uid",
+            "value": {
+              "stringValue": "cluster-uid-123456789"
+            }
+          },
+          {
+            "key": "sw.k8s.container.init",
+            "value": {
+              "stringValue": "false"
+            }
+          }
+        ]
+      },
+      "scopeMetrics": [
+        {
+          "metrics": [
+            {
+              "gauge": {
+                "dataPoints": [
+                  {
+                    "asDouble": 0.1,
+                    "attributes": [
+                      {
+                        "key": "endpoint",
+                        "value": {
+                          "stringValue": "http"
+                        }
+                      },
+                      {
+                        "key": "prometheus",
+                        "value": {
+                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
+                        }
+                      },
+                      {
+                        "key": "prometheus_replica",
+                        "value": {
+                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
+                        }
+                      },
+                      {
+                        "key": "resource",
+                        "value": {
+                          "stringValue": "cpu"
+                        }
+                      },
+                      {
+                        "key": "unit",
+                        "value": {
+                          "stringValue": "core"
+                        }
+                      }
+                    ],
+                    "timeUnixNano": "0"
+                  }
+                ]
+              },
+              "name": "k8s.container.spec.cpu.requests"
+            },
+            {
+              "gauge": {
+                "dataPoints": [
+                  {
+                    "asDouble": 0.1,
+                    "attributes": [
+                      {
+                        "key": "endpoint",
+                        "value": {
+                          "stringValue": "http"
+                        }
+                      },
+                      {
+                        "key": "prometheus",
+                        "value": {
+                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
+                        }
+                      },
+                      {
+                        "key": "prometheus_replica",
+                        "value": {
+                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
+                        }
+                      },
+                      {
+                        "key": "resource",
+                        "value": {
+                          "stringValue": "cpu"
+                        }
+                      },
+                      {
+                        "key": "unit",
+                        "value": {
+                          "stringValue": "core"
+                        }
+                      }
+                    ],
+                    "timeUnixNano": "0"
+                  }
+                ]
+              },
+              "name": "k8s.kube_pod_container_resource_requests"
+            }
+          ],
+          "scope": {}
+        }
+      ]
+    },
+    {
+      "resource": {
+        "attributes": [
+          {
+            "key": "http.scheme",
+            "value": {
+              "stringValue": "http"
+            }
+          },
+          {
+            "key": "k8s.cluster.name",
+            "value": {
+              "stringValue": "cluster name"
+            }
+          },
+          {
+            "key": "k8s.container.name",
+            "value": {
+              "stringValue": "test-container"
+            }
+          },
+          {
+            "key": "k8s.namespace.annotations.description",
+            "value": {
+              "stringValue": "This is a test namespace."
+            }
+          },
+          {
+            "key": "k8s.namespace.labels.app",
+            "value": {
+              "stringValue": "test-app"
+            }
+          },
+          {
+            "key": "k8s.namespace.labels.kubernetes.io/metadata.name",
+            "value": {
+              "stringValue": "test-namespace"
+            }
+          },
+          {
+            "key": "k8s.namespace.labels.purpose",
+            "value": {
+              "stringValue": "testing"
+            }
+          },
+          {
+            "key": "k8s.namespace.name",
+            "value": {
+              "stringValue": "test-namespace"
+            }
+          },
+          {
+            "key": "k8s.node.name",
+            "value": {
+              "stringValue": "test-node"
+            }
+          },
+          {
+            "key": "k8s.pod.name",
+            "value": {
+              "stringValue": "test-pod"
+            }
+          },
+          {
+            "key": "k8s.pod.uid",
+            "value": {
+              "stringValue": "f747708b-041d-4a63-b8df-6d452e164d0b"
+            }
+          },
+          {
+            "key": "net.host.name",
+            "value": {
+              "stringValue": "test-node"
+            }
+          },
+          {
+            "key": "net.host.port",
+            "value": {
+              "stringValue": ""
+            }
+          },
+          {
+            "key": "service.instance.id",
+            "value": {
+              "stringValue": "test-node"
+            }
+          },
+          {
+            "key": "sw.k8s.agent.app.version",
+            "value": {
+              "stringValue": "0.7.0"
+            }
+          },
+          {
+            "key": "sw.k8s.agent.manifest.version",
+            "value": {
+              "stringValue": "2.5.0-alpha.4"
             }
           },
           {
@@ -4788,7 +9112,7 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "2.5.0-alpha.3"
+              "stringValue": "2.5.0-alpha.4"
             }
           },
           {
@@ -5041,7 +9365,7 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "2.5.0-alpha.3"
+              "stringValue": "2.5.0-alpha.4"
             }
           },
           {
@@ -5205,7 +9529,7 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "2.5.0-alpha.3"
+              "stringValue": "2.5.0-alpha.4"
             }
           },
           {
@@ -5363,7 +9687,7 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "2.5.0-alpha.3"
+              "stringValue": "2.5.0-alpha.4"
             }
           },
           {
@@ -5521,7 +9845,7 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "2.5.0-alpha.3"
+              "stringValue": "2.5.0-alpha.4"
             }
           },
           {
@@ -5685,7 +10009,7 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "2.5.0-alpha.3"
+              "stringValue": "2.5.0-alpha.4"
             }
           },
           {
@@ -5843,7 +10167,7 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "2.5.0-alpha.3"
+              "stringValue": "2.5.0-alpha.4"
             }
           },
           {
@@ -6001,7 +10325,7 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "2.5.0-alpha.3"
+              "stringValue": "2.5.0-alpha.4"
             }
           },
           {
@@ -6165,7 +10489,7 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "2.5.0-alpha.3"
+              "stringValue": "2.5.0-alpha.4"
             }
           },
           {
@@ -6356,7 +10680,7 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "2.5.0-alpha.3"
+              "stringValue": "2.5.0-alpha.4"
             }
           },
           {
@@ -6719,7 +11043,7 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "2.5.0-alpha.3"
+              "stringValue": "2.5.0-alpha.4"
             }
           },
           {
@@ -6907,7 +11231,7 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "2.5.0-alpha.3"
+              "stringValue": "2.5.0-alpha.4"
             }
           },
           {
@@ -7228,7 +11552,7 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "2.5.0-alpha.3"
+              "stringValue": "2.5.0-alpha.4"
             }
           },
           {
@@ -7392,7 +11716,7 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "2.5.0-alpha.3"
+              "stringValue": "2.5.0-alpha.4"
             }
           },
           {
@@ -7711,7 +12035,7 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "2.5.0-alpha.3"
+              "stringValue": "2.5.0-alpha.4"
             }
           },
           {
@@ -7869,7 +12193,3041 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "2.5.0-alpha.3"
+              "stringValue": "2.5.0-alpha.4"
+            }
+          },
+          {
+            "key": "sw.k8s.cluster.uid",
+            "value": {
+              "stringValue": "cluster-uid-123456789"
+            }
+          }
+        ]
+      },
+      "scopeMetrics": [
+        {
+          "metrics": [
+            {
+              "gauge": {
+                "dataPoints": [
+                  {
+                    "asDouble": 0,
+                    "startTimeUnixNano": "0",
+                    "timeUnixNano": "0"
+                  }
+                ]
+              },
+              "name": "k8s.container.fs.iops"
+            },
+            {
+              "gauge": {
+                "dataPoints": [
+                  {
+                    "asDouble": 0,
+                    "startTimeUnixNano": "0",
+                    "timeUnixNano": "0"
+                  }
+                ]
+              },
+              "name": "k8s.container.fs.throughput"
+            }
+          ],
+          "scope": {}
+        }
+      ]
+    },
+    {
+      "resource": {
+        "attributes": [
+          {
+            "key": "http.scheme",
+            "value": {
+              "stringValue": "http"
+            }
+          },
+          {
+            "key": "k8s.cluster.name",
+            "value": {
+              "stringValue": "cluster name"
+            }
+          },
+          {
+            "key": "k8s.container.name",
+            "value": {
+              "stringValue": "test-container"
+            }
+          },
+          {
+            "key": "k8s.namespace.annotations.description",
+            "value": {
+              "stringValue": "This is a test namespace."
+            }
+          },
+          {
+            "key": "k8s.namespace.labels.app",
+            "value": {
+              "stringValue": "test-app"
+            }
+          },
+          {
+            "key": "k8s.namespace.labels.kubernetes.io/metadata.name",
+            "value": {
+              "stringValue": "test-namespace"
+            }
+          },
+          {
+            "key": "k8s.namespace.labels.purpose",
+            "value": {
+              "stringValue": "testing"
+            }
+          },
+          {
+            "key": "k8s.namespace.name",
+            "value": {
+              "stringValue": "test-namespace"
+            }
+          },
+          {
+            "key": "k8s.pod.name",
+            "value": {
+              "stringValue": "test-pod"
+            }
+          },
+          {
+            "key": "k8s.pod.uid",
+            "value": {
+              "stringValue": "03d2b55c-b225-476b-9178-c74f8e5eaba2"
+            }
+          },
+          {
+            "key": "net.host.name",
+            "value": {
+              "stringValue": "test-node"
+            }
+          },
+          {
+            "key": "net.host.port",
+            "value": {
+              "stringValue": ""
+            }
+          },
+          {
+            "key": "service.instance.id",
+            "value": {
+              "stringValue": "test-node"
+            }
+          },
+          {
+            "key": "sw.k8s.agent.app.version",
+            "value": {
+              "stringValue": "0.7.0"
+            }
+          },
+          {
+            "key": "sw.k8s.agent.manifest.version",
+            "value": {
+              "stringValue": "2.5.0-alpha.4"
+            }
+          },
+          {
+            "key": "sw.k8s.cluster.uid",
+            "value": {
+              "stringValue": "cluster-uid-123456789"
+            }
+          },
+          {
+            "key": "sw.k8s.container.init",
+            "value": {
+              "stringValue": "false"
+            }
+          }
+        ]
+      },
+      "scopeMetrics": [
+        {
+          "metrics": [
+            {
+              "gauge": {
+                "dataPoints": [
+                  {
+                    "asDouble": 1,
+                    "attributes": [
+                      {
+                        "key": "endpoint",
+                        "value": {
+                          "stringValue": "http"
+                        }
+                      },
+                      {
+                        "key": "prometheus",
+                        "value": {
+                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
+                        }
+                      },
+                      {
+                        "key": "prometheus_replica",
+                        "value": {
+                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
+                        }
+                      }
+                    ],
+                    "timeUnixNano": "0"
+                  }
+                ]
+              },
+              "name": "k8s.kube_pod_container_status_ready"
+            },
+            {
+              "name": "k8s.kube_pod_container_status_restarts_total",
+              "sum": {
+                "aggregationTemporality": 2,
+                "dataPoints": [
+                  {
+                    "asDouble": 0,
+                    "attributes": [
+                      {
+                        "key": "endpoint",
+                        "value": {
+                          "stringValue": "http"
+                        }
+                      },
+                      {
+                        "key": "prometheus",
+                        "value": {
+                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
+                        }
+                      },
+                      {
+                        "key": "prometheus_replica",
+                        "value": {
+                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
+                        }
+                      }
+                    ],
+                    "timeUnixNano": "0"
+                  }
+                ],
+                "isMonotonic": true
+              }
+            },
+            {
+              "gauge": {
+                "dataPoints": [
+                  {
+                    "asDouble": 1,
+                    "attributes": [
+                      {
+                        "key": "endpoint",
+                        "value": {
+                          "stringValue": "http"
+                        }
+                      },
+                      {
+                        "key": "prometheus",
+                        "value": {
+                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
+                        }
+                      },
+                      {
+                        "key": "prometheus_replica",
+                        "value": {
+                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
+                        }
+                      }
+                    ],
+                    "timeUnixNano": "0"
+                  }
+                ]
+              },
+              "name": "k8s.kube_pod_container_status_running"
+            },
+            {
+              "gauge": {
+                "dataPoints": [
+                  {
+                    "asDouble": 0,
+                    "attributes": [
+                      {
+                        "key": "endpoint",
+                        "value": {
+                          "stringValue": "http"
+                        }
+                      },
+                      {
+                        "key": "prometheus",
+                        "value": {
+                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
+                        }
+                      },
+                      {
+                        "key": "prometheus_replica",
+                        "value": {
+                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
+                        }
+                      }
+                    ],
+                    "timeUnixNano": "0"
+                  }
+                ]
+              },
+              "name": "k8s.kube_pod_container_status_waiting"
+            }
+          ],
+          "scope": {}
+        }
+      ]
+    },
+    {
+      "resource": {
+        "attributes": [
+          {
+            "key": "http.scheme",
+            "value": {
+              "stringValue": "http"
+            }
+          },
+          {
+            "key": "k8s.cluster.name",
+            "value": {
+              "stringValue": "cluster name"
+            }
+          },
+          {
+            "key": "k8s.container.name",
+            "value": {
+              "stringValue": "test-container"
+            }
+          },
+          {
+            "key": "k8s.namespace.annotations.description",
+            "value": {
+              "stringValue": "This is a test namespace."
+            }
+          },
+          {
+            "key": "k8s.namespace.labels.app",
+            "value": {
+              "stringValue": "test-app"
+            }
+          },
+          {
+            "key": "k8s.namespace.labels.kubernetes.io/metadata.name",
+            "value": {
+              "stringValue": "test-namespace"
+            }
+          },
+          {
+            "key": "k8s.namespace.labels.purpose",
+            "value": {
+              "stringValue": "testing"
+            }
+          },
+          {
+            "key": "k8s.namespace.name",
+            "value": {
+              "stringValue": "test-namespace"
+            }
+          },
+          {
+            "key": "k8s.pod.name",
+            "value": {
+              "stringValue": "test-pod"
+            }
+          },
+          {
+            "key": "k8s.pod.uid",
+            "value": {
+              "stringValue": "03d2b55c-b225-476b-9178-c74f8e5eaba2"
+            }
+          },
+          {
+            "key": "net.host.name",
+            "value": {
+              "stringValue": "test-node"
+            }
+          },
+          {
+            "key": "net.host.port",
+            "value": {
+              "stringValue": ""
+            }
+          },
+          {
+            "key": "service.instance.id",
+            "value": {
+              "stringValue": "test-node"
+            }
+          },
+          {
+            "key": "sw.k8s.agent.app.version",
+            "value": {
+              "stringValue": "0.7.0"
+            }
+          },
+          {
+            "key": "sw.k8s.agent.manifest.version",
+            "value": {
+              "stringValue": "2.5.0-alpha.4"
+            }
+          },
+          {
+            "key": "sw.k8s.cluster.uid",
+            "value": {
+              "stringValue": "cluster-uid-123456789"
+            }
+          },
+          {
+            "key": "sw.k8s.container.init",
+            "value": {
+              "stringValue": "false"
+            }
+          },
+          {
+            "key": "sw.k8s.container.status",
+            "value": {
+              "stringValue": "running"
+            }
+          }
+        ]
+      },
+      "scopeMetrics": [
+        {
+          "metrics": [
+            {
+              "gauge": {
+                "dataPoints": [
+                  {
+                    "asDouble": 1,
+                    "attributes": [
+                      {
+                        "key": "endpoint",
+                        "value": {
+                          "stringValue": "http"
+                        }
+                      },
+                      {
+                        "key": "prometheus",
+                        "value": {
+                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
+                        }
+                      },
+                      {
+                        "key": "prometheus_replica",
+                        "value": {
+                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
+                        }
+                      }
+                    ],
+                    "timeUnixNano": "0"
+                  }
+                ]
+              },
+              "name": "k8s.container.status"
+            }
+          ],
+          "scope": {}
+        }
+      ]
+    },
+    {
+      "resource": {
+        "attributes": [
+          {
+            "key": "http.scheme",
+            "value": {
+              "stringValue": "http"
+            }
+          },
+          {
+            "key": "k8s.cluster.name",
+            "value": {
+              "stringValue": "cluster name"
+            }
+          },
+          {
+            "key": "k8s.container.name",
+            "value": {
+              "stringValue": "test-container"
+            }
+          },
+          {
+            "key": "k8s.namespace.annotations.description",
+            "value": {
+              "stringValue": "This is a test namespace."
+            }
+          },
+          {
+            "key": "k8s.namespace.labels.app",
+            "value": {
+              "stringValue": "test-app"
+            }
+          },
+          {
+            "key": "k8s.namespace.labels.kubernetes.io/metadata.name",
+            "value": {
+              "stringValue": "test-namespace"
+            }
+          },
+          {
+            "key": "k8s.namespace.labels.purpose",
+            "value": {
+              "stringValue": "testing"
+            }
+          },
+          {
+            "key": "k8s.namespace.name",
+            "value": {
+              "stringValue": "test-namespace"
+            }
+          },
+          {
+            "key": "k8s.pod.name",
+            "value": {
+              "stringValue": "test-pod"
+            }
+          },
+          {
+            "key": "k8s.pod.uid",
+            "value": {
+              "stringValue": "1f36cbc1-95aa-40ee-8d06-e3dd4cae8b2f"
+            }
+          },
+          {
+            "key": "net.host.name",
+            "value": {
+              "stringValue": "test-node"
+            }
+          },
+          {
+            "key": "net.host.port",
+            "value": {
+              "stringValue": ""
+            }
+          },
+          {
+            "key": "service.instance.id",
+            "value": {
+              "stringValue": "test-node"
+            }
+          },
+          {
+            "key": "sw.k8s.agent.app.version",
+            "value": {
+              "stringValue": "0.7.0"
+            }
+          },
+          {
+            "key": "sw.k8s.agent.manifest.version",
+            "value": {
+              "stringValue": "2.5.0-alpha.4"
+            }
+          },
+          {
+            "key": "sw.k8s.cluster.uid",
+            "value": {
+              "stringValue": "cluster-uid-123456789"
+            }
+          },
+          {
+            "key": "sw.k8s.container.init",
+            "value": {
+              "stringValue": "false"
+            }
+          }
+        ]
+      },
+      "scopeMetrics": [
+        {
+          "metrics": [
+            {
+              "gauge": {
+                "dataPoints": [
+                  {
+                    "asDouble": 0,
+                    "attributes": [
+                      {
+                        "key": "endpoint",
+                        "value": {
+                          "stringValue": "http"
+                        }
+                      },
+                      {
+                        "key": "prometheus",
+                        "value": {
+                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
+                        }
+                      },
+                      {
+                        "key": "prometheus_replica",
+                        "value": {
+                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
+                        }
+                      }
+                    ],
+                    "timeUnixNano": "0"
+                  }
+                ]
+              },
+              "name": "k8s.kube_pod_container_status_terminated"
+            }
+          ],
+          "scope": {}
+        }
+      ]
+    },
+    {
+      "resource": {
+        "attributes": [
+          {
+            "key": "http.scheme",
+            "value": {
+              "stringValue": "http"
+            }
+          },
+          {
+            "key": "k8s.cluster.name",
+            "value": {
+              "stringValue": "cluster name"
+            }
+          },
+          {
+            "key": "k8s.container.name",
+            "value": {
+              "stringValue": "test-container"
+            }
+          },
+          {
+            "key": "k8s.namespace.annotations.description",
+            "value": {
+              "stringValue": "This is a test namespace."
+            }
+          },
+          {
+            "key": "k8s.namespace.labels.app",
+            "value": {
+              "stringValue": "test-app"
+            }
+          },
+          {
+            "key": "k8s.namespace.labels.kubernetes.io/metadata.name",
+            "value": {
+              "stringValue": "test-namespace"
+            }
+          },
+          {
+            "key": "k8s.namespace.labels.purpose",
+            "value": {
+              "stringValue": "testing"
+            }
+          },
+          {
+            "key": "k8s.namespace.name",
+            "value": {
+              "stringValue": "test-namespace"
+            }
+          },
+          {
+            "key": "k8s.pod.name",
+            "value": {
+              "stringValue": "test-pod"
+            }
+          },
+          {
+            "key": "k8s.pod.uid",
+            "value": {
+              "stringValue": "2a82ed12-a31a-427a-adb9-d14cf6a4a063"
+            }
+          },
+          {
+            "key": "net.host.name",
+            "value": {
+              "stringValue": "test-node"
+            }
+          },
+          {
+            "key": "net.host.port",
+            "value": {
+              "stringValue": ""
+            }
+          },
+          {
+            "key": "service.instance.id",
+            "value": {
+              "stringValue": "test-node"
+            }
+          },
+          {
+            "key": "sw.k8s.agent.app.version",
+            "value": {
+              "stringValue": "0.7.0"
+            }
+          },
+          {
+            "key": "sw.k8s.agent.manifest.version",
+            "value": {
+              "stringValue": "2.5.0-alpha.4"
+            }
+          },
+          {
+            "key": "sw.k8s.cluster.uid",
+            "value": {
+              "stringValue": "cluster-uid-123456789"
+            }
+          },
+          {
+            "key": "sw.k8s.container.init",
+            "value": {
+              "stringValue": "true"
+            }
+          }
+        ]
+      },
+      "scopeMetrics": [
+        {
+          "metrics": [
+            {
+              "gauge": {
+                "dataPoints": [
+                  {
+                    "asDouble": 0.1,
+                    "attributes": [
+                      {
+                        "key": "endpoint",
+                        "value": {
+                          "stringValue": "http"
+                        }
+                      },
+                      {
+                        "key": "prometheus",
+                        "value": {
+                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
+                        }
+                      },
+                      {
+                        "key": "prometheus_replica",
+                        "value": {
+                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
+                        }
+                      }
+                    ],
+                    "timeUnixNano": "0"
+                  }
+                ]
+              },
+              "name": "k8s.kube_pod_init_container_resource_limits_cpu_cores"
+            }
+          ],
+          "scope": {}
+        }
+      ]
+    },
+    {
+      "resource": {
+        "attributes": [
+          {
+            "key": "http.scheme",
+            "value": {
+              "stringValue": "http"
+            }
+          },
+          {
+            "key": "k8s.cluster.name",
+            "value": {
+              "stringValue": "cluster name"
+            }
+          },
+          {
+            "key": "k8s.container.name",
+            "value": {
+              "stringValue": "test-container"
+            }
+          },
+          {
+            "key": "k8s.namespace.annotations.description",
+            "value": {
+              "stringValue": "This is a test namespace."
+            }
+          },
+          {
+            "key": "k8s.namespace.labels.app",
+            "value": {
+              "stringValue": "test-app"
+            }
+          },
+          {
+            "key": "k8s.namespace.labels.kubernetes.io/metadata.name",
+            "value": {
+              "stringValue": "test-namespace"
+            }
+          },
+          {
+            "key": "k8s.namespace.labels.purpose",
+            "value": {
+              "stringValue": "testing"
+            }
+          },
+          {
+            "key": "k8s.namespace.name",
+            "value": {
+              "stringValue": "test-namespace"
+            }
+          },
+          {
+            "key": "k8s.pod.name",
+            "value": {
+              "stringValue": "test-pod"
+            }
+          },
+          {
+            "key": "k8s.pod.uid",
+            "value": {
+              "stringValue": "3d89e9f1-b348-45c1-96ce-6a2a1f127084"
+            }
+          },
+          {
+            "key": "net.host.name",
+            "value": {
+              "stringValue": "test-node"
+            }
+          },
+          {
+            "key": "net.host.port",
+            "value": {
+              "stringValue": ""
+            }
+          },
+          {
+            "key": "service.instance.id",
+            "value": {
+              "stringValue": "test-node"
+            }
+          },
+          {
+            "key": "sw.k8s.agent.app.version",
+            "value": {
+              "stringValue": "0.7.0"
+            }
+          },
+          {
+            "key": "sw.k8s.agent.manifest.version",
+            "value": {
+              "stringValue": "2.5.0-alpha.4"
+            }
+          },
+          {
+            "key": "sw.k8s.cluster.uid",
+            "value": {
+              "stringValue": "cluster-uid-123456789"
+            }
+          },
+          {
+            "key": "sw.k8s.container.init",
+            "value": {
+              "stringValue": "false"
+            }
+          }
+        ]
+      },
+      "scopeMetrics": [
+        {
+          "metrics": [
+            {
+              "gauge": {
+                "dataPoints": [
+                  {
+                    "asDouble": 1,
+                    "attributes": [
+                      {
+                        "key": "endpoint",
+                        "value": {
+                          "stringValue": "http"
+                        }
+                      },
+                      {
+                        "key": "prometheus",
+                        "value": {
+                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
+                        }
+                      },
+                      {
+                        "key": "prometheus_replica",
+                        "value": {
+                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
+                        }
+                      },
+                      {
+                        "key": "reason",
+                        "value": {
+                          "stringValue": "Error"
+                        }
+                      }
+                    ],
+                    "timeUnixNano": "0"
+                  }
+                ]
+              },
+              "name": "k8s.kube_pod_container_status_last_terminated_reason"
+            }
+          ],
+          "scope": {}
+        }
+      ]
+    },
+    {
+      "resource": {
+        "attributes": [
+          {
+            "key": "http.scheme",
+            "value": {
+              "stringValue": "http"
+            }
+          },
+          {
+            "key": "k8s.cluster.name",
+            "value": {
+              "stringValue": "cluster name"
+            }
+          },
+          {
+            "key": "k8s.container.name",
+            "value": {
+              "stringValue": "test-container"
+            }
+          },
+          {
+            "key": "k8s.namespace.annotations.description",
+            "value": {
+              "stringValue": "This is a test namespace."
+            }
+          },
+          {
+            "key": "k8s.namespace.labels.app",
+            "value": {
+              "stringValue": "test-app"
+            }
+          },
+          {
+            "key": "k8s.namespace.labels.kubernetes.io/metadata.name",
+            "value": {
+              "stringValue": "test-namespace"
+            }
+          },
+          {
+            "key": "k8s.namespace.labels.purpose",
+            "value": {
+              "stringValue": "testing"
+            }
+          },
+          {
+            "key": "k8s.namespace.name",
+            "value": {
+              "stringValue": "test-namespace"
+            }
+          },
+          {
+            "key": "k8s.pod.name",
+            "value": {
+              "stringValue": "test-pod"
+            }
+          },
+          {
+            "key": "k8s.pod.uid",
+            "value": {
+              "stringValue": "541e045c-feed-490e-88a6-b33b515bf3cf"
+            }
+          },
+          {
+            "key": "net.host.name",
+            "value": {
+              "stringValue": "test-node"
+            }
+          },
+          {
+            "key": "net.host.port",
+            "value": {
+              "stringValue": ""
+            }
+          },
+          {
+            "key": "service.instance.id",
+            "value": {
+              "stringValue": "test-node"
+            }
+          },
+          {
+            "key": "sw.k8s.agent.app.version",
+            "value": {
+              "stringValue": "0.7.0"
+            }
+          },
+          {
+            "key": "sw.k8s.agent.manifest.version",
+            "value": {
+              "stringValue": "2.5.0-alpha.4"
+            }
+          },
+          {
+            "key": "sw.k8s.cluster.uid",
+            "value": {
+              "stringValue": "cluster-uid-123456789"
+            }
+          },
+          {
+            "key": "sw.k8s.container.init",
+            "value": {
+              "stringValue": "false"
+            }
+          }
+        ]
+      },
+      "scopeMetrics": [
+        {
+          "metrics": [
+            {
+              "gauge": {
+                "dataPoints": [
+                  {
+                    "asDouble": 1679916695,
+                    "attributes": [
+                      {
+                        "key": "endpoint",
+                        "value": {
+                          "stringValue": "http"
+                        }
+                      },
+                      {
+                        "key": "prometheus",
+                        "value": {
+                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
+                        }
+                      },
+                      {
+                        "key": "prometheus_replica",
+                        "value": {
+                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
+                        }
+                      }
+                    ],
+                    "timeUnixNano": "0"
+                  }
+                ]
+              },
+              "name": "k8s.kube_pod_container_state_started"
+            }
+          ],
+          "scope": {}
+        }
+      ]
+    },
+    {
+      "resource": {
+        "attributes": [
+          {
+            "key": "http.scheme",
+            "value": {
+              "stringValue": "http"
+            }
+          },
+          {
+            "key": "k8s.cluster.name",
+            "value": {
+              "stringValue": "cluster name"
+            }
+          },
+          {
+            "key": "k8s.container.name",
+            "value": {
+              "stringValue": "test-container"
+            }
+          },
+          {
+            "key": "k8s.namespace.annotations.description",
+            "value": {
+              "stringValue": "This is a test namespace."
+            }
+          },
+          {
+            "key": "k8s.namespace.labels.app",
+            "value": {
+              "stringValue": "test-app"
+            }
+          },
+          {
+            "key": "k8s.namespace.labels.kubernetes.io/metadata.name",
+            "value": {
+              "stringValue": "test-namespace"
+            }
+          },
+          {
+            "key": "k8s.namespace.labels.purpose",
+            "value": {
+              "stringValue": "testing"
+            }
+          },
+          {
+            "key": "k8s.namespace.name",
+            "value": {
+              "stringValue": "test-namespace"
+            }
+          },
+          {
+            "key": "k8s.pod.name",
+            "value": {
+              "stringValue": "test-pod"
+            }
+          },
+          {
+            "key": "k8s.pod.uid",
+            "value": {
+              "stringValue": "64b6d309-44e3-4a41-8883-c15c7cc9bc4a"
+            }
+          },
+          {
+            "key": "net.host.name",
+            "value": {
+              "stringValue": "test-node"
+            }
+          },
+          {
+            "key": "net.host.port",
+            "value": {
+              "stringValue": ""
+            }
+          },
+          {
+            "key": "service.instance.id",
+            "value": {
+              "stringValue": "test-node"
+            }
+          },
+          {
+            "key": "sw.k8s.agent.app.version",
+            "value": {
+              "stringValue": "0.7.0"
+            }
+          },
+          {
+            "key": "sw.k8s.agent.manifest.version",
+            "value": {
+              "stringValue": "2.5.0-alpha.4"
+            }
+          },
+          {
+            "key": "sw.k8s.cluster.uid",
+            "value": {
+              "stringValue": "cluster-uid-123456789"
+            }
+          },
+          {
+            "key": "sw.k8s.container.init",
+            "value": {
+              "stringValue": "true"
+            }
+          }
+        ]
+      },
+      "scopeMetrics": [
+        {
+          "metrics": [
+            {
+              "gauge": {
+                "dataPoints": [
+                  {
+                    "asDouble": 1,
+                    "attributes": [
+                      {
+                        "key": "endpoint",
+                        "value": {
+                          "stringValue": "http"
+                        }
+                      },
+                      {
+                        "key": "prometheus",
+                        "value": {
+                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
+                        }
+                      },
+                      {
+                        "key": "prometheus_replica",
+                        "value": {
+                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
+                        }
+                      }
+                    ],
+                    "timeUnixNano": "0"
+                  }
+                ]
+              },
+              "name": "k8s.kube_pod_init_container_status_ready"
+            }
+          ],
+          "scope": {}
+        }
+      ]
+    },
+    {
+      "resource": {
+        "attributes": [
+          {
+            "key": "http.scheme",
+            "value": {
+              "stringValue": "http"
+            }
+          },
+          {
+            "key": "k8s.cluster.name",
+            "value": {
+              "stringValue": "cluster name"
+            }
+          },
+          {
+            "key": "k8s.container.name",
+            "value": {
+              "stringValue": "test-container"
+            }
+          },
+          {
+            "key": "k8s.namespace.annotations.description",
+            "value": {
+              "stringValue": "This is a test namespace."
+            }
+          },
+          {
+            "key": "k8s.namespace.labels.app",
+            "value": {
+              "stringValue": "test-app"
+            }
+          },
+          {
+            "key": "k8s.namespace.labels.kubernetes.io/metadata.name",
+            "value": {
+              "stringValue": "test-namespace"
+            }
+          },
+          {
+            "key": "k8s.namespace.labels.purpose",
+            "value": {
+              "stringValue": "testing"
+            }
+          },
+          {
+            "key": "k8s.namespace.name",
+            "value": {
+              "stringValue": "test-namespace"
+            }
+          },
+          {
+            "key": "k8s.pod.name",
+            "value": {
+              "stringValue": "test-pod"
+            }
+          },
+          {
+            "key": "k8s.pod.uid",
+            "value": {
+              "stringValue": "71057e83-7723-4db5-a7ca-52ad7904e34d"
+            }
+          },
+          {
+            "key": "net.host.name",
+            "value": {
+              "stringValue": "test-node"
+            }
+          },
+          {
+            "key": "net.host.port",
+            "value": {
+              "stringValue": ""
+            }
+          },
+          {
+            "key": "service.instance.id",
+            "value": {
+              "stringValue": "test-node"
+            }
+          },
+          {
+            "key": "sw.k8s.agent.app.version",
+            "value": {
+              "stringValue": "0.7.0"
+            }
+          },
+          {
+            "key": "sw.k8s.agent.manifest.version",
+            "value": {
+              "stringValue": "2.5.0-alpha.4"
+            }
+          },
+          {
+            "key": "sw.k8s.cluster.uid",
+            "value": {
+              "stringValue": "cluster-uid-123456789"
+            }
+          },
+          {
+            "key": "sw.k8s.container.init",
+            "value": {
+              "stringValue": "false"
+            }
+          }
+        ]
+      },
+      "scopeMetrics": [
+        {
+          "metrics": [
+            {
+              "gauge": {
+                "dataPoints": [
+                  {
+                    "asDouble": 1,
+                    "attributes": [
+                      {
+                        "key": "endpoint",
+                        "value": {
+                          "stringValue": "http"
+                        }
+                      },
+                      {
+                        "key": "prometheus",
+                        "value": {
+                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
+                        }
+                      },
+                      {
+                        "key": "prometheus_replica",
+                        "value": {
+                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
+                        }
+                      },
+                      {
+                        "key": "reason",
+                        "value": {
+                          "stringValue": "Completed"
+                        }
+                      }
+                    ],
+                    "timeUnixNano": "0"
+                  }
+                ]
+              },
+              "name": "k8s.kube_pod_container_status_terminated_reason"
+            }
+          ],
+          "scope": {}
+        }
+      ]
+    },
+    {
+      "resource": {
+        "attributes": [
+          {
+            "key": "http.scheme",
+            "value": {
+              "stringValue": "http"
+            }
+          },
+          {
+            "key": "k8s.cluster.name",
+            "value": {
+              "stringValue": "cluster name"
+            }
+          },
+          {
+            "key": "k8s.container.name",
+            "value": {
+              "stringValue": "test-container"
+            }
+          },
+          {
+            "key": "k8s.namespace.annotations.description",
+            "value": {
+              "stringValue": "This is a test namespace."
+            }
+          },
+          {
+            "key": "k8s.namespace.labels.app",
+            "value": {
+              "stringValue": "test-app"
+            }
+          },
+          {
+            "key": "k8s.namespace.labels.kubernetes.io/metadata.name",
+            "value": {
+              "stringValue": "test-namespace"
+            }
+          },
+          {
+            "key": "k8s.namespace.labels.purpose",
+            "value": {
+              "stringValue": "testing"
+            }
+          },
+          {
+            "key": "k8s.namespace.name",
+            "value": {
+              "stringValue": "test-namespace"
+            }
+          },
+          {
+            "key": "k8s.pod.name",
+            "value": {
+              "stringValue": "test-pod"
+            }
+          },
+          {
+            "key": "k8s.pod.uid",
+            "value": {
+              "stringValue": "a920ed2f-477d-4ad7-93d6-3222aabfece2"
+            }
+          },
+          {
+            "key": "net.host.name",
+            "value": {
+              "stringValue": "test-node"
+            }
+          },
+          {
+            "key": "net.host.port",
+            "value": {
+              "stringValue": ""
+            }
+          },
+          {
+            "key": "service.instance.id",
+            "value": {
+              "stringValue": "test-node"
+            }
+          },
+          {
+            "key": "sw.k8s.agent.app.version",
+            "value": {
+              "stringValue": "0.7.0"
+            }
+          },
+          {
+            "key": "sw.k8s.agent.manifest.version",
+            "value": {
+              "stringValue": "2.5.0-alpha.4"
+            }
+          },
+          {
+            "key": "sw.k8s.cluster.uid",
+            "value": {
+              "stringValue": "cluster-uid-123456789"
+            }
+          },
+          {
+            "key": "sw.k8s.container.init",
+            "value": {
+              "stringValue": "true"
+            }
+          }
+        ]
+      },
+      "scopeMetrics": [
+        {
+          "metrics": [
+            {
+              "gauge": {
+                "dataPoints": [
+                  {
+                    "asDouble": 1073741824,
+                    "attributes": [
+                      {
+                        "key": "endpoint",
+                        "value": {
+                          "stringValue": "http"
+                        }
+                      },
+                      {
+                        "key": "prometheus",
+                        "value": {
+                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
+                        }
+                      },
+                      {
+                        "key": "prometheus_replica",
+                        "value": {
+                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
+                        }
+                      }
+                    ],
+                    "timeUnixNano": "0"
+                  }
+                ]
+              },
+              "name": "k8s.kube_pod_init_container_resource_limits_memory_bytes"
+            },
+            {
+              "name": "k8s.kube_pod_init_container_status_restarts_total",
+              "sum": {
+                "aggregationTemporality": 2,
+                "dataPoints": [
+                  {
+                    "asDouble": 0,
+                    "attributes": [
+                      {
+                        "key": "endpoint",
+                        "value": {
+                          "stringValue": "http"
+                        }
+                      },
+                      {
+                        "key": "prometheus",
+                        "value": {
+                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
+                        }
+                      },
+                      {
+                        "key": "prometheus_replica",
+                        "value": {
+                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
+                        }
+                      }
+                    ],
+                    "timeUnixNano": "0"
+                  }
+                ],
+                "isMonotonic": true
+              }
+            }
+          ],
+          "scope": {}
+        }
+      ]
+    },
+    {
+      "resource": {
+        "attributes": [
+          {
+            "key": "http.scheme",
+            "value": {
+              "stringValue": "http"
+            }
+          },
+          {
+            "key": "k8s.cluster.name",
+            "value": {
+              "stringValue": "cluster name"
+            }
+          },
+          {
+            "key": "k8s.container.name",
+            "value": {
+              "stringValue": "test-container"
+            }
+          },
+          {
+            "key": "k8s.namespace.annotations.description",
+            "value": {
+              "stringValue": "This is a test namespace."
+            }
+          },
+          {
+            "key": "k8s.namespace.labels.app",
+            "value": {
+              "stringValue": "test-app"
+            }
+          },
+          {
+            "key": "k8s.namespace.labels.kubernetes.io/metadata.name",
+            "value": {
+              "stringValue": "test-namespace"
+            }
+          },
+          {
+            "key": "k8s.namespace.labels.purpose",
+            "value": {
+              "stringValue": "testing"
+            }
+          },
+          {
+            "key": "k8s.namespace.name",
+            "value": {
+              "stringValue": "test-namespace"
+            }
+          },
+          {
+            "key": "k8s.pod.name",
+            "value": {
+              "stringValue": "test-pod"
+            }
+          },
+          {
+            "key": "k8s.pod.uid",
+            "value": {
+              "stringValue": "bafeef2c-1292-4a5e-a92c-d709480b04b6"
+            }
+          },
+          {
+            "key": "net.host.name",
+            "value": {
+              "stringValue": "test-node"
+            }
+          },
+          {
+            "key": "net.host.port",
+            "value": {
+              "stringValue": ""
+            }
+          },
+          {
+            "key": "service.instance.id",
+            "value": {
+              "stringValue": "test-node"
+            }
+          },
+          {
+            "key": "sw.k8s.agent.app.version",
+            "value": {
+              "stringValue": "0.7.0"
+            }
+          },
+          {
+            "key": "sw.k8s.agent.manifest.version",
+            "value": {
+              "stringValue": "2.5.0-alpha.4"
+            }
+          },
+          {
+            "key": "sw.k8s.cluster.uid",
+            "value": {
+              "stringValue": "cluster-uid-123456789"
+            }
+          },
+          {
+            "key": "sw.k8s.container.init",
+            "value": {
+              "stringValue": "false"
+            }
+          }
+        ]
+      },
+      "scopeMetrics": [
+        {
+          "metrics": [
+            {
+              "gauge": {
+                "dataPoints": [
+                  {
+                    "asDouble": 1681390530,
+                    "attributes": [
+                      {
+                        "key": "endpoint",
+                        "value": {
+                          "stringValue": "http"
+                        }
+                      },
+                      {
+                        "key": "prometheus",
+                        "value": {
+                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
+                        }
+                      },
+                      {
+                        "key": "prometheus_replica",
+                        "value": {
+                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
+                        }
+                      }
+                    ],
+                    "timeUnixNano": "0"
+                  }
+                ]
+              },
+              "name": "k8s.kube_pod_container_state_started"
+            },
+            {
+              "gauge": {
+                "dataPoints": [
+                  {
+                    "asDouble": 1,
+                    "attributes": [
+                      {
+                        "key": "endpoint",
+                        "value": {
+                          "stringValue": "http"
+                        }
+                      },
+                      {
+                        "key": "prometheus",
+                        "value": {
+                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
+                        }
+                      },
+                      {
+                        "key": "prometheus_replica",
+                        "value": {
+                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
+                        }
+                      }
+                    ],
+                    "timeUnixNano": "0"
+                  }
+                ]
+              },
+              "name": "k8s.kube_pod_container_status_ready"
+            },
+            {
+              "name": "k8s.kube_pod_container_status_restarts_total",
+              "sum": {
+                "aggregationTemporality": 2,
+                "dataPoints": [
+                  {
+                    "asDouble": 0,
+                    "attributes": [
+                      {
+                        "key": "endpoint",
+                        "value": {
+                          "stringValue": "http"
+                        }
+                      },
+                      {
+                        "key": "prometheus",
+                        "value": {
+                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
+                        }
+                      },
+                      {
+                        "key": "prometheus_replica",
+                        "value": {
+                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
+                        }
+                      }
+                    ],
+                    "timeUnixNano": "0"
+                  },
+                  {
+                    "asDouble": 0,
+                    "attributes": [
+                      {
+                        "key": "endpoint",
+                        "value": {
+                          "stringValue": "tcp-model"
+                        }
+                      },
+                      {
+                        "key": "prometheus",
+                        "value": {
+                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
+                        }
+                      },
+                      {
+                        "key": "prometheus_replica",
+                        "value": {
+                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
+                        }
+                      }
+                    ],
+                    "timeUnixNano": "0"
+                  }
+                ],
+                "isMonotonic": true
+              }
+            },
+            {
+              "gauge": {
+                "dataPoints": [
+                  {
+                    "asDouble": 1,
+                    "attributes": [
+                      {
+                        "key": "endpoint",
+                        "value": {
+                          "stringValue": "http"
+                        }
+                      },
+                      {
+                        "key": "prometheus",
+                        "value": {
+                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
+                        }
+                      },
+                      {
+                        "key": "prometheus_replica",
+                        "value": {
+                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
+                        }
+                      }
+                    ],
+                    "timeUnixNano": "0"
+                  },
+                  {
+                    "asDouble": 1,
+                    "attributes": [
+                      {
+                        "key": "endpoint",
+                        "value": {
+                          "stringValue": "tcp-model"
+                        }
+                      },
+                      {
+                        "key": "prometheus",
+                        "value": {
+                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
+                        }
+                      },
+                      {
+                        "key": "prometheus_replica",
+                        "value": {
+                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
+                        }
+                      }
+                    ],
+                    "timeUnixNano": "0"
+                  }
+                ]
+              },
+              "name": "k8s.kube_pod_container_status_running"
+            },
+            {
+              "gauge": {
+                "dataPoints": [
+                  {
+                    "asDouble": 0,
+                    "attributes": [
+                      {
+                        "key": "endpoint",
+                        "value": {
+                          "stringValue": "http"
+                        }
+                      },
+                      {
+                        "key": "prometheus",
+                        "value": {
+                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
+                        }
+                      },
+                      {
+                        "key": "prometheus_replica",
+                        "value": {
+                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
+                        }
+                      }
+                    ],
+                    "timeUnixNano": "0"
+                  }
+                ]
+              },
+              "name": "k8s.kube_pod_container_status_terminated"
+            },
+            {
+              "gauge": {
+                "dataPoints": [
+                  {
+                    "asDouble": 0,
+                    "attributes": [
+                      {
+                        "key": "endpoint",
+                        "value": {
+                          "stringValue": "http"
+                        }
+                      },
+                      {
+                        "key": "prometheus",
+                        "value": {
+                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
+                        }
+                      },
+                      {
+                        "key": "prometheus_replica",
+                        "value": {
+                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
+                        }
+                      }
+                    ],
+                    "timeUnixNano": "0"
+                  }
+                ]
+              },
+              "name": "k8s.kube_pod_container_status_waiting"
+            }
+          ],
+          "scope": {}
+        }
+      ]
+    },
+    {
+      "resource": {
+        "attributes": [
+          {
+            "key": "http.scheme",
+            "value": {
+              "stringValue": "http"
+            }
+          },
+          {
+            "key": "k8s.cluster.name",
+            "value": {
+              "stringValue": "cluster name"
+            }
+          },
+          {
+            "key": "k8s.container.name",
+            "value": {
+              "stringValue": "test-container"
+            }
+          },
+          {
+            "key": "k8s.namespace.annotations.description",
+            "value": {
+              "stringValue": "This is a test namespace."
+            }
+          },
+          {
+            "key": "k8s.namespace.labels.app",
+            "value": {
+              "stringValue": "test-app"
+            }
+          },
+          {
+            "key": "k8s.namespace.labels.kubernetes.io/metadata.name",
+            "value": {
+              "stringValue": "test-namespace"
+            }
+          },
+          {
+            "key": "k8s.namespace.labels.purpose",
+            "value": {
+              "stringValue": "testing"
+            }
+          },
+          {
+            "key": "k8s.namespace.name",
+            "value": {
+              "stringValue": "test-namespace"
+            }
+          },
+          {
+            "key": "k8s.pod.name",
+            "value": {
+              "stringValue": "test-pod"
+            }
+          },
+          {
+            "key": "k8s.pod.uid",
+            "value": {
+              "stringValue": "bafeef2c-1292-4a5e-a92c-d709480b04b6"
+            }
+          },
+          {
+            "key": "net.host.name",
+            "value": {
+              "stringValue": "test-node"
+            }
+          },
+          {
+            "key": "net.host.port",
+            "value": {
+              "stringValue": ""
+            }
+          },
+          {
+            "key": "service.instance.id",
+            "value": {
+              "stringValue": "test-node"
+            }
+          },
+          {
+            "key": "sw.k8s.agent.app.version",
+            "value": {
+              "stringValue": "0.7.0"
+            }
+          },
+          {
+            "key": "sw.k8s.agent.manifest.version",
+            "value": {
+              "stringValue": "2.5.0-alpha.4"
+            }
+          },
+          {
+            "key": "sw.k8s.cluster.uid",
+            "value": {
+              "stringValue": "cluster-uid-123456789"
+            }
+          },
+          {
+            "key": "sw.k8s.container.init",
+            "value": {
+              "stringValue": "false"
+            }
+          },
+          {
+            "key": "sw.k8s.container.status",
+            "value": {
+              "stringValue": "running"
+            }
+          }
+        ]
+      },
+      "scopeMetrics": [
+        {
+          "metrics": [
+            {
+              "gauge": {
+                "dataPoints": [
+                  {
+                    "asDouble": 1,
+                    "attributes": [
+                      {
+                        "key": "endpoint",
+                        "value": {
+                          "stringValue": "http"
+                        }
+                      },
+                      {
+                        "key": "prometheus",
+                        "value": {
+                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
+                        }
+                      },
+                      {
+                        "key": "prometheus_replica",
+                        "value": {
+                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
+                        }
+                      }
+                    ],
+                    "timeUnixNano": "0"
+                  },
+                  {
+                    "asDouble": 1,
+                    "attributes": [
+                      {
+                        "key": "endpoint",
+                        "value": {
+                          "stringValue": "tcp-model"
+                        }
+                      },
+                      {
+                        "key": "prometheus",
+                        "value": {
+                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
+                        }
+                      },
+                      {
+                        "key": "prometheus_replica",
+                        "value": {
+                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
+                        }
+                      }
+                    ],
+                    "timeUnixNano": "0"
+                  }
+                ]
+              },
+              "name": "k8s.container.status"
+            }
+          ],
+          "scope": {}
+        }
+      ]
+    },
+    {
+      "resource": {
+        "attributes": [
+          {
+            "key": "http.scheme",
+            "value": {
+              "stringValue": "http"
+            }
+          },
+          {
+            "key": "k8s.cluster.name",
+            "value": {
+              "stringValue": "cluster name"
+            }
+          },
+          {
+            "key": "k8s.container.name",
+            "value": {
+              "stringValue": "test-container"
+            }
+          },
+          {
+            "key": "k8s.namespace.annotations.description",
+            "value": {
+              "stringValue": "This is a test namespace."
+            }
+          },
+          {
+            "key": "k8s.namespace.labels.app",
+            "value": {
+              "stringValue": "test-app"
+            }
+          },
+          {
+            "key": "k8s.namespace.labels.kubernetes.io/metadata.name",
+            "value": {
+              "stringValue": "test-namespace"
+            }
+          },
+          {
+            "key": "k8s.namespace.labels.purpose",
+            "value": {
+              "stringValue": "testing"
+            }
+          },
+          {
+            "key": "k8s.namespace.name",
+            "value": {
+              "stringValue": "test-namespace"
+            }
+          },
+          {
+            "key": "k8s.pod.name",
+            "value": {
+              "stringValue": "test-pod"
+            }
+          },
+          {
+            "key": "k8s.pod.uid",
+            "value": {
+              "stringValue": "bafeef2c-1292-4a5e-a92c-d709480b04b6"
+            }
+          },
+          {
+            "key": "net.host.name",
+            "value": {
+              "stringValue": "test-node"
+            }
+          },
+          {
+            "key": "net.host.port",
+            "value": {
+              "stringValue": ""
+            }
+          },
+          {
+            "key": "service.instance.id",
+            "value": {
+              "stringValue": "test-node"
+            }
+          },
+          {
+            "key": "sw.k8s.agent.app.version",
+            "value": {
+              "stringValue": "0.7.0"
+            }
+          },
+          {
+            "key": "sw.k8s.agent.manifest.version",
+            "value": {
+              "stringValue": "2.5.0-alpha.4"
+            }
+          },
+          {
+            "key": "sw.k8s.cluster.uid",
+            "value": {
+              "stringValue": "cluster-uid-123456789"
+            }
+          },
+          {
+            "key": "sw.k8s.container.init",
+            "value": {
+              "stringValue": "true"
+            }
+          }
+        ]
+      },
+      "scopeMetrics": [
+        {
+          "metrics": [
+            {
+              "gauge": {
+                "dataPoints": [
+                  {
+                    "asDouble": 1,
+                    "attributes": [
+                      {
+                        "key": "endpoint",
+                        "value": {
+                          "stringValue": "http"
+                        }
+                      },
+                      {
+                        "key": "prometheus",
+                        "value": {
+                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
+                        }
+                      },
+                      {
+                        "key": "prometheus_replica",
+                        "value": {
+                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
+                        }
+                      }
+                    ],
+                    "timeUnixNano": "0"
+                  }
+                ]
+              },
+              "name": "k8s.kube_pod_init_container_status_ready"
+            },
+            {
+              "name": "k8s.kube_pod_init_container_status_restarts_total",
+              "sum": {
+                "aggregationTemporality": 2,
+                "dataPoints": [
+                  {
+                    "asDouble": 0,
+                    "attributes": [
+                      {
+                        "key": "endpoint",
+                        "value": {
+                          "stringValue": "http"
+                        }
+                      },
+                      {
+                        "key": "prometheus",
+                        "value": {
+                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
+                        }
+                      },
+                      {
+                        "key": "prometheus_replica",
+                        "value": {
+                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
+                        }
+                      }
+                    ],
+                    "timeUnixNano": "0"
+                  }
+                ],
+                "isMonotonic": true
+              }
+            },
+            {
+              "gauge": {
+                "dataPoints": [
+                  {
+                    "asDouble": 0,
+                    "attributes": [
+                      {
+                        "key": "endpoint",
+                        "value": {
+                          "stringValue": "http"
+                        }
+                      },
+                      {
+                        "key": "prometheus",
+                        "value": {
+                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
+                        }
+                      },
+                      {
+                        "key": "prometheus_replica",
+                        "value": {
+                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
+                        }
+                      }
+                    ],
+                    "timeUnixNano": "0"
+                  }
+                ]
+              },
+              "name": "k8s.kube_pod_init_container_status_running"
+            },
+            {
+              "gauge": {
+                "dataPoints": [
+                  {
+                    "asDouble": 1,
+                    "attributes": [
+                      {
+                        "key": "endpoint",
+                        "value": {
+                          "stringValue": "http"
+                        }
+                      },
+                      {
+                        "key": "prometheus",
+                        "value": {
+                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
+                        }
+                      },
+                      {
+                        "key": "prometheus_replica",
+                        "value": {
+                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
+                        }
+                      }
+                    ],
+                    "timeUnixNano": "0"
+                  }
+                ]
+              },
+              "name": "k8s.kube_pod_init_container_status_terminated"
+            },
+            {
+              "gauge": {
+                "dataPoints": [
+                  {
+                    "asDouble": 1,
+                    "attributes": [
+                      {
+                        "key": "endpoint",
+                        "value": {
+                          "stringValue": "http"
+                        }
+                      },
+                      {
+                        "key": "prometheus",
+                        "value": {
+                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
+                        }
+                      },
+                      {
+                        "key": "prometheus_replica",
+                        "value": {
+                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
+                        }
+                      },
+                      {
+                        "key": "reason",
+                        "value": {
+                          "stringValue": "Completed"
+                        }
+                      }
+                    ],
+                    "timeUnixNano": "0"
+                  }
+                ]
+              },
+              "name": "k8s.kube_pod_init_container_status_terminated_reason"
+            },
+            {
+              "gauge": {
+                "dataPoints": [
+                  {
+                    "asDouble": 0,
+                    "attributes": [
+                      {
+                        "key": "endpoint",
+                        "value": {
+                          "stringValue": "http"
+                        }
+                      },
+                      {
+                        "key": "prometheus",
+                        "value": {
+                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
+                        }
+                      },
+                      {
+                        "key": "prometheus_replica",
+                        "value": {
+                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
+                        }
+                      }
+                    ],
+                    "timeUnixNano": "0"
+                  }
+                ]
+              },
+              "name": "k8s.kube_pod_init_container_status_waiting"
+            }
+          ],
+          "scope": {}
+        }
+      ]
+    },
+    {
+      "resource": {
+        "attributes": [
+          {
+            "key": "http.scheme",
+            "value": {
+              "stringValue": "http"
+            }
+          },
+          {
+            "key": "k8s.cluster.name",
+            "value": {
+              "stringValue": "cluster name"
+            }
+          },
+          {
+            "key": "k8s.container.name",
+            "value": {
+              "stringValue": "test-container"
+            }
+          },
+          {
+            "key": "k8s.namespace.annotations.description",
+            "value": {
+              "stringValue": "This is a test namespace."
+            }
+          },
+          {
+            "key": "k8s.namespace.labels.app",
+            "value": {
+              "stringValue": "test-app"
+            }
+          },
+          {
+            "key": "k8s.namespace.labels.kubernetes.io/metadata.name",
+            "value": {
+              "stringValue": "test-namespace"
+            }
+          },
+          {
+            "key": "k8s.namespace.labels.purpose",
+            "value": {
+              "stringValue": "testing"
+            }
+          },
+          {
+            "key": "k8s.namespace.name",
+            "value": {
+              "stringValue": "test-namespace"
+            }
+          },
+          {
+            "key": "k8s.pod.name",
+            "value": {
+              "stringValue": "test-pod"
+            }
+          },
+          {
+            "key": "k8s.pod.uid",
+            "value": {
+              "stringValue": "bafeef2c-1292-4a5e-a92c-d709480b04b6"
+            }
+          },
+          {
+            "key": "net.host.name",
+            "value": {
+              "stringValue": "test-node"
+            }
+          },
+          {
+            "key": "net.host.port",
+            "value": {
+              "stringValue": ""
+            }
+          },
+          {
+            "key": "service.instance.id",
+            "value": {
+              "stringValue": "test-node"
+            }
+          },
+          {
+            "key": "sw.k8s.agent.app.version",
+            "value": {
+              "stringValue": "0.7.0"
+            }
+          },
+          {
+            "key": "sw.k8s.agent.manifest.version",
+            "value": {
+              "stringValue": "2.5.0-alpha.4"
+            }
+          },
+          {
+            "key": "sw.k8s.cluster.uid",
+            "value": {
+              "stringValue": "cluster-uid-123456789"
+            }
+          },
+          {
+            "key": "sw.k8s.container.init",
+            "value": {
+              "stringValue": "true"
+            }
+          },
+          {
+            "key": "sw.k8s.container.status",
+            "value": {
+              "stringValue": "terminated"
+            }
+          }
+        ]
+      },
+      "scopeMetrics": [
+        {
+          "metrics": [
+            {
+              "gauge": {
+                "dataPoints": [
+                  {
+                    "asDouble": 1,
+                    "attributes": [
+                      {
+                        "key": "endpoint",
+                        "value": {
+                          "stringValue": "http"
+                        }
+                      },
+                      {
+                        "key": "prometheus",
+                        "value": {
+                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
+                        }
+                      },
+                      {
+                        "key": "prometheus_replica",
+                        "value": {
+                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
+                        }
+                      }
+                    ],
+                    "timeUnixNano": "0"
+                  }
+                ]
+              },
+              "name": "k8s.container.status"
+            }
+          ],
+          "scope": {}
+        }
+      ]
+    },
+    {
+      "resource": {
+        "attributes": [
+          {
+            "key": "http.scheme",
+            "value": {
+              "stringValue": "http"
+            }
+          },
+          {
+            "key": "k8s.cluster.name",
+            "value": {
+              "stringValue": "cluster name"
+            }
+          },
+          {
+            "key": "k8s.container.name",
+            "value": {
+              "stringValue": "test-container"
+            }
+          },
+          {
+            "key": "k8s.namespace.annotations.description",
+            "value": {
+              "stringValue": "This is a test namespace."
+            }
+          },
+          {
+            "key": "k8s.namespace.labels.app",
+            "value": {
+              "stringValue": "test-app"
+            }
+          },
+          {
+            "key": "k8s.namespace.labels.kubernetes.io/metadata.name",
+            "value": {
+              "stringValue": "test-namespace"
+            }
+          },
+          {
+            "key": "k8s.namespace.labels.purpose",
+            "value": {
+              "stringValue": "testing"
+            }
+          },
+          {
+            "key": "k8s.namespace.name",
+            "value": {
+              "stringValue": "test-namespace"
+            }
+          },
+          {
+            "key": "k8s.pod.name",
+            "value": {
+              "stringValue": "test-pod"
+            }
+          },
+          {
+            "key": "k8s.pod.uid",
+            "value": {
+              "stringValue": "c7f7a05a-a1b5-4fd0-a611-8e2a0e7acbf6"
+            }
+          },
+          {
+            "key": "net.host.name",
+            "value": {
+              "stringValue": "test-node"
+            }
+          },
+          {
+            "key": "net.host.port",
+            "value": {
+              "stringValue": ""
+            }
+          },
+          {
+            "key": "service.instance.id",
+            "value": {
+              "stringValue": "test-node"
+            }
+          },
+          {
+            "key": "sw.k8s.agent.app.version",
+            "value": {
+              "stringValue": "0.7.0"
+            }
+          },
+          {
+            "key": "sw.k8s.agent.manifest.version",
+            "value": {
+              "stringValue": "2.5.0-alpha.4"
+            }
+          },
+          {
+            "key": "sw.k8s.cluster.uid",
+            "value": {
+              "stringValue": "cluster-uid-123456789"
+            }
+          },
+          {
+            "key": "sw.k8s.container.init",
+            "value": {
+              "stringValue": "true"
+            }
+          }
+        ]
+      },
+      "scopeMetrics": [
+        {
+          "metrics": [
+            {
+              "gauge": {
+                "dataPoints": [
+                  {
+                    "asDouble": 0.25,
+                    "attributes": [
+                      {
+                        "key": "endpoint",
+                        "value": {
+                          "stringValue": "http"
+                        }
+                      },
+                      {
+                        "key": "prometheus",
+                        "value": {
+                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
+                        }
+                      },
+                      {
+                        "key": "prometheus_replica",
+                        "value": {
+                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
+                        }
+                      }
+                    ],
+                    "timeUnixNano": "0"
+                  }
+                ]
+              },
+              "name": "k8s.kube_pod_init_container_resource_requests_cpu_cores"
+            },
+            {
+              "gauge": {
+                "dataPoints": [
+                  {
+                    "asDouble": 67108864,
+                    "attributes": [
+                      {
+                        "key": "endpoint",
+                        "value": {
+                          "stringValue": "http"
+                        }
+                      },
+                      {
+                        "key": "prometheus",
+                        "value": {
+                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
+                        }
+                      },
+                      {
+                        "key": "prometheus_replica",
+                        "value": {
+                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
+                        }
+                      }
+                    ],
+                    "timeUnixNano": "0"
+                  }
+                ]
+              },
+              "name": "k8s.kube_pod_init_container_resource_requests_memory_bytes"
+            },
+            {
+              "gauge": {
+                "dataPoints": [
+                  {
+                    "asDouble": 0,
+                    "attributes": [
+                      {
+                        "key": "endpoint",
+                        "value": {
+                          "stringValue": "http"
+                        }
+                      },
+                      {
+                        "key": "prometheus",
+                        "value": {
+                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
+                        }
+                      },
+                      {
+                        "key": "prometheus_replica",
+                        "value": {
+                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
+                        }
+                      }
+                    ],
+                    "timeUnixNano": "0"
+                  }
+                ]
+              },
+              "name": "k8s.kube_pod_init_container_status_running"
+            },
+            {
+              "gauge": {
+                "dataPoints": [
+                  {
+                    "asDouble": 1,
+                    "attributes": [
+                      {
+                        "key": "endpoint",
+                        "value": {
+                          "stringValue": "http"
+                        }
+                      },
+                      {
+                        "key": "prometheus",
+                        "value": {
+                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
+                        }
+                      },
+                      {
+                        "key": "prometheus_replica",
+                        "value": {
+                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
+                        }
+                      }
+                    ],
+                    "timeUnixNano": "0"
+                  }
+                ]
+              },
+              "name": "k8s.kube_pod_init_container_status_terminated"
+            },
+            {
+              "gauge": {
+                "dataPoints": [
+                  {
+                    "asDouble": 1,
+                    "attributes": [
+                      {
+                        "key": "endpoint",
+                        "value": {
+                          "stringValue": "http"
+                        }
+                      },
+                      {
+                        "key": "prometheus",
+                        "value": {
+                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
+                        }
+                      },
+                      {
+                        "key": "prometheus_replica",
+                        "value": {
+                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
+                        }
+                      },
+                      {
+                        "key": "reason",
+                        "value": {
+                          "stringValue": "Completed"
+                        }
+                      }
+                    ],
+                    "timeUnixNano": "0"
+                  }
+                ]
+              },
+              "name": "k8s.kube_pod_init_container_status_terminated_reason"
+            },
+            {
+              "gauge": {
+                "dataPoints": [
+                  {
+                    "asDouble": 0,
+                    "attributes": [
+                      {
+                        "key": "endpoint",
+                        "value": {
+                          "stringValue": "http"
+                        }
+                      },
+                      {
+                        "key": "prometheus",
+                        "value": {
+                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
+                        }
+                      },
+                      {
+                        "key": "prometheus_replica",
+                        "value": {
+                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
+                        }
+                      }
+                    ],
+                    "timeUnixNano": "0"
+                  }
+                ]
+              },
+              "name": "k8s.kube_pod_init_container_status_waiting"
+            }
+          ],
+          "scope": {}
+        }
+      ]
+    },
+    {
+      "resource": {
+        "attributes": [
+          {
+            "key": "http.scheme",
+            "value": {
+              "stringValue": "http"
+            }
+          },
+          {
+            "key": "k8s.cluster.name",
+            "value": {
+              "stringValue": "cluster name"
+            }
+          },
+          {
+            "key": "k8s.container.name",
+            "value": {
+              "stringValue": "test-container"
+            }
+          },
+          {
+            "key": "k8s.namespace.annotations.description",
+            "value": {
+              "stringValue": "This is a test namespace."
+            }
+          },
+          {
+            "key": "k8s.namespace.labels.app",
+            "value": {
+              "stringValue": "test-app"
+            }
+          },
+          {
+            "key": "k8s.namespace.labels.kubernetes.io/metadata.name",
+            "value": {
+              "stringValue": "test-namespace"
+            }
+          },
+          {
+            "key": "k8s.namespace.labels.purpose",
+            "value": {
+              "stringValue": "testing"
+            }
+          },
+          {
+            "key": "k8s.namespace.name",
+            "value": {
+              "stringValue": "test-namespace"
+            }
+          },
+          {
+            "key": "k8s.pod.name",
+            "value": {
+              "stringValue": "test-pod"
+            }
+          },
+          {
+            "key": "k8s.pod.uid",
+            "value": {
+              "stringValue": "c7f7a05a-a1b5-4fd0-a611-8e2a0e7acbf6"
+            }
+          },
+          {
+            "key": "net.host.name",
+            "value": {
+              "stringValue": "test-node"
+            }
+          },
+          {
+            "key": "net.host.port",
+            "value": {
+              "stringValue": ""
+            }
+          },
+          {
+            "key": "service.instance.id",
+            "value": {
+              "stringValue": "test-node"
+            }
+          },
+          {
+            "key": "sw.k8s.agent.app.version",
+            "value": {
+              "stringValue": "0.7.0"
+            }
+          },
+          {
+            "key": "sw.k8s.agent.manifest.version",
+            "value": {
+              "stringValue": "2.5.0-alpha.4"
+            }
+          },
+          {
+            "key": "sw.k8s.cluster.uid",
+            "value": {
+              "stringValue": "cluster-uid-123456789"
+            }
+          },
+          {
+            "key": "sw.k8s.container.init",
+            "value": {
+              "stringValue": "true"
+            }
+          },
+          {
+            "key": "sw.k8s.container.status",
+            "value": {
+              "stringValue": "terminated"
+            }
+          }
+        ]
+      },
+      "scopeMetrics": [
+        {
+          "metrics": [
+            {
+              "gauge": {
+                "dataPoints": [
+                  {
+                    "asDouble": 1,
+                    "attributes": [
+                      {
+                        "key": "endpoint",
+                        "value": {
+                          "stringValue": "http"
+                        }
+                      },
+                      {
+                        "key": "prometheus",
+                        "value": {
+                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
+                        }
+                      },
+                      {
+                        "key": "prometheus_replica",
+                        "value": {
+                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
+                        }
+                      }
+                    ],
+                    "timeUnixNano": "0"
+                  }
+                ]
+              },
+              "name": "k8s.container.status"
+            }
+          ],
+          "scope": {}
+        }
+      ]
+    },
+    {
+      "resource": {
+        "attributes": [
+          {
+            "key": "http.scheme",
+            "value": {
+              "stringValue": "http"
+            }
+          },
+          {
+            "key": "k8s.cluster.name",
+            "value": {
+              "stringValue": "cluster name"
+            }
+          },
+          {
+            "key": "k8s.container.name",
+            "value": {
+              "stringValue": "test-container"
+            }
+          },
+          {
+            "key": "k8s.namespace.annotations.description",
+            "value": {
+              "stringValue": "This is a test namespace."
+            }
+          },
+          {
+            "key": "k8s.namespace.labels.app",
+            "value": {
+              "stringValue": "test-app"
+            }
+          },
+          {
+            "key": "k8s.namespace.labels.kubernetes.io/metadata.name",
+            "value": {
+              "stringValue": "test-namespace"
+            }
+          },
+          {
+            "key": "k8s.namespace.labels.purpose",
+            "value": {
+              "stringValue": "testing"
+            }
+          },
+          {
+            "key": "k8s.namespace.name",
+            "value": {
+              "stringValue": "test-namespace"
+            }
+          },
+          {
+            "key": "k8s.pod.name",
+            "value": {
+              "stringValue": "test-pod"
+            }
+          },
+          {
+            "key": "net.host.name",
+            "value": {
+              "stringValue": "test-node"
+            }
+          },
+          {
+            "key": "net.host.port",
+            "value": {
+              "stringValue": ""
+            }
+          },
+          {
+            "key": "service.instance.id",
+            "value": {
+              "stringValue": "test-node"
+            }
+          },
+          {
+            "key": "sw.k8s.agent.app.version",
+            "value": {
+              "stringValue": "0.7.0"
+            }
+          },
+          {
+            "key": "sw.k8s.agent.manifest.version",
+            "value": {
+              "stringValue": "2.5.0-alpha.4"
             }
           },
           {
@@ -8002,7 +15360,7 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "2.5.0-alpha.3"
+              "stringValue": "2.5.0-alpha.4"
             }
           },
           {
@@ -8396,7 +15754,153 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "2.5.0-alpha.3"
+              "stringValue": "2.5.0-alpha.4"
+            }
+          },
+          {
+            "key": "sw.k8s.cluster.uid",
+            "value": {
+              "stringValue": "cluster-uid-123456789"
+            }
+          }
+        ]
+      },
+      "scopeMetrics": [
+        {
+          "metrics": [
+            {
+              "gauge": {
+                "dataPoints": [
+                  {
+                    "asDouble": 1,
+                    "attributes": [
+                      {
+                        "key": "endpoint",
+                        "value": {
+                          "stringValue": "tcp-model"
+                        }
+                      },
+                      {
+                        "key": "owner_is_controller",
+                        "value": {
+                          "stringValue": "true"
+                        }
+                      },
+                      {
+                        "key": "owner_kind",
+                        "value": {
+                          "stringValue": "DaemonSet"
+                        }
+                      },
+                      {
+                        "key": "prometheus",
+                        "value": {
+                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
+                        }
+                      },
+                      {
+                        "key": "prometheus_replica",
+                        "value": {
+                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
+                        }
+                      }
+                    ],
+                    "timeUnixNano": "0"
+                  }
+                ]
+              },
+              "name": "k8s.kube.pod.owner.daemonset"
+            }
+          ],
+          "scope": {}
+        }
+      ]
+    },
+    {
+      "resource": {
+        "attributes": [
+          {
+            "key": "http.scheme",
+            "value": {
+              "stringValue": "http"
+            }
+          },
+          {
+            "key": "k8s.cluster.name",
+            "value": {
+              "stringValue": "cluster name"
+            }
+          },
+          {
+            "key": "k8s.daemonset.name",
+            "value": {
+              "stringValue": "spire-spiffe-csi-driver"
+            }
+          },
+          {
+            "key": "k8s.namespace.annotations.description",
+            "value": {
+              "stringValue": "This is a test namespace."
+            }
+          },
+          {
+            "key": "k8s.namespace.labels.app",
+            "value": {
+              "stringValue": "test-app"
+            }
+          },
+          {
+            "key": "k8s.namespace.labels.kubernetes.io/metadata.name",
+            "value": {
+              "stringValue": "test-namespace"
+            }
+          },
+          {
+            "key": "k8s.namespace.labels.purpose",
+            "value": {
+              "stringValue": "testing"
+            }
+          },
+          {
+            "key": "k8s.namespace.name",
+            "value": {
+              "stringValue": "test-namespace"
+            }
+          },
+          {
+            "key": "k8s.pod.name",
+            "value": {
+              "stringValue": "test-pod"
+            }
+          },
+          {
+            "key": "net.host.name",
+            "value": {
+              "stringValue": "test-node"
+            }
+          },
+          {
+            "key": "net.host.port",
+            "value": {
+              "stringValue": ""
+            }
+          },
+          {
+            "key": "service.instance.id",
+            "value": {
+              "stringValue": "test-node"
+            }
+          },
+          {
+            "key": "sw.k8s.agent.app.version",
+            "value": {
+              "stringValue": "0.7.0"
+            }
+          },
+          {
+            "key": "sw.k8s.agent.manifest.version",
+            "value": {
+              "stringValue": "2.5.0-alpha.4"
             }
           },
           {
@@ -8548,7 +16052,7 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "2.5.0-alpha.3"
+              "stringValue": "2.5.0-alpha.4"
             }
           },
           {
@@ -9299,7 +16803,7 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "2.5.0-alpha.3"
+              "stringValue": "2.5.0-alpha.4"
             }
           },
           {
@@ -9457,7 +16961,7 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "2.5.0-alpha.3"
+              "stringValue": "2.5.0-alpha.4"
             }
           },
           {
@@ -9597,7 +17101,7 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "2.5.0-alpha.3"
+              "stringValue": "2.5.0-alpha.4"
             }
           },
           {
@@ -10083,7 +17587,7 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "2.5.0-alpha.3"
+              "stringValue": "2.5.0-alpha.4"
             }
           },
           {
@@ -10265,7 +17769,7 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "2.5.0-alpha.3"
+              "stringValue": "2.5.0-alpha.4"
             }
           },
           {
@@ -10441,7 +17945,7 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "2.5.0-alpha.3"
+              "stringValue": "2.5.0-alpha.4"
             }
           },
           {
@@ -11196,6 +18700,638 @@
                 "dataPoints": [
                   {
                     "asDouble": 0,
+                    "startTimeUnixNano": "0",
+                    "timeUnixNano": "0"
+                  }
+                ]
+              },
+              "name": "k8s.pod.cpu.usage.seconds.rate"
+            },
+            {
+              "gauge": {
+                "dataPoints": [
+                  {
+                    "asDouble": 0,
+                    "startTimeUnixNano": "0",
+                    "timeUnixNano": "0"
+                  }
+                ]
+              },
+              "name": "k8s.pod.fs.iops"
+            },
+            {
+              "gauge": {
+                "dataPoints": [
+                  {
+                    "asDouble": 0,
+                    "startTimeUnixNano": "0",
+                    "timeUnixNano": "0"
+                  }
+                ]
+              },
+              "name": "k8s.pod.fs.reads.bytes.rate"
+            },
+            {
+              "gauge": {
+                "dataPoints": [
+                  {
+                    "asDouble": 0,
+                    "startTimeUnixNano": "0",
+                    "timeUnixNano": "0"
+                  }
+                ]
+              },
+              "name": "k8s.pod.fs.reads.rate"
+            },
+            {
+              "gauge": {
+                "dataPoints": [
+                  {
+                    "asDouble": 0,
+                    "startTimeUnixNano": "0",
+                    "timeUnixNano": "0"
+                  }
+                ]
+              },
+              "name": "k8s.pod.fs.throughput"
+            },
+            {
+              "gauge": {
+                "dataPoints": [
+                  {
+                    "asDouble": 552960,
+                    "timeUnixNano": "0"
+                  }
+                ]
+              },
+              "name": "k8s.pod.fs.usage.bytes"
+            },
+            {
+              "gauge": {
+                "dataPoints": [
+                  {
+                    "asDouble": 0,
+                    "startTimeUnixNano": "0",
+                    "timeUnixNano": "0"
+                  }
+                ]
+              },
+              "name": "k8s.pod.fs.writes.bytes.rate"
+            },
+            {
+              "gauge": {
+                "dataPoints": [
+                  {
+                    "asDouble": 0,
+                    "startTimeUnixNano": "0",
+                    "timeUnixNano": "0"
+                  }
+                ]
+              },
+              "name": "k8s.pod.fs.writes.rate"
+            },
+            {
+              "gauge": {
+                "dataPoints": [
+                  {
+                    "asDouble": 2078343168,
+                    "timeUnixNano": "0"
+                  }
+                ]
+              },
+              "name": "k8s.pod.memory.working_set"
+            },
+            {
+              "gauge": {
+                "dataPoints": [
+                  {
+                    "asDouble": 0,
+                    "startTimeUnixNano": "0",
+                    "timeUnixNano": "0"
+                  }
+                ]
+              },
+              "name": "k8s.pod.network.bytes_received"
+            },
+            {
+              "gauge": {
+                "dataPoints": [
+                  {
+                    "asDouble": 0,
+                    "startTimeUnixNano": "0",
+                    "timeUnixNano": "0"
+                  }
+                ]
+              },
+              "name": "k8s.pod.network.bytes_transmitted"
+            },
+            {
+              "gauge": {
+                "dataPoints": [
+                  {
+                    "asDouble": 0,
+                    "startTimeUnixNano": "0",
+                    "timeUnixNano": "0"
+                  }
+                ]
+              },
+              "name": "k8s.pod.network.packets_received"
+            },
+            {
+              "gauge": {
+                "dataPoints": [
+                  {
+                    "asDouble": 0,
+                    "startTimeUnixNano": "0",
+                    "timeUnixNano": "0"
+                  }
+                ]
+              },
+              "name": "k8s.pod.network.packets_transmitted"
+            },
+            {
+              "gauge": {
+                "dataPoints": [
+                  {
+                    "asDouble": 0,
+                    "startTimeUnixNano": "0",
+                    "timeUnixNano": "0"
+                  }
+                ]
+              },
+              "name": "k8s.pod.network.receive_packets_dropped"
+            },
+            {
+              "gauge": {
+                "dataPoints": [
+                  {
+                    "asDouble": 0,
+                    "startTimeUnixNano": "0",
+                    "timeUnixNano": "0"
+                  }
+                ]
+              },
+              "name": "k8s.pod.network.transmit_packets_dropped"
+            },
+            {
+              "gauge": {
+                "dataPoints": [
+                  {
+                    "asDouble": 1,
+                    "timeUnixNano": "0"
+                  }
+                ]
+              },
+              "name": "k8s.pod.spec.cpu.limit"
+            }
+          ],
+          "scope": {}
+        }
+      ]
+    },
+    {
+      "resource": {
+        "attributes": [
+          {
+            "key": "http.scheme",
+            "value": {
+              "stringValue": "http"
+            }
+          },
+          {
+            "key": "k8s.cluster.name",
+            "value": {
+              "stringValue": "cluster name"
+            }
+          },
+          {
+            "key": "k8s.namespace.annotations.description",
+            "value": {
+              "stringValue": "This is a test namespace."
+            }
+          },
+          {
+            "key": "k8s.namespace.labels.app",
+            "value": {
+              "stringValue": "test-app"
+            }
+          },
+          {
+            "key": "k8s.namespace.labels.kubernetes.io/metadata.name",
+            "value": {
+              "stringValue": "test-namespace"
+            }
+          },
+          {
+            "key": "k8s.namespace.labels.purpose",
+            "value": {
+              "stringValue": "testing"
+            }
+          },
+          {
+            "key": "k8s.namespace.name",
+            "value": {
+              "stringValue": "test-namespace"
+            }
+          },
+          {
+            "key": "k8s.node.name",
+            "value": {
+              "stringValue": "test-node"
+            }
+          },
+          {
+            "key": "k8s.pod.name",
+            "value": {
+              "stringValue": "test-pod"
+            }
+          },
+          {
+            "key": "k8s.pod.uid",
+            "value": {
+              "stringValue": "bafeef2c-1292-4a5e-a92c-d709480b04b6"
+            }
+          },
+          {
+            "key": "net.host.name",
+            "value": {
+              "stringValue": "test-node"
+            }
+          },
+          {
+            "key": "net.host.port",
+            "value": {
+              "stringValue": ""
+            }
+          },
+          {
+            "key": "service.instance.id",
+            "value": {
+              "stringValue": "test-node"
+            }
+          },
+          {
+            "key": "sw.k8s.agent.app.version",
+            "value": {
+              "stringValue": "0.7.0"
+            }
+          },
+          {
+            "key": "sw.k8s.agent.manifest.version",
+            "value": {
+              "stringValue": "2.5.0-alpha.4"
+            }
+          },
+          {
+            "key": "sw.k8s.cluster.uid",
+            "value": {
+              "stringValue": "cluster-uid-123456789"
+            }
+          },
+          {
+            "key": "sw.k8s.pod.createdby.kind",
+            "value": {
+              "stringValue": "ReplicaSet"
+            }
+          },
+          {
+            "key": "sw.k8s.pod.createdby.name",
+            "value": {
+              "stringValue": "swi-k8s-otel-collector-swo-k8s-collector-metrics-cf8f6886b"
+            }
+          },
+          {
+            "key": "sw.k8s.pod.host.ip",
+            "value": {
+              "stringValue": "172.22.2.84"
+            }
+          },
+          {
+            "key": "sw.k8s.pod.host.network",
+            "value": {
+              "stringValue": "false"
+            }
+          },
+          {
+            "key": "sw.k8s.pod.ip",
+            "value": {
+              "stringValue": "192.168.62.77"
+            }
+          }
+        ]
+      },
+      "scopeMetrics": [
+        {
+          "metrics": [
+            {
+              "gauge": {
+                "dataPoints": [
+                  {
+                    "asDouble": 1,
+                    "attributes": [
+                      {
+                        "key": "endpoint",
+                        "value": {
+                          "stringValue": "http"
+                        }
+                      },
+                      {
+                        "key": "prometheus",
+                        "value": {
+                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
+                        }
+                      },
+                      {
+                        "key": "prometheus_replica",
+                        "value": {
+                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
+                        }
+                      }
+                    ],
+                    "timeUnixNano": "0"
+                  }
+                ]
+              },
+              "name": "k8s.kube_pod_info"
+            }
+          ],
+          "scope": {}
+        }
+      ]
+    },
+    {
+      "resource": {
+        "attributes": [
+          {
+            "key": "http.scheme",
+            "value": {
+              "stringValue": "http"
+            }
+          },
+          {
+            "key": "k8s.cluster.name",
+            "value": {
+              "stringValue": "cluster name"
+            }
+          },
+          {
+            "key": "k8s.namespace.annotations.description",
+            "value": {
+              "stringValue": "This is a test namespace."
+            }
+          },
+          {
+            "key": "k8s.namespace.labels.app",
+            "value": {
+              "stringValue": "test-app"
+            }
+          },
+          {
+            "key": "k8s.namespace.labels.kubernetes.io/metadata.name",
+            "value": {
+              "stringValue": "test-namespace"
+            }
+          },
+          {
+            "key": "k8s.namespace.labels.purpose",
+            "value": {
+              "stringValue": "testing"
+            }
+          },
+          {
+            "key": "k8s.namespace.name",
+            "value": {
+              "stringValue": "test-namespace"
+            }
+          },
+          {
+            "key": "k8s.node.name",
+            "value": {
+              "stringValue": "test-node"
+            }
+          },
+          {
+            "key": "k8s.pod.name",
+            "value": {
+              "stringValue": "test-pod"
+            }
+          },
+          {
+            "key": "k8s.pod.uid",
+            "value": {
+              "stringValue": "e309e877-f170-4817-8ef7-3a27789d7271"
+            }
+          },
+          {
+            "key": "net.host.name",
+            "value": {
+              "stringValue": "test-node"
+            }
+          },
+          {
+            "key": "net.host.port",
+            "value": {
+              "stringValue": ""
+            }
+          },
+          {
+            "key": "service.instance.id",
+            "value": {
+              "stringValue": "test-node"
+            }
+          },
+          {
+            "key": "sw.k8s.agent.app.version",
+            "value": {
+              "stringValue": "0.7.0"
+            }
+          },
+          {
+            "key": "sw.k8s.agent.manifest.version",
+            "value": {
+              "stringValue": "2.5.0-alpha.4"
+            }
+          },
+          {
+            "key": "sw.k8s.cluster.uid",
+            "value": {
+              "stringValue": "cluster-uid-123456789"
+            }
+          },
+          {
+            "key": "sw.k8s.pod.createdby.kind",
+            "value": {
+              "stringValue": "<none>"
+            }
+          },
+          {
+            "key": "sw.k8s.pod.createdby.name",
+            "value": {
+              "stringValue": "<none>"
+            }
+          },
+          {
+            "key": "sw.k8s.pod.host.ip",
+            "value": {
+              "stringValue": "172.22.2.203"
+            }
+          },
+          {
+            "key": "sw.k8s.pod.host.network",
+            "value": {
+              "stringValue": "false"
+            }
+          },
+          {
+            "key": "sw.k8s.pod.ip",
+            "value": {
+              "stringValue": "192.168.83.92"
+            }
+          }
+        ]
+      },
+      "scopeMetrics": [
+        {
+          "metrics": [
+            {
+              "gauge": {
+                "dataPoints": [
+                  {
+                    "asDouble": 1,
+                    "attributes": [
+                      {
+                        "key": "endpoint",
+                        "value": {
+                          "stringValue": "http"
+                        }
+                      },
+                      {
+                        "key": "prometheus",
+                        "value": {
+                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
+                        }
+                      },
+                      {
+                        "key": "prometheus_replica",
+                        "value": {
+                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
+                        }
+                      }
+                    ],
+                    "timeUnixNano": "0"
+                  }
+                ]
+              },
+              "name": "k8s.kube_pod_info"
+            }
+          ],
+          "scope": {}
+        }
+      ]
+    },
+    {
+      "resource": {
+        "attributes": [
+          {
+            "key": "http.scheme",
+            "value": {
+              "stringValue": "http"
+            }
+          },
+          {
+            "key": "k8s.cluster.name",
+            "value": {
+              "stringValue": "cluster name"
+            }
+          },
+          {
+            "key": "k8s.namespace.annotations.description",
+            "value": {
+              "stringValue": "This is a test namespace."
+            }
+          },
+          {
+            "key": "k8s.namespace.labels.app",
+            "value": {
+              "stringValue": "test-app"
+            }
+          },
+          {
+            "key": "k8s.namespace.labels.kubernetes.io/metadata.name",
+            "value": {
+              "stringValue": "test-namespace"
+            }
+          },
+          {
+            "key": "k8s.namespace.labels.purpose",
+            "value": {
+              "stringValue": "testing"
+            }
+          },
+          {
+            "key": "k8s.namespace.name",
+            "value": {
+              "stringValue": "test-namespace"
+            }
+          },
+          {
+            "key": "k8s.node.name",
+            "value": {
+              "stringValue": "test-node"
+            }
+          },
+          {
+            "key": "k8s.pod.name",
+            "value": {
+              "stringValue": "test-pod"
+            }
+          },
+          {
+            "key": "net.host.name",
+            "value": {
+              "stringValue": "test-node"
+            }
+          },
+          {
+            "key": "net.host.port",
+            "value": {
+              "stringValue": ""
+            }
+          },
+          {
+            "key": "service.instance.id",
+            "value": {
+              "stringValue": "test-node"
+            }
+          },
+          {
+            "key": "sw.k8s.agent.app.version",
+            "value": {
+              "stringValue": "0.7.0"
+            }
+          },
+          {
+            "key": "sw.k8s.agent.manifest.version",
+            "value": {
+              "stringValue": "2.5.0-alpha.4"
+            }
+          },
+          {
+            "key": "sw.k8s.cluster.uid",
+            "value": {
+              "stringValue": "cluster-uid-123456789"
+            }
+          }
+        ]
+      },
+      "scopeMetrics": [
+        {
+          "metrics": [
+            {
+              "gauge": {
+                "dataPoints": [
+                  {
+                    "asDouble": 0,
                     "attributes": [
                       {
                         "key": "cpu",
@@ -11294,6 +19430,649 @@
                   }
                 ]
               },
+              "name": "k8s.container.cpu.usage.seconds.rate"
+            },
+            {
+              "name": "k8s.container_cpu_cfs_periods_total",
+              "sum": {
+                "aggregationTemporality": 2,
+                "dataPoints": [
+                  {
+                    "asDouble": 459152,
+                    "attributes": [
+                      {
+                        "key": "endpoint",
+                        "value": {
+                          "stringValue": "https-metrics"
+                        }
+                      },
+                      {
+                        "key": "id",
+                        "value": {
+                          "stringValue": "/kubepods/burstable/pod00d78412-39d4-4a5b-8e85-38a12611f369"
+                        }
+                      },
+                      {
+                        "key": "metrics_path",
+                        "value": {
+                          "stringValue": "/metrics/cadvisor"
+                        }
+                      },
+                      {
+                        "key": "prometheus",
+                        "value": {
+                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
+                        }
+                      },
+                      {
+                        "key": "prometheus_replica",
+                        "value": {
+                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
+                        }
+                      },
+                      {
+                        "key": "service",
+                        "value": {
+                          "stringValue": "test-service"
+                        }
+                      }
+                    ],
+                    "timeUnixNano": "0"
+                  }
+                ],
+                "isMonotonic": true
+              }
+            },
+            {
+              "name": "k8s.container_cpu_cfs_throttled_periods_total",
+              "sum": {
+                "aggregationTemporality": 2,
+                "dataPoints": [
+                  {
+                    "asDouble": 9795,
+                    "attributes": [
+                      {
+                        "key": "endpoint",
+                        "value": {
+                          "stringValue": "https-metrics"
+                        }
+                      },
+                      {
+                        "key": "id",
+                        "value": {
+                          "stringValue": "/kubepods/podd228bba1-5ce2-486b-a44f-cdcfe4780cb0"
+                        }
+                      },
+                      {
+                        "key": "metrics_path",
+                        "value": {
+                          "stringValue": "/metrics/cadvisor"
+                        }
+                      },
+                      {
+                        "key": "prometheus",
+                        "value": {
+                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
+                        }
+                      },
+                      {
+                        "key": "prometheus_replica",
+                        "value": {
+                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
+                        }
+                      },
+                      {
+                        "key": "service",
+                        "value": {
+                          "stringValue": "test-service"
+                        }
+                      }
+                    ],
+                    "timeUnixNano": "0"
+                  }
+                ],
+                "isMonotonic": true
+              }
+            },
+            {
+              "name": "k8s.container_cpu_usage_seconds_total",
+              "sum": {
+                "aggregationTemporality": 2,
+                "dataPoints": [
+                  {
+                    "asDouble": 2790.085179751,
+                    "attributes": [
+                      {
+                        "key": "cpu",
+                        "value": {
+                          "stringValue": "total"
+                        }
+                      },
+                      {
+                        "key": "endpoint",
+                        "value": {
+                          "stringValue": "https-metrics"
+                        }
+                      },
+                      {
+                        "key": "id",
+                        "value": {
+                          "stringValue": "/kubepods/besteffort/pod0fbfc1ac-4d28-4655-bf39-b6e44fecd6a9"
+                        }
+                      },
+                      {
+                        "key": "metrics_path",
+                        "value": {
+                          "stringValue": "/metrics/cadvisor"
+                        }
+                      },
+                      {
+                        "key": "prometheus",
+                        "value": {
+                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
+                        }
+                      },
+                      {
+                        "key": "prometheus_replica",
+                        "value": {
+                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
+                        }
+                      },
+                      {
+                        "key": "service",
+                        "value": {
+                          "stringValue": "test-service"
+                        }
+                      }
+                    ],
+                    "timeUnixNano": "0"
+                  },
+                  {
+                    "asDouble": 7940.956971964,
+                    "attributes": [
+                      {
+                        "key": "cpu",
+                        "value": {
+                          "stringValue": "total"
+                        }
+                      },
+                      {
+                        "key": "endpoint",
+                        "value": {
+                          "stringValue": "https-metrics"
+                        }
+                      },
+                      {
+                        "key": "id",
+                        "value": {
+                          "stringValue": "/kubepods/burstable/podbafeef2c-1292-4a5e-a92c-d709480b04b6"
+                        }
+                      },
+                      {
+                        "key": "metrics_path",
+                        "value": {
+                          "stringValue": "/metrics/cadvisor"
+                        }
+                      },
+                      {
+                        "key": "prometheus",
+                        "value": {
+                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
+                        }
+                      },
+                      {
+                        "key": "prometheus_replica",
+                        "value": {
+                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
+                        }
+                      },
+                      {
+                        "key": "service",
+                        "value": {
+                          "stringValue": "test-service"
+                        }
+                      }
+                    ],
+                    "timeUnixNano": "0"
+                  }
+                ],
+                "isMonotonic": true
+              }
+            },
+            {
+              "name": "k8s.container_fs_reads_bytes_total",
+              "sum": {
+                "aggregationTemporality": 2,
+                "dataPoints": [
+                  {
+                    "asDouble": 0,
+                    "attributes": [
+                      {
+                        "key": "device",
+                        "value": {
+                          "stringValue": "/dev/nvme0n1"
+                        }
+                      },
+                      {
+                        "key": "endpoint",
+                        "value": {
+                          "stringValue": "https-metrics"
+                        }
+                      },
+                      {
+                        "key": "id",
+                        "value": {
+                          "stringValue": "/kubepods/burstable/podbafeef2c-1292-4a5e-a92c-d709480b04b6"
+                        }
+                      },
+                      {
+                        "key": "metrics_path",
+                        "value": {
+                          "stringValue": "/metrics/cadvisor"
+                        }
+                      },
+                      {
+                        "key": "prometheus",
+                        "value": {
+                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
+                        }
+                      },
+                      {
+                        "key": "prometheus_replica",
+                        "value": {
+                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
+                        }
+                      },
+                      {
+                        "key": "service",
+                        "value": {
+                          "stringValue": "test-service"
+                        }
+                      }
+                    ],
+                    "timeUnixNano": "0"
+                  }
+                ],
+                "isMonotonic": true
+              }
+            },
+            {
+              "name": "k8s.container_fs_reads_total",
+              "sum": {
+                "aggregationTemporality": 2,
+                "dataPoints": [
+                  {
+                    "asDouble": 0,
+                    "attributes": [
+                      {
+                        "key": "device",
+                        "value": {
+                          "stringValue": "/dev/nvme0n1"
+                        }
+                      },
+                      {
+                        "key": "endpoint",
+                        "value": {
+                          "stringValue": "https-metrics"
+                        }
+                      },
+                      {
+                        "key": "id",
+                        "value": {
+                          "stringValue": "/kubepods/burstable/podbafeef2c-1292-4a5e-a92c-d709480b04b6"
+                        }
+                      },
+                      {
+                        "key": "metrics_path",
+                        "value": {
+                          "stringValue": "/metrics/cadvisor"
+                        }
+                      },
+                      {
+                        "key": "prometheus",
+                        "value": {
+                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
+                        }
+                      },
+                      {
+                        "key": "prometheus_replica",
+                        "value": {
+                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
+                        }
+                      },
+                      {
+                        "key": "service",
+                        "value": {
+                          "stringValue": "test-service"
+                        }
+                      }
+                    ],
+                    "timeUnixNano": "0"
+                  }
+                ],
+                "isMonotonic": true
+              }
+            },
+            {
+              "name": "k8s.container_fs_writes_bytes_total",
+              "sum": {
+                "aggregationTemporality": 2,
+                "dataPoints": [
+                  {
+                    "asDouble": 31744,
+                    "attributes": [
+                      {
+                        "key": "device",
+                        "value": {
+                          "stringValue": "/dev/nvme0n1"
+                        }
+                      },
+                      {
+                        "key": "endpoint",
+                        "value": {
+                          "stringValue": "https-metrics"
+                        }
+                      },
+                      {
+                        "key": "id",
+                        "value": {
+                          "stringValue": "/kubepods/burstable/podbafeef2c-1292-4a5e-a92c-d709480b04b6"
+                        }
+                      },
+                      {
+                        "key": "metrics_path",
+                        "value": {
+                          "stringValue": "/metrics/cadvisor"
+                        }
+                      },
+                      {
+                        "key": "prometheus",
+                        "value": {
+                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
+                        }
+                      },
+                      {
+                        "key": "prometheus_replica",
+                        "value": {
+                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
+                        }
+                      },
+                      {
+                        "key": "service",
+                        "value": {
+                          "stringValue": "test-service"
+                        }
+                      }
+                    ],
+                    "timeUnixNano": "0"
+                  }
+                ],
+                "isMonotonic": true
+              }
+            },
+            {
+              "name": "k8s.container_fs_writes_total",
+              "sum": {
+                "aggregationTemporality": 2,
+                "dataPoints": [
+                  {
+                    "asDouble": 2,
+                    "attributes": [
+                      {
+                        "key": "device",
+                        "value": {
+                          "stringValue": "/dev/nvme0n1"
+                        }
+                      },
+                      {
+                        "key": "endpoint",
+                        "value": {
+                          "stringValue": "https-metrics"
+                        }
+                      },
+                      {
+                        "key": "id",
+                        "value": {
+                          "stringValue": "/kubepods/burstable/podbafeef2c-1292-4a5e-a92c-d709480b04b6"
+                        }
+                      },
+                      {
+                        "key": "metrics_path",
+                        "value": {
+                          "stringValue": "/metrics/cadvisor"
+                        }
+                      },
+                      {
+                        "key": "prometheus",
+                        "value": {
+                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
+                        }
+                      },
+                      {
+                        "key": "prometheus_replica",
+                        "value": {
+                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
+                        }
+                      },
+                      {
+                        "key": "service",
+                        "value": {
+                          "stringValue": "test-service"
+                        }
+                      }
+                    ],
+                    "timeUnixNano": "0"
+                  }
+                ],
+                "isMonotonic": true
+              }
+            },
+            {
+              "gauge": {
+                "dataPoints": [
+                  {
+                    "asDouble": 2037620736,
+                    "attributes": [
+                      {
+                        "key": "endpoint",
+                        "value": {
+                          "stringValue": "https-metrics"
+                        }
+                      },
+                      {
+                        "key": "id",
+                        "value": {
+                          "stringValue": "/kubepods/burstable/podbafeef2c-1292-4a5e-a92c-d709480b04b6"
+                        }
+                      },
+                      {
+                        "key": "metrics_path",
+                        "value": {
+                          "stringValue": "/metrics/cadvisor"
+                        }
+                      },
+                      {
+                        "key": "prometheus",
+                        "value": {
+                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
+                        }
+                      },
+                      {
+                        "key": "prometheus_replica",
+                        "value": {
+                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
+                        }
+                      },
+                      {
+                        "key": "service",
+                        "value": {
+                          "stringValue": "test-service"
+                        }
+                      }
+                    ],
+                    "timeUnixNano": "0"
+                  }
+                ]
+              },
+              "name": "k8s.container_memory_working_set_bytes"
+            },
+            {
+              "gauge": {
+                "dataPoints": [
+                  {
+                    "asDouble": 100000,
+                    "attributes": [
+                      {
+                        "key": "endpoint",
+                        "value": {
+                          "stringValue": "https-metrics"
+                        }
+                      },
+                      {
+                        "key": "id",
+                        "value": {
+                          "stringValue": "/kubepods/burstable/podbafeef2c-1292-4a5e-a92c-d709480b04b6"
+                        }
+                      },
+                      {
+                        "key": "metrics_path",
+                        "value": {
+                          "stringValue": "/metrics/cadvisor"
+                        }
+                      },
+                      {
+                        "key": "prometheus",
+                        "value": {
+                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
+                        }
+                      },
+                      {
+                        "key": "prometheus_replica",
+                        "value": {
+                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
+                        }
+                      },
+                      {
+                        "key": "service",
+                        "value": {
+                          "stringValue": "test-service"
+                        }
+                      }
+                    ],
+                    "timeUnixNano": "0"
+                  }
+                ]
+              },
+              "name": "k8s.container_spec_cpu_period"
+            },
+            {
+              "gauge": {
+                "dataPoints": [
+                  {
+                    "asDouble": 300000,
+                    "attributes": [
+                      {
+                        "key": "endpoint",
+                        "value": {
+                          "stringValue": "https-metrics"
+                        }
+                      },
+                      {
+                        "key": "id",
+                        "value": {
+                          "stringValue": "/kubepods/burstable/pod00d78412-39d4-4a5b-8e85-38a12611f369"
+                        }
+                      },
+                      {
+                        "key": "metrics_path",
+                        "value": {
+                          "stringValue": "/metrics/cadvisor"
+                        }
+                      },
+                      {
+                        "key": "prometheus",
+                        "value": {
+                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
+                        }
+                      },
+                      {
+                        "key": "prometheus_replica",
+                        "value": {
+                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
+                        }
+                      },
+                      {
+                        "key": "service",
+                        "value": {
+                          "stringValue": "test-service"
+                        }
+                      }
+                    ],
+                    "timeUnixNano": "0"
+                  }
+                ]
+              },
+              "name": "k8s.container_spec_cpu_quota"
+            },
+            {
+              "gauge": {
+                "dataPoints": [
+                  {
+                    "asDouble": 0,
+                    "attributes": [
+                      {
+                        "key": "endpoint",
+                        "value": {
+                          "stringValue": "https-metrics"
+                        }
+                      },
+                      {
+                        "key": "id",
+                        "value": {
+                          "stringValue": "/kubepods/burstable/podbafeef2c-1292-4a5e-a92c-d709480b04b6"
+                        }
+                      },
+                      {
+                        "key": "metrics_path",
+                        "value": {
+                          "stringValue": "/metrics/cadvisor"
+                        }
+                      },
+                      {
+                        "key": "prometheus",
+                        "value": {
+                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
+                        }
+                      },
+                      {
+                        "key": "prometheus_replica",
+                        "value": {
+                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
+                        }
+                      },
+                      {
+                        "key": "service",
+                        "value": {
+                          "stringValue": "test-service"
+                        }
+                      }
+                    ],
+                    "timeUnixNano": "0"
+                  }
+                ]
+              },
+              "name": "k8s.container_spec_memory_limit_bytes"
+            },
+            {
+              "gauge": {
+                "dataPoints": [
+                  {
+                    "asDouble": 0,
+                    "startTimeUnixNano": "0",
+                    "timeUnixNano": "0"
+                  }
+                ]
+              },
               "name": "k8s.pod.cpu.usage.seconds.rate"
             },
             {
@@ -11383,45 +20162,7 @@
               "gauge": {
                 "dataPoints": [
                   {
-                    "asDouble": 2037620736,
-                    "attributes": [
-                      {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "https-metrics"
-                        }
-                      },
-                      {
-                        "key": "id",
-                        "value": {
-                          "stringValue": "/kubepods/burstable/podbafeef2c-1292-4a5e-a92c-d709480b04b6"
-                        }
-                      },
-                      {
-                        "key": "metrics_path",
-                        "value": {
-                          "stringValue": "/metrics/cadvisor"
-                        }
-                      },
-                      {
-                        "key": "prometheus",
-                        "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
-                        }
-                      },
-                      {
-                        "key": "prometheus_replica",
-                        "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
-                        }
-                      },
-                      {
-                        "key": "service",
-                        "value": {
-                          "stringValue": "test-service"
-                        }
-                      }
-                    ],
+                    "asDouble": 2078343168,
                     "timeUnixNano": "0"
                   }
                 ]
@@ -11504,45 +20245,7 @@
               "gauge": {
                 "dataPoints": [
                   {
-                    "asDouble": 3,
-                    "attributes": [
-                      {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "https-metrics"
-                        }
-                      },
-                      {
-                        "key": "id",
-                        "value": {
-                          "stringValue": "/kubepods/burstable/pod00d78412-39d4-4a5b-8e85-38a12611f369"
-                        }
-                      },
-                      {
-                        "key": "metrics_path",
-                        "value": {
-                          "stringValue": "/metrics/cadvisor"
-                        }
-                      },
-                      {
-                        "key": "prometheus",
-                        "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
-                        }
-                      },
-                      {
-                        "key": "prometheus_replica",
-                        "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
-                        }
-                      },
-                      {
-                        "key": "service",
-                        "value": {
-                          "stringValue": "test-service"
-                        }
-                      }
-                    ],
+                    "asDouble": 1,
                     "timeUnixNano": "0"
                   }
                 ]
@@ -11632,7 +20335,7 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "2.5.0-alpha.3"
+              "stringValue": "2.5.0-alpha.4"
             }
           },
           {
@@ -14611,7 +23314,7 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "2.5.0-alpha.3"
+              "stringValue": "2.5.0-alpha.4"
             }
           },
           {
@@ -14787,7 +23490,7 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "2.5.0-alpha.3"
+              "stringValue": "2.5.0-alpha.4"
             }
           },
           {
@@ -14963,7 +23666,7 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "2.5.0-alpha.3"
+              "stringValue": "2.5.0-alpha.4"
             }
           },
           {
@@ -15163,7 +23866,7 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "2.5.0-alpha.3"
+              "stringValue": "2.5.0-alpha.4"
             }
           },
           {
@@ -15333,7 +24036,7 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "2.5.0-alpha.3"
+              "stringValue": "2.5.0-alpha.4"
             }
           },
           {
@@ -15491,7 +24194,7 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "2.5.0-alpha.3"
+              "stringValue": "2.5.0-alpha.4"
             }
           },
           {
@@ -15692,7 +24395,7 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "2.5.0-alpha.3"
+              "stringValue": "2.5.0-alpha.4"
             }
           },
           {
@@ -15874,7 +24577,177 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "2.5.0-alpha.3"
+              "stringValue": "2.5.0-alpha.4"
+            }
+          },
+          {
+            "key": "sw.k8s.cluster.uid",
+            "value": {
+              "stringValue": "cluster-uid-123456789"
+            }
+          }
+        ]
+      },
+      "scopeMetrics": [
+        {
+          "metrics": [
+            {
+              "gauge": {
+                "dataPoints": [
+                  {
+                    "asDouble": 1,
+                    "attributes": [
+                      {
+                        "key": "endpoint",
+                        "value": {
+                          "stringValue": "http"
+                        }
+                      },
+                      {
+                        "key": "prometheus",
+                        "value": {
+                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
+                        }
+                      },
+                      {
+                        "key": "prometheus_replica",
+                        "value": {
+                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
+                        }
+                      },
+                      {
+                        "key": "volume",
+                        "value": {
+                          "stringValue": "data"
+                        }
+                      }
+                    ],
+                    "timeUnixNano": "0"
+                  }
+                ]
+              },
+              "name": "k8s.kube_pod_spec_volumes_persistentvolumeclaims_info"
+            }
+          ],
+          "scope": {}
+        }
+      ]
+    },
+    {
+      "resource": {
+        "attributes": [
+          {
+            "key": "http.scheme",
+            "value": {
+              "stringValue": "http"
+            }
+          },
+          {
+            "key": "k8s.cluster.name",
+            "value": {
+              "stringValue": "cluster name"
+            }
+          },
+          {
+            "key": "k8s.namespace.annotations.description",
+            "value": {
+              "stringValue": "This is a test namespace."
+            }
+          },
+          {
+            "key": "k8s.namespace.labels.app",
+            "value": {
+              "stringValue": "test-app"
+            }
+          },
+          {
+            "key": "k8s.namespace.labels.kubernetes.io/metadata.name",
+            "value": {
+              "stringValue": "test-namespace"
+            }
+          },
+          {
+            "key": "k8s.namespace.labels.purpose",
+            "value": {
+              "stringValue": "testing"
+            }
+          },
+          {
+            "key": "k8s.namespace.name",
+            "value": {
+              "stringValue": "test-namespace"
+            }
+          },
+          {
+            "key": "k8s.persistentvolumeclaim.annotations.example.com/annotation",
+            "value": {
+              "stringValue": "example-annotation"
+            }
+          },
+          {
+            "key": "k8s.persistentvolumeclaim.annotations.pv.kubernetes.io/bind-completed",
+            "value": {
+              "stringValue": "yes"
+            }
+          },
+          {
+            "key": "k8s.persistentvolumeclaim.annotations.pv.kubernetes.io/bound-by-controller",
+            "value": {
+              "stringValue": "yes"
+            }
+          },
+          {
+            "key": "k8s.persistentvolumeclaim.labels.example.com/label",
+            "value": {
+              "stringValue": "example-label"
+            }
+          },
+          {
+            "key": "k8s.persistentvolumeclaim.name",
+            "value": {
+              "stringValue": "test-pvc"
+            }
+          },
+          {
+            "key": "k8s.pod.name",
+            "value": {
+              "stringValue": "test-pod"
+            }
+          },
+          {
+            "key": "k8s.pod.uid",
+            "value": {
+              "stringValue": "0eb87a8e-caf5-42f7-8689-a3b36a00232e"
+            }
+          },
+          {
+            "key": "net.host.name",
+            "value": {
+              "stringValue": "test-node"
+            }
+          },
+          {
+            "key": "net.host.port",
+            "value": {
+              "stringValue": ""
+            }
+          },
+          {
+            "key": "service.instance.id",
+            "value": {
+              "stringValue": "test-node"
+            }
+          },
+          {
+            "key": "sw.k8s.agent.app.version",
+            "value": {
+              "stringValue": "0.7.0"
+            }
+          },
+          {
+            "key": "sw.k8s.agent.manifest.version",
+            "value": {
+              "stringValue": "2.5.0-alpha.4"
             }
           },
           {
@@ -16032,7 +24905,7 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "2.5.0-alpha.3"
+              "stringValue": "2.5.0-alpha.4"
             }
           },
           {
@@ -16221,7 +25094,7 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "2.5.0-alpha.3"
+              "stringValue": "2.5.0-alpha.4"
             }
           },
           {
@@ -16373,7 +25246,7 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "2.5.0-alpha.3"
+              "stringValue": "2.5.0-alpha.4"
             }
           },
           {
@@ -16556,7 +25429,7 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "2.5.0-alpha.3"
+              "stringValue": "2.5.0-alpha.4"
             }
           },
           {
@@ -16702,7 +25575,7 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "2.5.0-alpha.3"
+              "stringValue": "2.5.0-alpha.4"
             }
           },
           {
@@ -16854,7 +25727,7 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "2.5.0-alpha.3"
+              "stringValue": "2.5.0-alpha.4"
             }
           },
           {
@@ -17012,7 +25885,7 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "2.5.0-alpha.3"
+              "stringValue": "2.5.0-alpha.4"
             }
           },
           {
@@ -17335,7 +26208,7 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "2.5.0-alpha.3"
+              "stringValue": "2.5.0-alpha.4"
             }
           },
           {
@@ -17511,7 +26384,7 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "2.5.0-alpha.3"
+              "stringValue": "2.5.0-alpha.4"
             }
           },
           {
@@ -17663,7 +26536,1451 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "2.5.0-alpha.3"
+              "stringValue": "2.5.0-alpha.4"
+            }
+          },
+          {
+            "key": "sw.k8s.cluster.uid",
+            "value": {
+              "stringValue": "cluster-uid-123456789"
+            }
+          }
+        ]
+      },
+      "scopeMetrics": [
+        {
+          "metrics": [
+            {
+              "gauge": {
+                "dataPoints": [
+                  {
+                    "asDouble": 1,
+                    "attributes": [
+                      {
+                        "key": "endpoint",
+                        "value": {
+                          "stringValue": "tcp-model"
+                        }
+                      },
+                      {
+                        "key": "owner_is_controller",
+                        "value": {
+                          "stringValue": "true"
+                        }
+                      },
+                      {
+                        "key": "owner_kind",
+                        "value": {
+                          "stringValue": "DaemonSet"
+                        }
+                      },
+                      {
+                        "key": "owner_name",
+                        "value": {
+                          "stringValue": "spire-spiffe-csi-driver"
+                        }
+                      },
+                      {
+                        "key": "prometheus",
+                        "value": {
+                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
+                        }
+                      },
+                      {
+                        "key": "prometheus_replica",
+                        "value": {
+                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
+                        }
+                      }
+                    ],
+                    "timeUnixNano": "0"
+                  },
+                  {
+                    "asDouble": 1,
+                    "attributes": [
+                      {
+                        "key": "endpoint",
+                        "value": {
+                          "stringValue": "tcp-model"
+                        }
+                      },
+                      {
+                        "key": "owner_is_controller",
+                        "value": {
+                          "stringValue": "true"
+                        }
+                      },
+                      {
+                        "key": "owner_kind",
+                        "value": {
+                          "stringValue": "ReplicaSet"
+                        }
+                      },
+                      {
+                        "key": "owner_name",
+                        "value": {
+                          "stringValue": "swi-k8s-otel-collector-swo-k8s-collector-metrics-cf8f6886b"
+                        }
+                      },
+                      {
+                        "key": "prometheus",
+                        "value": {
+                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
+                        }
+                      },
+                      {
+                        "key": "prometheus_replica",
+                        "value": {
+                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
+                        }
+                      }
+                    ],
+                    "timeUnixNano": "0"
+                  }
+                ]
+              },
+              "name": "k8s.kube_pod_owner"
+            },
+            {
+              "gauge": {
+                "dataPoints": [
+                  {
+                    "asDouble": 2,
+                    "timeUnixNano": "0"
+                  }
+                ]
+              },
+              "name": "k8s.pod.containers"
+            },
+            {
+              "gauge": {
+                "dataPoints": [
+                  {
+                    "asDouble": 3,
+                    "timeUnixNano": "0"
+                  }
+                ]
+              },
+              "name": "k8s.pod.containers.running"
+            },
+            {
+              "gauge": {
+                "dataPoints": [
+                  {
+                    "asDouble": 0.1,
+                    "timeUnixNano": "0"
+                  }
+                ]
+              },
+              "name": "k8s.pod.spec.cpu.requests"
+            },
+            {
+              "gauge": {
+                "dataPoints": [
+                  {
+                    "asDouble": 6442450944,
+                    "timeUnixNano": "0"
+                  }
+                ]
+              },
+              "name": "k8s.pod.spec.memory.requests"
+            }
+          ],
+          "scope": {}
+        }
+      ]
+    },
+    {
+      "resource": {
+        "attributes": [
+          {
+            "key": "http.scheme",
+            "value": {
+              "stringValue": "http"
+            }
+          },
+          {
+            "key": "k8s.cluster.name",
+            "value": {
+              "stringValue": "cluster name"
+            }
+          },
+          {
+            "key": "k8s.namespace.annotations.description",
+            "value": {
+              "stringValue": "This is a test namespace."
+            }
+          },
+          {
+            "key": "k8s.namespace.labels.app",
+            "value": {
+              "stringValue": "test-app"
+            }
+          },
+          {
+            "key": "k8s.namespace.labels.kubernetes.io/metadata.name",
+            "value": {
+              "stringValue": "test-namespace"
+            }
+          },
+          {
+            "key": "k8s.namespace.labels.purpose",
+            "value": {
+              "stringValue": "testing"
+            }
+          },
+          {
+            "key": "k8s.namespace.name",
+            "value": {
+              "stringValue": "test-namespace"
+            }
+          },
+          {
+            "key": "k8s.pod.name",
+            "value": {
+              "stringValue": "test-pod"
+            }
+          },
+          {
+            "key": "k8s.pod.uid",
+            "value": {
+              "stringValue": "0eb87a8e-caf5-42f7-8689-a3b36a00232e"
+            }
+          },
+          {
+            "key": "net.host.name",
+            "value": {
+              "stringValue": "test-node"
+            }
+          },
+          {
+            "key": "net.host.port",
+            "value": {
+              "stringValue": ""
+            }
+          },
+          {
+            "key": "service.instance.id",
+            "value": {
+              "stringValue": "test-node"
+            }
+          },
+          {
+            "key": "sw.k8s.agent.app.version",
+            "value": {
+              "stringValue": "0.7.0"
+            }
+          },
+          {
+            "key": "sw.k8s.agent.manifest.version",
+            "value": {
+              "stringValue": "2.5.0-alpha.4"
+            }
+          },
+          {
+            "key": "sw.k8s.cluster.uid",
+            "value": {
+              "stringValue": "cluster-uid-123456789"
+            }
+          }
+        ]
+      },
+      "scopeMetrics": [
+        {
+          "metrics": [
+            {
+              "gauge": {
+                "dataPoints": [
+                  {
+                    "asDouble": 1679919168,
+                    "attributes": [
+                      {
+                        "key": "endpoint",
+                        "value": {
+                          "stringValue": "http"
+                        }
+                      },
+                      {
+                        "key": "prometheus",
+                        "value": {
+                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
+                        }
+                      },
+                      {
+                        "key": "prometheus_replica",
+                        "value": {
+                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
+                        }
+                      }
+                    ],
+                    "timeUnixNano": "0"
+                  }
+                ]
+              },
+              "name": "k8s.kube_pod_created"
+            },
+            {
+              "gauge": {
+                "dataPoints": [
+                  {
+                    "asDouble": 0,
+                    "attributes": [
+                      {
+                        "key": "condition",
+                        "value": {
+                          "stringValue": "unknown"
+                        }
+                      },
+                      {
+                        "key": "endpoint",
+                        "value": {
+                          "stringValue": "http"
+                        }
+                      },
+                      {
+                        "key": "prometheus",
+                        "value": {
+                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
+                        }
+                      },
+                      {
+                        "key": "prometheus_replica",
+                        "value": {
+                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
+                        }
+                      }
+                    ],
+                    "timeUnixNano": "0"
+                  }
+                ]
+              },
+              "name": "k8s.kube_pod_status_ready"
+            }
+          ],
+          "scope": {}
+        }
+      ]
+    },
+    {
+      "resource": {
+        "attributes": [
+          {
+            "key": "http.scheme",
+            "value": {
+              "stringValue": "http"
+            }
+          },
+          {
+            "key": "k8s.cluster.name",
+            "value": {
+              "stringValue": "cluster name"
+            }
+          },
+          {
+            "key": "k8s.namespace.annotations.description",
+            "value": {
+              "stringValue": "This is a test namespace."
+            }
+          },
+          {
+            "key": "k8s.namespace.labels.app",
+            "value": {
+              "stringValue": "test-app"
+            }
+          },
+          {
+            "key": "k8s.namespace.labels.kubernetes.io/metadata.name",
+            "value": {
+              "stringValue": "test-namespace"
+            }
+          },
+          {
+            "key": "k8s.namespace.labels.purpose",
+            "value": {
+              "stringValue": "testing"
+            }
+          },
+          {
+            "key": "k8s.namespace.name",
+            "value": {
+              "stringValue": "test-namespace"
+            }
+          },
+          {
+            "key": "k8s.pod.name",
+            "value": {
+              "stringValue": "test-pod"
+            }
+          },
+          {
+            "key": "k8s.pod.uid",
+            "value": {
+              "stringValue": "1263fc71-9ca0-468f-aa93-c6aba4e7e7fd"
+            }
+          },
+          {
+            "key": "net.host.name",
+            "value": {
+              "stringValue": "test-node"
+            }
+          },
+          {
+            "key": "net.host.port",
+            "value": {
+              "stringValue": ""
+            }
+          },
+          {
+            "key": "service.instance.id",
+            "value": {
+              "stringValue": "test-node"
+            }
+          },
+          {
+            "key": "sw.k8s.agent.app.version",
+            "value": {
+              "stringValue": "0.7.0"
+            }
+          },
+          {
+            "key": "sw.k8s.agent.manifest.version",
+            "value": {
+              "stringValue": "2.5.0-alpha.4"
+            }
+          },
+          {
+            "key": "sw.k8s.cluster.uid",
+            "value": {
+              "stringValue": "cluster-uid-123456789"
+            }
+          }
+        ]
+      },
+      "scopeMetrics": [
+        {
+          "metrics": [
+            {
+              "gauge": {
+                "dataPoints": [
+                  {
+                    "asDouble": 1679473328,
+                    "attributes": [
+                      {
+                        "key": "endpoint",
+                        "value": {
+                          "stringValue": "http"
+                        }
+                      },
+                      {
+                        "key": "prometheus",
+                        "value": {
+                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
+                        }
+                      },
+                      {
+                        "key": "prometheus_replica",
+                        "value": {
+                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
+                        }
+                      }
+                    ],
+                    "timeUnixNano": "0"
+                  }
+                ]
+              },
+              "name": "k8s.kube_pod_start_time"
+            }
+          ],
+          "scope": {}
+        }
+      ]
+    },
+    {
+      "resource": {
+        "attributes": [
+          {
+            "key": "http.scheme",
+            "value": {
+              "stringValue": "http"
+            }
+          },
+          {
+            "key": "k8s.cluster.name",
+            "value": {
+              "stringValue": "cluster name"
+            }
+          },
+          {
+            "key": "k8s.namespace.annotations.description",
+            "value": {
+              "stringValue": "This is a test namespace."
+            }
+          },
+          {
+            "key": "k8s.namespace.labels.app",
+            "value": {
+              "stringValue": "test-app"
+            }
+          },
+          {
+            "key": "k8s.namespace.labels.kubernetes.io/metadata.name",
+            "value": {
+              "stringValue": "test-namespace"
+            }
+          },
+          {
+            "key": "k8s.namespace.labels.purpose",
+            "value": {
+              "stringValue": "testing"
+            }
+          },
+          {
+            "key": "k8s.namespace.name",
+            "value": {
+              "stringValue": "test-namespace"
+            }
+          },
+          {
+            "key": "k8s.pod.name",
+            "value": {
+              "stringValue": "test-pod"
+            }
+          },
+          {
+            "key": "k8s.pod.uid",
+            "value": {
+              "stringValue": "5808b16d-a1bf-414b-a0d8-3e3ae381a1b7"
+            }
+          },
+          {
+            "key": "net.host.name",
+            "value": {
+              "stringValue": "test-node"
+            }
+          },
+          {
+            "key": "net.host.port",
+            "value": {
+              "stringValue": ""
+            }
+          },
+          {
+            "key": "service.instance.id",
+            "value": {
+              "stringValue": "test-node"
+            }
+          },
+          {
+            "key": "sw.k8s.agent.app.version",
+            "value": {
+              "stringValue": "0.7.0"
+            }
+          },
+          {
+            "key": "sw.k8s.agent.manifest.version",
+            "value": {
+              "stringValue": "2.5.0-alpha.4"
+            }
+          },
+          {
+            "key": "sw.k8s.cluster.uid",
+            "value": {
+              "stringValue": "cluster-uid-123456789"
+            }
+          }
+        ]
+      },
+      "scopeMetrics": [
+        {
+          "metrics": [
+            {
+              "gauge": {
+                "dataPoints": [
+                  {
+                    "asDouble": 1681221684,
+                    "attributes": [
+                      {
+                        "key": "endpoint",
+                        "value": {
+                          "stringValue": "http"
+                        }
+                      },
+                      {
+                        "key": "prometheus",
+                        "value": {
+                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
+                        }
+                      },
+                      {
+                        "key": "prometheus_replica",
+                        "value": {
+                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
+                        }
+                      }
+                    ],
+                    "timeUnixNano": "0"
+                  }
+                ]
+              },
+              "name": "k8s.kube_pod_completion_time"
+            }
+          ],
+          "scope": {}
+        }
+      ]
+    },
+    {
+      "resource": {
+        "attributes": [
+          {
+            "key": "http.scheme",
+            "value": {
+              "stringValue": "http"
+            }
+          },
+          {
+            "key": "k8s.cluster.name",
+            "value": {
+              "stringValue": "cluster name"
+            }
+          },
+          {
+            "key": "k8s.namespace.annotations.description",
+            "value": {
+              "stringValue": "This is a test namespace."
+            }
+          },
+          {
+            "key": "k8s.namespace.labels.app",
+            "value": {
+              "stringValue": "test-app"
+            }
+          },
+          {
+            "key": "k8s.namespace.labels.kubernetes.io/metadata.name",
+            "value": {
+              "stringValue": "test-namespace"
+            }
+          },
+          {
+            "key": "k8s.namespace.labels.purpose",
+            "value": {
+              "stringValue": "testing"
+            }
+          },
+          {
+            "key": "k8s.namespace.name",
+            "value": {
+              "stringValue": "test-namespace"
+            }
+          },
+          {
+            "key": "k8s.pod.name",
+            "value": {
+              "stringValue": "test-pod"
+            }
+          },
+          {
+            "key": "k8s.pod.uid",
+            "value": {
+              "stringValue": "bafeef2c-1292-4a5e-a92c-d709480b04b6"
+            }
+          },
+          {
+            "key": "k8s.replicaset.name",
+            "value": {
+              "stringValue": "swi-k8s-otel-collector-swo-k8s-collector-metrics-cf8f6886b"
+            }
+          },
+          {
+            "key": "net.host.name",
+            "value": {
+              "stringValue": "test-node"
+            }
+          },
+          {
+            "key": "net.host.port",
+            "value": {
+              "stringValue": ""
+            }
+          },
+          {
+            "key": "service.instance.id",
+            "value": {
+              "stringValue": "test-node"
+            }
+          },
+          {
+            "key": "sw.k8s.agent.app.version",
+            "value": {
+              "stringValue": "0.7.0"
+            }
+          },
+          {
+            "key": "sw.k8s.agent.manifest.version",
+            "value": {
+              "stringValue": "2.5.0-alpha.4"
+            }
+          },
+          {
+            "key": "sw.k8s.cluster.uid",
+            "value": {
+              "stringValue": "cluster-uid-123456789"
+            }
+          }
+        ]
+      },
+      "scopeMetrics": [
+        {
+          "metrics": [
+            {
+              "gauge": {
+                "dataPoints": [
+                  {
+                    "asDouble": 1,
+                    "attributes": [
+                      {
+                        "key": "endpoint",
+                        "value": {
+                          "stringValue": "http"
+                        }
+                      },
+                      {
+                        "key": "owner_is_controller",
+                        "value": {
+                          "stringValue": "true"
+                        }
+                      },
+                      {
+                        "key": "owner_kind",
+                        "value": {
+                          "stringValue": "ReplicaSet"
+                        }
+                      },
+                      {
+                        "key": "prometheus",
+                        "value": {
+                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
+                        }
+                      },
+                      {
+                        "key": "prometheus_replica",
+                        "value": {
+                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
+                        }
+                      }
+                    ],
+                    "timeUnixNano": "0"
+                  }
+                ]
+              },
+              "name": "k8s.kube.pod.owner.replicaset"
+            }
+          ],
+          "scope": {}
+        }
+      ]
+    },
+    {
+      "resource": {
+        "attributes": [
+          {
+            "key": "http.scheme",
+            "value": {
+              "stringValue": "http"
+            }
+          },
+          {
+            "key": "k8s.cluster.name",
+            "value": {
+              "stringValue": "cluster name"
+            }
+          },
+          {
+            "key": "k8s.namespace.annotations.description",
+            "value": {
+              "stringValue": "This is a test namespace."
+            }
+          },
+          {
+            "key": "k8s.namespace.labels.app",
+            "value": {
+              "stringValue": "test-app"
+            }
+          },
+          {
+            "key": "k8s.namespace.labels.kubernetes.io/metadata.name",
+            "value": {
+              "stringValue": "test-namespace"
+            }
+          },
+          {
+            "key": "k8s.namespace.labels.purpose",
+            "value": {
+              "stringValue": "testing"
+            }
+          },
+          {
+            "key": "k8s.namespace.name",
+            "value": {
+              "stringValue": "test-namespace"
+            }
+          },
+          {
+            "key": "k8s.pod.name",
+            "value": {
+              "stringValue": "test-pod"
+            }
+          },
+          {
+            "key": "k8s.pod.uid",
+            "value": {
+              "stringValue": "bafeef2c-1292-4a5e-a92c-d709480b04b6"
+            }
+          },
+          {
+            "key": "net.host.name",
+            "value": {
+              "stringValue": "test-node"
+            }
+          },
+          {
+            "key": "net.host.port",
+            "value": {
+              "stringValue": ""
+            }
+          },
+          {
+            "key": "service.instance.id",
+            "value": {
+              "stringValue": "test-node"
+            }
+          },
+          {
+            "key": "sw.k8s.agent.app.version",
+            "value": {
+              "stringValue": "0.7.0"
+            }
+          },
+          {
+            "key": "sw.k8s.agent.manifest.version",
+            "value": {
+              "stringValue": "2.5.0-alpha.4"
+            }
+          },
+          {
+            "key": "sw.k8s.cluster.uid",
+            "value": {
+              "stringValue": "cluster-uid-123456789"
+            }
+          }
+        ]
+      },
+      "scopeMetrics": [
+        {
+          "metrics": [
+            {
+              "gauge": {
+                "dataPoints": [
+                  {
+                    "asDouble": 1681390527,
+                    "attributes": [
+                      {
+                        "key": "endpoint",
+                        "value": {
+                          "stringValue": "http"
+                        }
+                      },
+                      {
+                        "key": "prometheus",
+                        "value": {
+                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
+                        }
+                      },
+                      {
+                        "key": "prometheus_replica",
+                        "value": {
+                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
+                        }
+                      }
+                    ],
+                    "timeUnixNano": "0"
+                  }
+                ]
+              },
+              "name": "k8s.kube_pod_created"
+            },
+            {
+              "gauge": {
+                "dataPoints": [
+                  {
+                    "asDouble": 1,
+                    "attributes": [
+                      {
+                        "key": "endpoint",
+                        "value": {
+                          "stringValue": "http"
+                        }
+                      },
+                      {
+                        "key": "owner_is_controller",
+                        "value": {
+                          "stringValue": "true"
+                        }
+                      },
+                      {
+                        "key": "owner_kind",
+                        "value": {
+                          "stringValue": "ReplicaSet"
+                        }
+                      },
+                      {
+                        "key": "owner_name",
+                        "value": {
+                          "stringValue": "swi-k8s-otel-collector-swo-k8s-collector-metrics-cf8f6886b"
+                        }
+                      },
+                      {
+                        "key": "prometheus",
+                        "value": {
+                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
+                        }
+                      },
+                      {
+                        "key": "prometheus_replica",
+                        "value": {
+                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
+                        }
+                      }
+                    ],
+                    "timeUnixNano": "0"
+                  }
+                ]
+              },
+              "name": "k8s.kube_pod_owner"
+            },
+            {
+              "gauge": {
+                "dataPoints": [
+                  {
+                    "asDouble": 1681390527,
+                    "attributes": [
+                      {
+                        "key": "endpoint",
+                        "value": {
+                          "stringValue": "http"
+                        }
+                      },
+                      {
+                        "key": "prometheus",
+                        "value": {
+                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
+                        }
+                      },
+                      {
+                        "key": "prometheus_replica",
+                        "value": {
+                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
+                        }
+                      }
+                    ],
+                    "timeUnixNano": "0"
+                  }
+                ]
+              },
+              "name": "k8s.kube_pod_start_time"
+            },
+            {
+              "gauge": {
+                "dataPoints": [
+                  {
+                    "asDouble": 0,
+                    "attributes": [
+                      {
+                        "key": "condition",
+                        "value": {
+                          "stringValue": "false"
+                        }
+                      },
+                      {
+                        "key": "endpoint",
+                        "value": {
+                          "stringValue": "http"
+                        }
+                      },
+                      {
+                        "key": "prometheus",
+                        "value": {
+                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
+                        }
+                      },
+                      {
+                        "key": "prometheus_replica",
+                        "value": {
+                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
+                        }
+                      }
+                    ],
+                    "timeUnixNano": "0"
+                  },
+                  {
+                    "asDouble": 1,
+                    "attributes": [
+                      {
+                        "key": "condition",
+                        "value": {
+                          "stringValue": "true"
+                        }
+                      },
+                      {
+                        "key": "endpoint",
+                        "value": {
+                          "stringValue": "http"
+                        }
+                      },
+                      {
+                        "key": "prometheus",
+                        "value": {
+                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
+                        }
+                      },
+                      {
+                        "key": "prometheus_replica",
+                        "value": {
+                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
+                        }
+                      }
+                    ],
+                    "timeUnixNano": "0"
+                  },
+                  {
+                    "asDouble": 0,
+                    "attributes": [
+                      {
+                        "key": "condition",
+                        "value": {
+                          "stringValue": "unknown"
+                        }
+                      },
+                      {
+                        "key": "endpoint",
+                        "value": {
+                          "stringValue": "http"
+                        }
+                      },
+                      {
+                        "key": "prometheus",
+                        "value": {
+                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
+                        }
+                      },
+                      {
+                        "key": "prometheus_replica",
+                        "value": {
+                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
+                        }
+                      }
+                    ],
+                    "timeUnixNano": "0"
+                  }
+                ]
+              },
+              "name": "k8s.kube_pod_status_ready"
+            }
+          ],
+          "scope": {}
+        }
+      ]
+    },
+    {
+      "resource": {
+        "attributes": [
+          {
+            "key": "http.scheme",
+            "value": {
+              "stringValue": "http"
+            }
+          },
+          {
+            "key": "k8s.cluster.name",
+            "value": {
+              "stringValue": "cluster name"
+            }
+          },
+          {
+            "key": "k8s.namespace.annotations.description",
+            "value": {
+              "stringValue": "This is a test namespace."
+            }
+          },
+          {
+            "key": "k8s.namespace.labels.app",
+            "value": {
+              "stringValue": "test-app"
+            }
+          },
+          {
+            "key": "k8s.namespace.labels.kubernetes.io/metadata.name",
+            "value": {
+              "stringValue": "test-namespace"
+            }
+          },
+          {
+            "key": "k8s.namespace.labels.purpose",
+            "value": {
+              "stringValue": "testing"
+            }
+          },
+          {
+            "key": "k8s.namespace.name",
+            "value": {
+              "stringValue": "test-namespace"
+            }
+          },
+          {
+            "key": "k8s.pod.name",
+            "value": {
+              "stringValue": "test-pod"
+            }
+          },
+          {
+            "key": "k8s.pod.uid",
+            "value": {
+              "stringValue": "bafeef2c-1292-4a5e-a92c-d709480b04b6"
+            }
+          },
+          {
+            "key": "net.host.name",
+            "value": {
+              "stringValue": "test-node"
+            }
+          },
+          {
+            "key": "net.host.port",
+            "value": {
+              "stringValue": ""
+            }
+          },
+          {
+            "key": "service.instance.id",
+            "value": {
+              "stringValue": "test-node"
+            }
+          },
+          {
+            "key": "sw.k8s.agent.app.version",
+            "value": {
+              "stringValue": "0.7.0"
+            }
+          },
+          {
+            "key": "sw.k8s.agent.manifest.version",
+            "value": {
+              "stringValue": "2.5.0-alpha.4"
+            }
+          },
+          {
+            "key": "sw.k8s.cluster.uid",
+            "value": {
+              "stringValue": "cluster-uid-123456789"
+            }
+          },
+          {
+            "key": "sw.k8s.pod.status",
+            "value": {
+              "stringValue": "Running"
+            }
+          }
+        ]
+      },
+      "scopeMetrics": [
+        {
+          "metrics": [
+            {
+              "gauge": {
+                "dataPoints": [
+                  {
+                    "asDouble": 1,
+                    "attributes": [
+                      {
+                        "key": "endpoint",
+                        "value": {
+                          "stringValue": "http"
+                        }
+                      },
+                      {
+                        "key": "prometheus",
+                        "value": {
+                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
+                        }
+                      },
+                      {
+                        "key": "prometheus_replica",
+                        "value": {
+                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
+                        }
+                      }
+                    ],
+                    "timeUnixNano": "0"
+                  },
+                  {
+                    "asDouble": 1,
+                    "attributes": [
+                      {
+                        "key": "endpoint",
+                        "value": {
+                          "stringValue": "tcp-model"
+                        }
+                      },
+                      {
+                        "key": "prometheus",
+                        "value": {
+                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
+                        }
+                      },
+                      {
+                        "key": "prometheus_replica",
+                        "value": {
+                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
+                        }
+                      }
+                    ],
+                    "timeUnixNano": "0"
+                  }
+                ]
+              },
+              "name": "k8s.kube_pod_status_phase"
+            }
+          ],
+          "scope": {}
+        }
+      ]
+    },
+    {
+      "resource": {
+        "attributes": [
+          {
+            "key": "http.scheme",
+            "value": {
+              "stringValue": "http"
+            }
+          },
+          {
+            "key": "k8s.cluster.name",
+            "value": {
+              "stringValue": "cluster name"
+            }
+          },
+          {
+            "key": "k8s.namespace.annotations.description",
+            "value": {
+              "stringValue": "This is a test namespace."
+            }
+          },
+          {
+            "key": "k8s.namespace.labels.app",
+            "value": {
+              "stringValue": "test-app"
+            }
+          },
+          {
+            "key": "k8s.namespace.labels.kubernetes.io/metadata.name",
+            "value": {
+              "stringValue": "test-namespace"
+            }
+          },
+          {
+            "key": "k8s.namespace.labels.purpose",
+            "value": {
+              "stringValue": "testing"
+            }
+          },
+          {
+            "key": "k8s.namespace.name",
+            "value": {
+              "stringValue": "test-namespace"
+            }
+          },
+          {
+            "key": "k8s.pod.name",
+            "value": {
+              "stringValue": "test-pod"
+            }
+          },
+          {
+            "key": "k8s.replicaset.name",
+            "value": {
+              "stringValue": "swi-k8s-otel-collector-swo-k8s-collector-metrics-cf8f6886b"
+            }
+          },
+          {
+            "key": "net.host.name",
+            "value": {
+              "stringValue": "test-node"
+            }
+          },
+          {
+            "key": "net.host.port",
+            "value": {
+              "stringValue": ""
+            }
+          },
+          {
+            "key": "service.instance.id",
+            "value": {
+              "stringValue": "test-node"
+            }
+          },
+          {
+            "key": "sw.k8s.agent.app.version",
+            "value": {
+              "stringValue": "0.7.0"
+            }
+          },
+          {
+            "key": "sw.k8s.agent.manifest.version",
+            "value": {
+              "stringValue": "2.5.0-alpha.4"
+            }
+          },
+          {
+            "key": "sw.k8s.cluster.uid",
+            "value": {
+              "stringValue": "cluster-uid-123456789"
+            }
+          }
+        ]
+      },
+      "scopeMetrics": [
+        {
+          "metrics": [
+            {
+              "gauge": {
+                "dataPoints": [
+                  {
+                    "asDouble": 1,
+                    "attributes": [
+                      {
+                        "key": "endpoint",
+                        "value": {
+                          "stringValue": "tcp-model"
+                        }
+                      },
+                      {
+                        "key": "owner_is_controller",
+                        "value": {
+                          "stringValue": "true"
+                        }
+                      },
+                      {
+                        "key": "owner_kind",
+                        "value": {
+                          "stringValue": "ReplicaSet"
+                        }
+                      },
+                      {
+                        "key": "prometheus",
+                        "value": {
+                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
+                        }
+                      },
+                      {
+                        "key": "prometheus_replica",
+                        "value": {
+                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
+                        }
+                      }
+                    ],
+                    "timeUnixNano": "0"
+                  }
+                ]
+              },
+              "name": "k8s.kube.pod.owner.replicaset"
+            }
+          ],
+          "scope": {}
+        }
+      ]
+    },
+    {
+      "resource": {
+        "attributes": [
+          {
+            "key": "http.scheme",
+            "value": {
+              "stringValue": "http"
+            }
+          },
+          {
+            "key": "k8s.cluster.name",
+            "value": {
+              "stringValue": "cluster name"
+            }
+          },
+          {
+            "key": "k8s.namespace.annotations.description",
+            "value": {
+              "stringValue": "This is a test namespace."
+            }
+          },
+          {
+            "key": "k8s.namespace.labels.app",
+            "value": {
+              "stringValue": "test-app"
+            }
+          },
+          {
+            "key": "k8s.namespace.labels.kubernetes.io/metadata.name",
+            "value": {
+              "stringValue": "test-namespace"
+            }
+          },
+          {
+            "key": "k8s.namespace.labels.purpose",
+            "value": {
+              "stringValue": "testing"
+            }
+          },
+          {
+            "key": "k8s.namespace.name",
+            "value": {
+              "stringValue": "test-namespace"
+            }
+          },
+          {
+            "key": "k8s.pod.name",
+            "value": {
+              "stringValue": "test-pod"
+            }
+          },
+          {
+            "key": "net.host.name",
+            "value": {
+              "stringValue": "test-node"
+            }
+          },
+          {
+            "key": "net.host.port",
+            "value": {
+              "stringValue": ""
+            }
+          },
+          {
+            "key": "service.instance.id",
+            "value": {
+              "stringValue": "test-node"
+            }
+          },
+          {
+            "key": "sw.k8s.agent.app.version",
+            "value": {
+              "stringValue": "0.7.0"
+            }
+          },
+          {
+            "key": "sw.k8s.agent.manifest.version",
+            "value": {
+              "stringValue": "2.5.0-alpha.4"
             }
           },
           {
@@ -17907,7 +28224,7 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "2.5.0-alpha.3"
+              "stringValue": "2.5.0-alpha.4"
             }
           },
           {
@@ -18231,7 +28548,7 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "2.5.0-alpha.3"
+              "stringValue": "2.5.0-alpha.4"
             }
           },
           {
@@ -18508,7 +28825,7 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "2.5.0-alpha.3"
+              "stringValue": "2.5.0-alpha.4"
             }
           },
           {
@@ -18679,7 +28996,7 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "2.5.0-alpha.3"
+              "stringValue": "2.5.0-alpha.4"
             }
           },
           {
@@ -18807,7 +29124,7 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "2.5.0-alpha.3"
+              "stringValue": "2.5.0-alpha.4"
             }
           },
           {
@@ -18911,7 +29228,7 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "2.5.0-alpha.3"
+              "stringValue": "2.5.0-alpha.4"
             }
           },
           {
@@ -31088,7 +41405,7 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "2.5.0-alpha.3"
+              "stringValue": "2.5.0-alpha.4"
             }
           },
           {


### PR DESCRIPTION
not relying on Pod level datapoints, but doing SUM of container datapoints