### PR TITLE
NH-42434: Use specific versions of 3rd party docker images

### DIFF
--- a/deploy/helm/CHANGELOG.md
+++ b/deploy/helm/CHANGELOG.md
@@ -7,7 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
-## [2.5.0-alpha.5] - 2023-06-05
+## [2.5.0-alpha.6] - 2023-06-08
+
+### Changed
+- Updating docker images `solarwinds/swo-agent`, `busybox`, `fullstorydev/grpcurl` and `alpine/k8s` to latest available versions
+
+## [2.5.0-alpha.5] - 2023-06-07
 ### Fixed
 - Fixed node level network metrics for environments where pod level network metrics are not available (for example Docker runtime)
 

--- a/deploy/helm/Chart.yaml
+++ b/deploy/helm/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: swo-k8s-collector
-version: 2.5.0-alpha.5
+version: 2.5.0-alpha.6
 appVersion: "0.7.0"
 description: SolarWinds Kubernetes Integration
 keywords:

--- a/deploy/helm/templates/autoupdate/autoupdate-cronjob.yaml
+++ b/deploy/helm/templates/autoupdate/autoupdate-cronjob.yaml
@@ -15,7 +15,7 @@ spec:
           serviceAccountName: {{ include "common.fullname" . }}-autoupdate
           containers:
           - name: helm-upgrade
-            image: alpine/k8s:1.24.10@sha256:327fcfdef83a8c7f3a26dc893b0d903385dcaeacc5ad9eb0099065f6c55795ac
+            image: alpine/k8s:1.27.2@sha256:bbdbcb2e799b50958beb278de4a309d60bd238c14bdaff50c4e5ae42e446f745
             command: 
               - /bin/bash
               - /scripts/helm-upgrade.sh

--- a/deploy/helm/templates/metrics-deployment.yaml
+++ b/deploy/helm/templates/metrics-deployment.yaml
@@ -34,7 +34,7 @@ spec:
       initContainers:
         {{- if .Values.otel.metrics.prometheus_check }}
         - name: prometheus-check
-          image: busybox
+          image: busybox:1.36.1@sha256:5cd3db04b8be5773388576a83177aff4f40a03457a63855f4b9cbe30542b9a43
           command: ['sh', '-c', 'until $(wget --spider -nv $PROMETHEUS_URL/federate?); do echo waiting on prometheus; sleep 1; done']
           envFrom:
             - configMapRef:
@@ -42,7 +42,7 @@ spec:
         {{- end }}
         {{- if .Values.otel.metrics.swi_endpoint_check }}
         - name: otel-endpoint-check
-          image: fullstorydev/grpcurl
+          image: fullstorydev/grpcurl:v1.8.7@sha256:ee1a84e31a5f99af12e0767314c59f05a578c01d28404049a3964d67a15b3580
           command: ['/bin/grpcurl', '-expand-headers',
                     '-proto', 'opentelemetry/proto/collector/logs/v1/logs_service.proto',
                     '-H', 'Authorization: Bearer ${SOLARWINDS_API_TOKEN}',

--- a/deploy/helm/templates/swo-agent-statefulset.yaml
+++ b/deploy/helm/templates/swo-agent-statefulset.yaml
@@ -29,7 +29,7 @@ spec:
       securityContext: {}
       containers:
         - name: swo-agent
-          image: {{ printf "%s:%s" .Values.swoagent.image.repository .Values.swoagent.image.tag }}
+          image: "{{ .Values.swoagent.image.repository }}:{{ .Values.swoagent.image.tag | default "v2.3.16@sha256:c42c9ca134db54341dc88c3e0c35b1a04db4629b1d97bfde524dfc5d2b8722e5" }}"
           imagePullPolicy: {{ .Values.swoagent.image.pullPolicy }}
           env:
             - name: UAMS_CLIENT_ID_OVERRIDE_SOURCE_NAME

--- a/deploy/helm/values.yaml
+++ b/deploy/helm/values.yaml
@@ -386,8 +386,8 @@ swoagent:
   enabled: false
   image:
     repository: solarwinds/swo-agent
-    tag: "latest"
-    pullPolicy: Always
+    tag: ""
+    pullPolicy: IfNotPresent
   resources:
     limits:
       memory: 800Mi

--- a/tests/integration/expected_output.json
+++ b/tests/integration/expected_output.json
@@ -108,7 +108,7 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "2.5.0-alpha.5"
+              "stringValue": "2.5.0-alpha.6"
             }
           },
           {
@@ -284,7 +284,7 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "2.5.0-alpha.5"
+              "stringValue": "2.5.0-alpha.6"
             }
           },
           {
@@ -466,7 +466,7 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "2.5.0-alpha.5"
+              "stringValue": "2.5.0-alpha.6"
             }
           },
           {
@@ -648,7 +648,7 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "2.5.0-alpha.5"
+              "stringValue": "2.5.0-alpha.6"
             }
           },
           {
@@ -830,7 +830,7 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "2.5.0-alpha.5"
+              "stringValue": "2.5.0-alpha.6"
             }
           },
           {
@@ -1012,7 +1012,7 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "2.5.0-alpha.5"
+              "stringValue": "2.5.0-alpha.6"
             }
           },
           {
@@ -1176,7 +1176,7 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "2.5.0-alpha.5"
+              "stringValue": "2.5.0-alpha.6"
             }
           },
           {
@@ -1607,7 +1607,7 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "2.5.0-alpha.5"
+              "stringValue": "2.5.0-alpha.6"
             }
           },
           {
@@ -1789,7 +1789,7 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "2.5.0-alpha.5"
+              "stringValue": "2.5.0-alpha.6"
             }
           },
           {
@@ -2085,7 +2085,7 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "2.5.0-alpha.5"
+              "stringValue": "2.5.0-alpha.6"
             }
           },
           {
@@ -2338,7 +2338,7 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "2.5.0-alpha.5"
+              "stringValue": "2.5.0-alpha.6"
             }
           },
           {
@@ -3176,7 +3176,7 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "2.5.0-alpha.5"
+              "stringValue": "2.5.0-alpha.6"
             }
           },
           {
@@ -3366,7 +3366,7 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "2.5.0-alpha.5"
+              "stringValue": "2.5.0-alpha.6"
             }
           },
           {
@@ -3548,7 +3548,7 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "2.5.0-alpha.5"
+              "stringValue": "2.5.0-alpha.6"
             }
           },
           {
@@ -3712,7 +3712,7 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "2.5.0-alpha.5"
+              "stringValue": "2.5.0-alpha.6"
             }
           },
           {
@@ -3876,7 +3876,7 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "2.5.0-alpha.5"
+              "stringValue": "2.5.0-alpha.6"
             }
           },
           {
@@ -4356,7 +4356,7 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "2.5.0-alpha.5"
+              "stringValue": "2.5.0-alpha.6"
             }
           },
           {
@@ -4575,7 +4575,7 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "2.5.0-alpha.5"
+              "stringValue": "2.5.0-alpha.6"
             }
           },
           {
@@ -4788,7 +4788,7 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "2.5.0-alpha.5"
+              "stringValue": "2.5.0-alpha.6"
             }
           },
           {
@@ -5041,7 +5041,7 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "2.5.0-alpha.5"
+              "stringValue": "2.5.0-alpha.6"
             }
           },
           {
@@ -5205,7 +5205,7 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "2.5.0-alpha.5"
+              "stringValue": "2.5.0-alpha.6"
             }
           },
           {
@@ -5363,7 +5363,7 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "2.5.0-alpha.5"
+              "stringValue": "2.5.0-alpha.6"
             }
           },
           {
@@ -5521,7 +5521,7 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "2.5.0-alpha.5"
+              "stringValue": "2.5.0-alpha.6"
             }
           },
           {
@@ -5685,7 +5685,7 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "2.5.0-alpha.5"
+              "stringValue": "2.5.0-alpha.6"
             }
           },
           {
@@ -5843,7 +5843,7 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "2.5.0-alpha.5"
+              "stringValue": "2.5.0-alpha.6"
             }
           },
           {
@@ -6001,7 +6001,7 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "2.5.0-alpha.5"
+              "stringValue": "2.5.0-alpha.6"
             }
           },
           {
@@ -6165,7 +6165,7 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "2.5.0-alpha.5"
+              "stringValue": "2.5.0-alpha.6"
             }
           },
           {
@@ -6356,7 +6356,7 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "2.5.0-alpha.5"
+              "stringValue": "2.5.0-alpha.6"
             }
           },
           {
@@ -6719,7 +6719,7 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "2.5.0-alpha.5"
+              "stringValue": "2.5.0-alpha.6"
             }
           },
           {
@@ -6907,7 +6907,7 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "2.5.0-alpha.5"
+              "stringValue": "2.5.0-alpha.6"
             }
           },
           {
@@ -7228,7 +7228,7 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "2.5.0-alpha.5"
+              "stringValue": "2.5.0-alpha.6"
             }
           },
           {
@@ -7392,7 +7392,7 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "2.5.0-alpha.5"
+              "stringValue": "2.5.0-alpha.6"
             }
           },
           {
@@ -7711,7 +7711,7 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "2.5.0-alpha.5"
+              "stringValue": "2.5.0-alpha.6"
             }
           },
           {
@@ -7869,7 +7869,7 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "2.5.0-alpha.5"
+              "stringValue": "2.5.0-alpha.6"
             }
           },
           {
@@ -8002,7 +8002,7 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "2.5.0-alpha.5"
+              "stringValue": "2.5.0-alpha.6"
             }
           },
           {
@@ -8396,7 +8396,7 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "2.5.0-alpha.5"
+              "stringValue": "2.5.0-alpha.6"
             }
           },
           {
@@ -8548,7 +8548,7 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "2.5.0-alpha.5"
+              "stringValue": "2.5.0-alpha.6"
             }
           },
           {
@@ -9299,7 +9299,7 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "2.5.0-alpha.5"
+              "stringValue": "2.5.0-alpha.6"
             }
           },
           {
@@ -9457,7 +9457,7 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "2.5.0-alpha.5"
+              "stringValue": "2.5.0-alpha.6"
             }
           },
           {
@@ -9597,7 +9597,7 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "2.5.0-alpha.5"
+              "stringValue": "2.5.0-alpha.6"
             }
           },
           {
@@ -10083,7 +10083,7 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "2.5.0-alpha.5"
+              "stringValue": "2.5.0-alpha.6"
             }
           },
           {
@@ -10265,7 +10265,7 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "2.5.0-alpha.5"
+              "stringValue": "2.5.0-alpha.6"
             }
           },
           {
@@ -10441,7 +10441,7 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "2.5.0-alpha.5"
+              "stringValue": "2.5.0-alpha.6"
             }
           },
           {
@@ -11463,7 +11463,7 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "2.5.0-alpha.5"
+              "stringValue": "2.5.0-alpha.6"
             }
           },
           {
@@ -14442,7 +14442,7 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "2.5.0-alpha.5"
+              "stringValue": "2.5.0-alpha.6"
             }
           },
           {
@@ -14618,7 +14618,7 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "2.5.0-alpha.5"
+              "stringValue": "2.5.0-alpha.6"
             }
           },
           {
@@ -14794,7 +14794,7 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "2.5.0-alpha.5"
+              "stringValue": "2.5.0-alpha.6"
             }
           },
           {
@@ -14994,7 +14994,7 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "2.5.0-alpha.5"
+              "stringValue": "2.5.0-alpha.6"
             }
           },
           {
@@ -15164,7 +15164,7 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "2.5.0-alpha.5"
+              "stringValue": "2.5.0-alpha.6"
             }
           },
           {
@@ -15322,7 +15322,7 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "2.5.0-alpha.5"
+              "stringValue": "2.5.0-alpha.6"
             }
           },
           {
@@ -15523,7 +15523,7 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "2.5.0-alpha.5"
+              "stringValue": "2.5.0-alpha.6"
             }
           },
           {
@@ -15705,7 +15705,7 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "2.5.0-alpha.5"
+              "stringValue": "2.5.0-alpha.6"
             }
           },
           {
@@ -15863,7 +15863,7 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "2.5.0-alpha.5"
+              "stringValue": "2.5.0-alpha.6"
             }
           },
           {
@@ -16052,7 +16052,7 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "2.5.0-alpha.5"
+              "stringValue": "2.5.0-alpha.6"
             }
           },
           {
@@ -16204,7 +16204,7 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "2.5.0-alpha.5"
+              "stringValue": "2.5.0-alpha.6"
             }
           },
           {
@@ -16387,7 +16387,7 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "2.5.0-alpha.5"
+              "stringValue": "2.5.0-alpha.6"
             }
           },
           {
@@ -16533,7 +16533,7 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "2.5.0-alpha.5"
+              "stringValue": "2.5.0-alpha.6"
             }
           },
           {
@@ -16685,7 +16685,7 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "2.5.0-alpha.5"
+              "stringValue": "2.5.0-alpha.6"
             }
           },
           {
@@ -16843,7 +16843,7 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "2.5.0-alpha.5"
+              "stringValue": "2.5.0-alpha.6"
             }
           },
           {
@@ -17166,7 +17166,7 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "2.5.0-alpha.5"
+              "stringValue": "2.5.0-alpha.6"
             }
           },
           {
@@ -17342,7 +17342,7 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "2.5.0-alpha.5"
+              "stringValue": "2.5.0-alpha.6"
             }
           },
           {
@@ -17494,7 +17494,7 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "2.5.0-alpha.5"
+              "stringValue": "2.5.0-alpha.6"
             }
           },
           {
@@ -17738,7 +17738,7 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "2.5.0-alpha.5"
+              "stringValue": "2.5.0-alpha.6"
             }
           },
           {
@@ -18062,7 +18062,7 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "2.5.0-alpha.5"
+              "stringValue": "2.5.0-alpha.6"
             }
           },
           {
@@ -18339,7 +18339,7 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "2.5.0-alpha.5"
+              "stringValue": "2.5.0-alpha.6"
             }
           },
           {
@@ -18510,7 +18510,7 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "2.5.0-alpha.5"
+              "stringValue": "2.5.0-alpha.6"
             }
           },
           {
@@ -18638,7 +18638,7 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "2.5.0-alpha.5"
+              "stringValue": "2.5.0-alpha.6"
             }
           },
           {
@@ -18742,7 +18742,7 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "2.5.0-alpha.5"
+              "stringValue": "2.5.0-alpha.6"
             }
           },
           {
@@ -30919,7 +30919,7 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "2.5.0-alpha.5"
+              "stringValue": "2.5.0-alpha.6"
             }
           },
           {


### PR DESCRIPTION
Updating docker images `solarwinds/swo-agent`, `busybox`, `fullstorydev/grpcurl` and `alpine/k8s` to latest available versions.