### PR TITLE
NH-53106: Release chart 2.7.0-alpha.3

### DIFF
--- a/deploy/helm/CHANGELOG.md
+++ b/deploy/helm/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## [2.7.0-alpha.3] - 2023-08-17
+
 ### Added
 - There are new Helm settings `aws_fargate.enabled` and `aws_fargate.logs.enabled` that allow the k8s collector Helm chart to setup AWS EKS Fargate logging ConfigMap
 

--- a/deploy/helm/Chart.yaml
+++ b/deploy/helm/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: swo-k8s-collector
-version: 2.7.0-alpha.2
+version: 2.7.0-alpha.3
 appVersion: "0.8.0"
 description: SolarWinds Kubernetes Integration
 keywords:

--- a/deploy/helm/values.yaml
+++ b/deploy/helm/values.yaml
@@ -263,7 +263,7 @@ otel:
     #   * k8s.pod.uid - pod's uid
     container: true
 
-    # This filter is applied after metric processing, it is the place where metrics could be filtered out
+    # This filter is applied after initial log processing, it is the place where logs could be filtered out
     # see https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/processor/filterprocessor for configuration reference
     filter:
       include:

--- a/tests/integration/expected_output.json
+++ b/tests/integration/expected_output.json
@@ -150,7 +150,7 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "2.7.0-alpha.2"
+              "stringValue": "2.7.0-alpha.3"
             }
           },
           {
@@ -377,7 +377,7 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "2.7.0-alpha.2"
+              "stringValue": "2.7.0-alpha.3"
             }
           },
           {
@@ -616,7 +616,7 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "2.7.0-alpha.2"
+              "stringValue": "2.7.0-alpha.3"
             }
           },
           {
@@ -855,7 +855,7 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "2.7.0-alpha.2"
+              "stringValue": "2.7.0-alpha.3"
             }
           },
           {
@@ -1094,7 +1094,7 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "2.7.0-alpha.2"
+              "stringValue": "2.7.0-alpha.3"
             }
           },
           {
@@ -1333,7 +1333,7 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "2.7.0-alpha.2"
+              "stringValue": "2.7.0-alpha.3"
             }
           },
           {
@@ -1548,7 +1548,7 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "2.7.0-alpha.2"
+              "stringValue": "2.7.0-alpha.3"
             }
           },
           {
@@ -1805,7 +1805,7 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "2.7.0-alpha.2"
+              "stringValue": "2.7.0-alpha.3"
             }
           },
           {
@@ -2068,7 +2068,7 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "2.7.0-alpha.2"
+              "stringValue": "2.7.0-alpha.3"
             }
           },
           {
@@ -2319,7 +2319,7 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "2.7.0-alpha.2"
+              "stringValue": "2.7.0-alpha.3"
             }
           },
           {
@@ -2540,7 +2540,7 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "2.7.0-alpha.2"
+              "stringValue": "2.7.0-alpha.3"
             }
           },
           {
@@ -2743,7 +2743,7 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "2.7.0-alpha.2"
+              "stringValue": "2.7.0-alpha.3"
             }
           },
           {
@@ -3242,7 +3242,7 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "2.7.0-alpha.2"
+              "stringValue": "2.7.0-alpha.3"
             }
           },
           {
@@ -3457,7 +3457,7 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "2.7.0-alpha.2"
+              "stringValue": "2.7.0-alpha.3"
             }
           },
           {
@@ -3660,7 +3660,7 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "2.7.0-alpha.2"
+              "stringValue": "2.7.0-alpha.3"
             }
           },
           {
@@ -4558,7 +4558,7 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "2.7.0-alpha.2"
+              "stringValue": "2.7.0-alpha.3"
             }
           },
           {
@@ -5040,7 +5040,7 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "2.7.0-alpha.2"
+              "stringValue": "2.7.0-alpha.3"
             }
           },
           {
@@ -5249,7 +5249,7 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "2.7.0-alpha.2"
+              "stringValue": "2.7.0-alpha.3"
             }
           },
           {
@@ -5584,7 +5584,7 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "2.7.0-alpha.2"
+              "stringValue": "2.7.0-alpha.3"
             }
           },
           {
@@ -5870,7 +5870,7 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "2.7.0-alpha.2"
+              "stringValue": "2.7.0-alpha.3"
             }
           },
           {
@@ -6801,7 +6801,7 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "2.7.0-alpha.2"
+              "stringValue": "2.7.0-alpha.3"
             }
           },
           {
@@ -7018,7 +7018,7 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "2.7.0-alpha.2"
+              "stringValue": "2.7.0-alpha.3"
             }
           },
           {
@@ -7221,7 +7221,7 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "2.7.0-alpha.2"
+              "stringValue": "2.7.0-alpha.3"
             }
           },
           {
@@ -7794,7 +7794,7 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "2.7.0-alpha.2"
+              "stringValue": "2.7.0-alpha.3"
             }
           },
           {
@@ -7991,7 +7991,7 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "2.7.0-alpha.2"
+              "stringValue": "2.7.0-alpha.3"
             }
           },
           {
@@ -8188,7 +8188,7 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "2.7.0-alpha.2"
+              "stringValue": "2.7.0-alpha.3"
             }
           },
           {
@@ -8900,7 +8900,7 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "2.7.0-alpha.2"
+              "stringValue": "2.7.0-alpha.3"
             }
           },
           {
@@ -9164,7 +9164,7 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "2.7.0-alpha.2"
+              "stringValue": "2.7.0-alpha.3"
             }
           },
           {
@@ -9422,7 +9422,7 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "2.7.0-alpha.2"
+              "stringValue": "2.7.0-alpha.3"
             }
           },
           {
@@ -13376,7 +13376,7 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "2.7.0-alpha.2"
+              "stringValue": "2.7.0-alpha.3"
             }
           },
           {
@@ -13651,7 +13651,7 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "2.7.0-alpha.2"
+              "stringValue": "2.7.0-alpha.3"
             }
           },
           {
@@ -13872,7 +13872,7 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "2.7.0-alpha.2"
+              "stringValue": "2.7.0-alpha.3"
             }
           },
           {
@@ -14081,7 +14081,7 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "2.7.0-alpha.2"
+              "stringValue": "2.7.0-alpha.3"
             }
           },
           {
@@ -14345,7 +14345,7 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "2.7.0-alpha.2"
+              "stringValue": "2.7.0-alpha.3"
             }
           },
           {
@@ -14560,7 +14560,7 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "2.7.0-alpha.2"
+              "stringValue": "2.7.0-alpha.3"
             }
           },
           {
@@ -14775,7 +14775,7 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "2.7.0-alpha.2"
+              "stringValue": "2.7.0-alpha.3"
             }
           },
           {
@@ -15021,7 +15021,7 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "2.7.0-alpha.2"
+              "stringValue": "2.7.0-alpha.3"
             }
           },
           {
@@ -15200,7 +15200,7 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "2.7.0-alpha.2"
+              "stringValue": "2.7.0-alpha.3"
             }
           },
           {
@@ -15391,7 +15391,7 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "2.7.0-alpha.2"
+              "stringValue": "2.7.0-alpha.3"
             }
           },
           {
@@ -15689,7 +15689,7 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "2.7.0-alpha.2"
+              "stringValue": "2.7.0-alpha.3"
             }
           },
           {
@@ -15911,7 +15911,7 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "2.7.0-alpha.2"
+              "stringValue": "2.7.0-alpha.3"
             }
           },
           {
@@ -16090,7 +16090,7 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "2.7.0-alpha.2"
+              "stringValue": "2.7.0-alpha.3"
             }
           },
           {
@@ -16275,7 +16275,7 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "2.7.0-alpha.2"
+              "stringValue": "2.7.0-alpha.3"
             }
           },
           {
@@ -16460,7 +16460,7 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "2.7.0-alpha.2"
+              "stringValue": "2.7.0-alpha.3"
             }
           },
           {
@@ -16651,7 +16651,7 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "2.7.0-alpha.2"
+              "stringValue": "2.7.0-alpha.3"
             }
           },
           {
@@ -16836,7 +16836,7 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "2.7.0-alpha.2"
+              "stringValue": "2.7.0-alpha.3"
             }
           },
           {
@@ -17015,7 +17015,7 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "2.7.0-alpha.2"
+              "stringValue": "2.7.0-alpha.3"
             }
           },
           {
@@ -17200,7 +17200,7 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "2.7.0-alpha.2"
+              "stringValue": "2.7.0-alpha.3"
             }
           },
           {
@@ -17391,7 +17391,7 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "2.7.0-alpha.2"
+              "stringValue": "2.7.0-alpha.3"
             }
           },
           {
@@ -17627,7 +17627,7 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "2.7.0-alpha.2"
+              "stringValue": "2.7.0-alpha.3"
             }
           },
           {
@@ -17818,7 +17818,7 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "2.7.0-alpha.2"
+              "stringValue": "2.7.0-alpha.3"
             }
           },
           {
@@ -18039,7 +18039,7 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "2.7.0-alpha.2"
+              "stringValue": "2.7.0-alpha.3"
             }
           },
           {
@@ -18471,7 +18471,7 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "2.7.0-alpha.2"
+              "stringValue": "2.7.0-alpha.3"
             }
           },
           {
@@ -18662,7 +18662,7 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "2.7.0-alpha.2"
+              "stringValue": "2.7.0-alpha.3"
             }
           },
           {
@@ -19040,7 +19040,7 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "2.7.0-alpha.2"
+              "stringValue": "2.7.0-alpha.3"
             }
           },
           {
@@ -19267,7 +19267,7 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "2.7.0-alpha.2"
+              "stringValue": "2.7.0-alpha.3"
             }
           },
           {
@@ -19653,7 +19653,7 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "2.7.0-alpha.2"
+              "stringValue": "2.7.0-alpha.3"
             }
           },
           {
@@ -19844,7 +19844,7 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "2.7.0-alpha.2"
+              "stringValue": "2.7.0-alpha.3"
             }
           },
           {
@@ -20238,7 +20238,7 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "2.7.0-alpha.2"
+              "stringValue": "2.7.0-alpha.3"
             }
           },
           {
@@ -20631,7 +20631,7 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "2.7.0-alpha.2"
+              "stringValue": "2.7.0-alpha.3"
             }
           },
           {
@@ -20834,7 +20834,7 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "2.7.0-alpha.2"
+              "stringValue": "2.7.0-alpha.3"
             }
           },
           {
@@ -21186,7 +21186,7 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "2.7.0-alpha.2"
+              "stringValue": "2.7.0-alpha.3"
             }
           },
           {
@@ -21535,7 +21535,7 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "2.7.0-alpha.2"
+              "stringValue": "2.7.0-alpha.3"
             }
           },
           {
@@ -21708,7 +21708,7 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "2.7.0-alpha.2"
+              "stringValue": "2.7.0-alpha.3"
             }
           },
           {
@@ -22868,7 +22868,7 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "2.7.0-alpha.2"
+              "stringValue": "2.7.0-alpha.3"
             }
           },
           {
@@ -22954,7 +22954,7 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "2.7.0-alpha.2"
+              "stringValue": "2.7.0-alpha.3"
             }
           },
           {
@@ -36610,7 +36610,7 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "2.7.0-alpha.2"
+              "stringValue": "2.7.0-alpha.3"
             }
           },
           {


### PR DESCRIPTION
### Added
- There are new Helm settings `aws_fargate.enabled` and `aws_fargate.logs.enabled` that allow the k8s collector Helm chart to setup AWS EKS Fargate logging ConfigMap

### Changed
- Log collection DaemonSet now restrict where it runs:
  - Fargate nodes are excluded
  - Only linux nodes with amd64 architecture are included
### Fixed
- Fixed Journal log collection on EKS (and other environment where journal logs are stored in `/var/log/journal`)