### PR TITLE
NH-43083 increasing version of build dependency

### DIFF
--- a/build/docker/structure-test.yaml
+++ b/build/docker/structure-test.yaml
@@ -18,4 +18,4 @@ commandTests:
   - name: "swi-otelcol is working in the image"
     command: "/swi-otelcol"
     args: ["-v"]
-    expectedOutput: ["swi-k8s-opentelemetry-collector version 0.7.0"]
+    expectedOutput: ["swi-k8s-opentelemetry-collector version 0.7.1"]

--- a/build/swi-k8s-opentelemetry-collector.yaml
+++ b/build/swi-k8s-opentelemetry-collector.yaml
@@ -2,7 +2,7 @@ dist:
   name: swi-k8s-opentelemetry-collector
   description: "SolarWinds distribution for OpenTelemetry"
   otelcol_version: "0.73.0"
-  version: "0.7.0"
+  version: "0.7.1"
 exporters:
   - gomod: go.opentelemetry.io/collector/exporter/otlpexporter v0.73.0
 
@@ -43,3 +43,4 @@ replaces:
   - github.com/aws/aws-sdk-go => github.com/aws/aws-sdk-go v1.44.249
   - github.com/prometheus/prometheus => github.com/prometheus/prometheus v0.43.0
   - google.golang.org/protobuf => google.golang.org/protobuf v1.29.1
+  - github.com/docker/distribution => github.com/docker/distribution v2.8.2+incompatible


### PR DESCRIPTION
increasing version of github.com/docker/distribution because of security issue

current image
![image](https://github.com/solarwinds/swi-k8s-opentelemetry-collector/assets/63846087/7adf259e-f2e8-4c0d-a711-21413197afb8)

new image
![image](https://github.com/solarwinds/swi-k8s-opentelemetry-collector/assets/63846087/bfbe3add-9722-45cc-939a-304bb20e71f1)
