### PR TITLE
NH-53106: Add EKS Fargate logging support

### DIFF
--- a/deploy/helm/CHANGELOG.md
+++ b/deploy/helm/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Added
+- There are new Helm settings `aws_fargate.enabled` and `aws_fargate.logs.enabled` that allow the k8s collector Helm chart to setup AWS EKS Fargate logging ConfigMap
+
 ### Changed
 - Log collection DaemonSet now restrict where it runs:
   - Fargate nodes are excluded

--- a/deploy/helm/templates/logs-fargate-config-map.yaml
+++ b/deploy/helm/templates/logs-fargate-config-map.yaml
@@ -1,0 +1,53 @@
+{{- if and .Values.aws_fargate.enabled .Values.aws_fargate.logs.enabled }}
+{{- $pattern := "[^a-zA-Z0-9\\.\\-_/#]" -}}
+{{- $replacement := "" -}}
+{{- $name := regexReplaceAll $pattern .Values.cluster.name $replacement | default .Values.cluster.uid | lower | trunc 512 -}}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: aws-logging
+  namespace: aws-observability
+  labels:
+{{ include "common.labels" . | indent 4 }}
+data:
+  flb_log_cw: "false"  # Set to true to ship Fluent Bit process logs to CloudWatch.
+  filters.conf: |
+    [FILTER]
+        Name parser
+        Match *
+        Key_name log
+        Parser crio
+    [FILTER]
+        Name kubernetes
+        Match kube.*
+        Merge_Log On
+        Keep_Log Off
+        Buffer_Size 0
+        Kube_Meta_Cache_TTL 300s
+        Labels Off
+        Annotations Off
+{{- if .Values.aws_fargate.logs.filters }}
+{{ toString .Values.aws_fargate.logs.filters | indent 4 }}
+{{- end }}
+    [FILTER]
+        Name modify
+        Match *
+        Add sw.k8s.cluster.uid {{ .Values.cluster.uid }}
+        Add sw.k8s.log.type container
+  output.conf: |
+    [OUTPUT]
+        Name cloudwatch_logs
+        Match kube.*
+        region {{ required "A valid value for aws_fargate.logs.region is required!" .Values.aws_fargate.logs.region }}
+        log_group_name aws/eks/{{ $name }}/application
+        log_stream_prefix from-fluent-bit-
+        log_retention_days 30
+        auto_create_group true
+  parsers.conf: |
+    [PARSER]
+        Name crio
+        Format Regex
+        Regex ^(?<time>[^ ]+) (?<stream>stdout|stderr) (?<logtag>P|F) (?<log>.*)$
+        Time_Key time
+        Time_Format %Y-%m-%dT%H:%M:%S.%L%z
+{{- end }}

--- a/deploy/helm/templates/logs-fargate-namespace.yaml
+++ b/deploy/helm/templates/logs-fargate-namespace.yaml
@@ -1,0 +1,9 @@
+{{- if and .Values.aws_fargate.enabled .Values.aws_fargate.logs.enabled }}
+kind: Namespace
+apiVersion: v1
+metadata:
+  name: aws-observability
+  labels:
+    aws-observability: enabled
+{{ include "common.labels" . | indent 4 }}
+{{- end }}

--- a/deploy/helm/tests/__snapshot__/logs-fargate-config-map_test.yaml.snap
+++ b/deploy/helm/tests/__snapshot__/logs-fargate-config-map_test.yaml.snap
@@ -1,0 +1,82 @@
+Fargate logging ConfigMap spec should include additional filters when they are configured in values.yaml:
+  1: |
+    filters.conf: |
+      [FILTER]
+          Name parser
+          Match *
+          Key_name log
+          Parser crio
+      [FILTER]
+          Name kubernetes
+          Match kube.*
+          Merge_Log On
+          Keep_Log Off
+          Buffer_Size 0
+          Kube_Meta_Cache_TTL 300s
+          Labels Off
+          Annotations Off
+      [FILTER]
+          Name filter_name
+          Match *
+
+      [FILTER]
+          Name modify
+          Match *
+          Add sw.k8s.cluster.uid <CLUSTER_UID>
+          Add sw.k8s.log.type container
+    flb_log_cw: "false"
+    output.conf: |
+      [OUTPUT]
+          Name cloudwatch_logs
+          Match kube.*
+          region test-region
+          log_group_name aws/eks/cluster_name/application
+          log_stream_prefix from-fluent-bit-
+          log_retention_days 30
+          auto_create_group true
+    parsers.conf: |-
+      [PARSER]
+          Name crio
+          Format Regex
+          Regex ^(?<time>[^ ]+) (?<stream>stdout|stderr) (?<logtag>P|F) (?<log>.*)$
+          Time_Key time
+          Time_Format %Y-%m-%dT%H:%M:%S.%L%z
+Fargate logging ConfigMap spec should match snapshot when Fargate logging is enabled:
+  1: |
+    filters.conf: |
+      [FILTER]
+          Name parser
+          Match *
+          Key_name log
+          Parser crio
+      [FILTER]
+          Name kubernetes
+          Match kube.*
+          Merge_Log On
+          Keep_Log Off
+          Buffer_Size 0
+          Kube_Meta_Cache_TTL 300s
+          Labels Off
+          Annotations Off
+      [FILTER]
+          Name modify
+          Match *
+          Add sw.k8s.cluster.uid <CLUSTER_UID>
+          Add sw.k8s.log.type container
+    flb_log_cw: "false"
+    output.conf: |
+      [OUTPUT]
+          Name cloudwatch_logs
+          Match kube.*
+          region test-region
+          log_group_name aws/eks/cluster_name/application
+          log_stream_prefix from-fluent-bit-
+          log_retention_days 30
+          auto_create_group true
+    parsers.conf: |-
+      [PARSER]
+          Name crio
+          Format Regex
+          Regex ^(?<time>[^ ]+) (?<stream>stdout|stderr) (?<logtag>P|F) (?<log>.*)$
+          Time_Key time
+          Time_Format %Y-%m-%dT%H:%M:%S.%L%z

--- a/deploy/helm/tests/logs-fargate-config-map_test.yaml
+++ b/deploy/helm/tests/logs-fargate-config-map_test.yaml
@@ -1,0 +1,32 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/helm-unittest/helm-unittest/main/schema/helm-testsuite.json
+suite: Test for logs-fargate-config-map
+templates:
+  - logs-fargate-config-map.yaml
+tests:
+  - it: Fargate logging ConfigMap spec should match snapshot when Fargate logging is enabled
+    template: logs-fargate-config-map.yaml
+    set:
+      aws_fargate.enabled: true
+      aws_fargate.logs.enabled: true
+      aws_fargate.logs.region: test-region
+    asserts:
+      - matchSnapshot:
+          path: data
+  - it: Fargate logging ConfigMap should not be generated when using default values
+    template: logs-fargate-config-map.yaml
+    asserts:
+      - hasDocuments:
+          count: 0
+  - it: Fargate logging ConfigMap spec should include additional filters when they are configured in values.yaml
+    template: logs-fargate-config-map.yaml
+    set:
+      aws_fargate.enabled: true
+      aws_fargate.logs.enabled: true
+      aws_fargate.logs.region: test-region
+      aws_fargate.logs.filters: |
+        [FILTER]
+            Name filter_name
+            Match *
+    asserts:
+      - matchSnapshot:
+          path: data

--- a/deploy/helm/values.yaml
+++ b/deploy/helm/values.yaml
@@ -45,7 +45,7 @@ otel:
     kube-state-metrics:
       # URL of kube-state-metrics where to scrape
       url: ""
-      
+
       # Prometheus URL scheme. It can take the values `http` or `https`
       scheme: http
 
@@ -113,7 +113,6 @@ otel:
         # excludePattern: ".*internal.*|.*private.*"
         excludePattern:
 
-
     # Telemetry information of the collector
     # see https://github.com/open-telemetry/opentelemetry-collector/blob/main/docs/troubleshooting.md#observability for configuration reference
     telemetry:
@@ -139,7 +138,7 @@ otel:
 
           # Timeout if metrics can't be retrieved in given time interval
           scrapeTimeout: 25s
-    
+
     # Scheduling configurations
     # By default: set to run on linux amd64 nodes
     nodeSelector: {}
@@ -206,7 +205,7 @@ otel:
 
           # Timeout if metrics can't be retrieved in given time interval
           scrapeTimeout: 25s
-    
+
     # k8s_instrumentation controls the automatic extraction of Kubernetes metadata from resources.
     # It instruments OpenTelemetry (OTEL) resources being sent.
     k8s_instrumentation:
@@ -408,3 +407,20 @@ swoagent:
     requests:
       memory: 800Mi
       cpu: 100m
+
+aws_fargate:
+  # Enable support for AWS EKS Fargate environment
+  enabled: false
+
+  # Configuration for Logs collection
+  logs:
+    # Enable deployment of AWS FluentBit to the Fargate cluster
+    enabled: false
+
+    # AWS region where the Fargate cluster is running
+    region:
+
+    # Include additional FluentBit filters
+    # see https://docs.fluentbit.io/manual/pipeline/filters
+    # NOTE: The FluentBit configuration expects four spaces as indentation within sections
+    filters:

--- a/doc/development.md
+++ b/doc/development.md
@@ -115,19 +115,28 @@ In order to change Prometheus endpoint that is hosted on HTTPS you can adjust sk
 - update `otel.metrics.prometheus.url: <remote prometheus>`
 
 ## Helm Unit tests
+
 Helm Unit tests are located in `deploy/helm/tests` and are supposed to verify how Helm chart is rendered.
 
 ### Setup
-* Run in bash (or Git Bash): `helm plugin install https://github.com/helm-unittest/helm-unittest.git` 
+
+Run in bash (or Git Bash):
+
+```shell
+helm plugin install https://github.com/helm-unittest/helm-unittest.git
+```
 
 ### Run tests locally
+
 ```shell
 helm unittest deploy/helm
 ```
 
 ### Refresh snapshot tests
-* Remove `deploy/helm/tests/__snapshots__` folder
-* Run tests locally (which will regenerate snapshots)
+
+```shell
+helm unittest -u deploy/helm
+```
 
 ## Integration tests
 Integration tests are located in `tests/integration` and are supposed to verify if metric processing is delivering expected outcome.


### PR DESCRIPTION
Create a special NameSpace and ConfigMap configured to send logs to `aws/eks/{{ $name }}/application` CloudWatch log group, where `{{ $name }}` is a sanitized cluster name.
The ConfigMap is configured to enrich logs with `sw.k8s.cluster.uid`and `sw.k8s.log.type` attributes.