### PR TITLE
NH-53106: Adjusted bundled prometheus to not run on Fargate nodes by default

### DIFF
--- a/deploy/helm/CHANGELOG.md
+++ b/deploy/helm/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## [2.7.0-alpha.5] - 2023-08-22
+
+### Changed
+- Adjusted bundled prometheus to not run on Fargate nodes by default
+- Allowed use of `prometheus.forceNamespace` option of bundled prometheus, to force namespace where prometheus is deployed
+
 ## [2.7.0-alpha.4] - 2023-08-17
 
 ### Changed

--- a/deploy/helm/Chart.yaml
+++ b/deploy/helm/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: swo-k8s-collector
-version: 2.7.0-alpha.4
+version: 2.7.0-alpha.5
 appVersion: "0.8.1"
 description: SolarWinds Kubernetes Integration
 keywords:

--- a/deploy/helm/templates/metrics-collector-env-config-map.yaml
+++ b/deploy/helm/templates/metrics-collector-env-config-map.yaml
@@ -8,7 +8,11 @@ metadata:
 {{ include "common.labels" . | indent 4 }}
 data:
 {{- if .Values.prometheus.enabled }}
+{{- if .Values.prometheus.forceNamespace }}
+  PROMETHEUS_URL: "{{ .Release.Name }}-prometheus-server.{{ .Values.prometheus.forceNamespace }}.svc.cluster.local:80"
+{{- else }}
   PROMETHEUS_URL: "{{ .Release.Name }}-prometheus-server.{{ .Release.Namespace }}.svc.cluster.local:80"
+{{- end }}
 {{- else }}
   PROMETHEUS_URL: {{ quote .Values.otel.metrics.prometheus.url }}
 {{- end }}

--- a/deploy/helm/tests/__snapshot__/logs-fargate-config-map_test.yaml.snap
+++ b/deploy/helm/tests/__snapshot__/logs-fargate-config-map_test.yaml.snap
@@ -24,7 +24,7 @@ Fargate logging ConfigMap spec should include additional filters when they are c
           Match *
           Add sw.k8s.cluster.uid <CLUSTER_UID>
           Add sw.k8s.log.type container
-          Add sw.k8s.agent.manifest.version "2.7.0-alpha.4"
+          Add sw.k8s.agent.manifest.version "2.7.0-alpha.5"
     flb_log_cw: "false"
     output.conf: |
       [OUTPUT]
@@ -64,7 +64,7 @@ Fargate logging ConfigMap spec should match snapshot when Fargate logging is ena
           Match *
           Add sw.k8s.cluster.uid <CLUSTER_UID>
           Add sw.k8s.log.type container
-          Add sw.k8s.agent.manifest.version "2.7.0-alpha.4"
+          Add sw.k8s.agent.manifest.version "2.7.0-alpha.5"
     flb_log_cw: "false"
     output.conf: |
       [OUTPUT]

--- a/deploy/helm/values.yaml
+++ b/deploy/helm/values.yaml
@@ -386,6 +386,15 @@ prometheus:
     # (this matches the behavior of `kube-prometheus-stack` chart).
     persistentVolume:
       enabled: false
+    affinity:
+      nodeAffinity:
+        requiredDuringSchedulingIgnoredDuringExecution:
+          nodeSelectorTerms:
+          - matchExpressions:
+            - key: eks.amazonaws.com/compute-type
+              operator: NotIn
+              values:
+              - fargate
 
 kube-state-metrics:
   enabled: true

--- a/tests/integration/expected_output.json
+++ b/tests/integration/expected_output.json
@@ -150,7 +150,7 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "2.7.0-alpha.4"
+              "stringValue": "2.7.0-alpha.5"
             }
           },
           {
@@ -374,7 +374,7 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "2.7.0-alpha.4"
+              "stringValue": "2.7.0-alpha.5"
             }
           },
           {
@@ -610,7 +610,7 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "2.7.0-alpha.4"
+              "stringValue": "2.7.0-alpha.5"
             }
           },
           {
@@ -846,7 +846,7 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "2.7.0-alpha.4"
+              "stringValue": "2.7.0-alpha.5"
             }
           },
           {
@@ -1082,7 +1082,7 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "2.7.0-alpha.4"
+              "stringValue": "2.7.0-alpha.5"
             }
           },
           {
@@ -1318,7 +1318,7 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "2.7.0-alpha.4"
+              "stringValue": "2.7.0-alpha.5"
             }
           },
           {
@@ -1530,7 +1530,7 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "2.7.0-alpha.4"
+              "stringValue": "2.7.0-alpha.5"
             }
           },
           {
@@ -1784,7 +1784,7 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "2.7.0-alpha.4"
+              "stringValue": "2.7.0-alpha.5"
             }
           },
           {
@@ -2044,7 +2044,7 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "2.7.0-alpha.4"
+              "stringValue": "2.7.0-alpha.5"
             }
           },
           {
@@ -2292,7 +2292,7 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "2.7.0-alpha.4"
+              "stringValue": "2.7.0-alpha.5"
             }
           },
           {
@@ -2510,7 +2510,7 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "2.7.0-alpha.4"
+              "stringValue": "2.7.0-alpha.5"
             }
           },
           {
@@ -2710,7 +2710,7 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "2.7.0-alpha.4"
+              "stringValue": "2.7.0-alpha.5"
             }
           },
           {
@@ -3206,7 +3206,7 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "2.7.0-alpha.4"
+              "stringValue": "2.7.0-alpha.5"
             }
           },
           {
@@ -3418,7 +3418,7 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "2.7.0-alpha.4"
+              "stringValue": "2.7.0-alpha.5"
             }
           },
           {
@@ -3618,7 +3618,7 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "2.7.0-alpha.4"
+              "stringValue": "2.7.0-alpha.5"
             }
           },
           {
@@ -4513,7 +4513,7 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "2.7.0-alpha.4"
+              "stringValue": "2.7.0-alpha.5"
             }
           },
           {
@@ -4992,7 +4992,7 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "2.7.0-alpha.4"
+              "stringValue": "2.7.0-alpha.5"
             }
           },
           {
@@ -5198,7 +5198,7 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "2.7.0-alpha.4"
+              "stringValue": "2.7.0-alpha.5"
             }
           },
           {
@@ -5530,7 +5530,7 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "2.7.0-alpha.4"
+              "stringValue": "2.7.0-alpha.5"
             }
           },
           {
@@ -5813,7 +5813,7 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "2.7.0-alpha.4"
+              "stringValue": "2.7.0-alpha.5"
             }
           },
           {
@@ -6741,7 +6741,7 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "2.7.0-alpha.4"
+              "stringValue": "2.7.0-alpha.5"
             }
           },
           {
@@ -6955,7 +6955,7 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "2.7.0-alpha.4"
+              "stringValue": "2.7.0-alpha.5"
             }
           },
           {
@@ -7155,7 +7155,7 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "2.7.0-alpha.4"
+              "stringValue": "2.7.0-alpha.5"
             }
           },
           {
@@ -7725,7 +7725,7 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "2.7.0-alpha.4"
+              "stringValue": "2.7.0-alpha.5"
             }
           },
           {
@@ -7919,7 +7919,7 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "2.7.0-alpha.4"
+              "stringValue": "2.7.0-alpha.5"
             }
           },
           {
@@ -8113,7 +8113,7 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "2.7.0-alpha.4"
+              "stringValue": "2.7.0-alpha.5"
             }
           },
           {
@@ -8822,7 +8822,7 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "2.7.0-alpha.4"
+              "stringValue": "2.7.0-alpha.5"
             }
           },
           {
@@ -9083,7 +9083,7 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "2.7.0-alpha.4"
+              "stringValue": "2.7.0-alpha.5"
             }
           },
           {
@@ -9338,7 +9338,7 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "2.7.0-alpha.4"
+              "stringValue": "2.7.0-alpha.5"
             }
           },
           {
@@ -13289,7 +13289,7 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "2.7.0-alpha.4"
+              "stringValue": "2.7.0-alpha.5"
             }
           },
           {
@@ -13561,7 +13561,7 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "2.7.0-alpha.4"
+              "stringValue": "2.7.0-alpha.5"
             }
           },
           {
@@ -13779,7 +13779,7 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "2.7.0-alpha.4"
+              "stringValue": "2.7.0-alpha.5"
             }
           },
           {
@@ -13985,7 +13985,7 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "2.7.0-alpha.4"
+              "stringValue": "2.7.0-alpha.5"
             }
           },
           {
@@ -14246,7 +14246,7 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "2.7.0-alpha.4"
+              "stringValue": "2.7.0-alpha.5"
             }
           },
           {
@@ -14458,7 +14458,7 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "2.7.0-alpha.4"
+              "stringValue": "2.7.0-alpha.5"
             }
           },
           {
@@ -14670,7 +14670,7 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "2.7.0-alpha.4"
+              "stringValue": "2.7.0-alpha.5"
             }
           },
           {
@@ -14913,7 +14913,7 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "2.7.0-alpha.4"
+              "stringValue": "2.7.0-alpha.5"
             }
           },
           {
@@ -15089,7 +15089,7 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "2.7.0-alpha.4"
+              "stringValue": "2.7.0-alpha.5"
             }
           },
           {
@@ -15277,7 +15277,7 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "2.7.0-alpha.4"
+              "stringValue": "2.7.0-alpha.5"
             }
           },
           {
@@ -15572,7 +15572,7 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "2.7.0-alpha.4"
+              "stringValue": "2.7.0-alpha.5"
             }
           },
           {
@@ -15791,7 +15791,7 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "2.7.0-alpha.4"
+              "stringValue": "2.7.0-alpha.5"
             }
           },
           {
@@ -15967,7 +15967,7 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "2.7.0-alpha.4"
+              "stringValue": "2.7.0-alpha.5"
             }
           },
           {
@@ -16149,7 +16149,7 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "2.7.0-alpha.4"
+              "stringValue": "2.7.0-alpha.5"
             }
           },
           {
@@ -16331,7 +16331,7 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "2.7.0-alpha.4"
+              "stringValue": "2.7.0-alpha.5"
             }
           },
           {
@@ -16519,7 +16519,7 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "2.7.0-alpha.4"
+              "stringValue": "2.7.0-alpha.5"
             }
           },
           {
@@ -16701,7 +16701,7 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "2.7.0-alpha.4"
+              "stringValue": "2.7.0-alpha.5"
             }
           },
           {
@@ -16877,7 +16877,7 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "2.7.0-alpha.4"
+              "stringValue": "2.7.0-alpha.5"
             }
           },
           {
@@ -17059,7 +17059,7 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "2.7.0-alpha.4"
+              "stringValue": "2.7.0-alpha.5"
             }
           },
           {
@@ -17247,7 +17247,7 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "2.7.0-alpha.4"
+              "stringValue": "2.7.0-alpha.5"
             }
           },
           {
@@ -17480,7 +17480,7 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "2.7.0-alpha.4"
+              "stringValue": "2.7.0-alpha.5"
             }
           },
           {
@@ -17668,7 +17668,7 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "2.7.0-alpha.4"
+              "stringValue": "2.7.0-alpha.5"
             }
           },
           {
@@ -17886,7 +17886,7 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "2.7.0-alpha.4"
+              "stringValue": "2.7.0-alpha.5"
             }
           },
           {
@@ -18315,7 +18315,7 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "2.7.0-alpha.4"
+              "stringValue": "2.7.0-alpha.5"
             }
           },
           {
@@ -18503,7 +18503,7 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "2.7.0-alpha.4"
+              "stringValue": "2.7.0-alpha.5"
             }
           },
           {
@@ -18878,7 +18878,7 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "2.7.0-alpha.4"
+              "stringValue": "2.7.0-alpha.5"
             }
           },
           {
@@ -19102,7 +19102,7 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "2.7.0-alpha.4"
+              "stringValue": "2.7.0-alpha.5"
             }
           },
           {
@@ -19485,7 +19485,7 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "2.7.0-alpha.4"
+              "stringValue": "2.7.0-alpha.5"
             }
           },
           {
@@ -19673,7 +19673,7 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "2.7.0-alpha.4"
+              "stringValue": "2.7.0-alpha.5"
             }
           },
           {
@@ -20064,7 +20064,7 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "2.7.0-alpha.4"
+              "stringValue": "2.7.0-alpha.5"
             }
           },
           {
@@ -20454,7 +20454,7 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "2.7.0-alpha.4"
+              "stringValue": "2.7.0-alpha.5"
             }
           },
           {
@@ -20654,7 +20654,7 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "2.7.0-alpha.4"
+              "stringValue": "2.7.0-alpha.5"
             }
           },
           {
@@ -21003,7 +21003,7 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "2.7.0-alpha.4"
+              "stringValue": "2.7.0-alpha.5"
             }
           },
           {
@@ -21349,7 +21349,7 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "2.7.0-alpha.4"
+              "stringValue": "2.7.0-alpha.5"
             }
           },
           {
@@ -21519,7 +21519,7 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "2.7.0-alpha.4"
+              "stringValue": "2.7.0-alpha.5"
             }
           },
           {
@@ -22676,7 +22676,7 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "2.7.0-alpha.4"
+              "stringValue": "2.7.0-alpha.5"
             }
           },
           {
@@ -22759,7 +22759,7 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "2.7.0-alpha.4"
+              "stringValue": "2.7.0-alpha.5"
             }
           },
           {
@@ -36412,7 +36412,7 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "2.7.0-alpha.4"
+              "stringValue": "2.7.0-alpha.5"
             }
           },
           {


### PR DESCRIPTION
Also allowed use of `prometheus.forceNamespace` option of bundled prometheus, to force namespace where prometheus is deployed (allow other namespace than the one where Helm chart is installed). This is useful when Fargate is restricted to specific namespace
