### PR TITLE
NH-53106: Handling `k8s.node.name` attributes from Metrics correctly

### DIFF
--- a/deploy/helm/CHANGELOG.md
+++ b/deploy/helm/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## [2.7.0-alpha.6] - 2023-08-28
+
+### Changed
+- Metrics will no longer send `k8s.node.name` resource attribute if node does not exists in Kubernetes (for example in case of Fargate nodes)
+
 ## [2.7.0-alpha.5] - 2023-08-22
 
 ### Changed

--- a/deploy/helm/Chart.yaml
+++ b/deploy/helm/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: swo-k8s-collector
-version: 2.7.0-alpha.5
+version: 2.7.0-alpha.6
 appVersion: "0.8.1"
 description: SolarWinds Kubernetes Integration
 keywords:

--- a/deploy/helm/metrics-collector-config.yaml
+++ b/deploy/helm/metrics-collector-config.yaml
@@ -12,7 +12,7 @@ extensions:
 
 processors:
   k8sattributes:
-{{ include "common.k8s-instrumentation" (tuple . .Values.otel.metrics.k8s_instrumentation.annotations.enabled .Values.otel.metrics.k8s_instrumentation.labels.enabled "false") | indent 4 }}
+{{ include "common.k8s-instrumentation" (tuple . .Values.otel.metrics.k8s_instrumentation.annotations.enabled .Values.otel.metrics.k8s_instrumentation.labels.enabled "true") | indent 4 }}
 {{- if not (empty .Values.otel.metrics.k8s_instrumentation.labels.excludePattern) }}
   resource/k8sattributes_labels_filter:
     attributes:
@@ -66,9 +66,6 @@ processors:
     actions:
       - key: k8s.node.name
         from_attribute: node
-        action: insert
-      - key: k8s.node.name
-        from_attribute: kubernetes_io_hostname
         action: insert
       - key: k8s.node.name
         from_attribute: instance
@@ -1280,6 +1277,20 @@ processors:
         from_attribute: persistentvolumeclaim
         action: insert      
 
+  transform/cleanup_attributes_for_nonexisting_entities:
+    metric_statements:
+      - context: metric
+        statements:
+          - delete_key(resource.attributes, "k8s.node.name") where resource.attributes["sw.k8s.node.found"] == "false"
+          - delete_key(resource.attributes, "sw.k8s.pod.found")
+          - delete_key(resource.attributes, "sw.k8s.deployment.found")
+          - delete_key(resource.attributes, "sw.k8s.statefulset.found")
+          - delete_key(resource.attributes, "sw.k8s.replicaset.found")
+          - delete_key(resource.attributes, "sw.k8s.daemonset.found")
+          - delete_key(resource.attributes, "sw.k8s.job.found")
+          - delete_key(resource.attributes, "sw.k8s.cronjob.found")
+          - delete_key(resource.attributes, "sw.k8s.node.found")
+
   resource/events:
     attributes:
       # Collector and Manifest version
@@ -1498,6 +1509,7 @@ service:
 {{- if not (empty .Values.otel.metrics.k8s_instrumentation.annotations.excludePattern) }}
         - resource/k8sattributes_annotations_filter
 {{- end }}
+        - transform/cleanup_attributes_for_nonexisting_entities
         - batch
       receivers:
         - forward/prometheus

--- a/deploy/helm/templates/_helpers.tpl
+++ b/deploy/helm/templates/_helpers.tpl
@@ -145,6 +145,7 @@ extract:
     - k8s.job.name
     - k8s.cronjob.name
     - k8s.statefulset.name
+    - k8s.node.name
 {{- if index . 1 }}
   annotations:
     - key_regex: (.*)

--- a/deploy/helm/tests/__snapshot__/events-collector-config-map_test.yaml.snap
+++ b/deploy/helm/tests/__snapshot__/events-collector-config-map_test.yaml.snap
@@ -70,6 +70,7 @@ Events config should match snapshot when using default values:
             - k8s.job.name
             - k8s.cronjob.name
             - k8s.statefulset.name
+            - k8s.node.name
           job:
             association:
             - sources:

--- a/deploy/helm/tests/__snapshot__/logs-fargate-config-map_test.yaml.snap
+++ b/deploy/helm/tests/__snapshot__/logs-fargate-config-map_test.yaml.snap
@@ -24,7 +24,7 @@ Fargate logging ConfigMap spec should include additional filters when they are c
           Match *
           Add sw.k8s.cluster.uid <CLUSTER_UID>
           Add sw.k8s.log.type container
-          Add sw.k8s.agent.manifest.version "2.7.0-alpha.5"
+          Add sw.k8s.agent.manifest.version "2.7.0-alpha.6"
     flb_log_cw: "false"
     output.conf: |
       [OUTPUT]
@@ -64,7 +64,7 @@ Fargate logging ConfigMap spec should match snapshot when Fargate logging is ena
           Match *
           Add sw.k8s.cluster.uid <CLUSTER_UID>
           Add sw.k8s.log.type container
-          Add sw.k8s.agent.manifest.version "2.7.0-alpha.5"
+          Add sw.k8s.agent.manifest.version "2.7.0-alpha.6"
     flb_log_cw: "false"
     output.conf: |
       [OUTPUT]

--- a/deploy/helm/tests/__snapshot__/metrics-collector-config-map_test.yaml.snap
+++ b/deploy/helm/tests/__snapshot__/metrics-collector-config-map_test.yaml.snap
@@ -340,9 +340,6 @@ Metrics config should match snapshot when using default values:
             from_attribute: node
             key: k8s.node.name
           - action: insert
-            from_attribute: kubernetes_io_hostname
-            key: k8s.node.name
-          - action: insert
             from_attribute: instance
             key: k8s.node.name
           include:
@@ -667,6 +664,7 @@ Metrics config should match snapshot when using default values:
             - k8s.job.name
             - k8s.cronjob.name
             - k8s.statefulset.name
+            - k8s.node.name
           job:
             association:
             - sources:
@@ -750,7 +748,7 @@ Metrics config should match snapshot when using default values:
               - from: replicaset
                 key_regex: (.*)
                 tag_name: k8s.replicaset.labels.$$1
-          set_object_existence: false
+          set_object_existence: true
           statefulset:
             association:
             - sources:
@@ -1914,6 +1912,20 @@ Metrics config should match snapshot when using default values:
             - set(attributes["job_condition"], "Complete") where IsMatch(metric.name, "^.*kube_job_complete$")
               == true and IsMatch(attributes["condition"], "^true$") == true and value_double
               > 0
+        transform/cleanup_attributes_for_nonexisting_entities:
+          metric_statements:
+          - context: metric
+            statements:
+            - delete_key(resource.attributes, "k8s.node.name") where resource.attributes["sw.k8s.node.found"]
+              == "false"
+            - delete_key(resource.attributes, "sw.k8s.pod.found")
+            - delete_key(resource.attributes, "sw.k8s.deployment.found")
+            - delete_key(resource.attributes, "sw.k8s.statefulset.found")
+            - delete_key(resource.attributes, "sw.k8s.replicaset.found")
+            - delete_key(resource.attributes, "sw.k8s.daemonset.found")
+            - delete_key(resource.attributes, "sw.k8s.job.found")
+            - delete_key(resource.attributes, "sw.k8s.cronjob.found")
+            - delete_key(resource.attributes, "sw.k8s.node.found")
       receivers:
         k8s_events: null
         prometheus/kube-state-metrics:
@@ -1999,6 +2011,7 @@ Metrics config should match snapshot when using default values:
             - filter
             - resource/metrics
             - k8sattributes
+            - transform/cleanup_attributes_for_nonexisting_entities
             - batch
             receivers:
             - forward/prometheus

--- a/tests/integration/expected_output.json
+++ b/tests/integration/expected_output.json
@@ -64,6 +64,12 @@
             }
           },
           {
+            "key": "k8s.node.name",
+            "value": {
+              "stringValue": "test-node"
+            }
+          },
+          {
             "key": "k8s.persistentvolumeclaim.annotations.example.com/annotation",
             "value": {
               "stringValue": "example-annotation"
@@ -157,6 +163,12 @@
             "key": "sw.k8s.cluster.uid",
             "value": {
               "stringValue": "cluster-uid-123456789"
+            }
+          },
+          {
+            "key": "sw.k8s.persistentvolumeclaim.found",
+            "value": {
+              "stringValue": "true"
             }
           }
         ]
@@ -315,6 +327,12 @@
             "key": "k8s.namespace.name",
             "value": {
               "stringValue": "test-namespace"
+            }
+          },
+          {
+            "key": "k8s.node.name",
+            "value": {
+              "stringValue": "test-node"
             }
           },
           {
@@ -554,6 +572,12 @@
             }
           },
           {
+            "key": "k8s.node.name",
+            "value": {
+              "stringValue": "test-node"
+            }
+          },
+          {
             "key": "k8s.pod.annotations.test-annotation",
             "value": {
               "stringValue": "test-value"
@@ -787,6 +811,12 @@
             "key": "k8s.namespace.name",
             "value": {
               "stringValue": "test-namespace"
+            }
+          },
+          {
+            "key": "k8s.node.name",
+            "value": {
+              "stringValue": "test-node"
             }
           },
           {
@@ -1026,6 +1056,12 @@
             }
           },
           {
+            "key": "k8s.node.name",
+            "value": {
+              "stringValue": "test-node"
+            }
+          },
+          {
             "key": "k8s.pod.annotations.test-annotation",
             "value": {
               "stringValue": "test-value"
@@ -1262,6 +1298,12 @@
             }
           },
           {
+            "key": "k8s.node.name",
+            "value": {
+              "stringValue": "test-node"
+            }
+          },
+          {
             "key": "k8s.pod.annotations.test-annotation",
             "value": {
               "stringValue": "test-value"
@@ -1453,12 +1495,6 @@
             "key": "k8s.namespace.name",
             "value": {
               "stringValue": "test-namespace"
-            }
-          },
-          {
-            "key": "k8s.node.name",
-            "value": {
-              "stringValue": "test-node"
             }
           },
           {
@@ -1707,12 +1743,6 @@
             "key": "k8s.namespace.name",
             "value": {
               "stringValue": "test-namespace"
-            }
-          },
-          {
-            "key": "k8s.node.name",
-            "value": {
-              "stringValue": "test-node"
             }
           },
           {
@@ -1976,12 +2006,6 @@
             }
           },
           {
-            "key": "k8s.node.name",
-            "value": {
-              "stringValue": "test-node"
-            }
-          },
-          {
             "key": "k8s.pod.annotations.test-annotation",
             "value": {
               "stringValue": "test-value"
@@ -2224,12 +2248,6 @@
             }
           },
           {
-            "key": "k8s.node.name",
-            "value": {
-              "stringValue": "test-node"
-            }
-          },
-          {
             "key": "k8s.pod.annotations.test-annotation",
             "value": {
               "stringValue": "test-value"
@@ -2460,6 +2478,12 @@
             }
           },
           {
+            "key": "k8s.node.name",
+            "value": {
+              "stringValue": "test-node"
+            }
+          },
+          {
             "key": "k8s.pod.annotations.test-annotation",
             "value": {
               "stringValue": "test-value"
@@ -2657,6 +2681,12 @@
             "key": "k8s.namespace.name",
             "value": {
               "stringValue": "test-namespace"
+            }
+          },
+          {
+            "key": "k8s.node.name",
+            "value": {
+              "stringValue": "test-node"
             }
           },
           {
@@ -3132,6 +3162,12 @@
             }
           },
           {
+            "key": "k8s.node.name",
+            "value": {
+              "stringValue": "test-node"
+            }
+          },
+          {
             "key": "k8s.pod.annotations.test-annotation",
             "value": {
               "stringValue": "test-value"
@@ -3341,6 +3377,12 @@
             "key": "k8s.namespace.name",
             "value": {
               "stringValue": "test-namespace"
+            }
+          },
+          {
+            "key": "k8s.node.name",
+            "value": {
+              "stringValue": "test-node"
             }
           },
           {
@@ -3565,6 +3607,12 @@
             "key": "k8s.namespace.name",
             "value": {
               "stringValue": "test-namespace"
+            }
+          },
+          {
+            "key": "k8s.node.name",
+            "value": {
+              "stringValue": "test-node"
             }
           },
           {
@@ -4457,12 +4505,6 @@
             }
           },
           {
-            "key": "k8s.node.name",
-            "value": {
-              "stringValue": "test-node"
-            }
-          },
-          {
             "key": "k8s.pod.annotations.test-annotation",
             "value": {
               "stringValue": "test-value"
@@ -4936,12 +4978,6 @@
             }
           },
           {
-            "key": "k8s.node.name",
-            "value": {
-              "stringValue": "test-node"
-            }
-          },
-          {
             "key": "k8s.pod.annotations.test-annotation",
             "value": {
               "stringValue": "test-value"
@@ -5139,12 +5175,6 @@
             "key": "k8s.namespace.name",
             "value": {
               "stringValue": "test-namespace"
-            }
-          },
-          {
-            "key": "k8s.node.name",
-            "value": {
-              "stringValue": "test-node"
             }
           },
           {
@@ -5474,12 +5504,6 @@
             }
           },
           {
-            "key": "k8s.node.name",
-            "value": {
-              "stringValue": "test-node"
-            }
-          },
-          {
             "key": "k8s.pod.annotations.test-annotation",
             "value": {
               "stringValue": "test-value"
@@ -5754,12 +5778,6 @@
             "key": "k8s.namespace.name",
             "value": {
               "stringValue": "test-namespace"
-            }
-          },
-          {
-            "key": "k8s.node.name",
-            "value": {
-              "stringValue": "test-node"
             }
           },
           {
@@ -6685,12 +6703,6 @@
             }
           },
           {
-            "key": "k8s.node.name",
-            "value": {
-              "stringValue": "test-node"
-            }
-          },
-          {
             "key": "k8s.pod.annotations.test-annotation",
             "value": {
               "stringValue": "test-value"
@@ -6899,12 +6911,6 @@
             }
           },
           {
-            "key": "k8s.node.name",
-            "value": {
-              "stringValue": "test-node"
-            }
-          },
-          {
             "key": "k8s.pod.annotations.test-annotation",
             "value": {
               "stringValue": "test-value"
@@ -7102,6 +7108,12 @@
             "key": "k8s.namespace.name",
             "value": {
               "stringValue": "test-namespace"
+            }
+          },
+          {
+            "key": "k8s.node.name",
+            "value": {
+              "stringValue": "test-node"
             }
           },
           {
@@ -7669,6 +7681,8264 @@
             }
           },
           {
+            "key": "k8s.persistentvolume.annotations.example.com/annotation",
+            "value": {
+              "stringValue": "example-annotation"
+            }
+          },
+          {
+            "key": "k8s.persistentvolume.annotations.pv.kubernetes.io/bound-by-controller",
+            "value": {
+              "stringValue": "yes"
+            }
+          },
+          {
+            "key": "k8s.persistentvolume.labels.example.com/label",
+            "value": {
+              "stringValue": "example-label"
+            }
+          },
+          {
+            "key": "k8s.persistentvolume.labels.type",
+            "value": {
+              "stringValue": "local"
+            }
+          },
+          {
+            "key": "k8s.persistentvolume.name",
+            "value": {
+              "stringValue": "test-pv"
+            }
+          },
+          {
+            "key": "k8s.persistentvolumeclaim.name",
+            "value": {
+              "stringValue": "data-zookeeper-2"
+            }
+          },
+          {
+            "key": "k8s.pod.annotations.test-annotation",
+            "value": {
+              "stringValue": "test-value"
+            }
+          },
+          {
+            "key": "k8s.pod.labels.app",
+            "value": {
+              "stringValue": "test-pod"
+            }
+          },
+          {
+            "key": "k8s.pod.name",
+            "value": {
+              "stringValue": "test-pod"
+            }
+          },
+          {
+            "key": "namespace",
+            "value": {
+              "stringValue": "test-namespace"
+            }
+          },
+          {
+            "key": "net.host.name",
+            "value": {
+              "stringValue": "test-node"
+            }
+          },
+          {
+            "key": "net.host.port",
+            "value": {
+              "stringValue": ""
+            }
+          },
+          {
+            "key": "persistentvolume",
+            "value": {
+              "stringValue": "test-pv"
+            }
+          },
+          {
+            "key": "persistentvolumeclaim",
+            "value": {
+              "stringValue": "data-zookeeper-2"
+            }
+          },
+          {
+            "key": "pod",
+            "value": {
+              "stringValue": "test-pod"
+            }
+          },
+          {
+            "key": "sw.k8s.agent.app.version",
+            "value": {
+              "stringValue": "0.8.1"
+            }
+          },
+          {
+            "key": "sw.k8s.agent.manifest.version",
+            "value": {
+              "stringValue": "2.7.0-alpha.6"
+            }
+          },
+          {
+            "key": "sw.k8s.cluster.uid",
+            "value": {
+              "stringValue": "cluster-uid-123456789"
+            }
+          },
+          {
+            "key": "sw.k8s.persistentvolume.found",
+            "value": {
+              "stringValue": "true"
+            }
+          },
+          {
+            "key": "sw.k8s.persistentvolumeclaim.found",
+            "value": {
+              "stringValue": "false"
+            }
+          }
+        ]
+      },
+      "scopeMetrics": [
+        {
+          "metrics": [
+            {
+              "gauge": {
+                "dataPoints": [
+                  {
+                    "asDouble": 1,
+                    "attributes": [
+                      {
+                        "key": "claim_namespace",
+                        "value": {
+                          "stringValue": "test-namespace"
+                        }
+                      },
+                      {
+                        "key": "endpoint",
+                        "value": {
+                          "stringValue": "http"
+                        }
+                      },
+                      {
+                        "key": "name",
+                        "value": {
+                          "stringValue": "data-zookeeper-2"
+                        }
+                      },
+                      {
+                        "key": "prometheus",
+                        "value": {
+                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
+                        }
+                      },
+                      {
+                        "key": "prometheus_replica",
+                        "value": {
+                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
+                        }
+                      },
+                      {
+                        "key": "service",
+                        "value": {
+                          "stringValue": "test-service"
+                        }
+                      }
+                    ],
+                    "timeUnixNano": "0"
+                  }
+                ]
+              },
+              "name": "k8s.kube_persistentvolume_claim_ref"
+            }
+          ],
+          "scope": {}
+        }
+      ]
+    },
+    {
+      "resource": {
+        "attributes": [
+          {
+            "key": "container",
+            "value": {
+              "stringValue": "test-container"
+            }
+          },
+          {
+            "key": "http.scheme",
+            "value": {
+              "stringValue": "http"
+            }
+          },
+          {
+            "key": "k8s.cluster.name",
+            "value": {
+              "stringValue": "cluster name"
+            }
+          },
+          {
+            "key": "k8s.container.name",
+            "value": {
+              "stringValue": "test-container"
+            }
+          },
+          {
+            "key": "k8s.namespace.annotations.description",
+            "value": {
+              "stringValue": "This is a test namespace."
+            }
+          },
+          {
+            "key": "k8s.namespace.labels.app",
+            "value": {
+              "stringValue": "test-app"
+            }
+          },
+          {
+            "key": "k8s.namespace.labels.kubernetes.io/metadata.name",
+            "value": {
+              "stringValue": "test-namespace"
+            }
+          },
+          {
+            "key": "k8s.namespace.labels.purpose",
+            "value": {
+              "stringValue": "testing"
+            }
+          },
+          {
+            "key": "k8s.namespace.name",
+            "value": {
+              "stringValue": "test-namespace"
+            }
+          },
+          {
+            "key": "k8s.node.name",
+            "value": {
+              "stringValue": "test-node"
+            }
+          },
+          {
+            "key": "k8s.persistentvolume.annotations.example.com/annotation",
+            "value": {
+              "stringValue": "example-annotation"
+            }
+          },
+          {
+            "key": "k8s.persistentvolume.annotations.pv.kubernetes.io/bound-by-controller",
+            "value": {
+              "stringValue": "yes"
+            }
+          },
+          {
+            "key": "k8s.persistentvolume.labels.example.com/label",
+            "value": {
+              "stringValue": "example-label"
+            }
+          },
+          {
+            "key": "k8s.persistentvolume.labels.type",
+            "value": {
+              "stringValue": "local"
+            }
+          },
+          {
+            "key": "k8s.persistentvolume.name",
+            "value": {
+              "stringValue": "test-pv"
+            }
+          },
+          {
+            "key": "k8s.pod.annotations.test-annotation",
+            "value": {
+              "stringValue": "test-value"
+            }
+          },
+          {
+            "key": "k8s.pod.labels.app",
+            "value": {
+              "stringValue": "test-pod"
+            }
+          },
+          {
+            "key": "k8s.pod.name",
+            "value": {
+              "stringValue": "test-pod"
+            }
+          },
+          {
+            "key": "namespace",
+            "value": {
+              "stringValue": "test-namespace"
+            }
+          },
+          {
+            "key": "net.host.name",
+            "value": {
+              "stringValue": "test-node"
+            }
+          },
+          {
+            "key": "net.host.port",
+            "value": {
+              "stringValue": ""
+            }
+          },
+          {
+            "key": "persistentvolume",
+            "value": {
+              "stringValue": "test-pv"
+            }
+          },
+          {
+            "key": "pod",
+            "value": {
+              "stringValue": "test-pod"
+            }
+          },
+          {
+            "key": "storageclass",
+            "value": {
+              "stringValue": "gp2"
+            }
+          },
+          {
+            "key": "sw.k8s.agent.app.version",
+            "value": {
+              "stringValue": "0.8.1"
+            }
+          },
+          {
+            "key": "sw.k8s.agent.manifest.version",
+            "value": {
+              "stringValue": "2.7.0-alpha.6"
+            }
+          },
+          {
+            "key": "sw.k8s.cluster.uid",
+            "value": {
+              "stringValue": "cluster-uid-123456789"
+            }
+          },
+          {
+            "key": "sw.k8s.persistentvolume.found",
+            "value": {
+              "stringValue": "true"
+            }
+          }
+        ]
+      },
+      "scopeMetrics": [
+        {
+          "metrics": [
+            {
+              "gauge": {
+                "dataPoints": [
+                  {
+                    "asDouble": 1,
+                    "attributes": [
+                      {
+                        "key": "ebs_volume_id",
+                        "value": {
+                          "stringValue": "aws://us-east-1a/vol-0fb83c152e8ad8514"
+                        }
+                      },
+                      {
+                        "key": "endpoint",
+                        "value": {
+                          "stringValue": "http"
+                        }
+                      },
+                      {
+                        "key": "prometheus",
+                        "value": {
+                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
+                        }
+                      },
+                      {
+                        "key": "prometheus_replica",
+                        "value": {
+                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
+                        }
+                      },
+                      {
+                        "key": "service",
+                        "value": {
+                          "stringValue": "test-service"
+                        }
+                      }
+                    ],
+                    "timeUnixNano": "0"
+                  }
+                ]
+              },
+              "name": "k8s.kube_persistentvolume_info"
+            }
+          ],
+          "scope": {}
+        }
+      ]
+    },
+    {
+      "resource": {
+        "attributes": [
+          {
+            "key": "container",
+            "value": {
+              "stringValue": "test-container"
+            }
+          },
+          {
+            "key": "http.scheme",
+            "value": {
+              "stringValue": "http"
+            }
+          },
+          {
+            "key": "k8s.cluster.name",
+            "value": {
+              "stringValue": "cluster name"
+            }
+          },
+          {
+            "key": "k8s.container.name",
+            "value": {
+              "stringValue": "test-container"
+            }
+          },
+          {
+            "key": "k8s.namespace.annotations.description",
+            "value": {
+              "stringValue": "This is a test namespace."
+            }
+          },
+          {
+            "key": "k8s.namespace.labels.app",
+            "value": {
+              "stringValue": "test-app"
+            }
+          },
+          {
+            "key": "k8s.namespace.labels.kubernetes.io/metadata.name",
+            "value": {
+              "stringValue": "test-namespace"
+            }
+          },
+          {
+            "key": "k8s.namespace.labels.purpose",
+            "value": {
+              "stringValue": "testing"
+            }
+          },
+          {
+            "key": "k8s.namespace.name",
+            "value": {
+              "stringValue": "test-namespace"
+            }
+          },
+          {
+            "key": "k8s.node.name",
+            "value": {
+              "stringValue": "test-node"
+            }
+          },
+          {
+            "key": "k8s.persistentvolume.annotations.example.com/annotation",
+            "value": {
+              "stringValue": "example-annotation"
+            }
+          },
+          {
+            "key": "k8s.persistentvolume.annotations.pv.kubernetes.io/bound-by-controller",
+            "value": {
+              "stringValue": "yes"
+            }
+          },
+          {
+            "key": "k8s.persistentvolume.labels.example.com/label",
+            "value": {
+              "stringValue": "example-label"
+            }
+          },
+          {
+            "key": "k8s.persistentvolume.labels.type",
+            "value": {
+              "stringValue": "local"
+            }
+          },
+          {
+            "key": "k8s.persistentvolume.name",
+            "value": {
+              "stringValue": "test-pv"
+            }
+          },
+          {
+            "key": "k8s.pod.annotations.test-annotation",
+            "value": {
+              "stringValue": "test-value"
+            }
+          },
+          {
+            "key": "k8s.pod.labels.app",
+            "value": {
+              "stringValue": "test-pod"
+            }
+          },
+          {
+            "key": "k8s.pod.name",
+            "value": {
+              "stringValue": "test-pod"
+            }
+          },
+          {
+            "key": "namespace",
+            "value": {
+              "stringValue": "test-namespace"
+            }
+          },
+          {
+            "key": "net.host.name",
+            "value": {
+              "stringValue": "test-node"
+            }
+          },
+          {
+            "key": "net.host.port",
+            "value": {
+              "stringValue": ""
+            }
+          },
+          {
+            "key": "persistentvolume",
+            "value": {
+              "stringValue": "test-pv"
+            }
+          },
+          {
+            "key": "pod",
+            "value": {
+              "stringValue": "test-pod"
+            }
+          },
+          {
+            "key": "sw.k8s.agent.app.version",
+            "value": {
+              "stringValue": "0.8.1"
+            }
+          },
+          {
+            "key": "sw.k8s.agent.manifest.version",
+            "value": {
+              "stringValue": "2.7.0-alpha.6"
+            }
+          },
+          {
+            "key": "sw.k8s.cluster.uid",
+            "value": {
+              "stringValue": "cluster-uid-123456789"
+            }
+          },
+          {
+            "key": "sw.k8s.persistentvolume.found",
+            "value": {
+              "stringValue": "true"
+            }
+          }
+        ]
+      },
+      "scopeMetrics": [
+        {
+          "metrics": [
+            {
+              "gauge": {
+                "dataPoints": [
+                  {
+                    "asDouble": 107374182400,
+                    "attributes": [
+                      {
+                        "key": "endpoint",
+                        "value": {
+                          "stringValue": "tcp-model"
+                        }
+                      },
+                      {
+                        "key": "prometheus",
+                        "value": {
+                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
+                        }
+                      },
+                      {
+                        "key": "prometheus_replica",
+                        "value": {
+                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
+                        }
+                      },
+                      {
+                        "key": "service",
+                        "value": {
+                          "stringValue": "test-service"
+                        }
+                      }
+                    ],
+                    "timeUnixNano": "0"
+                  }
+                ]
+              },
+              "name": "k8s.kube_persistentvolume_capacity_bytes"
+            },
+            {
+              "gauge": {
+                "dataPoints": [
+                  {
+                    "asDouble": 0,
+                    "attributes": [
+                      {
+                        "key": "endpoint",
+                        "value": {
+                          "stringValue": "http"
+                        }
+                      },
+                      {
+                        "key": "phase",
+                        "value": {
+                          "stringValue": "Released"
+                        }
+                      },
+                      {
+                        "key": "prometheus",
+                        "value": {
+                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
+                        }
+                      },
+                      {
+                        "key": "prometheus_replica",
+                        "value": {
+                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
+                        }
+                      },
+                      {
+                        "key": "service",
+                        "value": {
+                          "stringValue": "test-service"
+                        }
+                      }
+                    ],
+                    "timeUnixNano": "0"
+                  }
+                ]
+              },
+              "name": "k8s.kube_persistentvolume_status_phase"
+            }
+          ],
+          "scope": {}
+        }
+      ]
+    },
+    {
+      "resource": {
+        "attributes": [
+          {
+            "key": "container",
+            "value": {
+              "stringValue": "test-container"
+            }
+          },
+          {
+            "key": "http.scheme",
+            "value": {
+              "stringValue": "http"
+            }
+          },
+          {
+            "key": "k8s.cluster.name",
+            "value": {
+              "stringValue": "cluster name"
+            }
+          },
+          {
+            "key": "k8s.container.name",
+            "value": {
+              "stringValue": "test-container"
+            }
+          },
+          {
+            "key": "k8s.namespace.annotations.description",
+            "value": {
+              "stringValue": "This is a test namespace."
+            }
+          },
+          {
+            "key": "k8s.namespace.labels.app",
+            "value": {
+              "stringValue": "test-app"
+            }
+          },
+          {
+            "key": "k8s.namespace.labels.kubernetes.io/metadata.name",
+            "value": {
+              "stringValue": "test-namespace"
+            }
+          },
+          {
+            "key": "k8s.namespace.labels.purpose",
+            "value": {
+              "stringValue": "testing"
+            }
+          },
+          {
+            "key": "k8s.namespace.name",
+            "value": {
+              "stringValue": "test-namespace"
+            }
+          },
+          {
+            "key": "k8s.node.name",
+            "value": {
+              "stringValue": "test-node"
+            }
+          },
+          {
+            "key": "k8s.persistentvolume.name",
+            "value": {
+              "stringValue": "pvc-6a8b6907-4bef-4d47-88d6-668cf699e6b0"
+            }
+          },
+          {
+            "key": "k8s.persistentvolumeclaim.annotations.example.com/annotation",
+            "value": {
+              "stringValue": "example-annotation"
+            }
+          },
+          {
+            "key": "k8s.persistentvolumeclaim.annotations.pv.kubernetes.io/bind-completed",
+            "value": {
+              "stringValue": "yes"
+            }
+          },
+          {
+            "key": "k8s.persistentvolumeclaim.annotations.pv.kubernetes.io/bound-by-controller",
+            "value": {
+              "stringValue": "yes"
+            }
+          },
+          {
+            "key": "k8s.persistentvolumeclaim.labels.example.com/label",
+            "value": {
+              "stringValue": "example-label"
+            }
+          },
+          {
+            "key": "k8s.persistentvolumeclaim.name",
+            "value": {
+              "stringValue": "test-pvc"
+            }
+          },
+          {
+            "key": "k8s.pod.annotations.test-annotation",
+            "value": {
+              "stringValue": "test-value"
+            }
+          },
+          {
+            "key": "k8s.pod.labels.app",
+            "value": {
+              "stringValue": "test-pod"
+            }
+          },
+          {
+            "key": "k8s.pod.name",
+            "value": {
+              "stringValue": "test-pod"
+            }
+          },
+          {
+            "key": "namespace",
+            "value": {
+              "stringValue": "test-namespace"
+            }
+          },
+          {
+            "key": "net.host.name",
+            "value": {
+              "stringValue": "test-node"
+            }
+          },
+          {
+            "key": "net.host.port",
+            "value": {
+              "stringValue": ""
+            }
+          },
+          {
+            "key": "persistentvolume",
+            "value": {
+              "stringValue": "pvc-6a8b6907-4bef-4d47-88d6-668cf699e6b0"
+            }
+          },
+          {
+            "key": "persistentvolumeclaim",
+            "value": {
+              "stringValue": "test-pvc"
+            }
+          },
+          {
+            "key": "pod",
+            "value": {
+              "stringValue": "test-pod"
+            }
+          },
+          {
+            "key": "storageclass",
+            "value": {
+              "stringValue": "gp3-xfs-encrypted"
+            }
+          },
+          {
+            "key": "sw.k8s.agent.app.version",
+            "value": {
+              "stringValue": "0.8.1"
+            }
+          },
+          {
+            "key": "sw.k8s.agent.manifest.version",
+            "value": {
+              "stringValue": "2.7.0-alpha.6"
+            }
+          },
+          {
+            "key": "sw.k8s.cluster.uid",
+            "value": {
+              "stringValue": "cluster-uid-123456789"
+            }
+          },
+          {
+            "key": "sw.k8s.persistentvolume.found",
+            "value": {
+              "stringValue": "false"
+            }
+          },
+          {
+            "key": "sw.k8s.persistentvolumeclaim.found",
+            "value": {
+              "stringValue": "true"
+            }
+          }
+        ]
+      },
+      "scopeMetrics": [
+        {
+          "metrics": [
+            {
+              "gauge": {
+                "dataPoints": [
+                  {
+                    "asDouble": 1,
+                    "attributes": [
+                      {
+                        "key": "endpoint",
+                        "value": {
+                          "stringValue": "tcp-model"
+                        }
+                      },
+                      {
+                        "key": "prometheus",
+                        "value": {
+                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
+                        }
+                      },
+                      {
+                        "key": "prometheus_replica",
+                        "value": {
+                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
+                        }
+                      },
+                      {
+                        "key": "service",
+                        "value": {
+                          "stringValue": "test-service"
+                        }
+                      },
+                      {
+                        "key": "volumename",
+                        "value": {
+                          "stringValue": "pvc-6a8b6907-4bef-4d47-88d6-668cf699e6b0"
+                        }
+                      }
+                    ],
+                    "timeUnixNano": "0"
+                  }
+                ]
+              },
+              "name": "k8s.kube_persistentvolumeclaim_info"
+            }
+          ],
+          "scope": {}
+        }
+      ]
+    },
+    {
+      "resource": {
+        "attributes": [
+          {
+            "key": "container",
+            "value": {
+              "stringValue": "test-container"
+            }
+          },
+          {
+            "key": "http.scheme",
+            "value": {
+              "stringValue": "http"
+            }
+          },
+          {
+            "key": "k8s.cluster.name",
+            "value": {
+              "stringValue": "cluster name"
+            }
+          },
+          {
+            "key": "k8s.container.name",
+            "value": {
+              "stringValue": "test-container"
+            }
+          },
+          {
+            "key": "k8s.namespace.annotations.description",
+            "value": {
+              "stringValue": "This is a test namespace."
+            }
+          },
+          {
+            "key": "k8s.namespace.labels.app",
+            "value": {
+              "stringValue": "test-app"
+            }
+          },
+          {
+            "key": "k8s.namespace.labels.kubernetes.io/metadata.name",
+            "value": {
+              "stringValue": "test-namespace"
+            }
+          },
+          {
+            "key": "k8s.namespace.labels.purpose",
+            "value": {
+              "stringValue": "testing"
+            }
+          },
+          {
+            "key": "k8s.namespace.name",
+            "value": {
+              "stringValue": "test-namespace"
+            }
+          },
+          {
+            "key": "k8s.node.name",
+            "value": {
+              "stringValue": "test-node"
+            }
+          },
+          {
+            "key": "k8s.persistentvolumeclaim.annotations.example.com/annotation",
+            "value": {
+              "stringValue": "example-annotation"
+            }
+          },
+          {
+            "key": "k8s.persistentvolumeclaim.annotations.pv.kubernetes.io/bind-completed",
+            "value": {
+              "stringValue": "yes"
+            }
+          },
+          {
+            "key": "k8s.persistentvolumeclaim.annotations.pv.kubernetes.io/bound-by-controller",
+            "value": {
+              "stringValue": "yes"
+            }
+          },
+          {
+            "key": "k8s.persistentvolumeclaim.labels.example.com/label",
+            "value": {
+              "stringValue": "example-label"
+            }
+          },
+          {
+            "key": "k8s.persistentvolumeclaim.name",
+            "value": {
+              "stringValue": "test-pvc"
+            }
+          },
+          {
+            "key": "k8s.pod.annotations.test-annotation",
+            "value": {
+              "stringValue": "test-value"
+            }
+          },
+          {
+            "key": "k8s.pod.labels.app",
+            "value": {
+              "stringValue": "test-pod"
+            }
+          },
+          {
+            "key": "k8s.pod.name",
+            "value": {
+              "stringValue": "test-pod"
+            }
+          },
+          {
+            "key": "k8s.pod.uid",
+            "value": {
+              "stringValue": "0eb87a8e-caf5-42f7-8689-a3b36a00232e"
+            }
+          },
+          {
+            "key": "namespace",
+            "value": {
+              "stringValue": "test-namespace"
+            }
+          },
+          {
+            "key": "net.host.name",
+            "value": {
+              "stringValue": "test-node"
+            }
+          },
+          {
+            "key": "net.host.port",
+            "value": {
+              "stringValue": ""
+            }
+          },
+          {
+            "key": "persistentvolumeclaim",
+            "value": {
+              "stringValue": "test-pvc"
+            }
+          },
+          {
+            "key": "pod",
+            "value": {
+              "stringValue": "test-pod"
+            }
+          },
+          {
+            "key": "sw.k8s.agent.app.version",
+            "value": {
+              "stringValue": "0.8.1"
+            }
+          },
+          {
+            "key": "sw.k8s.agent.manifest.version",
+            "value": {
+              "stringValue": "2.7.0-alpha.6"
+            }
+          },
+          {
+            "key": "sw.k8s.cluster.uid",
+            "value": {
+              "stringValue": "cluster-uid-123456789"
+            }
+          },
+          {
+            "key": "sw.k8s.persistentvolumeclaim.found",
+            "value": {
+              "stringValue": "true"
+            }
+          },
+          {
+            "key": "uid",
+            "value": {
+              "stringValue": "0eb87a8e-caf5-42f7-8689-a3b36a00232e"
+            }
+          }
+        ]
+      },
+      "scopeMetrics": [
+        {
+          "metrics": [
+            {
+              "gauge": {
+                "dataPoints": [
+                  {
+                    "asDouble": 1,
+                    "attributes": [
+                      {
+                        "key": "endpoint",
+                        "value": {
+                          "stringValue": "http"
+                        }
+                      },
+                      {
+                        "key": "prometheus",
+                        "value": {
+                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
+                        }
+                      },
+                      {
+                        "key": "prometheus_replica",
+                        "value": {
+                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
+                        }
+                      },
+                      {
+                        "key": "service",
+                        "value": {
+                          "stringValue": "test-service"
+                        }
+                      },
+                      {
+                        "key": "volume",
+                        "value": {
+                          "stringValue": "data"
+                        }
+                      }
+                    ],
+                    "timeUnixNano": "0"
+                  }
+                ]
+              },
+              "name": "k8s.kube_pod_spec_volumes_persistentvolumeclaims_info"
+            }
+          ],
+          "scope": {}
+        }
+      ]
+    },
+    {
+      "resource": {
+        "attributes": [
+          {
+            "key": "container",
+            "value": {
+              "stringValue": "test-container"
+            }
+          },
+          {
+            "key": "http.scheme",
+            "value": {
+              "stringValue": "http"
+            }
+          },
+          {
+            "key": "k8s.cluster.name",
+            "value": {
+              "stringValue": "cluster name"
+            }
+          },
+          {
+            "key": "k8s.container.name",
+            "value": {
+              "stringValue": "test-container"
+            }
+          },
+          {
+            "key": "k8s.namespace.annotations.description",
+            "value": {
+              "stringValue": "This is a test namespace."
+            }
+          },
+          {
+            "key": "k8s.namespace.labels.app",
+            "value": {
+              "stringValue": "test-app"
+            }
+          },
+          {
+            "key": "k8s.namespace.labels.kubernetes.io/metadata.name",
+            "value": {
+              "stringValue": "test-namespace"
+            }
+          },
+          {
+            "key": "k8s.namespace.labels.purpose",
+            "value": {
+              "stringValue": "testing"
+            }
+          },
+          {
+            "key": "k8s.namespace.name",
+            "value": {
+              "stringValue": "test-namespace"
+            }
+          },
+          {
+            "key": "k8s.node.name",
+            "value": {
+              "stringValue": "test-node"
+            }
+          },
+          {
+            "key": "k8s.persistentvolumeclaim.annotations.example.com/annotation",
+            "value": {
+              "stringValue": "example-annotation"
+            }
+          },
+          {
+            "key": "k8s.persistentvolumeclaim.annotations.pv.kubernetes.io/bind-completed",
+            "value": {
+              "stringValue": "yes"
+            }
+          },
+          {
+            "key": "k8s.persistentvolumeclaim.annotations.pv.kubernetes.io/bound-by-controller",
+            "value": {
+              "stringValue": "yes"
+            }
+          },
+          {
+            "key": "k8s.persistentvolumeclaim.labels.example.com/label",
+            "value": {
+              "stringValue": "example-label"
+            }
+          },
+          {
+            "key": "k8s.persistentvolumeclaim.name",
+            "value": {
+              "stringValue": "test-pvc"
+            }
+          },
+          {
+            "key": "k8s.pod.annotations.test-annotation",
+            "value": {
+              "stringValue": "test-value"
+            }
+          },
+          {
+            "key": "k8s.pod.labels.app",
+            "value": {
+              "stringValue": "test-pod"
+            }
+          },
+          {
+            "key": "k8s.pod.name",
+            "value": {
+              "stringValue": "test-pod"
+            }
+          },
+          {
+            "key": "namespace",
+            "value": {
+              "stringValue": "test-namespace"
+            }
+          },
+          {
+            "key": "net.host.name",
+            "value": {
+              "stringValue": "test-node"
+            }
+          },
+          {
+            "key": "net.host.port",
+            "value": {
+              "stringValue": ""
+            }
+          },
+          {
+            "key": "persistentvolumeclaim",
+            "value": {
+              "stringValue": "test-pvc"
+            }
+          },
+          {
+            "key": "pod",
+            "value": {
+              "stringValue": "test-pod"
+            }
+          },
+          {
+            "key": "sw.k8s.agent.app.version",
+            "value": {
+              "stringValue": "0.8.1"
+            }
+          },
+          {
+            "key": "sw.k8s.agent.manifest.version",
+            "value": {
+              "stringValue": "2.7.0-alpha.6"
+            }
+          },
+          {
+            "key": "sw.k8s.cluster.uid",
+            "value": {
+              "stringValue": "cluster-uid-123456789"
+            }
+          },
+          {
+            "key": "sw.k8s.persistentvolumeclaim.found",
+            "value": {
+              "stringValue": "true"
+            }
+          }
+        ]
+      },
+      "scopeMetrics": [
+        {
+          "metrics": [
+            {
+              "gauge": {
+                "dataPoints": [
+                  {
+                    "asDouble": 107374182400,
+                    "attributes": [
+                      {
+                        "key": "endpoint",
+                        "value": {
+                          "stringValue": "tcp-model"
+                        }
+                      },
+                      {
+                        "key": "prometheus",
+                        "value": {
+                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
+                        }
+                      },
+                      {
+                        "key": "prometheus_replica",
+                        "value": {
+                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
+                        }
+                      },
+                      {
+                        "key": "service",
+                        "value": {
+                          "stringValue": "test-service"
+                        }
+                      }
+                    ],
+                    "timeUnixNano": "0"
+                  }
+                ]
+              },
+              "name": "k8s.kube_persistentvolumeclaim_resource_requests_storage_bytes"
+            },
+            {
+              "gauge": {
+                "dataPoints": [
+                  {
+                    "asDouble": 1,
+                    "attributes": [
+                      {
+                        "key": "endpoint",
+                        "value": {
+                          "stringValue": "http"
+                        }
+                      },
+                      {
+                        "key": "phase",
+                        "value": {
+                          "stringValue": "Bound"
+                        }
+                      },
+                      {
+                        "key": "prometheus",
+                        "value": {
+                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
+                        }
+                      },
+                      {
+                        "key": "prometheus_replica",
+                        "value": {
+                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
+                        }
+                      },
+                      {
+                        "key": "service",
+                        "value": {
+                          "stringValue": "test-service"
+                        }
+                      }
+                    ],
+                    "timeUnixNano": "0"
+                  }
+                ]
+              },
+              "name": "k8s.kube_persistentvolumeclaim_status_phase"
+            }
+          ],
+          "scope": {}
+        }
+      ]
+    },
+    {
+      "resource": {
+        "attributes": [
+          {
+            "key": "container",
+            "value": {
+              "stringValue": "test-container"
+            }
+          },
+          {
+            "key": "http.scheme",
+            "value": {
+              "stringValue": "http"
+            }
+          },
+          {
+            "key": "k8s.cluster.name",
+            "value": {
+              "stringValue": "cluster name"
+            }
+          },
+          {
+            "key": "k8s.container.name",
+            "value": {
+              "stringValue": "test-container"
+            }
+          },
+          {
+            "key": "k8s.namespace.annotations.description",
+            "value": {
+              "stringValue": "This is a test namespace."
+            }
+          },
+          {
+            "key": "k8s.namespace.labels.app",
+            "value": {
+              "stringValue": "test-app"
+            }
+          },
+          {
+            "key": "k8s.namespace.labels.kubernetes.io/metadata.name",
+            "value": {
+              "stringValue": "test-namespace"
+            }
+          },
+          {
+            "key": "k8s.namespace.labels.purpose",
+            "value": {
+              "stringValue": "testing"
+            }
+          },
+          {
+            "key": "k8s.namespace.name",
+            "value": {
+              "stringValue": "test-namespace"
+            }
+          },
+          {
+            "key": "k8s.node.name",
+            "value": {
+              "stringValue": "test-node"
+            }
+          },
+          {
+            "key": "k8s.persistentvolumeclaim.annotations.example.com/annotation",
+            "value": {
+              "stringValue": "example-annotation"
+            }
+          },
+          {
+            "key": "k8s.persistentvolumeclaim.annotations.pv.kubernetes.io/bind-completed",
+            "value": {
+              "stringValue": "yes"
+            }
+          },
+          {
+            "key": "k8s.persistentvolumeclaim.annotations.pv.kubernetes.io/bound-by-controller",
+            "value": {
+              "stringValue": "yes"
+            }
+          },
+          {
+            "key": "k8s.persistentvolumeclaim.labels.example.com/label",
+            "value": {
+              "stringValue": "example-label"
+            }
+          },
+          {
+            "key": "k8s.persistentvolumeclaim.name",
+            "value": {
+              "stringValue": "test-pvc"
+            }
+          },
+          {
+            "key": "k8s.pod.annotations.test-annotation",
+            "value": {
+              "stringValue": "test-value"
+            }
+          },
+          {
+            "key": "k8s.pod.labels.app",
+            "value": {
+              "stringValue": "test-pod"
+            }
+          },
+          {
+            "key": "k8s.pod.name",
+            "value": {
+              "stringValue": "test-pod"
+            }
+          },
+          {
+            "key": "namespace",
+            "value": {
+              "stringValue": "test-namespace"
+            }
+          },
+          {
+            "key": "net.host.name",
+            "value": {
+              "stringValue": "test-node"
+            }
+          },
+          {
+            "key": "net.host.port",
+            "value": {
+              "stringValue": ""
+            }
+          },
+          {
+            "key": "persistentvolumeclaim",
+            "value": {
+              "stringValue": "test-pvc"
+            }
+          },
+          {
+            "key": "pod",
+            "value": {
+              "stringValue": "test-pod"
+            }
+          },
+          {
+            "key": "sw.k8s.agent.app.version",
+            "value": {
+              "stringValue": "0.8.1"
+            }
+          },
+          {
+            "key": "sw.k8s.agent.manifest.version",
+            "value": {
+              "stringValue": "2.7.0-alpha.6"
+            }
+          },
+          {
+            "key": "sw.k8s.cluster.uid",
+            "value": {
+              "stringValue": "cluster-uid-123456789"
+            }
+          },
+          {
+            "key": "sw.k8s.persistentvolumeclaim.found",
+            "value": {
+              "stringValue": "true"
+            }
+          },
+          {
+            "key": "sw.k8s.persistentvolumeclaim.status",
+            "value": {
+              "stringValue": "Bound"
+            }
+          }
+        ]
+      },
+      "scopeMetrics": [
+        {
+          "metrics": [
+            {
+              "gauge": {
+                "dataPoints": [
+                  {
+                    "asDouble": 1,
+                    "attributes": [
+                      {
+                        "key": "endpoint",
+                        "value": {
+                          "stringValue": "http"
+                        }
+                      },
+                      {
+                        "key": "prometheus",
+                        "value": {
+                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
+                        }
+                      },
+                      {
+                        "key": "prometheus_replica",
+                        "value": {
+                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
+                        }
+                      },
+                      {
+                        "key": "service",
+                        "value": {
+                          "stringValue": "test-service"
+                        }
+                      }
+                    ],
+                    "timeUnixNano": "0"
+                  }
+                ]
+              },
+              "name": "k8s.persistentvolumeclaim.status.phase"
+            }
+          ],
+          "scope": {}
+        }
+      ]
+    },
+    {
+      "resource": {
+        "attributes": [
+          {
+            "key": "container",
+            "value": {
+              "stringValue": "test-container"
+            }
+          },
+          {
+            "key": "http.scheme",
+            "value": {
+              "stringValue": "http"
+            }
+          },
+          {
+            "key": "k8s.cluster.name",
+            "value": {
+              "stringValue": "cluster name"
+            }
+          },
+          {
+            "key": "k8s.container.name",
+            "value": {
+              "stringValue": "test-container"
+            }
+          },
+          {
+            "key": "k8s.namespace.annotations.description",
+            "value": {
+              "stringValue": "This is a test namespace."
+            }
+          },
+          {
+            "key": "k8s.namespace.labels.app",
+            "value": {
+              "stringValue": "test-app"
+            }
+          },
+          {
+            "key": "k8s.namespace.labels.kubernetes.io/metadata.name",
+            "value": {
+              "stringValue": "test-namespace"
+            }
+          },
+          {
+            "key": "k8s.namespace.labels.purpose",
+            "value": {
+              "stringValue": "testing"
+            }
+          },
+          {
+            "key": "k8s.namespace.name",
+            "value": {
+              "stringValue": "test-namespace"
+            }
+          },
+          {
+            "key": "k8s.node.name",
+            "value": {
+              "stringValue": "test-node"
+            }
+          },
+          {
+            "key": "k8s.pod.annotations.test-annotation",
+            "value": {
+              "stringValue": "test-value"
+            }
+          },
+          {
+            "key": "k8s.pod.labels.app",
+            "value": {
+              "stringValue": "test-pod"
+            }
+          },
+          {
+            "key": "k8s.pod.name",
+            "value": {
+              "stringValue": "test-pod"
+            }
+          },
+          {
+            "key": "k8s.pod.uid",
+            "value": {
+              "stringValue": "03d2b55c-b225-476b-9178-c74f8e5eaba2"
+            }
+          },
+          {
+            "key": "namespace",
+            "value": {
+              "stringValue": "test-namespace"
+            }
+          },
+          {
+            "key": "net.host.name",
+            "value": {
+              "stringValue": "test-node"
+            }
+          },
+          {
+            "key": "net.host.port",
+            "value": {
+              "stringValue": ""
+            }
+          },
+          {
+            "key": "pod",
+            "value": {
+              "stringValue": "test-pod"
+            }
+          },
+          {
+            "key": "sw.k8s.agent.app.version",
+            "value": {
+              "stringValue": "0.8.1"
+            }
+          },
+          {
+            "key": "sw.k8s.agent.manifest.version",
+            "value": {
+              "stringValue": "2.7.0-alpha.6"
+            }
+          },
+          {
+            "key": "sw.k8s.cluster.uid",
+            "value": {
+              "stringValue": "cluster-uid-123456789"
+            }
+          },
+          {
+            "key": "sw.k8s.container.init",
+            "value": {
+              "stringValue": "false"
+            }
+          },
+          {
+            "key": "sw.k8s.container.status",
+            "value": {
+              "stringValue": "running"
+            }
+          },
+          {
+            "key": "uid",
+            "value": {
+              "stringValue": "03d2b55c-b225-476b-9178-c74f8e5eaba2"
+            }
+          }
+        ]
+      },
+      "scopeMetrics": [
+        {
+          "metrics": [
+            {
+              "gauge": {
+                "dataPoints": [
+                  {
+                    "asDouble": 1,
+                    "attributes": [
+                      {
+                        "key": "endpoint",
+                        "value": {
+                          "stringValue": "http"
+                        }
+                      },
+                      {
+                        "key": "prometheus",
+                        "value": {
+                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
+                        }
+                      },
+                      {
+                        "key": "prometheus_replica",
+                        "value": {
+                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
+                        }
+                      },
+                      {
+                        "key": "service",
+                        "value": {
+                          "stringValue": "test-service"
+                        }
+                      }
+                    ],
+                    "timeUnixNano": "0"
+                  }
+                ]
+              },
+              "name": "k8s.container.status"
+            }
+          ],
+          "scope": {}
+        }
+      ]
+    },
+    {
+      "resource": {
+        "attributes": [
+          {
+            "key": "container",
+            "value": {
+              "stringValue": "test-container"
+            }
+          },
+          {
+            "key": "http.scheme",
+            "value": {
+              "stringValue": "http"
+            }
+          },
+          {
+            "key": "k8s.cluster.name",
+            "value": {
+              "stringValue": "cluster name"
+            }
+          },
+          {
+            "key": "k8s.container.name",
+            "value": {
+              "stringValue": "test-container"
+            }
+          },
+          {
+            "key": "k8s.namespace.annotations.description",
+            "value": {
+              "stringValue": "This is a test namespace."
+            }
+          },
+          {
+            "key": "k8s.namespace.labels.app",
+            "value": {
+              "stringValue": "test-app"
+            }
+          },
+          {
+            "key": "k8s.namespace.labels.kubernetes.io/metadata.name",
+            "value": {
+              "stringValue": "test-namespace"
+            }
+          },
+          {
+            "key": "k8s.namespace.labels.purpose",
+            "value": {
+              "stringValue": "testing"
+            }
+          },
+          {
+            "key": "k8s.namespace.name",
+            "value": {
+              "stringValue": "test-namespace"
+            }
+          },
+          {
+            "key": "k8s.node.name",
+            "value": {
+              "stringValue": "test-node"
+            }
+          },
+          {
+            "key": "k8s.pod.annotations.test-annotation",
+            "value": {
+              "stringValue": "test-value"
+            }
+          },
+          {
+            "key": "k8s.pod.labels.app",
+            "value": {
+              "stringValue": "test-pod"
+            }
+          },
+          {
+            "key": "k8s.pod.name",
+            "value": {
+              "stringValue": "test-pod"
+            }
+          },
+          {
+            "key": "k8s.pod.uid",
+            "value": {
+              "stringValue": "03d2b55c-b225-476b-9178-c74f8e5eaba2"
+            }
+          },
+          {
+            "key": "namespace",
+            "value": {
+              "stringValue": "test-namespace"
+            }
+          },
+          {
+            "key": "net.host.name",
+            "value": {
+              "stringValue": "test-node"
+            }
+          },
+          {
+            "key": "net.host.port",
+            "value": {
+              "stringValue": ""
+            }
+          },
+          {
+            "key": "pod",
+            "value": {
+              "stringValue": "test-pod"
+            }
+          },
+          {
+            "key": "sw.k8s.agent.app.version",
+            "value": {
+              "stringValue": "0.8.1"
+            }
+          },
+          {
+            "key": "sw.k8s.agent.manifest.version",
+            "value": {
+              "stringValue": "2.7.0-alpha.6"
+            }
+          },
+          {
+            "key": "sw.k8s.cluster.uid",
+            "value": {
+              "stringValue": "cluster-uid-123456789"
+            }
+          },
+          {
+            "key": "sw.k8s.container.init",
+            "value": {
+              "stringValue": "false"
+            }
+          },
+          {
+            "key": "uid",
+            "value": {
+              "stringValue": "03d2b55c-b225-476b-9178-c74f8e5eaba2"
+            }
+          }
+        ]
+      },
+      "scopeMetrics": [
+        {
+          "metrics": [
+            {
+              "gauge": {
+                "dataPoints": [
+                  {
+                    "asDouble": 1,
+                    "attributes": [
+                      {
+                        "key": "endpoint",
+                        "value": {
+                          "stringValue": "http"
+                        }
+                      },
+                      {
+                        "key": "prometheus",
+                        "value": {
+                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
+                        }
+                      },
+                      {
+                        "key": "prometheus_replica",
+                        "value": {
+                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
+                        }
+                      },
+                      {
+                        "key": "service",
+                        "value": {
+                          "stringValue": "test-service"
+                        }
+                      }
+                    ],
+                    "timeUnixNano": "0"
+                  }
+                ]
+              },
+              "name": "k8s.kube_pod_container_status_ready"
+            },
+            {
+              "name": "k8s.kube_pod_container_status_restarts_total",
+              "sum": {
+                "aggregationTemporality": 2,
+                "dataPoints": [
+                  {
+                    "asDouble": 0,
+                    "attributes": [
+                      {
+                        "key": "endpoint",
+                        "value": {
+                          "stringValue": "http"
+                        }
+                      },
+                      {
+                        "key": "prometheus",
+                        "value": {
+                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
+                        }
+                      },
+                      {
+                        "key": "prometheus_replica",
+                        "value": {
+                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
+                        }
+                      },
+                      {
+                        "key": "service",
+                        "value": {
+                          "stringValue": "test-service"
+                        }
+                      }
+                    ],
+                    "timeUnixNano": "0"
+                  }
+                ],
+                "isMonotonic": true
+              }
+            },
+            {
+              "gauge": {
+                "dataPoints": [
+                  {
+                    "asDouble": 1,
+                    "attributes": [
+                      {
+                        "key": "endpoint",
+                        "value": {
+                          "stringValue": "http"
+                        }
+                      },
+                      {
+                        "key": "prometheus",
+                        "value": {
+                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
+                        }
+                      },
+                      {
+                        "key": "prometheus_replica",
+                        "value": {
+                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
+                        }
+                      },
+                      {
+                        "key": "service",
+                        "value": {
+                          "stringValue": "test-service"
+                        }
+                      }
+                    ],
+                    "timeUnixNano": "0"
+                  }
+                ]
+              },
+              "name": "k8s.kube_pod_container_status_running"
+            },
+            {
+              "gauge": {
+                "dataPoints": [
+                  {
+                    "asDouble": 0,
+                    "attributes": [
+                      {
+                        "key": "endpoint",
+                        "value": {
+                          "stringValue": "http"
+                        }
+                      },
+                      {
+                        "key": "prometheus",
+                        "value": {
+                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
+                        }
+                      },
+                      {
+                        "key": "prometheus_replica",
+                        "value": {
+                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
+                        }
+                      },
+                      {
+                        "key": "service",
+                        "value": {
+                          "stringValue": "test-service"
+                        }
+                      }
+                    ],
+                    "timeUnixNano": "0"
+                  }
+                ]
+              },
+              "name": "k8s.kube_pod_container_status_waiting"
+            }
+          ],
+          "scope": {}
+        }
+      ]
+    },
+    {
+      "resource": {
+        "attributes": [
+          {
+            "key": "container",
+            "value": {
+              "stringValue": "test-container"
+            }
+          },
+          {
+            "key": "http.scheme",
+            "value": {
+              "stringValue": "http"
+            }
+          },
+          {
+            "key": "k8s.cluster.name",
+            "value": {
+              "stringValue": "cluster name"
+            }
+          },
+          {
+            "key": "k8s.container.name",
+            "value": {
+              "stringValue": "test-container"
+            }
+          },
+          {
+            "key": "k8s.namespace.annotations.description",
+            "value": {
+              "stringValue": "This is a test namespace."
+            }
+          },
+          {
+            "key": "k8s.namespace.labels.app",
+            "value": {
+              "stringValue": "test-app"
+            }
+          },
+          {
+            "key": "k8s.namespace.labels.kubernetes.io/metadata.name",
+            "value": {
+              "stringValue": "test-namespace"
+            }
+          },
+          {
+            "key": "k8s.namespace.labels.purpose",
+            "value": {
+              "stringValue": "testing"
+            }
+          },
+          {
+            "key": "k8s.namespace.name",
+            "value": {
+              "stringValue": "test-namespace"
+            }
+          },
+          {
+            "key": "k8s.node.name",
+            "value": {
+              "stringValue": "test-node"
+            }
+          },
+          {
+            "key": "k8s.pod.annotations.test-annotation",
+            "value": {
+              "stringValue": "test-value"
+            }
+          },
+          {
+            "key": "k8s.pod.labels.app",
+            "value": {
+              "stringValue": "test-pod"
+            }
+          },
+          {
+            "key": "k8s.pod.name",
+            "value": {
+              "stringValue": "test-pod"
+            }
+          },
+          {
+            "key": "k8s.pod.uid",
+            "value": {
+              "stringValue": "0eb87a8e-caf5-42f7-8689-a3b36a00232e"
+            }
+          },
+          {
+            "key": "namespace",
+            "value": {
+              "stringValue": "test-namespace"
+            }
+          },
+          {
+            "key": "net.host.name",
+            "value": {
+              "stringValue": "test-node"
+            }
+          },
+          {
+            "key": "net.host.port",
+            "value": {
+              "stringValue": ""
+            }
+          },
+          {
+            "key": "pod",
+            "value": {
+              "stringValue": "test-pod"
+            }
+          },
+          {
+            "key": "sw.k8s.agent.app.version",
+            "value": {
+              "stringValue": "0.8.1"
+            }
+          },
+          {
+            "key": "sw.k8s.agent.manifest.version",
+            "value": {
+              "stringValue": "2.7.0-alpha.6"
+            }
+          },
+          {
+            "key": "sw.k8s.cluster.uid",
+            "value": {
+              "stringValue": "cluster-uid-123456789"
+            }
+          },
+          {
+            "key": "uid",
+            "value": {
+              "stringValue": "0eb87a8e-caf5-42f7-8689-a3b36a00232e"
+            }
+          }
+        ]
+      },
+      "scopeMetrics": [
+        {
+          "metrics": [
+            {
+              "gauge": {
+                "dataPoints": [
+                  {
+                    "asDouble": 1679919168,
+                    "attributes": [
+                      {
+                        "key": "endpoint",
+                        "value": {
+                          "stringValue": "http"
+                        }
+                      },
+                      {
+                        "key": "prometheus",
+                        "value": {
+                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
+                        }
+                      },
+                      {
+                        "key": "prometheus_replica",
+                        "value": {
+                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
+                        }
+                      },
+                      {
+                        "key": "service",
+                        "value": {
+                          "stringValue": "test-service"
+                        }
+                      }
+                    ],
+                    "timeUnixNano": "0"
+                  }
+                ]
+              },
+              "name": "k8s.kube_pod_created"
+            },
+            {
+              "gauge": {
+                "dataPoints": [
+                  {
+                    "asDouble": 0,
+                    "attributes": [
+                      {
+                        "key": "condition",
+                        "value": {
+                          "stringValue": "unknown"
+                        }
+                      },
+                      {
+                        "key": "endpoint",
+                        "value": {
+                          "stringValue": "http"
+                        }
+                      },
+                      {
+                        "key": "prometheus",
+                        "value": {
+                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
+                        }
+                      },
+                      {
+                        "key": "prometheus_replica",
+                        "value": {
+                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
+                        }
+                      },
+                      {
+                        "key": "service",
+                        "value": {
+                          "stringValue": "test-service"
+                        }
+                      }
+                    ],
+                    "timeUnixNano": "0"
+                  }
+                ]
+              },
+              "name": "k8s.kube_pod_status_ready"
+            }
+          ],
+          "scope": {}
+        }
+      ]
+    },
+    {
+      "resource": {
+        "attributes": [
+          {
+            "key": "container",
+            "value": {
+              "stringValue": "test-container"
+            }
+          },
+          {
+            "key": "http.scheme",
+            "value": {
+              "stringValue": "http"
+            }
+          },
+          {
+            "key": "k8s.cluster.name",
+            "value": {
+              "stringValue": "cluster name"
+            }
+          },
+          {
+            "key": "k8s.container.name",
+            "value": {
+              "stringValue": "test-container"
+            }
+          },
+          {
+            "key": "k8s.namespace.annotations.description",
+            "value": {
+              "stringValue": "This is a test namespace."
+            }
+          },
+          {
+            "key": "k8s.namespace.labels.app",
+            "value": {
+              "stringValue": "test-app"
+            }
+          },
+          {
+            "key": "k8s.namespace.labels.kubernetes.io/metadata.name",
+            "value": {
+              "stringValue": "test-namespace"
+            }
+          },
+          {
+            "key": "k8s.namespace.labels.purpose",
+            "value": {
+              "stringValue": "testing"
+            }
+          },
+          {
+            "key": "k8s.namespace.name",
+            "value": {
+              "stringValue": "test-namespace"
+            }
+          },
+          {
+            "key": "k8s.node.name",
+            "value": {
+              "stringValue": "test-node"
+            }
+          },
+          {
+            "key": "k8s.pod.annotations.test-annotation",
+            "value": {
+              "stringValue": "test-value"
+            }
+          },
+          {
+            "key": "k8s.pod.labels.app",
+            "value": {
+              "stringValue": "test-pod"
+            }
+          },
+          {
+            "key": "k8s.pod.name",
+            "value": {
+              "stringValue": "test-pod"
+            }
+          },
+          {
+            "key": "k8s.pod.uid",
+            "value": {
+              "stringValue": "1263fc71-9ca0-468f-aa93-c6aba4e7e7fd"
+            }
+          },
+          {
+            "key": "namespace",
+            "value": {
+              "stringValue": "test-namespace"
+            }
+          },
+          {
+            "key": "net.host.name",
+            "value": {
+              "stringValue": "test-node"
+            }
+          },
+          {
+            "key": "net.host.port",
+            "value": {
+              "stringValue": ""
+            }
+          },
+          {
+            "key": "pod",
+            "value": {
+              "stringValue": "test-pod"
+            }
+          },
+          {
+            "key": "sw.k8s.agent.app.version",
+            "value": {
+              "stringValue": "0.8.1"
+            }
+          },
+          {
+            "key": "sw.k8s.agent.manifest.version",
+            "value": {
+              "stringValue": "2.7.0-alpha.6"
+            }
+          },
+          {
+            "key": "sw.k8s.cluster.uid",
+            "value": {
+              "stringValue": "cluster-uid-123456789"
+            }
+          },
+          {
+            "key": "uid",
+            "value": {
+              "stringValue": "1263fc71-9ca0-468f-aa93-c6aba4e7e7fd"
+            }
+          }
+        ]
+      },
+      "scopeMetrics": [
+        {
+          "metrics": [
+            {
+              "gauge": {
+                "dataPoints": [
+                  {
+                    "asDouble": 1679473328,
+                    "attributes": [
+                      {
+                        "key": "endpoint",
+                        "value": {
+                          "stringValue": "http"
+                        }
+                      },
+                      {
+                        "key": "prometheus",
+                        "value": {
+                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
+                        }
+                      },
+                      {
+                        "key": "prometheus_replica",
+                        "value": {
+                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
+                        }
+                      },
+                      {
+                        "key": "service",
+                        "value": {
+                          "stringValue": "test-service"
+                        }
+                      }
+                    ],
+                    "timeUnixNano": "0"
+                  }
+                ]
+              },
+              "name": "k8s.kube_pod_start_time"
+            }
+          ],
+          "scope": {}
+        }
+      ]
+    },
+    {
+      "resource": {
+        "attributes": [
+          {
+            "key": "container",
+            "value": {
+              "stringValue": "test-container"
+            }
+          },
+          {
+            "key": "http.scheme",
+            "value": {
+              "stringValue": "http"
+            }
+          },
+          {
+            "key": "k8s.cluster.name",
+            "value": {
+              "stringValue": "cluster name"
+            }
+          },
+          {
+            "key": "k8s.container.name",
+            "value": {
+              "stringValue": "test-container"
+            }
+          },
+          {
+            "key": "k8s.namespace.annotations.description",
+            "value": {
+              "stringValue": "This is a test namespace."
+            }
+          },
+          {
+            "key": "k8s.namespace.labels.app",
+            "value": {
+              "stringValue": "test-app"
+            }
+          },
+          {
+            "key": "k8s.namespace.labels.kubernetes.io/metadata.name",
+            "value": {
+              "stringValue": "test-namespace"
+            }
+          },
+          {
+            "key": "k8s.namespace.labels.purpose",
+            "value": {
+              "stringValue": "testing"
+            }
+          },
+          {
+            "key": "k8s.namespace.name",
+            "value": {
+              "stringValue": "test-namespace"
+            }
+          },
+          {
+            "key": "k8s.node.name",
+            "value": {
+              "stringValue": "test-node"
+            }
+          },
+          {
+            "key": "k8s.pod.annotations.test-annotation",
+            "value": {
+              "stringValue": "test-value"
+            }
+          },
+          {
+            "key": "k8s.pod.labels.app",
+            "value": {
+              "stringValue": "test-pod"
+            }
+          },
+          {
+            "key": "k8s.pod.name",
+            "value": {
+              "stringValue": "test-pod"
+            }
+          },
+          {
+            "key": "k8s.pod.uid",
+            "value": {
+              "stringValue": "1f36cbc1-95aa-40ee-8d06-e3dd4cae8b2f"
+            }
+          },
+          {
+            "key": "namespace",
+            "value": {
+              "stringValue": "test-namespace"
+            }
+          },
+          {
+            "key": "net.host.name",
+            "value": {
+              "stringValue": "test-node"
+            }
+          },
+          {
+            "key": "net.host.port",
+            "value": {
+              "stringValue": ""
+            }
+          },
+          {
+            "key": "pod",
+            "value": {
+              "stringValue": "test-pod"
+            }
+          },
+          {
+            "key": "sw.k8s.agent.app.version",
+            "value": {
+              "stringValue": "0.8.1"
+            }
+          },
+          {
+            "key": "sw.k8s.agent.manifest.version",
+            "value": {
+              "stringValue": "2.7.0-alpha.6"
+            }
+          },
+          {
+            "key": "sw.k8s.cluster.uid",
+            "value": {
+              "stringValue": "cluster-uid-123456789"
+            }
+          },
+          {
+            "key": "sw.k8s.container.init",
+            "value": {
+              "stringValue": "false"
+            }
+          },
+          {
+            "key": "uid",
+            "value": {
+              "stringValue": "1f36cbc1-95aa-40ee-8d06-e3dd4cae8b2f"
+            }
+          }
+        ]
+      },
+      "scopeMetrics": [
+        {
+          "metrics": [
+            {
+              "gauge": {
+                "dataPoints": [
+                  {
+                    "asDouble": 0,
+                    "attributes": [
+                      {
+                        "key": "endpoint",
+                        "value": {
+                          "stringValue": "http"
+                        }
+                      },
+                      {
+                        "key": "prometheus",
+                        "value": {
+                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
+                        }
+                      },
+                      {
+                        "key": "prometheus_replica",
+                        "value": {
+                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
+                        }
+                      },
+                      {
+                        "key": "service",
+                        "value": {
+                          "stringValue": "test-service"
+                        }
+                      }
+                    ],
+                    "timeUnixNano": "0"
+                  }
+                ]
+              },
+              "name": "k8s.kube_pod_container_status_terminated"
+            }
+          ],
+          "scope": {}
+        }
+      ]
+    },
+    {
+      "resource": {
+        "attributes": [
+          {
+            "key": "container",
+            "value": {
+              "stringValue": "test-container"
+            }
+          },
+          {
+            "key": "http.scheme",
+            "value": {
+              "stringValue": "http"
+            }
+          },
+          {
+            "key": "k8s.cluster.name",
+            "value": {
+              "stringValue": "cluster name"
+            }
+          },
+          {
+            "key": "k8s.container.name",
+            "value": {
+              "stringValue": "test-container"
+            }
+          },
+          {
+            "key": "k8s.namespace.annotations.description",
+            "value": {
+              "stringValue": "This is a test namespace."
+            }
+          },
+          {
+            "key": "k8s.namespace.labels.app",
+            "value": {
+              "stringValue": "test-app"
+            }
+          },
+          {
+            "key": "k8s.namespace.labels.kubernetes.io/metadata.name",
+            "value": {
+              "stringValue": "test-namespace"
+            }
+          },
+          {
+            "key": "k8s.namespace.labels.purpose",
+            "value": {
+              "stringValue": "testing"
+            }
+          },
+          {
+            "key": "k8s.namespace.name",
+            "value": {
+              "stringValue": "test-namespace"
+            }
+          },
+          {
+            "key": "k8s.node.name",
+            "value": {
+              "stringValue": "test-node"
+            }
+          },
+          {
+            "key": "k8s.pod.annotations.test-annotation",
+            "value": {
+              "stringValue": "test-value"
+            }
+          },
+          {
+            "key": "k8s.pod.labels.app",
+            "value": {
+              "stringValue": "test-pod"
+            }
+          },
+          {
+            "key": "k8s.pod.name",
+            "value": {
+              "stringValue": "test-pod"
+            }
+          },
+          {
+            "key": "k8s.pod.uid",
+            "value": {
+              "stringValue": "2a82ed12-a31a-427a-adb9-d14cf6a4a063"
+            }
+          },
+          {
+            "key": "namespace",
+            "value": {
+              "stringValue": "test-namespace"
+            }
+          },
+          {
+            "key": "net.host.name",
+            "value": {
+              "stringValue": "test-node"
+            }
+          },
+          {
+            "key": "net.host.port",
+            "value": {
+              "stringValue": ""
+            }
+          },
+          {
+            "key": "pod",
+            "value": {
+              "stringValue": "test-pod"
+            }
+          },
+          {
+            "key": "sw.k8s.agent.app.version",
+            "value": {
+              "stringValue": "0.8.1"
+            }
+          },
+          {
+            "key": "sw.k8s.agent.manifest.version",
+            "value": {
+              "stringValue": "2.7.0-alpha.6"
+            }
+          },
+          {
+            "key": "sw.k8s.cluster.uid",
+            "value": {
+              "stringValue": "cluster-uid-123456789"
+            }
+          },
+          {
+            "key": "sw.k8s.container.init",
+            "value": {
+              "stringValue": "true"
+            }
+          },
+          {
+            "key": "uid",
+            "value": {
+              "stringValue": "2a82ed12-a31a-427a-adb9-d14cf6a4a063"
+            }
+          }
+        ]
+      },
+      "scopeMetrics": [
+        {
+          "metrics": [
+            {
+              "gauge": {
+                "dataPoints": [
+                  {
+                    "asDouble": 0.1,
+                    "attributes": [
+                      {
+                        "key": "endpoint",
+                        "value": {
+                          "stringValue": "http"
+                        }
+                      },
+                      {
+                        "key": "prometheus",
+                        "value": {
+                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
+                        }
+                      },
+                      {
+                        "key": "prometheus_replica",
+                        "value": {
+                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
+                        }
+                      },
+                      {
+                        "key": "service",
+                        "value": {
+                          "stringValue": "test-service"
+                        }
+                      }
+                    ],
+                    "timeUnixNano": "0"
+                  }
+                ]
+              },
+              "name": "k8s.kube_pod_init_container_resource_limits_cpu_cores"
+            }
+          ],
+          "scope": {}
+        }
+      ]
+    },
+    {
+      "resource": {
+        "attributes": [
+          {
+            "key": "container",
+            "value": {
+              "stringValue": "test-container"
+            }
+          },
+          {
+            "key": "http.scheme",
+            "value": {
+              "stringValue": "http"
+            }
+          },
+          {
+            "key": "k8s.cluster.name",
+            "value": {
+              "stringValue": "cluster name"
+            }
+          },
+          {
+            "key": "k8s.container.name",
+            "value": {
+              "stringValue": "test-container"
+            }
+          },
+          {
+            "key": "k8s.namespace.annotations.description",
+            "value": {
+              "stringValue": "This is a test namespace."
+            }
+          },
+          {
+            "key": "k8s.namespace.labels.app",
+            "value": {
+              "stringValue": "test-app"
+            }
+          },
+          {
+            "key": "k8s.namespace.labels.kubernetes.io/metadata.name",
+            "value": {
+              "stringValue": "test-namespace"
+            }
+          },
+          {
+            "key": "k8s.namespace.labels.purpose",
+            "value": {
+              "stringValue": "testing"
+            }
+          },
+          {
+            "key": "k8s.namespace.name",
+            "value": {
+              "stringValue": "test-namespace"
+            }
+          },
+          {
+            "key": "k8s.node.name",
+            "value": {
+              "stringValue": "test-node"
+            }
+          },
+          {
+            "key": "k8s.pod.annotations.test-annotation",
+            "value": {
+              "stringValue": "test-value"
+            }
+          },
+          {
+            "key": "k8s.pod.labels.app",
+            "value": {
+              "stringValue": "test-pod"
+            }
+          },
+          {
+            "key": "k8s.pod.name",
+            "value": {
+              "stringValue": "test-pod"
+            }
+          },
+          {
+            "key": "k8s.pod.uid",
+            "value": {
+              "stringValue": "3d89e9f1-b348-45c1-96ce-6a2a1f127084"
+            }
+          },
+          {
+            "key": "namespace",
+            "value": {
+              "stringValue": "test-namespace"
+            }
+          },
+          {
+            "key": "net.host.name",
+            "value": {
+              "stringValue": "test-node"
+            }
+          },
+          {
+            "key": "net.host.port",
+            "value": {
+              "stringValue": ""
+            }
+          },
+          {
+            "key": "pod",
+            "value": {
+              "stringValue": "test-pod"
+            }
+          },
+          {
+            "key": "sw.k8s.agent.app.version",
+            "value": {
+              "stringValue": "0.8.1"
+            }
+          },
+          {
+            "key": "sw.k8s.agent.manifest.version",
+            "value": {
+              "stringValue": "2.7.0-alpha.6"
+            }
+          },
+          {
+            "key": "sw.k8s.cluster.uid",
+            "value": {
+              "stringValue": "cluster-uid-123456789"
+            }
+          },
+          {
+            "key": "sw.k8s.container.init",
+            "value": {
+              "stringValue": "false"
+            }
+          },
+          {
+            "key": "uid",
+            "value": {
+              "stringValue": "3d89e9f1-b348-45c1-96ce-6a2a1f127084"
+            }
+          }
+        ]
+      },
+      "scopeMetrics": [
+        {
+          "metrics": [
+            {
+              "gauge": {
+                "dataPoints": [
+                  {
+                    "asDouble": 1,
+                    "attributes": [
+                      {
+                        "key": "endpoint",
+                        "value": {
+                          "stringValue": "http"
+                        }
+                      },
+                      {
+                        "key": "prometheus",
+                        "value": {
+                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
+                        }
+                      },
+                      {
+                        "key": "prometheus_replica",
+                        "value": {
+                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
+                        }
+                      },
+                      {
+                        "key": "reason",
+                        "value": {
+                          "stringValue": "Error"
+                        }
+                      },
+                      {
+                        "key": "service",
+                        "value": {
+                          "stringValue": "test-service"
+                        }
+                      }
+                    ],
+                    "timeUnixNano": "0"
+                  }
+                ]
+              },
+              "name": "k8s.kube_pod_container_status_last_terminated_reason"
+            }
+          ],
+          "scope": {}
+        }
+      ]
+    },
+    {
+      "resource": {
+        "attributes": [
+          {
+            "key": "container",
+            "value": {
+              "stringValue": "test-container"
+            }
+          },
+          {
+            "key": "http.scheme",
+            "value": {
+              "stringValue": "http"
+            }
+          },
+          {
+            "key": "k8s.cluster.name",
+            "value": {
+              "stringValue": "cluster name"
+            }
+          },
+          {
+            "key": "k8s.container.name",
+            "value": {
+              "stringValue": "test-container"
+            }
+          },
+          {
+            "key": "k8s.namespace.annotations.description",
+            "value": {
+              "stringValue": "This is a test namespace."
+            }
+          },
+          {
+            "key": "k8s.namespace.labels.app",
+            "value": {
+              "stringValue": "test-app"
+            }
+          },
+          {
+            "key": "k8s.namespace.labels.kubernetes.io/metadata.name",
+            "value": {
+              "stringValue": "test-namespace"
+            }
+          },
+          {
+            "key": "k8s.namespace.labels.purpose",
+            "value": {
+              "stringValue": "testing"
+            }
+          },
+          {
+            "key": "k8s.namespace.name",
+            "value": {
+              "stringValue": "test-namespace"
+            }
+          },
+          {
+            "key": "k8s.node.name",
+            "value": {
+              "stringValue": "test-node"
+            }
+          },
+          {
+            "key": "k8s.pod.annotations.test-annotation",
+            "value": {
+              "stringValue": "test-value"
+            }
+          },
+          {
+            "key": "k8s.pod.labels.app",
+            "value": {
+              "stringValue": "test-pod"
+            }
+          },
+          {
+            "key": "k8s.pod.name",
+            "value": {
+              "stringValue": "test-pod"
+            }
+          },
+          {
+            "key": "k8s.pod.uid",
+            "value": {
+              "stringValue": "541e045c-feed-490e-88a6-b33b515bf3cf"
+            }
+          },
+          {
+            "key": "namespace",
+            "value": {
+              "stringValue": "test-namespace"
+            }
+          },
+          {
+            "key": "net.host.name",
+            "value": {
+              "stringValue": "test-node"
+            }
+          },
+          {
+            "key": "net.host.port",
+            "value": {
+              "stringValue": ""
+            }
+          },
+          {
+            "key": "pod",
+            "value": {
+              "stringValue": "test-pod"
+            }
+          },
+          {
+            "key": "sw.k8s.agent.app.version",
+            "value": {
+              "stringValue": "0.8.1"
+            }
+          },
+          {
+            "key": "sw.k8s.agent.manifest.version",
+            "value": {
+              "stringValue": "2.7.0-alpha.6"
+            }
+          },
+          {
+            "key": "sw.k8s.cluster.uid",
+            "value": {
+              "stringValue": "cluster-uid-123456789"
+            }
+          },
+          {
+            "key": "sw.k8s.container.init",
+            "value": {
+              "stringValue": "false"
+            }
+          },
+          {
+            "key": "uid",
+            "value": {
+              "stringValue": "541e045c-feed-490e-88a6-b33b515bf3cf"
+            }
+          }
+        ]
+      },
+      "scopeMetrics": [
+        {
+          "metrics": [
+            {
+              "gauge": {
+                "dataPoints": [
+                  {
+                    "asDouble": 1679916695,
+                    "attributes": [
+                      {
+                        "key": "endpoint",
+                        "value": {
+                          "stringValue": "http"
+                        }
+                      },
+                      {
+                        "key": "prometheus",
+                        "value": {
+                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
+                        }
+                      },
+                      {
+                        "key": "prometheus_replica",
+                        "value": {
+                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
+                        }
+                      },
+                      {
+                        "key": "service",
+                        "value": {
+                          "stringValue": "test-service"
+                        }
+                      }
+                    ],
+                    "timeUnixNano": "0"
+                  }
+                ]
+              },
+              "name": "k8s.kube_pod_container_state_started"
+            }
+          ],
+          "scope": {}
+        }
+      ]
+    },
+    {
+      "resource": {
+        "attributes": [
+          {
+            "key": "container",
+            "value": {
+              "stringValue": "test-container"
+            }
+          },
+          {
+            "key": "http.scheme",
+            "value": {
+              "stringValue": "http"
+            }
+          },
+          {
+            "key": "k8s.cluster.name",
+            "value": {
+              "stringValue": "cluster name"
+            }
+          },
+          {
+            "key": "k8s.container.name",
+            "value": {
+              "stringValue": "test-container"
+            }
+          },
+          {
+            "key": "k8s.namespace.annotations.description",
+            "value": {
+              "stringValue": "This is a test namespace."
+            }
+          },
+          {
+            "key": "k8s.namespace.labels.app",
+            "value": {
+              "stringValue": "test-app"
+            }
+          },
+          {
+            "key": "k8s.namespace.labels.kubernetes.io/metadata.name",
+            "value": {
+              "stringValue": "test-namespace"
+            }
+          },
+          {
+            "key": "k8s.namespace.labels.purpose",
+            "value": {
+              "stringValue": "testing"
+            }
+          },
+          {
+            "key": "k8s.namespace.name",
+            "value": {
+              "stringValue": "test-namespace"
+            }
+          },
+          {
+            "key": "k8s.node.name",
+            "value": {
+              "stringValue": "test-node"
+            }
+          },
+          {
+            "key": "k8s.pod.annotations.test-annotation",
+            "value": {
+              "stringValue": "test-value"
+            }
+          },
+          {
+            "key": "k8s.pod.labels.app",
+            "value": {
+              "stringValue": "test-pod"
+            }
+          },
+          {
+            "key": "k8s.pod.name",
+            "value": {
+              "stringValue": "test-pod"
+            }
+          },
+          {
+            "key": "k8s.pod.uid",
+            "value": {
+              "stringValue": "5808b16d-a1bf-414b-a0d8-3e3ae381a1b7"
+            }
+          },
+          {
+            "key": "namespace",
+            "value": {
+              "stringValue": "test-namespace"
+            }
+          },
+          {
+            "key": "net.host.name",
+            "value": {
+              "stringValue": "test-node"
+            }
+          },
+          {
+            "key": "net.host.port",
+            "value": {
+              "stringValue": ""
+            }
+          },
+          {
+            "key": "pod",
+            "value": {
+              "stringValue": "test-pod"
+            }
+          },
+          {
+            "key": "sw.k8s.agent.app.version",
+            "value": {
+              "stringValue": "0.8.1"
+            }
+          },
+          {
+            "key": "sw.k8s.agent.manifest.version",
+            "value": {
+              "stringValue": "2.7.0-alpha.6"
+            }
+          },
+          {
+            "key": "sw.k8s.cluster.uid",
+            "value": {
+              "stringValue": "cluster-uid-123456789"
+            }
+          },
+          {
+            "key": "uid",
+            "value": {
+              "stringValue": "5808b16d-a1bf-414b-a0d8-3e3ae381a1b7"
+            }
+          }
+        ]
+      },
+      "scopeMetrics": [
+        {
+          "metrics": [
+            {
+              "gauge": {
+                "dataPoints": [
+                  {
+                    "asDouble": 1681221684,
+                    "attributes": [
+                      {
+                        "key": "endpoint",
+                        "value": {
+                          "stringValue": "http"
+                        }
+                      },
+                      {
+                        "key": "prometheus",
+                        "value": {
+                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
+                        }
+                      },
+                      {
+                        "key": "prometheus_replica",
+                        "value": {
+                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
+                        }
+                      },
+                      {
+                        "key": "service",
+                        "value": {
+                          "stringValue": "test-service"
+                        }
+                      }
+                    ],
+                    "timeUnixNano": "0"
+                  }
+                ]
+              },
+              "name": "k8s.kube_pod_completion_time"
+            }
+          ],
+          "scope": {}
+        }
+      ]
+    },
+    {
+      "resource": {
+        "attributes": [
+          {
+            "key": "container",
+            "value": {
+              "stringValue": "test-container"
+            }
+          },
+          {
+            "key": "http.scheme",
+            "value": {
+              "stringValue": "http"
+            }
+          },
+          {
+            "key": "k8s.cluster.name",
+            "value": {
+              "stringValue": "cluster name"
+            }
+          },
+          {
+            "key": "k8s.container.name",
+            "value": {
+              "stringValue": "test-container"
+            }
+          },
+          {
+            "key": "k8s.namespace.annotations.description",
+            "value": {
+              "stringValue": "This is a test namespace."
+            }
+          },
+          {
+            "key": "k8s.namespace.labels.app",
+            "value": {
+              "stringValue": "test-app"
+            }
+          },
+          {
+            "key": "k8s.namespace.labels.kubernetes.io/metadata.name",
+            "value": {
+              "stringValue": "test-namespace"
+            }
+          },
+          {
+            "key": "k8s.namespace.labels.purpose",
+            "value": {
+              "stringValue": "testing"
+            }
+          },
+          {
+            "key": "k8s.namespace.name",
+            "value": {
+              "stringValue": "test-namespace"
+            }
+          },
+          {
+            "key": "k8s.node.name",
+            "value": {
+              "stringValue": "test-node"
+            }
+          },
+          {
+            "key": "k8s.pod.annotations.test-annotation",
+            "value": {
+              "stringValue": "test-value"
+            }
+          },
+          {
+            "key": "k8s.pod.labels.app",
+            "value": {
+              "stringValue": "test-pod"
+            }
+          },
+          {
+            "key": "k8s.pod.name",
+            "value": {
+              "stringValue": "test-pod"
+            }
+          },
+          {
+            "key": "k8s.pod.uid",
+            "value": {
+              "stringValue": "64b6d309-44e3-4a41-8883-c15c7cc9bc4a"
+            }
+          },
+          {
+            "key": "namespace",
+            "value": {
+              "stringValue": "test-namespace"
+            }
+          },
+          {
+            "key": "net.host.name",
+            "value": {
+              "stringValue": "test-node"
+            }
+          },
+          {
+            "key": "net.host.port",
+            "value": {
+              "stringValue": ""
+            }
+          },
+          {
+            "key": "pod",
+            "value": {
+              "stringValue": "test-pod"
+            }
+          },
+          {
+            "key": "sw.k8s.agent.app.version",
+            "value": {
+              "stringValue": "0.8.1"
+            }
+          },
+          {
+            "key": "sw.k8s.agent.manifest.version",
+            "value": {
+              "stringValue": "2.7.0-alpha.6"
+            }
+          },
+          {
+            "key": "sw.k8s.cluster.uid",
+            "value": {
+              "stringValue": "cluster-uid-123456789"
+            }
+          },
+          {
+            "key": "sw.k8s.container.init",
+            "value": {
+              "stringValue": "true"
+            }
+          },
+          {
+            "key": "uid",
+            "value": {
+              "stringValue": "64b6d309-44e3-4a41-8883-c15c7cc9bc4a"
+            }
+          }
+        ]
+      },
+      "scopeMetrics": [
+        {
+          "metrics": [
+            {
+              "gauge": {
+                "dataPoints": [
+                  {
+                    "asDouble": 1,
+                    "attributes": [
+                      {
+                        "key": "endpoint",
+                        "value": {
+                          "stringValue": "http"
+                        }
+                      },
+                      {
+                        "key": "prometheus",
+                        "value": {
+                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
+                        }
+                      },
+                      {
+                        "key": "prometheus_replica",
+                        "value": {
+                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
+                        }
+                      },
+                      {
+                        "key": "service",
+                        "value": {
+                          "stringValue": "test-service"
+                        }
+                      }
+                    ],
+                    "timeUnixNano": "0"
+                  }
+                ]
+              },
+              "name": "k8s.kube_pod_init_container_status_ready"
+            }
+          ],
+          "scope": {}
+        }
+      ]
+    },
+    {
+      "resource": {
+        "attributes": [
+          {
+            "key": "container",
+            "value": {
+              "stringValue": "test-container"
+            }
+          },
+          {
+            "key": "http.scheme",
+            "value": {
+              "stringValue": "http"
+            }
+          },
+          {
+            "key": "k8s.cluster.name",
+            "value": {
+              "stringValue": "cluster name"
+            }
+          },
+          {
+            "key": "k8s.container.name",
+            "value": {
+              "stringValue": "test-container"
+            }
+          },
+          {
+            "key": "k8s.namespace.annotations.description",
+            "value": {
+              "stringValue": "This is a test namespace."
+            }
+          },
+          {
+            "key": "k8s.namespace.labels.app",
+            "value": {
+              "stringValue": "test-app"
+            }
+          },
+          {
+            "key": "k8s.namespace.labels.kubernetes.io/metadata.name",
+            "value": {
+              "stringValue": "test-namespace"
+            }
+          },
+          {
+            "key": "k8s.namespace.labels.purpose",
+            "value": {
+              "stringValue": "testing"
+            }
+          },
+          {
+            "key": "k8s.namespace.name",
+            "value": {
+              "stringValue": "test-namespace"
+            }
+          },
+          {
+            "key": "k8s.node.name",
+            "value": {
+              "stringValue": "test-node"
+            }
+          },
+          {
+            "key": "k8s.pod.annotations.test-annotation",
+            "value": {
+              "stringValue": "test-value"
+            }
+          },
+          {
+            "key": "k8s.pod.labels.app",
+            "value": {
+              "stringValue": "test-pod"
+            }
+          },
+          {
+            "key": "k8s.pod.name",
+            "value": {
+              "stringValue": "test-pod"
+            }
+          },
+          {
+            "key": "k8s.pod.uid",
+            "value": {
+              "stringValue": "71057e83-7723-4db5-a7ca-52ad7904e34d"
+            }
+          },
+          {
+            "key": "namespace",
+            "value": {
+              "stringValue": "test-namespace"
+            }
+          },
+          {
+            "key": "net.host.name",
+            "value": {
+              "stringValue": "test-node"
+            }
+          },
+          {
+            "key": "net.host.port",
+            "value": {
+              "stringValue": ""
+            }
+          },
+          {
+            "key": "pod",
+            "value": {
+              "stringValue": "test-pod"
+            }
+          },
+          {
+            "key": "sw.k8s.agent.app.version",
+            "value": {
+              "stringValue": "0.8.1"
+            }
+          },
+          {
+            "key": "sw.k8s.agent.manifest.version",
+            "value": {
+              "stringValue": "2.7.0-alpha.6"
+            }
+          },
+          {
+            "key": "sw.k8s.cluster.uid",
+            "value": {
+              "stringValue": "cluster-uid-123456789"
+            }
+          },
+          {
+            "key": "sw.k8s.container.init",
+            "value": {
+              "stringValue": "false"
+            }
+          },
+          {
+            "key": "uid",
+            "value": {
+              "stringValue": "71057e83-7723-4db5-a7ca-52ad7904e34d"
+            }
+          }
+        ]
+      },
+      "scopeMetrics": [
+        {
+          "metrics": [
+            {
+              "gauge": {
+                "dataPoints": [
+                  {
+                    "asDouble": 1,
+                    "attributes": [
+                      {
+                        "key": "endpoint",
+                        "value": {
+                          "stringValue": "http"
+                        }
+                      },
+                      {
+                        "key": "prometheus",
+                        "value": {
+                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
+                        }
+                      },
+                      {
+                        "key": "prometheus_replica",
+                        "value": {
+                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
+                        }
+                      },
+                      {
+                        "key": "reason",
+                        "value": {
+                          "stringValue": "Completed"
+                        }
+                      },
+                      {
+                        "key": "service",
+                        "value": {
+                          "stringValue": "test-service"
+                        }
+                      }
+                    ],
+                    "timeUnixNano": "0"
+                  }
+                ]
+              },
+              "name": "k8s.kube_pod_container_status_terminated_reason"
+            }
+          ],
+          "scope": {}
+        }
+      ]
+    },
+    {
+      "resource": {
+        "attributes": [
+          {
+            "key": "container",
+            "value": {
+              "stringValue": "test-container"
+            }
+          },
+          {
+            "key": "http.scheme",
+            "value": {
+              "stringValue": "http"
+            }
+          },
+          {
+            "key": "k8s.cluster.name",
+            "value": {
+              "stringValue": "cluster name"
+            }
+          },
+          {
+            "key": "k8s.container.name",
+            "value": {
+              "stringValue": "test-container"
+            }
+          },
+          {
+            "key": "k8s.namespace.annotations.description",
+            "value": {
+              "stringValue": "This is a test namespace."
+            }
+          },
+          {
+            "key": "k8s.namespace.labels.app",
+            "value": {
+              "stringValue": "test-app"
+            }
+          },
+          {
+            "key": "k8s.namespace.labels.kubernetes.io/metadata.name",
+            "value": {
+              "stringValue": "test-namespace"
+            }
+          },
+          {
+            "key": "k8s.namespace.labels.purpose",
+            "value": {
+              "stringValue": "testing"
+            }
+          },
+          {
+            "key": "k8s.namespace.name",
+            "value": {
+              "stringValue": "test-namespace"
+            }
+          },
+          {
+            "key": "k8s.node.name",
+            "value": {
+              "stringValue": "test-node"
+            }
+          },
+          {
+            "key": "k8s.pod.annotations.test-annotation",
+            "value": {
+              "stringValue": "test-value"
+            }
+          },
+          {
+            "key": "k8s.pod.labels.app",
+            "value": {
+              "stringValue": "test-pod"
+            }
+          },
+          {
+            "key": "k8s.pod.name",
+            "value": {
+              "stringValue": "test-pod"
+            }
+          },
+          {
+            "key": "k8s.pod.uid",
+            "value": {
+              "stringValue": "a920ed2f-477d-4ad7-93d6-3222aabfece2"
+            }
+          },
+          {
+            "key": "namespace",
+            "value": {
+              "stringValue": "test-namespace"
+            }
+          },
+          {
+            "key": "net.host.name",
+            "value": {
+              "stringValue": "test-node"
+            }
+          },
+          {
+            "key": "net.host.port",
+            "value": {
+              "stringValue": ""
+            }
+          },
+          {
+            "key": "pod",
+            "value": {
+              "stringValue": "test-pod"
+            }
+          },
+          {
+            "key": "sw.k8s.agent.app.version",
+            "value": {
+              "stringValue": "0.8.1"
+            }
+          },
+          {
+            "key": "sw.k8s.agent.manifest.version",
+            "value": {
+              "stringValue": "2.7.0-alpha.6"
+            }
+          },
+          {
+            "key": "sw.k8s.cluster.uid",
+            "value": {
+              "stringValue": "cluster-uid-123456789"
+            }
+          },
+          {
+            "key": "sw.k8s.container.init",
+            "value": {
+              "stringValue": "true"
+            }
+          },
+          {
+            "key": "uid",
+            "value": {
+              "stringValue": "a920ed2f-477d-4ad7-93d6-3222aabfece2"
+            }
+          }
+        ]
+      },
+      "scopeMetrics": [
+        {
+          "metrics": [
+            {
+              "gauge": {
+                "dataPoints": [
+                  {
+                    "asDouble": 1073741824,
+                    "attributes": [
+                      {
+                        "key": "endpoint",
+                        "value": {
+                          "stringValue": "http"
+                        }
+                      },
+                      {
+                        "key": "prometheus",
+                        "value": {
+                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
+                        }
+                      },
+                      {
+                        "key": "prometheus_replica",
+                        "value": {
+                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
+                        }
+                      },
+                      {
+                        "key": "service",
+                        "value": {
+                          "stringValue": "test-service"
+                        }
+                      }
+                    ],
+                    "timeUnixNano": "0"
+                  }
+                ]
+              },
+              "name": "k8s.kube_pod_init_container_resource_limits_memory_bytes"
+            },
+            {
+              "name": "k8s.kube_pod_init_container_status_restarts_total",
+              "sum": {
+                "aggregationTemporality": 2,
+                "dataPoints": [
+                  {
+                    "asDouble": 0,
+                    "attributes": [
+                      {
+                        "key": "endpoint",
+                        "value": {
+                          "stringValue": "http"
+                        }
+                      },
+                      {
+                        "key": "prometheus",
+                        "value": {
+                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
+                        }
+                      },
+                      {
+                        "key": "prometheus_replica",
+                        "value": {
+                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
+                        }
+                      },
+                      {
+                        "key": "service",
+                        "value": {
+                          "stringValue": "test-service"
+                        }
+                      }
+                    ],
+                    "timeUnixNano": "0"
+                  }
+                ],
+                "isMonotonic": true
+              }
+            }
+          ],
+          "scope": {}
+        }
+      ]
+    },
+    {
+      "resource": {
+        "attributes": [
+          {
+            "key": "container",
+            "value": {
+              "stringValue": "test-container"
+            }
+          },
+          {
+            "key": "http.scheme",
+            "value": {
+              "stringValue": "http"
+            }
+          },
+          {
+            "key": "k8s.cluster.name",
+            "value": {
+              "stringValue": "cluster name"
+            }
+          },
+          {
+            "key": "k8s.container.name",
+            "value": {
+              "stringValue": "test-container"
+            }
+          },
+          {
+            "key": "k8s.namespace.annotations.description",
+            "value": {
+              "stringValue": "This is a test namespace."
+            }
+          },
+          {
+            "key": "k8s.namespace.labels.app",
+            "value": {
+              "stringValue": "test-app"
+            }
+          },
+          {
+            "key": "k8s.namespace.labels.kubernetes.io/metadata.name",
+            "value": {
+              "stringValue": "test-namespace"
+            }
+          },
+          {
+            "key": "k8s.namespace.labels.purpose",
+            "value": {
+              "stringValue": "testing"
+            }
+          },
+          {
+            "key": "k8s.namespace.name",
+            "value": {
+              "stringValue": "test-namespace"
+            }
+          },
+          {
+            "key": "k8s.node.name",
+            "value": {
+              "stringValue": "test-node"
+            }
+          },
+          {
+            "key": "k8s.pod.annotations.test-annotation",
+            "value": {
+              "stringValue": "test-value"
+            }
+          },
+          {
+            "key": "k8s.pod.labels.app",
+            "value": {
+              "stringValue": "test-pod"
+            }
+          },
+          {
+            "key": "k8s.pod.name",
+            "value": {
+              "stringValue": "test-pod"
+            }
+          },
+          {
+            "key": "k8s.pod.uid",
+            "value": {
+              "stringValue": "bafeef2c-1292-4a5e-a92c-d709480b04b6"
+            }
+          },
+          {
+            "key": "k8s.replicaset.name",
+            "value": {
+              "stringValue": "swi-k8s-otel-collector-swo-k8s-collector-metrics-cf8f6886b"
+            }
+          },
+          {
+            "key": "namespace",
+            "value": {
+              "stringValue": "test-namespace"
+            }
+          },
+          {
+            "key": "net.host.name",
+            "value": {
+              "stringValue": "test-node"
+            }
+          },
+          {
+            "key": "net.host.port",
+            "value": {
+              "stringValue": ""
+            }
+          },
+          {
+            "key": "pod",
+            "value": {
+              "stringValue": "test-pod"
+            }
+          },
+          {
+            "key": "replicaset",
+            "value": {
+              "stringValue": "swi-k8s-otel-collector-swo-k8s-collector-metrics-cf8f6886b"
+            }
+          },
+          {
+            "key": "sw.k8s.agent.app.version",
+            "value": {
+              "stringValue": "0.8.1"
+            }
+          },
+          {
+            "key": "sw.k8s.agent.manifest.version",
+            "value": {
+              "stringValue": "2.7.0-alpha.6"
+            }
+          },
+          {
+            "key": "sw.k8s.cluster.uid",
+            "value": {
+              "stringValue": "cluster-uid-123456789"
+            }
+          },
+          {
+            "key": "uid",
+            "value": {
+              "stringValue": "bafeef2c-1292-4a5e-a92c-d709480b04b6"
+            }
+          }
+        ]
+      },
+      "scopeMetrics": [
+        {
+          "metrics": [
+            {
+              "gauge": {
+                "dataPoints": [
+                  {
+                    "asDouble": 1,
+                    "attributes": [
+                      {
+                        "key": "endpoint",
+                        "value": {
+                          "stringValue": "http"
+                        }
+                      },
+                      {
+                        "key": "owner_is_controller",
+                        "value": {
+                          "stringValue": "true"
+                        }
+                      },
+                      {
+                        "key": "owner_kind",
+                        "value": {
+                          "stringValue": "ReplicaSet"
+                        }
+                      },
+                      {
+                        "key": "prometheus",
+                        "value": {
+                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
+                        }
+                      },
+                      {
+                        "key": "prometheus_replica",
+                        "value": {
+                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
+                        }
+                      },
+                      {
+                        "key": "service",
+                        "value": {
+                          "stringValue": "test-service"
+                        }
+                      }
+                    ],
+                    "timeUnixNano": "0"
+                  }
+                ]
+              },
+              "name": "k8s.kube.pod.owner.replicaset"
+            }
+          ],
+          "scope": {}
+        }
+      ]
+    },
+    {
+      "resource": {
+        "attributes": [
+          {
+            "key": "container",
+            "value": {
+              "stringValue": "test-container"
+            }
+          },
+          {
+            "key": "http.scheme",
+            "value": {
+              "stringValue": "http"
+            }
+          },
+          {
+            "key": "k8s.cluster.name",
+            "value": {
+              "stringValue": "cluster name"
+            }
+          },
+          {
+            "key": "k8s.container.name",
+            "value": {
+              "stringValue": "test-container"
+            }
+          },
+          {
+            "key": "k8s.namespace.annotations.description",
+            "value": {
+              "stringValue": "This is a test namespace."
+            }
+          },
+          {
+            "key": "k8s.namespace.labels.app",
+            "value": {
+              "stringValue": "test-app"
+            }
+          },
+          {
+            "key": "k8s.namespace.labels.kubernetes.io/metadata.name",
+            "value": {
+              "stringValue": "test-namespace"
+            }
+          },
+          {
+            "key": "k8s.namespace.labels.purpose",
+            "value": {
+              "stringValue": "testing"
+            }
+          },
+          {
+            "key": "k8s.namespace.name",
+            "value": {
+              "stringValue": "test-namespace"
+            }
+          },
+          {
+            "key": "k8s.node.name",
+            "value": {
+              "stringValue": "test-node"
+            }
+          },
+          {
+            "key": "k8s.pod.annotations.test-annotation",
+            "value": {
+              "stringValue": "test-value"
+            }
+          },
+          {
+            "key": "k8s.pod.labels.app",
+            "value": {
+              "stringValue": "test-pod"
+            }
+          },
+          {
+            "key": "k8s.pod.name",
+            "value": {
+              "stringValue": "test-pod"
+            }
+          },
+          {
+            "key": "k8s.pod.uid",
+            "value": {
+              "stringValue": "bafeef2c-1292-4a5e-a92c-d709480b04b6"
+            }
+          },
+          {
+            "key": "namespace",
+            "value": {
+              "stringValue": "test-namespace"
+            }
+          },
+          {
+            "key": "net.host.name",
+            "value": {
+              "stringValue": "test-node"
+            }
+          },
+          {
+            "key": "net.host.port",
+            "value": {
+              "stringValue": ""
+            }
+          },
+          {
+            "key": "pod",
+            "value": {
+              "stringValue": "test-pod"
+            }
+          },
+          {
+            "key": "sw.k8s.agent.app.version",
+            "value": {
+              "stringValue": "0.8.1"
+            }
+          },
+          {
+            "key": "sw.k8s.agent.manifest.version",
+            "value": {
+              "stringValue": "2.7.0-alpha.6"
+            }
+          },
+          {
+            "key": "sw.k8s.cluster.uid",
+            "value": {
+              "stringValue": "cluster-uid-123456789"
+            }
+          },
+          {
+            "key": "sw.k8s.container.init",
+            "value": {
+              "stringValue": "false"
+            }
+          },
+          {
+            "key": "sw.k8s.container.status",
+            "value": {
+              "stringValue": "running"
+            }
+          },
+          {
+            "key": "uid",
+            "value": {
+              "stringValue": "bafeef2c-1292-4a5e-a92c-d709480b04b6"
+            }
+          }
+        ]
+      },
+      "scopeMetrics": [
+        {
+          "metrics": [
+            {
+              "gauge": {
+                "dataPoints": [
+                  {
+                    "asDouble": 1,
+                    "attributes": [
+                      {
+                        "key": "endpoint",
+                        "value": {
+                          "stringValue": "http"
+                        }
+                      },
+                      {
+                        "key": "prometheus",
+                        "value": {
+                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
+                        }
+                      },
+                      {
+                        "key": "prometheus_replica",
+                        "value": {
+                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
+                        }
+                      },
+                      {
+                        "key": "service",
+                        "value": {
+                          "stringValue": "test-service"
+                        }
+                      }
+                    ],
+                    "timeUnixNano": "0"
+                  },
+                  {
+                    "asDouble": 1,
+                    "attributes": [
+                      {
+                        "key": "endpoint",
+                        "value": {
+                          "stringValue": "tcp-model"
+                        }
+                      },
+                      {
+                        "key": "prometheus",
+                        "value": {
+                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
+                        }
+                      },
+                      {
+                        "key": "prometheus_replica",
+                        "value": {
+                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
+                        }
+                      },
+                      {
+                        "key": "service",
+                        "value": {
+                          "stringValue": "test-service"
+                        }
+                      }
+                    ],
+                    "timeUnixNano": "0"
+                  }
+                ]
+              },
+              "name": "k8s.container.status"
+            }
+          ],
+          "scope": {}
+        }
+      ]
+    },
+    {
+      "resource": {
+        "attributes": [
+          {
+            "key": "container",
+            "value": {
+              "stringValue": "test-container"
+            }
+          },
+          {
+            "key": "http.scheme",
+            "value": {
+              "stringValue": "http"
+            }
+          },
+          {
+            "key": "k8s.cluster.name",
+            "value": {
+              "stringValue": "cluster name"
+            }
+          },
+          {
+            "key": "k8s.container.name",
+            "value": {
+              "stringValue": "test-container"
+            }
+          },
+          {
+            "key": "k8s.namespace.annotations.description",
+            "value": {
+              "stringValue": "This is a test namespace."
+            }
+          },
+          {
+            "key": "k8s.namespace.labels.app",
+            "value": {
+              "stringValue": "test-app"
+            }
+          },
+          {
+            "key": "k8s.namespace.labels.kubernetes.io/metadata.name",
+            "value": {
+              "stringValue": "test-namespace"
+            }
+          },
+          {
+            "key": "k8s.namespace.labels.purpose",
+            "value": {
+              "stringValue": "testing"
+            }
+          },
+          {
+            "key": "k8s.namespace.name",
+            "value": {
+              "stringValue": "test-namespace"
+            }
+          },
+          {
+            "key": "k8s.node.name",
+            "value": {
+              "stringValue": "test-node"
+            }
+          },
+          {
+            "key": "k8s.pod.annotations.test-annotation",
+            "value": {
+              "stringValue": "test-value"
+            }
+          },
+          {
+            "key": "k8s.pod.labels.app",
+            "value": {
+              "stringValue": "test-pod"
+            }
+          },
+          {
+            "key": "k8s.pod.name",
+            "value": {
+              "stringValue": "test-pod"
+            }
+          },
+          {
+            "key": "k8s.pod.uid",
+            "value": {
+              "stringValue": "bafeef2c-1292-4a5e-a92c-d709480b04b6"
+            }
+          },
+          {
+            "key": "namespace",
+            "value": {
+              "stringValue": "test-namespace"
+            }
+          },
+          {
+            "key": "net.host.name",
+            "value": {
+              "stringValue": "test-node"
+            }
+          },
+          {
+            "key": "net.host.port",
+            "value": {
+              "stringValue": ""
+            }
+          },
+          {
+            "key": "pod",
+            "value": {
+              "stringValue": "test-pod"
+            }
+          },
+          {
+            "key": "sw.k8s.agent.app.version",
+            "value": {
+              "stringValue": "0.8.1"
+            }
+          },
+          {
+            "key": "sw.k8s.agent.manifest.version",
+            "value": {
+              "stringValue": "2.7.0-alpha.6"
+            }
+          },
+          {
+            "key": "sw.k8s.cluster.uid",
+            "value": {
+              "stringValue": "cluster-uid-123456789"
+            }
+          },
+          {
+            "key": "sw.k8s.container.init",
+            "value": {
+              "stringValue": "false"
+            }
+          },
+          {
+            "key": "uid",
+            "value": {
+              "stringValue": "bafeef2c-1292-4a5e-a92c-d709480b04b6"
+            }
+          }
+        ]
+      },
+      "scopeMetrics": [
+        {
+          "metrics": [
+            {
+              "gauge": {
+                "dataPoints": [
+                  {
+                    "asDouble": 1681390530,
+                    "attributes": [
+                      {
+                        "key": "endpoint",
+                        "value": {
+                          "stringValue": "http"
+                        }
+                      },
+                      {
+                        "key": "prometheus",
+                        "value": {
+                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
+                        }
+                      },
+                      {
+                        "key": "prometheus_replica",
+                        "value": {
+                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
+                        }
+                      },
+                      {
+                        "key": "service",
+                        "value": {
+                          "stringValue": "test-service"
+                        }
+                      }
+                    ],
+                    "timeUnixNano": "0"
+                  }
+                ]
+              },
+              "name": "k8s.kube_pod_container_state_started"
+            },
+            {
+              "gauge": {
+                "dataPoints": [
+                  {
+                    "asDouble": 1,
+                    "attributes": [
+                      {
+                        "key": "endpoint",
+                        "value": {
+                          "stringValue": "http"
+                        }
+                      },
+                      {
+                        "key": "prometheus",
+                        "value": {
+                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
+                        }
+                      },
+                      {
+                        "key": "prometheus_replica",
+                        "value": {
+                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
+                        }
+                      },
+                      {
+                        "key": "service",
+                        "value": {
+                          "stringValue": "test-service"
+                        }
+                      }
+                    ],
+                    "timeUnixNano": "0"
+                  }
+                ]
+              },
+              "name": "k8s.kube_pod_container_status_ready"
+            },
+            {
+              "name": "k8s.kube_pod_container_status_restarts_total",
+              "sum": {
+                "aggregationTemporality": 2,
+                "dataPoints": [
+                  {
+                    "asDouble": 0,
+                    "attributes": [
+                      {
+                        "key": "endpoint",
+                        "value": {
+                          "stringValue": "http"
+                        }
+                      },
+                      {
+                        "key": "prometheus",
+                        "value": {
+                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
+                        }
+                      },
+                      {
+                        "key": "prometheus_replica",
+                        "value": {
+                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
+                        }
+                      },
+                      {
+                        "key": "service",
+                        "value": {
+                          "stringValue": "test-service"
+                        }
+                      }
+                    ],
+                    "timeUnixNano": "0"
+                  },
+                  {
+                    "asDouble": 0,
+                    "attributes": [
+                      {
+                        "key": "endpoint",
+                        "value": {
+                          "stringValue": "tcp-model"
+                        }
+                      },
+                      {
+                        "key": "prometheus",
+                        "value": {
+                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
+                        }
+                      },
+                      {
+                        "key": "prometheus_replica",
+                        "value": {
+                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
+                        }
+                      },
+                      {
+                        "key": "service",
+                        "value": {
+                          "stringValue": "test-service"
+                        }
+                      }
+                    ],
+                    "timeUnixNano": "0"
+                  }
+                ],
+                "isMonotonic": true
+              }
+            },
+            {
+              "gauge": {
+                "dataPoints": [
+                  {
+                    "asDouble": 1,
+                    "attributes": [
+                      {
+                        "key": "endpoint",
+                        "value": {
+                          "stringValue": "http"
+                        }
+                      },
+                      {
+                        "key": "prometheus",
+                        "value": {
+                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
+                        }
+                      },
+                      {
+                        "key": "prometheus_replica",
+                        "value": {
+                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
+                        }
+                      },
+                      {
+                        "key": "service",
+                        "value": {
+                          "stringValue": "test-service"
+                        }
+                      }
+                    ],
+                    "timeUnixNano": "0"
+                  },
+                  {
+                    "asDouble": 1,
+                    "attributes": [
+                      {
+                        "key": "endpoint",
+                        "value": {
+                          "stringValue": "tcp-model"
+                        }
+                      },
+                      {
+                        "key": "prometheus",
+                        "value": {
+                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
+                        }
+                      },
+                      {
+                        "key": "prometheus_replica",
+                        "value": {
+                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
+                        }
+                      },
+                      {
+                        "key": "service",
+                        "value": {
+                          "stringValue": "test-service"
+                        }
+                      }
+                    ],
+                    "timeUnixNano": "0"
+                  }
+                ]
+              },
+              "name": "k8s.kube_pod_container_status_running"
+            },
+            {
+              "gauge": {
+                "dataPoints": [
+                  {
+                    "asDouble": 0,
+                    "attributes": [
+                      {
+                        "key": "endpoint",
+                        "value": {
+                          "stringValue": "http"
+                        }
+                      },
+                      {
+                        "key": "prometheus",
+                        "value": {
+                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
+                        }
+                      },
+                      {
+                        "key": "prometheus_replica",
+                        "value": {
+                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
+                        }
+                      },
+                      {
+                        "key": "service",
+                        "value": {
+                          "stringValue": "test-service"
+                        }
+                      }
+                    ],
+                    "timeUnixNano": "0"
+                  }
+                ]
+              },
+              "name": "k8s.kube_pod_container_status_terminated"
+            },
+            {
+              "gauge": {
+                "dataPoints": [
+                  {
+                    "asDouble": 0,
+                    "attributes": [
+                      {
+                        "key": "endpoint",
+                        "value": {
+                          "stringValue": "http"
+                        }
+                      },
+                      {
+                        "key": "prometheus",
+                        "value": {
+                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
+                        }
+                      },
+                      {
+                        "key": "prometheus_replica",
+                        "value": {
+                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
+                        }
+                      },
+                      {
+                        "key": "service",
+                        "value": {
+                          "stringValue": "test-service"
+                        }
+                      }
+                    ],
+                    "timeUnixNano": "0"
+                  }
+                ]
+              },
+              "name": "k8s.kube_pod_container_status_waiting"
+            }
+          ],
+          "scope": {}
+        }
+      ]
+    },
+    {
+      "resource": {
+        "attributes": [
+          {
+            "key": "container",
+            "value": {
+              "stringValue": "test-container"
+            }
+          },
+          {
+            "key": "http.scheme",
+            "value": {
+              "stringValue": "http"
+            }
+          },
+          {
+            "key": "k8s.cluster.name",
+            "value": {
+              "stringValue": "cluster name"
+            }
+          },
+          {
+            "key": "k8s.container.name",
+            "value": {
+              "stringValue": "test-container"
+            }
+          },
+          {
+            "key": "k8s.namespace.annotations.description",
+            "value": {
+              "stringValue": "This is a test namespace."
+            }
+          },
+          {
+            "key": "k8s.namespace.labels.app",
+            "value": {
+              "stringValue": "test-app"
+            }
+          },
+          {
+            "key": "k8s.namespace.labels.kubernetes.io/metadata.name",
+            "value": {
+              "stringValue": "test-namespace"
+            }
+          },
+          {
+            "key": "k8s.namespace.labels.purpose",
+            "value": {
+              "stringValue": "testing"
+            }
+          },
+          {
+            "key": "k8s.namespace.name",
+            "value": {
+              "stringValue": "test-namespace"
+            }
+          },
+          {
+            "key": "k8s.node.name",
+            "value": {
+              "stringValue": "test-node"
+            }
+          },
+          {
+            "key": "k8s.pod.annotations.test-annotation",
+            "value": {
+              "stringValue": "test-value"
+            }
+          },
+          {
+            "key": "k8s.pod.labels.app",
+            "value": {
+              "stringValue": "test-pod"
+            }
+          },
+          {
+            "key": "k8s.pod.name",
+            "value": {
+              "stringValue": "test-pod"
+            }
+          },
+          {
+            "key": "k8s.pod.uid",
+            "value": {
+              "stringValue": "bafeef2c-1292-4a5e-a92c-d709480b04b6"
+            }
+          },
+          {
+            "key": "namespace",
+            "value": {
+              "stringValue": "test-namespace"
+            }
+          },
+          {
+            "key": "net.host.name",
+            "value": {
+              "stringValue": "test-node"
+            }
+          },
+          {
+            "key": "net.host.port",
+            "value": {
+              "stringValue": ""
+            }
+          },
+          {
+            "key": "pod",
+            "value": {
+              "stringValue": "test-pod"
+            }
+          },
+          {
+            "key": "sw.k8s.agent.app.version",
+            "value": {
+              "stringValue": "0.8.1"
+            }
+          },
+          {
+            "key": "sw.k8s.agent.manifest.version",
+            "value": {
+              "stringValue": "2.7.0-alpha.6"
+            }
+          },
+          {
+            "key": "sw.k8s.cluster.uid",
+            "value": {
+              "stringValue": "cluster-uid-123456789"
+            }
+          },
+          {
+            "key": "sw.k8s.container.init",
+            "value": {
+              "stringValue": "true"
+            }
+          },
+          {
+            "key": "sw.k8s.container.status",
+            "value": {
+              "stringValue": "terminated"
+            }
+          },
+          {
+            "key": "uid",
+            "value": {
+              "stringValue": "bafeef2c-1292-4a5e-a92c-d709480b04b6"
+            }
+          }
+        ]
+      },
+      "scopeMetrics": [
+        {
+          "metrics": [
+            {
+              "gauge": {
+                "dataPoints": [
+                  {
+                    "asDouble": 1,
+                    "attributes": [
+                      {
+                        "key": "endpoint",
+                        "value": {
+                          "stringValue": "http"
+                        }
+                      },
+                      {
+                        "key": "prometheus",
+                        "value": {
+                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
+                        }
+                      },
+                      {
+                        "key": "prometheus_replica",
+                        "value": {
+                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
+                        }
+                      },
+                      {
+                        "key": "service",
+                        "value": {
+                          "stringValue": "test-service"
+                        }
+                      }
+                    ],
+                    "timeUnixNano": "0"
+                  }
+                ]
+              },
+              "name": "k8s.container.status"
+            }
+          ],
+          "scope": {}
+        }
+      ]
+    },
+    {
+      "resource": {
+        "attributes": [
+          {
+            "key": "container",
+            "value": {
+              "stringValue": "test-container"
+            }
+          },
+          {
+            "key": "http.scheme",
+            "value": {
+              "stringValue": "http"
+            }
+          },
+          {
+            "key": "k8s.cluster.name",
+            "value": {
+              "stringValue": "cluster name"
+            }
+          },
+          {
+            "key": "k8s.container.name",
+            "value": {
+              "stringValue": "test-container"
+            }
+          },
+          {
+            "key": "k8s.namespace.annotations.description",
+            "value": {
+              "stringValue": "This is a test namespace."
+            }
+          },
+          {
+            "key": "k8s.namespace.labels.app",
+            "value": {
+              "stringValue": "test-app"
+            }
+          },
+          {
+            "key": "k8s.namespace.labels.kubernetes.io/metadata.name",
+            "value": {
+              "stringValue": "test-namespace"
+            }
+          },
+          {
+            "key": "k8s.namespace.labels.purpose",
+            "value": {
+              "stringValue": "testing"
+            }
+          },
+          {
+            "key": "k8s.namespace.name",
+            "value": {
+              "stringValue": "test-namespace"
+            }
+          },
+          {
+            "key": "k8s.node.name",
+            "value": {
+              "stringValue": "test-node"
+            }
+          },
+          {
+            "key": "k8s.pod.annotations.test-annotation",
+            "value": {
+              "stringValue": "test-value"
+            }
+          },
+          {
+            "key": "k8s.pod.labels.app",
+            "value": {
+              "stringValue": "test-pod"
+            }
+          },
+          {
+            "key": "k8s.pod.name",
+            "value": {
+              "stringValue": "test-pod"
+            }
+          },
+          {
+            "key": "k8s.pod.uid",
+            "value": {
+              "stringValue": "bafeef2c-1292-4a5e-a92c-d709480b04b6"
+            }
+          },
+          {
+            "key": "namespace",
+            "value": {
+              "stringValue": "test-namespace"
+            }
+          },
+          {
+            "key": "net.host.name",
+            "value": {
+              "stringValue": "test-node"
+            }
+          },
+          {
+            "key": "net.host.port",
+            "value": {
+              "stringValue": ""
+            }
+          },
+          {
+            "key": "pod",
+            "value": {
+              "stringValue": "test-pod"
+            }
+          },
+          {
+            "key": "sw.k8s.agent.app.version",
+            "value": {
+              "stringValue": "0.8.1"
+            }
+          },
+          {
+            "key": "sw.k8s.agent.manifest.version",
+            "value": {
+              "stringValue": "2.7.0-alpha.6"
+            }
+          },
+          {
+            "key": "sw.k8s.cluster.uid",
+            "value": {
+              "stringValue": "cluster-uid-123456789"
+            }
+          },
+          {
+            "key": "sw.k8s.container.init",
+            "value": {
+              "stringValue": "true"
+            }
+          },
+          {
+            "key": "uid",
+            "value": {
+              "stringValue": "bafeef2c-1292-4a5e-a92c-d709480b04b6"
+            }
+          }
+        ]
+      },
+      "scopeMetrics": [
+        {
+          "metrics": [
+            {
+              "gauge": {
+                "dataPoints": [
+                  {
+                    "asDouble": 1,
+                    "attributes": [
+                      {
+                        "key": "endpoint",
+                        "value": {
+                          "stringValue": "http"
+                        }
+                      },
+                      {
+                        "key": "prometheus",
+                        "value": {
+                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
+                        }
+                      },
+                      {
+                        "key": "prometheus_replica",
+                        "value": {
+                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
+                        }
+                      },
+                      {
+                        "key": "service",
+                        "value": {
+                          "stringValue": "test-service"
+                        }
+                      }
+                    ],
+                    "timeUnixNano": "0"
+                  }
+                ]
+              },
+              "name": "k8s.kube_pod_init_container_status_ready"
+            },
+            {
+              "name": "k8s.kube_pod_init_container_status_restarts_total",
+              "sum": {
+                "aggregationTemporality": 2,
+                "dataPoints": [
+                  {
+                    "asDouble": 0,
+                    "attributes": [
+                      {
+                        "key": "endpoint",
+                        "value": {
+                          "stringValue": "http"
+                        }
+                      },
+                      {
+                        "key": "prometheus",
+                        "value": {
+                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
+                        }
+                      },
+                      {
+                        "key": "prometheus_replica",
+                        "value": {
+                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
+                        }
+                      },
+                      {
+                        "key": "service",
+                        "value": {
+                          "stringValue": "test-service"
+                        }
+                      }
+                    ],
+                    "timeUnixNano": "0"
+                  }
+                ],
+                "isMonotonic": true
+              }
+            },
+            {
+              "gauge": {
+                "dataPoints": [
+                  {
+                    "asDouble": 0,
+                    "attributes": [
+                      {
+                        "key": "endpoint",
+                        "value": {
+                          "stringValue": "http"
+                        }
+                      },
+                      {
+                        "key": "prometheus",
+                        "value": {
+                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
+                        }
+                      },
+                      {
+                        "key": "prometheus_replica",
+                        "value": {
+                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
+                        }
+                      },
+                      {
+                        "key": "service",
+                        "value": {
+                          "stringValue": "test-service"
+                        }
+                      }
+                    ],
+                    "timeUnixNano": "0"
+                  }
+                ]
+              },
+              "name": "k8s.kube_pod_init_container_status_running"
+            },
+            {
+              "gauge": {
+                "dataPoints": [
+                  {
+                    "asDouble": 1,
+                    "attributes": [
+                      {
+                        "key": "endpoint",
+                        "value": {
+                          "stringValue": "http"
+                        }
+                      },
+                      {
+                        "key": "prometheus",
+                        "value": {
+                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
+                        }
+                      },
+                      {
+                        "key": "prometheus_replica",
+                        "value": {
+                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
+                        }
+                      },
+                      {
+                        "key": "service",
+                        "value": {
+                          "stringValue": "test-service"
+                        }
+                      }
+                    ],
+                    "timeUnixNano": "0"
+                  }
+                ]
+              },
+              "name": "k8s.kube_pod_init_container_status_terminated"
+            },
+            {
+              "gauge": {
+                "dataPoints": [
+                  {
+                    "asDouble": 1,
+                    "attributes": [
+                      {
+                        "key": "endpoint",
+                        "value": {
+                          "stringValue": "http"
+                        }
+                      },
+                      {
+                        "key": "prometheus",
+                        "value": {
+                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
+                        }
+                      },
+                      {
+                        "key": "prometheus_replica",
+                        "value": {
+                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
+                        }
+                      },
+                      {
+                        "key": "reason",
+                        "value": {
+                          "stringValue": "Completed"
+                        }
+                      },
+                      {
+                        "key": "service",
+                        "value": {
+                          "stringValue": "test-service"
+                        }
+                      }
+                    ],
+                    "timeUnixNano": "0"
+                  }
+                ]
+              },
+              "name": "k8s.kube_pod_init_container_status_terminated_reason"
+            },
+            {
+              "gauge": {
+                "dataPoints": [
+                  {
+                    "asDouble": 0,
+                    "attributes": [
+                      {
+                        "key": "endpoint",
+                        "value": {
+                          "stringValue": "http"
+                        }
+                      },
+                      {
+                        "key": "prometheus",
+                        "value": {
+                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
+                        }
+                      },
+                      {
+                        "key": "prometheus_replica",
+                        "value": {
+                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
+                        }
+                      },
+                      {
+                        "key": "service",
+                        "value": {
+                          "stringValue": "test-service"
+                        }
+                      }
+                    ],
+                    "timeUnixNano": "0"
+                  }
+                ]
+              },
+              "name": "k8s.kube_pod_init_container_status_waiting"
+            }
+          ],
+          "scope": {}
+        }
+      ]
+    },
+    {
+      "resource": {
+        "attributes": [
+          {
+            "key": "container",
+            "value": {
+              "stringValue": "test-container"
+            }
+          },
+          {
+            "key": "http.scheme",
+            "value": {
+              "stringValue": "http"
+            }
+          },
+          {
+            "key": "k8s.cluster.name",
+            "value": {
+              "stringValue": "cluster name"
+            }
+          },
+          {
+            "key": "k8s.container.name",
+            "value": {
+              "stringValue": "test-container"
+            }
+          },
+          {
+            "key": "k8s.namespace.annotations.description",
+            "value": {
+              "stringValue": "This is a test namespace."
+            }
+          },
+          {
+            "key": "k8s.namespace.labels.app",
+            "value": {
+              "stringValue": "test-app"
+            }
+          },
+          {
+            "key": "k8s.namespace.labels.kubernetes.io/metadata.name",
+            "value": {
+              "stringValue": "test-namespace"
+            }
+          },
+          {
+            "key": "k8s.namespace.labels.purpose",
+            "value": {
+              "stringValue": "testing"
+            }
+          },
+          {
+            "key": "k8s.namespace.name",
+            "value": {
+              "stringValue": "test-namespace"
+            }
+          },
+          {
+            "key": "k8s.node.name",
+            "value": {
+              "stringValue": "test-node"
+            }
+          },
+          {
+            "key": "k8s.pod.annotations.test-annotation",
+            "value": {
+              "stringValue": "test-value"
+            }
+          },
+          {
+            "key": "k8s.pod.labels.app",
+            "value": {
+              "stringValue": "test-pod"
+            }
+          },
+          {
+            "key": "k8s.pod.name",
+            "value": {
+              "stringValue": "test-pod"
+            }
+          },
+          {
+            "key": "k8s.pod.uid",
+            "value": {
+              "stringValue": "bafeef2c-1292-4a5e-a92c-d709480b04b6"
+            }
+          },
+          {
+            "key": "namespace",
+            "value": {
+              "stringValue": "test-namespace"
+            }
+          },
+          {
+            "key": "net.host.name",
+            "value": {
+              "stringValue": "test-node"
+            }
+          },
+          {
+            "key": "net.host.port",
+            "value": {
+              "stringValue": ""
+            }
+          },
+          {
+            "key": "pod",
+            "value": {
+              "stringValue": "test-pod"
+            }
+          },
+          {
+            "key": "sw.k8s.agent.app.version",
+            "value": {
+              "stringValue": "0.8.1"
+            }
+          },
+          {
+            "key": "sw.k8s.agent.manifest.version",
+            "value": {
+              "stringValue": "2.7.0-alpha.6"
+            }
+          },
+          {
+            "key": "sw.k8s.cluster.uid",
+            "value": {
+              "stringValue": "cluster-uid-123456789"
+            }
+          },
+          {
+            "key": "sw.k8s.pod.status",
+            "value": {
+              "stringValue": "Running"
+            }
+          },
+          {
+            "key": "uid",
+            "value": {
+              "stringValue": "bafeef2c-1292-4a5e-a92c-d709480b04b6"
+            }
+          }
+        ]
+      },
+      "scopeMetrics": [
+        {
+          "metrics": [
+            {
+              "gauge": {
+                "dataPoints": [
+                  {
+                    "asDouble": 1,
+                    "attributes": [
+                      {
+                        "key": "endpoint",
+                        "value": {
+                          "stringValue": "http"
+                        }
+                      },
+                      {
+                        "key": "phase",
+                        "value": {
+                          "stringValue": "Running"
+                        }
+                      },
+                      {
+                        "key": "prometheus",
+                        "value": {
+                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
+                        }
+                      },
+                      {
+                        "key": "prometheus_replica",
+                        "value": {
+                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
+                        }
+                      },
+                      {
+                        "key": "service",
+                        "value": {
+                          "stringValue": "test-service"
+                        }
+                      }
+                    ],
+                    "timeUnixNano": "0"
+                  },
+                  {
+                    "asDouble": 1,
+                    "attributes": [
+                      {
+                        "key": "endpoint",
+                        "value": {
+                          "stringValue": "tcp-model"
+                        }
+                      },
+                      {
+                        "key": "phase",
+                        "value": {
+                          "stringValue": "Running"
+                        }
+                      },
+                      {
+                        "key": "prometheus",
+                        "value": {
+                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
+                        }
+                      },
+                      {
+                        "key": "prometheus_replica",
+                        "value": {
+                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
+                        }
+                      },
+                      {
+                        "key": "service",
+                        "value": {
+                          "stringValue": "test-service"
+                        }
+                      }
+                    ],
+                    "timeUnixNano": "0"
+                  }
+                ]
+              },
+              "name": "k8s.kube_pod_status_phase"
+            }
+          ],
+          "scope": {}
+        }
+      ]
+    },
+    {
+      "resource": {
+        "attributes": [
+          {
+            "key": "container",
+            "value": {
+              "stringValue": "test-container"
+            }
+          },
+          {
+            "key": "http.scheme",
+            "value": {
+              "stringValue": "http"
+            }
+          },
+          {
+            "key": "k8s.cluster.name",
+            "value": {
+              "stringValue": "cluster name"
+            }
+          },
+          {
+            "key": "k8s.container.name",
+            "value": {
+              "stringValue": "test-container"
+            }
+          },
+          {
+            "key": "k8s.namespace.annotations.description",
+            "value": {
+              "stringValue": "This is a test namespace."
+            }
+          },
+          {
+            "key": "k8s.namespace.labels.app",
+            "value": {
+              "stringValue": "test-app"
+            }
+          },
+          {
+            "key": "k8s.namespace.labels.kubernetes.io/metadata.name",
+            "value": {
+              "stringValue": "test-namespace"
+            }
+          },
+          {
+            "key": "k8s.namespace.labels.purpose",
+            "value": {
+              "stringValue": "testing"
+            }
+          },
+          {
+            "key": "k8s.namespace.name",
+            "value": {
+              "stringValue": "test-namespace"
+            }
+          },
+          {
+            "key": "k8s.node.name",
+            "value": {
+              "stringValue": "test-node"
+            }
+          },
+          {
+            "key": "k8s.pod.annotations.test-annotation",
+            "value": {
+              "stringValue": "test-value"
+            }
+          },
+          {
+            "key": "k8s.pod.labels.app",
+            "value": {
+              "stringValue": "test-pod"
+            }
+          },
+          {
+            "key": "k8s.pod.name",
+            "value": {
+              "stringValue": "test-pod"
+            }
+          },
+          {
+            "key": "k8s.pod.uid",
+            "value": {
+              "stringValue": "bafeef2c-1292-4a5e-a92c-d709480b04b6"
+            }
+          },
+          {
+            "key": "namespace",
+            "value": {
+              "stringValue": "test-namespace"
+            }
+          },
+          {
+            "key": "net.host.name",
+            "value": {
+              "stringValue": "test-node"
+            }
+          },
+          {
+            "key": "net.host.port",
+            "value": {
+              "stringValue": ""
+            }
+          },
+          {
+            "key": "pod",
+            "value": {
+              "stringValue": "test-pod"
+            }
+          },
+          {
+            "key": "sw.k8s.agent.app.version",
+            "value": {
+              "stringValue": "0.8.1"
+            }
+          },
+          {
+            "key": "sw.k8s.agent.manifest.version",
+            "value": {
+              "stringValue": "2.7.0-alpha.6"
+            }
+          },
+          {
+            "key": "sw.k8s.cluster.uid",
+            "value": {
+              "stringValue": "cluster-uid-123456789"
+            }
+          },
+          {
+            "key": "uid",
+            "value": {
+              "stringValue": "bafeef2c-1292-4a5e-a92c-d709480b04b6"
+            }
+          }
+        ]
+      },
+      "scopeMetrics": [
+        {
+          "metrics": [
+            {
+              "gauge": {
+                "dataPoints": [
+                  {
+                    "asDouble": 1681390527,
+                    "attributes": [
+                      {
+                        "key": "endpoint",
+                        "value": {
+                          "stringValue": "http"
+                        }
+                      },
+                      {
+                        "key": "prometheus",
+                        "value": {
+                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
+                        }
+                      },
+                      {
+                        "key": "prometheus_replica",
+                        "value": {
+                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
+                        }
+                      },
+                      {
+                        "key": "service",
+                        "value": {
+                          "stringValue": "test-service"
+                        }
+                      }
+                    ],
+                    "timeUnixNano": "0"
+                  }
+                ]
+              },
+              "name": "k8s.kube_pod_created"
+            },
+            {
+              "gauge": {
+                "dataPoints": [
+                  {
+                    "asDouble": 1,
+                    "attributes": [
+                      {
+                        "key": "endpoint",
+                        "value": {
+                          "stringValue": "http"
+                        }
+                      },
+                      {
+                        "key": "owner_is_controller",
+                        "value": {
+                          "stringValue": "true"
+                        }
+                      },
+                      {
+                        "key": "owner_kind",
+                        "value": {
+                          "stringValue": "ReplicaSet"
+                        }
+                      },
+                      {
+                        "key": "owner_name",
+                        "value": {
+                          "stringValue": "swi-k8s-otel-collector-swo-k8s-collector-metrics-cf8f6886b"
+                        }
+                      },
+                      {
+                        "key": "prometheus",
+                        "value": {
+                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
+                        }
+                      },
+                      {
+                        "key": "prometheus_replica",
+                        "value": {
+                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
+                        }
+                      },
+                      {
+                        "key": "service",
+                        "value": {
+                          "stringValue": "test-service"
+                        }
+                      }
+                    ],
+                    "timeUnixNano": "0"
+                  }
+                ]
+              },
+              "name": "k8s.kube_pod_owner"
+            },
+            {
+              "gauge": {
+                "dataPoints": [
+                  {
+                    "asDouble": 1681390527,
+                    "attributes": [
+                      {
+                        "key": "endpoint",
+                        "value": {
+                          "stringValue": "http"
+                        }
+                      },
+                      {
+                        "key": "prometheus",
+                        "value": {
+                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
+                        }
+                      },
+                      {
+                        "key": "prometheus_replica",
+                        "value": {
+                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
+                        }
+                      },
+                      {
+                        "key": "service",
+                        "value": {
+                          "stringValue": "test-service"
+                        }
+                      }
+                    ],
+                    "timeUnixNano": "0"
+                  }
+                ]
+              },
+              "name": "k8s.kube_pod_start_time"
+            },
+            {
+              "gauge": {
+                "dataPoints": [
+                  {
+                    "asDouble": 0,
+                    "attributes": [
+                      {
+                        "key": "condition",
+                        "value": {
+                          "stringValue": "false"
+                        }
+                      },
+                      {
+                        "key": "endpoint",
+                        "value": {
+                          "stringValue": "http"
+                        }
+                      },
+                      {
+                        "key": "prometheus",
+                        "value": {
+                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
+                        }
+                      },
+                      {
+                        "key": "prometheus_replica",
+                        "value": {
+                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
+                        }
+                      },
+                      {
+                        "key": "service",
+                        "value": {
+                          "stringValue": "test-service"
+                        }
+                      }
+                    ],
+                    "timeUnixNano": "0"
+                  },
+                  {
+                    "asDouble": 1,
+                    "attributes": [
+                      {
+                        "key": "condition",
+                        "value": {
+                          "stringValue": "true"
+                        }
+                      },
+                      {
+                        "key": "endpoint",
+                        "value": {
+                          "stringValue": "http"
+                        }
+                      },
+                      {
+                        "key": "prometheus",
+                        "value": {
+                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
+                        }
+                      },
+                      {
+                        "key": "prometheus_replica",
+                        "value": {
+                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
+                        }
+                      },
+                      {
+                        "key": "service",
+                        "value": {
+                          "stringValue": "test-service"
+                        }
+                      }
+                    ],
+                    "timeUnixNano": "0"
+                  },
+                  {
+                    "asDouble": 0,
+                    "attributes": [
+                      {
+                        "key": "condition",
+                        "value": {
+                          "stringValue": "unknown"
+                        }
+                      },
+                      {
+                        "key": "endpoint",
+                        "value": {
+                          "stringValue": "http"
+                        }
+                      },
+                      {
+                        "key": "prometheus",
+                        "value": {
+                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
+                        }
+                      },
+                      {
+                        "key": "prometheus_replica",
+                        "value": {
+                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
+                        }
+                      },
+                      {
+                        "key": "service",
+                        "value": {
+                          "stringValue": "test-service"
+                        }
+                      }
+                    ],
+                    "timeUnixNano": "0"
+                  }
+                ]
+              },
+              "name": "k8s.kube_pod_status_ready"
+            }
+          ],
+          "scope": {}
+        }
+      ]
+    },
+    {
+      "resource": {
+        "attributes": [
+          {
+            "key": "container",
+            "value": {
+              "stringValue": "test-container"
+            }
+          },
+          {
+            "key": "http.scheme",
+            "value": {
+              "stringValue": "http"
+            }
+          },
+          {
+            "key": "k8s.cluster.name",
+            "value": {
+              "stringValue": "cluster name"
+            }
+          },
+          {
+            "key": "k8s.container.name",
+            "value": {
+              "stringValue": "test-container"
+            }
+          },
+          {
+            "key": "k8s.namespace.annotations.description",
+            "value": {
+              "stringValue": "This is a test namespace."
+            }
+          },
+          {
+            "key": "k8s.namespace.labels.app",
+            "value": {
+              "stringValue": "test-app"
+            }
+          },
+          {
+            "key": "k8s.namespace.labels.kubernetes.io/metadata.name",
+            "value": {
+              "stringValue": "test-namespace"
+            }
+          },
+          {
+            "key": "k8s.namespace.labels.purpose",
+            "value": {
+              "stringValue": "testing"
+            }
+          },
+          {
+            "key": "k8s.namespace.name",
+            "value": {
+              "stringValue": "test-namespace"
+            }
+          },
+          {
+            "key": "k8s.node.name",
+            "value": {
+              "stringValue": "test-node"
+            }
+          },
+          {
+            "key": "k8s.pod.annotations.test-annotation",
+            "value": {
+              "stringValue": "test-value"
+            }
+          },
+          {
+            "key": "k8s.pod.labels.app",
+            "value": {
+              "stringValue": "test-pod"
+            }
+          },
+          {
+            "key": "k8s.pod.name",
+            "value": {
+              "stringValue": "test-pod"
+            }
+          },
+          {
+            "key": "k8s.pod.uid",
+            "value": {
+              "stringValue": "c7f7a05a-a1b5-4fd0-a611-8e2a0e7acbf6"
+            }
+          },
+          {
+            "key": "namespace",
+            "value": {
+              "stringValue": "test-namespace"
+            }
+          },
+          {
+            "key": "net.host.name",
+            "value": {
+              "stringValue": "test-node"
+            }
+          },
+          {
+            "key": "net.host.port",
+            "value": {
+              "stringValue": ""
+            }
+          },
+          {
+            "key": "pod",
+            "value": {
+              "stringValue": "test-pod"
+            }
+          },
+          {
+            "key": "sw.k8s.agent.app.version",
+            "value": {
+              "stringValue": "0.8.1"
+            }
+          },
+          {
+            "key": "sw.k8s.agent.manifest.version",
+            "value": {
+              "stringValue": "2.7.0-alpha.6"
+            }
+          },
+          {
+            "key": "sw.k8s.cluster.uid",
+            "value": {
+              "stringValue": "cluster-uid-123456789"
+            }
+          },
+          {
+            "key": "sw.k8s.container.init",
+            "value": {
+              "stringValue": "true"
+            }
+          },
+          {
+            "key": "sw.k8s.container.status",
+            "value": {
+              "stringValue": "terminated"
+            }
+          },
+          {
+            "key": "uid",
+            "value": {
+              "stringValue": "c7f7a05a-a1b5-4fd0-a611-8e2a0e7acbf6"
+            }
+          }
+        ]
+      },
+      "scopeMetrics": [
+        {
+          "metrics": [
+            {
+              "gauge": {
+                "dataPoints": [
+                  {
+                    "asDouble": 1,
+                    "attributes": [
+                      {
+                        "key": "endpoint",
+                        "value": {
+                          "stringValue": "http"
+                        }
+                      },
+                      {
+                        "key": "prometheus",
+                        "value": {
+                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
+                        }
+                      },
+                      {
+                        "key": "prometheus_replica",
+                        "value": {
+                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
+                        }
+                      },
+                      {
+                        "key": "service",
+                        "value": {
+                          "stringValue": "test-service"
+                        }
+                      }
+                    ],
+                    "timeUnixNano": "0"
+                  }
+                ]
+              },
+              "name": "k8s.container.status"
+            }
+          ],
+          "scope": {}
+        }
+      ]
+    },
+    {
+      "resource": {
+        "attributes": [
+          {
+            "key": "container",
+            "value": {
+              "stringValue": "test-container"
+            }
+          },
+          {
+            "key": "http.scheme",
+            "value": {
+              "stringValue": "http"
+            }
+          },
+          {
+            "key": "k8s.cluster.name",
+            "value": {
+              "stringValue": "cluster name"
+            }
+          },
+          {
+            "key": "k8s.container.name",
+            "value": {
+              "stringValue": "test-container"
+            }
+          },
+          {
+            "key": "k8s.namespace.annotations.description",
+            "value": {
+              "stringValue": "This is a test namespace."
+            }
+          },
+          {
+            "key": "k8s.namespace.labels.app",
+            "value": {
+              "stringValue": "test-app"
+            }
+          },
+          {
+            "key": "k8s.namespace.labels.kubernetes.io/metadata.name",
+            "value": {
+              "stringValue": "test-namespace"
+            }
+          },
+          {
+            "key": "k8s.namespace.labels.purpose",
+            "value": {
+              "stringValue": "testing"
+            }
+          },
+          {
+            "key": "k8s.namespace.name",
+            "value": {
+              "stringValue": "test-namespace"
+            }
+          },
+          {
+            "key": "k8s.node.name",
+            "value": {
+              "stringValue": "test-node"
+            }
+          },
+          {
+            "key": "k8s.pod.annotations.test-annotation",
+            "value": {
+              "stringValue": "test-value"
+            }
+          },
+          {
+            "key": "k8s.pod.labels.app",
+            "value": {
+              "stringValue": "test-pod"
+            }
+          },
+          {
+            "key": "k8s.pod.name",
+            "value": {
+              "stringValue": "test-pod"
+            }
+          },
+          {
+            "key": "k8s.pod.uid",
+            "value": {
+              "stringValue": "c7f7a05a-a1b5-4fd0-a611-8e2a0e7acbf6"
+            }
+          },
+          {
+            "key": "namespace",
+            "value": {
+              "stringValue": "test-namespace"
+            }
+          },
+          {
+            "key": "net.host.name",
+            "value": {
+              "stringValue": "test-node"
+            }
+          },
+          {
+            "key": "net.host.port",
+            "value": {
+              "stringValue": ""
+            }
+          },
+          {
+            "key": "pod",
+            "value": {
+              "stringValue": "test-pod"
+            }
+          },
+          {
+            "key": "sw.k8s.agent.app.version",
+            "value": {
+              "stringValue": "0.8.1"
+            }
+          },
+          {
+            "key": "sw.k8s.agent.manifest.version",
+            "value": {
+              "stringValue": "2.7.0-alpha.6"
+            }
+          },
+          {
+            "key": "sw.k8s.cluster.uid",
+            "value": {
+              "stringValue": "cluster-uid-123456789"
+            }
+          },
+          {
+            "key": "sw.k8s.container.init",
+            "value": {
+              "stringValue": "true"
+            }
+          },
+          {
+            "key": "uid",
+            "value": {
+              "stringValue": "c7f7a05a-a1b5-4fd0-a611-8e2a0e7acbf6"
+            }
+          }
+        ]
+      },
+      "scopeMetrics": [
+        {
+          "metrics": [
+            {
+              "gauge": {
+                "dataPoints": [
+                  {
+                    "asDouble": 0.25,
+                    "attributes": [
+                      {
+                        "key": "endpoint",
+                        "value": {
+                          "stringValue": "http"
+                        }
+                      },
+                      {
+                        "key": "prometheus",
+                        "value": {
+                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
+                        }
+                      },
+                      {
+                        "key": "prometheus_replica",
+                        "value": {
+                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
+                        }
+                      },
+                      {
+                        "key": "service",
+                        "value": {
+                          "stringValue": "test-service"
+                        }
+                      }
+                    ],
+                    "timeUnixNano": "0"
+                  }
+                ]
+              },
+              "name": "k8s.kube_pod_init_container_resource_requests_cpu_cores"
+            },
+            {
+              "gauge": {
+                "dataPoints": [
+                  {
+                    "asDouble": 67108864,
+                    "attributes": [
+                      {
+                        "key": "endpoint",
+                        "value": {
+                          "stringValue": "http"
+                        }
+                      },
+                      {
+                        "key": "prometheus",
+                        "value": {
+                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
+                        }
+                      },
+                      {
+                        "key": "prometheus_replica",
+                        "value": {
+                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
+                        }
+                      },
+                      {
+                        "key": "service",
+                        "value": {
+                          "stringValue": "test-service"
+                        }
+                      }
+                    ],
+                    "timeUnixNano": "0"
+                  }
+                ]
+              },
+              "name": "k8s.kube_pod_init_container_resource_requests_memory_bytes"
+            },
+            {
+              "gauge": {
+                "dataPoints": [
+                  {
+                    "asDouble": 0,
+                    "attributes": [
+                      {
+                        "key": "endpoint",
+                        "value": {
+                          "stringValue": "http"
+                        }
+                      },
+                      {
+                        "key": "prometheus",
+                        "value": {
+                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
+                        }
+                      },
+                      {
+                        "key": "prometheus_replica",
+                        "value": {
+                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
+                        }
+                      },
+                      {
+                        "key": "service",
+                        "value": {
+                          "stringValue": "test-service"
+                        }
+                      }
+                    ],
+                    "timeUnixNano": "0"
+                  }
+                ]
+              },
+              "name": "k8s.kube_pod_init_container_status_running"
+            },
+            {
+              "gauge": {
+                "dataPoints": [
+                  {
+                    "asDouble": 1,
+                    "attributes": [
+                      {
+                        "key": "endpoint",
+                        "value": {
+                          "stringValue": "http"
+                        }
+                      },
+                      {
+                        "key": "prometheus",
+                        "value": {
+                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
+                        }
+                      },
+                      {
+                        "key": "prometheus_replica",
+                        "value": {
+                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
+                        }
+                      },
+                      {
+                        "key": "service",
+                        "value": {
+                          "stringValue": "test-service"
+                        }
+                      }
+                    ],
+                    "timeUnixNano": "0"
+                  }
+                ]
+              },
+              "name": "k8s.kube_pod_init_container_status_terminated"
+            },
+            {
+              "gauge": {
+                "dataPoints": [
+                  {
+                    "asDouble": 1,
+                    "attributes": [
+                      {
+                        "key": "endpoint",
+                        "value": {
+                          "stringValue": "http"
+                        }
+                      },
+                      {
+                        "key": "prometheus",
+                        "value": {
+                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
+                        }
+                      },
+                      {
+                        "key": "prometheus_replica",
+                        "value": {
+                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
+                        }
+                      },
+                      {
+                        "key": "reason",
+                        "value": {
+                          "stringValue": "Completed"
+                        }
+                      },
+                      {
+                        "key": "service",
+                        "value": {
+                          "stringValue": "test-service"
+                        }
+                      }
+                    ],
+                    "timeUnixNano": "0"
+                  }
+                ]
+              },
+              "name": "k8s.kube_pod_init_container_status_terminated_reason"
+            },
+            {
+              "gauge": {
+                "dataPoints": [
+                  {
+                    "asDouble": 0,
+                    "attributes": [
+                      {
+                        "key": "endpoint",
+                        "value": {
+                          "stringValue": "http"
+                        }
+                      },
+                      {
+                        "key": "prometheus",
+                        "value": {
+                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
+                        }
+                      },
+                      {
+                        "key": "prometheus_replica",
+                        "value": {
+                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
+                        }
+                      },
+                      {
+                        "key": "service",
+                        "value": {
+                          "stringValue": "test-service"
+                        }
+                      }
+                    ],
+                    "timeUnixNano": "0"
+                  }
+                ]
+              },
+              "name": "k8s.kube_pod_init_container_status_waiting"
+            }
+          ],
+          "scope": {}
+        }
+      ]
+    },
+    {
+      "resource": {
+        "attributes": [
+          {
+            "key": "container",
+            "value": {
+              "stringValue": "test-container"
+            }
+          },
+          {
+            "key": "http.scheme",
+            "value": {
+              "stringValue": "http"
+            }
+          },
+          {
+            "key": "k8s.cluster.name",
+            "value": {
+              "stringValue": "cluster name"
+            }
+          },
+          {
+            "key": "k8s.container.name",
+            "value": {
+              "stringValue": "test-container"
+            }
+          },
+          {
+            "key": "k8s.namespace.annotations.description",
+            "value": {
+              "stringValue": "This is a test namespace."
+            }
+          },
+          {
+            "key": "k8s.namespace.labels.app",
+            "value": {
+              "stringValue": "test-app"
+            }
+          },
+          {
+            "key": "k8s.namespace.labels.kubernetes.io/metadata.name",
+            "value": {
+              "stringValue": "test-namespace"
+            }
+          },
+          {
+            "key": "k8s.namespace.labels.purpose",
+            "value": {
+              "stringValue": "testing"
+            }
+          },
+          {
+            "key": "k8s.namespace.name",
+            "value": {
+              "stringValue": "test-namespace"
+            }
+          },
+          {
+            "key": "k8s.node.name",
+            "value": {
+              "stringValue": "test-node"
+            }
+          },
+          {
+            "key": "k8s.pod.annotations.test-annotation",
+            "value": {
+              "stringValue": "test-value"
+            }
+          },
+          {
+            "key": "k8s.pod.labels.app",
+            "value": {
+              "stringValue": "test-pod"
+            }
+          },
+          {
+            "key": "k8s.pod.name",
+            "value": {
+              "stringValue": "test-pod"
+            }
+          },
+          {
+            "key": "k8s.replicaset.annotations.test-annotation",
+            "value": {
+              "stringValue": "test-value"
+            }
+          },
+          {
+            "key": "k8s.replicaset.labels.app",
+            "value": {
+              "stringValue": "test-replicaset"
+            }
+          },
+          {
+            "key": "k8s.replicaset.name",
+            "value": {
+              "stringValue": "test-replicaset"
+            }
+          },
+          {
+            "key": "namespace",
+            "value": {
+              "stringValue": "test-namespace"
+            }
+          },
+          {
+            "key": "net.host.name",
+            "value": {
+              "stringValue": "test-node"
+            }
+          },
+          {
+            "key": "net.host.port",
+            "value": {
+              "stringValue": ""
+            }
+          },
+          {
+            "key": "pod",
+            "value": {
+              "stringValue": "test-pod"
+            }
+          },
+          {
+            "key": "replicaset",
+            "value": {
+              "stringValue": "test-replicaset"
+            }
+          },
+          {
+            "key": "sw.k8s.agent.app.version",
+            "value": {
+              "stringValue": "0.8.1"
+            }
+          },
+          {
+            "key": "sw.k8s.agent.manifest.version",
+            "value": {
+              "stringValue": "2.7.0-alpha.6"
+            }
+          },
+          {
+            "key": "sw.k8s.cluster.uid",
+            "value": {
+              "stringValue": "cluster-uid-123456789"
+            }
+          }
+        ]
+      },
+      "scopeMetrics": [
+        {
+          "metrics": [
+            {
+              "gauge": {
+                "dataPoints": [
+                  {
+                    "asDouble": 1678895204,
+                    "attributes": [
+                      {
+                        "key": "endpoint",
+                        "value": {
+                          "stringValue": "http"
+                        }
+                      },
+                      {
+                        "key": "prometheus",
+                        "value": {
+                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
+                        }
+                      },
+                      {
+                        "key": "prometheus_replica",
+                        "value": {
+                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
+                        }
+                      },
+                      {
+                        "key": "service",
+                        "value": {
+                          "stringValue": "test-service"
+                        }
+                      }
+                    ],
+                    "timeUnixNano": "0"
+                  }
+                ]
+              },
+              "name": "k8s.kube_replicaset_created"
+            },
+            {
+              "gauge": {
+                "dataPoints": [
+                  {
+                    "asDouble": 1,
+                    "attributes": [
+                      {
+                        "key": "endpoint",
+                        "value": {
+                          "stringValue": "http"
+                        }
+                      },
+                      {
+                        "key": "owner_is_controller",
+                        "value": {
+                          "stringValue": "true"
+                        }
+                      },
+                      {
+                        "key": "owner_kind",
+                        "value": {
+                          "stringValue": "Deployment"
+                        }
+                      },
+                      {
+                        "key": "owner_name",
+                        "value": {
+                          "stringValue": "core-c1"
+                        }
+                      },
+                      {
+                        "key": "prometheus",
+                        "value": {
+                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
+                        }
+                      },
+                      {
+                        "key": "prometheus_replica",
+                        "value": {
+                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
+                        }
+                      },
+                      {
+                        "key": "service",
+                        "value": {
+                          "stringValue": "test-service"
+                        }
+                      }
+                    ],
+                    "timeUnixNano": "0"
+                  },
+                  {
+                    "asDouble": 1,
+                    "attributes": [
+                      {
+                        "key": "endpoint",
+                        "value": {
+                          "stringValue": "http"
+                        }
+                      },
+                      {
+                        "key": "owner_is_controller",
+                        "value": {
+                          "stringValue": "true"
+                        }
+                      },
+                      {
+                        "key": "owner_kind",
+                        "value": {
+                          "stringValue": "Deployment"
+                        }
+                      },
+                      {
+                        "key": "owner_name",
+                        "value": {
+                          "stringValue": "swi-k8s-otel-collector-swo-k8s-collector-metrics"
+                        }
+                      },
+                      {
+                        "key": "prometheus",
+                        "value": {
+                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
+                        }
+                      },
+                      {
+                        "key": "prometheus_replica",
+                        "value": {
+                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
+                        }
+                      },
+                      {
+                        "key": "service",
+                        "value": {
+                          "stringValue": "test-service"
+                        }
+                      }
+                    ],
+                    "timeUnixNano": "0"
+                  }
+                ]
+              },
+              "name": "k8s.kube_replicaset_owner"
+            },
+            {
+              "gauge": {
+                "dataPoints": [
+                  {
+                    "asDouble": 0,
+                    "attributes": [
+                      {
+                        "key": "endpoint",
+                        "value": {
+                          "stringValue": "http"
+                        }
+                      },
+                      {
+                        "key": "prometheus",
+                        "value": {
+                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
+                        }
+                      },
+                      {
+                        "key": "prometheus_replica",
+                        "value": {
+                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
+                        }
+                      },
+                      {
+                        "key": "service",
+                        "value": {
+                          "stringValue": "test-service"
+                        }
+                      }
+                    ],
+                    "timeUnixNano": "0"
+                  }
+                ]
+              },
+              "name": "k8s.kube_replicaset_spec_replicas"
+            },
+            {
+              "gauge": {
+                "dataPoints": [
+                  {
+                    "asDouble": 0,
+                    "attributes": [
+                      {
+                        "key": "endpoint",
+                        "value": {
+                          "stringValue": "http"
+                        }
+                      },
+                      {
+                        "key": "prometheus",
+                        "value": {
+                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
+                        }
+                      },
+                      {
+                        "key": "prometheus_replica",
+                        "value": {
+                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
+                        }
+                      },
+                      {
+                        "key": "service",
+                        "value": {
+                          "stringValue": "test-service"
+                        }
+                      }
+                    ],
+                    "timeUnixNano": "0"
+                  }
+                ]
+              },
+              "name": "k8s.kube_replicaset_status_ready_replicas"
+            },
+            {
+              "gauge": {
+                "dataPoints": [
+                  {
+                    "asDouble": 0,
+                    "attributes": [
+                      {
+                        "key": "endpoint",
+                        "value": {
+                          "stringValue": "http"
+                        }
+                      },
+                      {
+                        "key": "prometheus",
+                        "value": {
+                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
+                        }
+                      },
+                      {
+                        "key": "prometheus_replica",
+                        "value": {
+                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
+                        }
+                      },
+                      {
+                        "key": "service",
+                        "value": {
+                          "stringValue": "test-service"
+                        }
+                      }
+                    ],
+                    "timeUnixNano": "0"
+                  }
+                ]
+              },
+              "name": "k8s.kube_replicaset_status_replicas"
+            }
+          ],
+          "scope": {}
+        }
+      ]
+    },
+    {
+      "resource": {
+        "attributes": [
+          {
+            "key": "container",
+            "value": {
+              "stringValue": "test-container"
+            }
+          },
+          {
+            "key": "http.scheme",
+            "value": {
+              "stringValue": "http"
+            }
+          },
+          {
+            "key": "k8s.cluster.name",
+            "value": {
+              "stringValue": "cluster name"
+            }
+          },
+          {
+            "key": "k8s.container.name",
+            "value": {
+              "stringValue": "test-container"
+            }
+          },
+          {
+            "key": "k8s.namespace.annotations.description",
+            "value": {
+              "stringValue": "This is a test namespace."
+            }
+          },
+          {
+            "key": "k8s.namespace.labels.app",
+            "value": {
+              "stringValue": "test-app"
+            }
+          },
+          {
+            "key": "k8s.namespace.labels.kubernetes.io/metadata.name",
+            "value": {
+              "stringValue": "test-namespace"
+            }
+          },
+          {
+            "key": "k8s.namespace.labels.purpose",
+            "value": {
+              "stringValue": "testing"
+            }
+          },
+          {
+            "key": "k8s.namespace.name",
+            "value": {
+              "stringValue": "test-namespace"
+            }
+          },
+          {
+            "key": "k8s.node.name",
+            "value": {
+              "stringValue": "test-node"
+            }
+          },
+          {
+            "key": "k8s.pod.annotations.test-annotation",
+            "value": {
+              "stringValue": "test-value"
+            }
+          },
+          {
+            "key": "k8s.pod.labels.app",
+            "value": {
+              "stringValue": "test-pod"
+            }
+          },
+          {
+            "key": "k8s.pod.name",
+            "value": {
+              "stringValue": "test-pod"
+            }
+          },
+          {
+            "key": "k8s.replicaset.name",
+            "value": {
+              "stringValue": "swi-k8s-otel-collector-swo-k8s-collector-metrics-cf8f6886b"
+            }
+          },
+          {
+            "key": "namespace",
+            "value": {
+              "stringValue": "test-namespace"
+            }
+          },
+          {
+            "key": "net.host.name",
+            "value": {
+              "stringValue": "test-node"
+            }
+          },
+          {
+            "key": "net.host.port",
+            "value": {
+              "stringValue": ""
+            }
+          },
+          {
+            "key": "pod",
+            "value": {
+              "stringValue": "test-pod"
+            }
+          },
+          {
+            "key": "replicaset",
+            "value": {
+              "stringValue": "swi-k8s-otel-collector-swo-k8s-collector-metrics-cf8f6886b"
+            }
+          },
+          {
+            "key": "sw.k8s.agent.app.version",
+            "value": {
+              "stringValue": "0.8.1"
+            }
+          },
+          {
+            "key": "sw.k8s.agent.manifest.version",
+            "value": {
+              "stringValue": "2.7.0-alpha.6"
+            }
+          },
+          {
+            "key": "sw.k8s.cluster.uid",
+            "value": {
+              "stringValue": "cluster-uid-123456789"
+            }
+          }
+        ]
+      },
+      "scopeMetrics": [
+        {
+          "metrics": [
+            {
+              "gauge": {
+                "dataPoints": [
+                  {
+                    "asDouble": 1,
+                    "attributes": [
+                      {
+                        "key": "endpoint",
+                        "value": {
+                          "stringValue": "tcp-model"
+                        }
+                      },
+                      {
+                        "key": "owner_is_controller",
+                        "value": {
+                          "stringValue": "true"
+                        }
+                      },
+                      {
+                        "key": "owner_kind",
+                        "value": {
+                          "stringValue": "ReplicaSet"
+                        }
+                      },
+                      {
+                        "key": "prometheus",
+                        "value": {
+                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
+                        }
+                      },
+                      {
+                        "key": "prometheus_replica",
+                        "value": {
+                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
+                        }
+                      },
+                      {
+                        "key": "service",
+                        "value": {
+                          "stringValue": "test-service"
+                        }
+                      }
+                    ],
+                    "timeUnixNano": "0"
+                  }
+                ]
+              },
+              "name": "k8s.kube.pod.owner.replicaset"
+            }
+          ],
+          "scope": {}
+        }
+      ]
+    },
+    {
+      "resource": {
+        "attributes": [
+          {
+            "key": "container",
+            "value": {
+              "stringValue": "test-container"
+            }
+          },
+          {
+            "key": "http.scheme",
+            "value": {
+              "stringValue": "http"
+            }
+          },
+          {
+            "key": "k8s.cluster.name",
+            "value": {
+              "stringValue": "cluster name"
+            }
+          },
+          {
+            "key": "k8s.container.name",
+            "value": {
+              "stringValue": "test-container"
+            }
+          },
+          {
+            "key": "k8s.namespace.annotations.description",
+            "value": {
+              "stringValue": "This is a test namespace."
+            }
+          },
+          {
+            "key": "k8s.namespace.labels.app",
+            "value": {
+              "stringValue": "test-app"
+            }
+          },
+          {
+            "key": "k8s.namespace.labels.kubernetes.io/metadata.name",
+            "value": {
+              "stringValue": "test-namespace"
+            }
+          },
+          {
+            "key": "k8s.namespace.labels.purpose",
+            "value": {
+              "stringValue": "testing"
+            }
+          },
+          {
+            "key": "k8s.namespace.name",
+            "value": {
+              "stringValue": "test-namespace"
+            }
+          },
+          {
+            "key": "k8s.node.name",
+            "value": {
+              "stringValue": "test-node"
+            }
+          },
+          {
+            "key": "k8s.pod.annotations.test-annotation",
+            "value": {
+              "stringValue": "test-value"
+            }
+          },
+          {
+            "key": "k8s.pod.labels.app",
+            "value": {
+              "stringValue": "test-pod"
+            }
+          },
+          {
+            "key": "k8s.pod.name",
+            "value": {
+              "stringValue": "test-pod"
+            }
+          },
+          {
+            "key": "k8s.statefulset.annotations.test-annotation",
+            "value": {
+              "stringValue": "test-value"
+            }
+          },
+          {
+            "key": "k8s.statefulset.labels.app",
+            "value": {
+              "stringValue": "test-statefulset"
+            }
+          },
+          {
+            "key": "k8s.statefulset.name",
+            "value": {
+              "stringValue": "test-statefulset"
+            }
+          },
+          {
+            "key": "namespace",
+            "value": {
+              "stringValue": "test-namespace"
+            }
+          },
+          {
+            "key": "net.host.name",
+            "value": {
+              "stringValue": "test-node"
+            }
+          },
+          {
+            "key": "net.host.port",
+            "value": {
+              "stringValue": ""
+            }
+          },
+          {
+            "key": "pod",
+            "value": {
+              "stringValue": "test-pod"
+            }
+          },
+          {
+            "key": "statefulset",
+            "value": {
+              "stringValue": "test-statefulset"
+            }
+          },
+          {
+            "key": "sw.k8s.agent.app.version",
+            "value": {
+              "stringValue": "0.8.1"
+            }
+          },
+          {
+            "key": "sw.k8s.agent.manifest.version",
+            "value": {
+              "stringValue": "2.7.0-alpha.6"
+            }
+          },
+          {
+            "key": "sw.k8s.cluster.uid",
+            "value": {
+              "stringValue": "cluster-uid-123456789"
+            }
+          }
+        ]
+      },
+      "scopeMetrics": [
+        {
+          "metrics": [
+            {
+              "gauge": {
+                "dataPoints": [
+                  {
+                    "asDouble": 1645144985,
+                    "attributes": [
+                      {
+                        "key": "endpoint",
+                        "value": {
+                          "stringValue": "http"
+                        }
+                      },
+                      {
+                        "key": "prometheus",
+                        "value": {
+                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
+                        }
+                      },
+                      {
+                        "key": "prometheus_replica",
+                        "value": {
+                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
+                        }
+                      },
+                      {
+                        "key": "service",
+                        "value": {
+                          "stringValue": "test-service"
+                        }
+                      }
+                    ],
+                    "timeUnixNano": "0"
+                  }
+                ]
+              },
+              "name": "k8s.kube_statefulset_created"
+            },
+            {
+              "gauge": {
+                "dataPoints": [
+                  {
+                    "asDouble": 1,
+                    "attributes": [
+                      {
+                        "key": "endpoint",
+                        "value": {
+                          "stringValue": "http"
+                        }
+                      },
+                      {
+                        "key": "prometheus",
+                        "value": {
+                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
+                        }
+                      },
+                      {
+                        "key": "prometheus_replica",
+                        "value": {
+                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
+                        }
+                      },
+                      {
+                        "key": "service",
+                        "value": {
+                          "stringValue": "test-service"
+                        }
+                      }
+                    ],
+                    "timeUnixNano": "0"
+                  }
+                ]
+              },
+              "name": "k8s.kube_statefulset_labels"
+            },
+            {
+              "gauge": {
+                "dataPoints": [
+                  {
+                    "asDouble": 3,
+                    "attributes": [
+                      {
+                        "key": "endpoint",
+                        "value": {
+                          "stringValue": "http"
+                        }
+                      },
+                      {
+                        "key": "prometheus",
+                        "value": {
+                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
+                        }
+                      },
+                      {
+                        "key": "prometheus_replica",
+                        "value": {
+                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
+                        }
+                      },
+                      {
+                        "key": "service",
+                        "value": {
+                          "stringValue": "test-service"
+                        }
+                      }
+                    ],
+                    "timeUnixNano": "0"
+                  }
+                ]
+              },
+              "name": "k8s.kube_statefulset_replicas"
+            },
+            {
+              "gauge": {
+                "dataPoints": [
+                  {
+                    "asDouble": 3,
+                    "attributes": [
+                      {
+                        "key": "endpoint",
+                        "value": {
+                          "stringValue": "http"
+                        }
+                      },
+                      {
+                        "key": "prometheus",
+                        "value": {
+                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
+                        }
+                      },
+                      {
+                        "key": "prometheus_replica",
+                        "value": {
+                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
+                        }
+                      },
+                      {
+                        "key": "service",
+                        "value": {
+                          "stringValue": "test-service"
+                        }
+                      }
+                    ],
+                    "timeUnixNano": "0"
+                  }
+                ]
+              },
+              "name": "k8s.kube_statefulset_status_replicas_current"
+            },
+            {
+              "gauge": {
+                "dataPoints": [
+                  {
+                    "asDouble": 1,
+                    "attributes": [
+                      {
+                        "key": "endpoint",
+                        "value": {
+                          "stringValue": "http"
+                        }
+                      },
+                      {
+                        "key": "prometheus",
+                        "value": {
+                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
+                        }
+                      },
+                      {
+                        "key": "prometheus_replica",
+                        "value": {
+                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
+                        }
+                      },
+                      {
+                        "key": "service",
+                        "value": {
+                          "stringValue": "test-service"
+                        }
+                      }
+                    ],
+                    "timeUnixNano": "0"
+                  }
+                ]
+              },
+              "name": "k8s.kube_statefulset_status_replicas_ready"
+            },
+            {
+              "gauge": {
+                "dataPoints": [
+                  {
+                    "asDouble": 1,
+                    "attributes": [
+                      {
+                        "key": "endpoint",
+                        "value": {
+                          "stringValue": "http"
+                        }
+                      },
+                      {
+                        "key": "prometheus",
+                        "value": {
+                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
+                        }
+                      },
+                      {
+                        "key": "prometheus_replica",
+                        "value": {
+                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
+                        }
+                      },
+                      {
+                        "key": "service",
+                        "value": {
+                          "stringValue": "test-service"
+                        }
+                      }
+                    ],
+                    "timeUnixNano": "0"
+                  }
+                ]
+              },
+              "name": "k8s.kube_statefulset_status_replicas_updated"
+            }
+          ],
+          "scope": {}
+        }
+      ]
+    },
+    {
+      "resource": {
+        "attributes": [
+          {
+            "key": "container",
+            "value": {
+              "stringValue": "test-container"
+            }
+          },
+          {
+            "key": "http.scheme",
+            "value": {
+              "stringValue": "http"
+            }
+          },
+          {
+            "key": "k8s.cluster.name",
+            "value": {
+              "stringValue": "cluster name"
+            }
+          },
+          {
+            "key": "k8s.container.name",
+            "value": {
+              "stringValue": "test-container"
+            }
+          },
+          {
+            "key": "k8s.namespace.annotations.description",
+            "value": {
+              "stringValue": "This is a test namespace."
+            }
+          },
+          {
+            "key": "k8s.namespace.labels.app",
+            "value": {
+              "stringValue": "test-app"
+            }
+          },
+          {
+            "key": "k8s.namespace.labels.kubernetes.io/metadata.name",
+            "value": {
+              "stringValue": "test-namespace"
+            }
+          },
+          {
+            "key": "k8s.namespace.labels.purpose",
+            "value": {
+              "stringValue": "testing"
+            }
+          },
+          {
+            "key": "k8s.namespace.name",
+            "value": {
+              "stringValue": "test-namespace"
+            }
+          },
+          {
+            "key": "k8s.node.name",
+            "value": {
+              "stringValue": "test-node"
+            }
+          },
+          {
+            "key": "k8s.pod.annotations.test-annotation",
+            "value": {
+              "stringValue": "test-value"
+            }
+          },
+          {
+            "key": "k8s.pod.labels.app",
+            "value": {
+              "stringValue": "test-pod"
+            }
+          },
+          {
+            "key": "k8s.pod.name",
+            "value": {
+              "stringValue": "test-pod"
+            }
+          },
+          {
+            "key": "namespace",
+            "value": {
+              "stringValue": "test-namespace"
+            }
+          },
+          {
+            "key": "net.host.name",
+            "value": {
+              "stringValue": "test-node"
+            }
+          },
+          {
+            "key": "net.host.port",
+            "value": {
+              "stringValue": ""
+            }
+          },
+          {
+            "key": "pod",
+            "value": {
+              "stringValue": "test-pod"
+            }
+          },
+          {
+            "key": "sw.k8s.agent.app.version",
+            "value": {
+              "stringValue": "0.8.1"
+            }
+          },
+          {
+            "key": "sw.k8s.agent.manifest.version",
+            "value": {
+              "stringValue": "2.7.0-alpha.6"
+            }
+          },
+          {
+            "key": "sw.k8s.cluster.uid",
+            "value": {
+              "stringValue": "cluster-uid-123456789"
+            }
+          }
+        ]
+      },
+      "scopeMetrics": [
+        {
+          "metrics": [
+            {
+              "gauge": {
+                "dataPoints": [
+                  {
+                    "asDouble": 0,
+                    "startTimeUnixNano": "0",
+                    "timeUnixNano": "0"
+                  }
+                ]
+              },
+              "name": "k8s.container.fs.iops"
+            },
+            {
+              "gauge": {
+                "dataPoints": [
+                  {
+                    "asDouble": 0,
+                    "startTimeUnixNano": "0",
+                    "timeUnixNano": "0"
+                  }
+                ]
+              },
+              "name": "k8s.container.fs.throughput"
+            },
+            {
+              "gauge": {
+                "dataPoints": [
+                  {
+                    "asDouble": 1648847018,
+                    "attributes": [
+                      {
+                        "key": "endpoint",
+                        "value": {
+                          "stringValue": "http"
+                        }
+                      },
+                      {
+                        "key": "prometheus",
+                        "value": {
+                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
+                        }
+                      },
+                      {
+                        "key": "prometheus_replica",
+                        "value": {
+                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
+                        }
+                      },
+                      {
+                        "key": "service",
+                        "value": {
+                          "stringValue": "test-service"
+                        }
+                      }
+                    ],
+                    "timeUnixNano": "0"
+                  }
+                ]
+              },
+              "name": "k8s.kube_namespace_created"
+            },
+            {
+              "gauge": {
+                "dataPoints": [
+                  {
+                    "asDouble": 1,
+                    "attributes": [
+                      {
+                        "key": "endpoint",
+                        "value": {
+                          "stringValue": "tcp-model"
+                        }
+                      },
+                      {
+                        "key": "owner_is_controller",
+                        "value": {
+                          "stringValue": "true"
+                        }
+                      },
+                      {
+                        "key": "owner_kind",
+                        "value": {
+                          "stringValue": "DaemonSet"
+                        }
+                      },
+                      {
+                        "key": "owner_name",
+                        "value": {
+                          "stringValue": "spire-spiffe-csi-driver"
+                        }
+                      },
+                      {
+                        "key": "prometheus",
+                        "value": {
+                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
+                        }
+                      },
+                      {
+                        "key": "prometheus_replica",
+                        "value": {
+                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
+                        }
+                      },
+                      {
+                        "key": "service",
+                        "value": {
+                          "stringValue": "test-service"
+                        }
+                      }
+                    ],
+                    "timeUnixNano": "0"
+                  },
+                  {
+                    "asDouble": 1,
+                    "attributes": [
+                      {
+                        "key": "endpoint",
+                        "value": {
+                          "stringValue": "tcp-model"
+                        }
+                      },
+                      {
+                        "key": "owner_is_controller",
+                        "value": {
+                          "stringValue": "true"
+                        }
+                      },
+                      {
+                        "key": "owner_kind",
+                        "value": {
+                          "stringValue": "ReplicaSet"
+                        }
+                      },
+                      {
+                        "key": "owner_name",
+                        "value": {
+                          "stringValue": "swi-k8s-otel-collector-swo-k8s-collector-metrics-cf8f6886b"
+                        }
+                      },
+                      {
+                        "key": "prometheus",
+                        "value": {
+                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
+                        }
+                      },
+                      {
+                        "key": "prometheus_replica",
+                        "value": {
+                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
+                        }
+                      },
+                      {
+                        "key": "service",
+                        "value": {
+                          "stringValue": "test-service"
+                        }
+                      }
+                    ],
+                    "timeUnixNano": "0"
+                  }
+                ]
+              },
+              "name": "k8s.kube_pod_owner"
+            },
+            {
+              "gauge": {
+                "dataPoints": [
+                  {
+                    "asDouble": 100,
+                    "attributes": [
+                      {
+                        "key": "endpoint",
+                        "value": {
+                          "stringValue": "http"
+                        }
+                      },
+                      {
+                        "key": "prometheus",
+                        "value": {
+                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
+                        }
+                      },
+                      {
+                        "key": "prometheus_replica",
+                        "value": {
+                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
+                        }
+                      },
+                      {
+                        "key": "resource",
+                        "value": {
+                          "stringValue": "pods"
+                        }
+                      },
+                      {
+                        "key": "resourcequota",
+                        "value": {
+                          "stringValue": "gatekeeper-critical-pods"
+                        }
+                      },
+                      {
+                        "key": "service",
+                        "value": {
+                          "stringValue": "test-service"
+                        }
+                      },
+                      {
+                        "key": "type",
+                        "value": {
+                          "stringValue": "hard"
+                        }
+                      }
+                    ],
+                    "timeUnixNano": "0"
+                  }
+                ]
+              },
+              "name": "k8s.kube_resourcequota"
+            }
+          ],
+          "scope": {}
+        }
+      ]
+    },
+    {
+      "resource": {
+        "attributes": [
+          {
+            "key": "container",
+            "value": {
+              "stringValue": "test-container"
+            }
+          },
+          {
+            "key": "http.scheme",
+            "value": {
+              "stringValue": "http"
+            }
+          },
+          {
+            "key": "k8s.cluster.name",
+            "value": {
+              "stringValue": "cluster name"
+            }
+          },
+          {
+            "key": "k8s.container.name",
+            "value": {
+              "stringValue": "test-container"
+            }
+          },
+          {
+            "key": "k8s.namespace.annotations.description",
+            "value": {
+              "stringValue": "This is a test namespace."
+            }
+          },
+          {
+            "key": "k8s.namespace.labels.app",
+            "value": {
+              "stringValue": "test-app"
+            }
+          },
+          {
+            "key": "k8s.namespace.labels.kubernetes.io/metadata.name",
+            "value": {
+              "stringValue": "test-namespace"
+            }
+          },
+          {
+            "key": "k8s.namespace.labels.purpose",
+            "value": {
+              "stringValue": "testing"
+            }
+          },
+          {
+            "key": "k8s.namespace.name",
+            "value": {
+              "stringValue": "test-namespace"
+            }
+          },
+          {
+            "key": "k8s.node.name",
+            "value": {
+              "stringValue": "test-node"
+            }
+          },
+          {
+            "key": "k8s.pod.annotations.test-annotation",
+            "value": {
+              "stringValue": "test-value"
+            }
+          },
+          {
+            "key": "k8s.pod.labels.app",
+            "value": {
+              "stringValue": "test-pod"
+            }
+          },
+          {
+            "key": "k8s.pod.name",
+            "value": {
+              "stringValue": "test-pod"
+            }
+          },
+          {
+            "key": "namespace",
+            "value": {
+              "stringValue": "test-namespace"
+            }
+          },
+          {
+            "key": "net.host.name",
+            "value": {
+              "stringValue": "test-node"
+            }
+          },
+          {
+            "key": "net.host.port",
+            "value": {
+              "stringValue": ""
+            }
+          },
+          {
+            "key": "pod",
+            "value": {
+              "stringValue": "test-pod"
+            }
+          },
+          {
+            "key": "sw.k8s.agent.app.version",
+            "value": {
+              "stringValue": "0.8.1"
+            }
+          },
+          {
+            "key": "sw.k8s.agent.manifest.version",
+            "value": {
+              "stringValue": "2.7.0-alpha.6"
+            }
+          },
+          {
+            "key": "sw.k8s.cluster.uid",
+            "value": {
+              "stringValue": "cluster-uid-123456789"
+            }
+          },
+          {
+            "key": "sw.k8s.namespace.status",
+            "value": {
+              "stringValue": "Active"
+            }
+          }
+        ]
+      },
+      "scopeMetrics": [
+        {
+          "metrics": [
+            {
+              "gauge": {
+                "dataPoints": [
+                  {
+                    "asDouble": 1,
+                    "attributes": [
+                      {
+                        "key": "endpoint",
+                        "value": {
+                          "stringValue": "http"
+                        }
+                      },
+                      {
+                        "key": "phase",
+                        "value": {
+                          "stringValue": "Active"
+                        }
+                      },
+                      {
+                        "key": "prometheus",
+                        "value": {
+                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
+                        }
+                      },
+                      {
+                        "key": "prometheus_replica",
+                        "value": {
+                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
+                        }
+                      },
+                      {
+                        "key": "service",
+                        "value": {
+                          "stringValue": "test-service"
+                        }
+                      }
+                    ],
+                    "timeUnixNano": "0"
+                  }
+                ]
+              },
+              "name": "k8s.kube_namespace_status_phase"
+            }
+          ],
+          "scope": {}
+        }
+      ]
+    },
+    {
+      "resource": {
+        "attributes": [
+          {
+            "key": "container",
+            "value": {
+              "stringValue": "test-container"
+            }
+          },
+          {
+            "key": "http.scheme",
+            "value": {
+              "stringValue": "http"
+            }
+          },
+          {
+            "key": "k8s.cluster.name",
+            "value": {
+              "stringValue": "cluster name"
+            }
+          },
+          {
+            "key": "k8s.container.name",
+            "value": {
+              "stringValue": "test-container"
+            }
+          },
+          {
+            "key": "k8s.namespace.annotations.description",
+            "value": {
+              "stringValue": "This is a test namespace."
+            }
+          },
+          {
+            "key": "k8s.namespace.labels.app",
+            "value": {
+              "stringValue": "test-app"
+            }
+          },
+          {
+            "key": "k8s.namespace.labels.kubernetes.io/metadata.name",
+            "value": {
+              "stringValue": "test-namespace"
+            }
+          },
+          {
+            "key": "k8s.namespace.labels.purpose",
+            "value": {
+              "stringValue": "testing"
+            }
+          },
+          {
+            "key": "k8s.namespace.name",
+            "value": {
+              "stringValue": "test-namespace"
+            }
+          },
+          {
             "key": "k8s.pod.annotations.test-annotation",
             "value": {
               "stringValue": "test-value"
@@ -7857,12 +16127,6 @@
             }
           },
           {
-            "key": "k8s.node.name",
-            "value": {
-              "stringValue": "test-node"
-            }
-          },
-          {
             "key": "k8s.pod.annotations.test-annotation",
             "value": {
               "stringValue": "test-value"
@@ -8048,12 +16312,6 @@
             "key": "k8s.namespace.name",
             "value": {
               "stringValue": "test-namespace"
-            }
-          },
-          {
-            "key": "k8s.node.name",
-            "value": {
-              "stringValue": "test-node"
             }
           },
           {
@@ -8760,12 +17018,6 @@
             }
           },
           {
-            "key": "k8s.node.name",
-            "value": {
-              "stringValue": "test-node"
-            }
-          },
-          {
             "key": "k8s.pod.annotations.test-annotation",
             "value": {
               "stringValue": "test-value"
@@ -9021,12 +17273,6 @@
             }
           },
           {
-            "key": "k8s.node.name",
-            "value": {
-              "stringValue": "test-node"
-            }
-          },
-          {
             "key": "k8s.pod.annotations.test-annotation",
             "value": {
               "stringValue": "test-value"
@@ -9279,12 +17525,6 @@
             "key": "k8s.namespace.name",
             "value": {
               "stringValue": "test-namespace"
-            }
-          },
-          {
-            "key": "k8s.node.name",
-            "value": {
-              "stringValue": "test-node"
             }
           },
           {
@@ -13233,12 +21473,6 @@
             }
           },
           {
-            "key": "k8s.node.name",
-            "value": {
-              "stringValue": "test-node"
-            }
-          },
-          {
             "key": "k8s.pod.annotations.test-annotation",
             "value": {
               "stringValue": "test-value"
@@ -13409,8018 +21643,6 @@
       "resource": {
         "attributes": [
           {
-            "key": "container",
-            "value": {
-              "stringValue": "test-container"
-            }
-          },
-          {
-            "key": "http.scheme",
-            "value": {
-              "stringValue": "http"
-            }
-          },
-          {
-            "key": "k8s.cluster.name",
-            "value": {
-              "stringValue": "cluster name"
-            }
-          },
-          {
-            "key": "k8s.container.name",
-            "value": {
-              "stringValue": "test-container"
-            }
-          },
-          {
-            "key": "k8s.namespace.annotations.description",
-            "value": {
-              "stringValue": "This is a test namespace."
-            }
-          },
-          {
-            "key": "k8s.namespace.labels.app",
-            "value": {
-              "stringValue": "test-app"
-            }
-          },
-          {
-            "key": "k8s.namespace.labels.kubernetes.io/metadata.name",
-            "value": {
-              "stringValue": "test-namespace"
-            }
-          },
-          {
-            "key": "k8s.namespace.labels.purpose",
-            "value": {
-              "stringValue": "testing"
-            }
-          },
-          {
-            "key": "k8s.namespace.name",
-            "value": {
-              "stringValue": "test-namespace"
-            }
-          },
-          {
-            "key": "k8s.persistentvolume.annotations.example.com/annotation",
-            "value": {
-              "stringValue": "example-annotation"
-            }
-          },
-          {
-            "key": "k8s.persistentvolume.annotations.pv.kubernetes.io/bound-by-controller",
-            "value": {
-              "stringValue": "yes"
-            }
-          },
-          {
-            "key": "k8s.persistentvolume.labels.example.com/label",
-            "value": {
-              "stringValue": "example-label"
-            }
-          },
-          {
-            "key": "k8s.persistentvolume.labels.type",
-            "value": {
-              "stringValue": "local"
-            }
-          },
-          {
-            "key": "k8s.persistentvolume.name",
-            "value": {
-              "stringValue": "test-pv"
-            }
-          },
-          {
-            "key": "k8s.persistentvolumeclaim.name",
-            "value": {
-              "stringValue": "data-zookeeper-2"
-            }
-          },
-          {
-            "key": "k8s.pod.annotations.test-annotation",
-            "value": {
-              "stringValue": "test-value"
-            }
-          },
-          {
-            "key": "k8s.pod.labels.app",
-            "value": {
-              "stringValue": "test-pod"
-            }
-          },
-          {
-            "key": "k8s.pod.name",
-            "value": {
-              "stringValue": "test-pod"
-            }
-          },
-          {
-            "key": "namespace",
-            "value": {
-              "stringValue": "test-namespace"
-            }
-          },
-          {
-            "key": "net.host.name",
-            "value": {
-              "stringValue": "test-node"
-            }
-          },
-          {
-            "key": "net.host.port",
-            "value": {
-              "stringValue": ""
-            }
-          },
-          {
-            "key": "persistentvolume",
-            "value": {
-              "stringValue": "test-pv"
-            }
-          },
-          {
-            "key": "persistentvolumeclaim",
-            "value": {
-              "stringValue": "data-zookeeper-2"
-            }
-          },
-          {
-            "key": "pod",
-            "value": {
-              "stringValue": "test-pod"
-            }
-          },
-          {
-            "key": "sw.k8s.agent.app.version",
-            "value": {
-              "stringValue": "0.8.1"
-            }
-          },
-          {
-            "key": "sw.k8s.agent.manifest.version",
-            "value": {
-              "stringValue": "2.7.0-alpha.6"
-            }
-          },
-          {
-            "key": "sw.k8s.cluster.uid",
-            "value": {
-              "stringValue": "cluster-uid-123456789"
-            }
-          }
-        ]
-      },
-      "scopeMetrics": [
-        {
-          "metrics": [
-            {
-              "gauge": {
-                "dataPoints": [
-                  {
-                    "asDouble": 1,
-                    "attributes": [
-                      {
-                        "key": "claim_namespace",
-                        "value": {
-                          "stringValue": "test-namespace"
-                        }
-                      },
-                      {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "http"
-                        }
-                      },
-                      {
-                        "key": "name",
-                        "value": {
-                          "stringValue": "data-zookeeper-2"
-                        }
-                      },
-                      {
-                        "key": "prometheus",
-                        "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
-                        }
-                      },
-                      {
-                        "key": "prometheus_replica",
-                        "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
-                        }
-                      },
-                      {
-                        "key": "service",
-                        "value": {
-                          "stringValue": "test-service"
-                        }
-                      }
-                    ],
-                    "timeUnixNano": "0"
-                  }
-                ]
-              },
-              "name": "k8s.kube_persistentvolume_claim_ref"
-            }
-          ],
-          "scope": {}
-        }
-      ]
-    },
-    {
-      "resource": {
-        "attributes": [
-          {
-            "key": "container",
-            "value": {
-              "stringValue": "test-container"
-            }
-          },
-          {
-            "key": "http.scheme",
-            "value": {
-              "stringValue": "http"
-            }
-          },
-          {
-            "key": "k8s.cluster.name",
-            "value": {
-              "stringValue": "cluster name"
-            }
-          },
-          {
-            "key": "k8s.container.name",
-            "value": {
-              "stringValue": "test-container"
-            }
-          },
-          {
-            "key": "k8s.namespace.annotations.description",
-            "value": {
-              "stringValue": "This is a test namespace."
-            }
-          },
-          {
-            "key": "k8s.namespace.labels.app",
-            "value": {
-              "stringValue": "test-app"
-            }
-          },
-          {
-            "key": "k8s.namespace.labels.kubernetes.io/metadata.name",
-            "value": {
-              "stringValue": "test-namespace"
-            }
-          },
-          {
-            "key": "k8s.namespace.labels.purpose",
-            "value": {
-              "stringValue": "testing"
-            }
-          },
-          {
-            "key": "k8s.namespace.name",
-            "value": {
-              "stringValue": "test-namespace"
-            }
-          },
-          {
-            "key": "k8s.persistentvolume.annotations.example.com/annotation",
-            "value": {
-              "stringValue": "example-annotation"
-            }
-          },
-          {
-            "key": "k8s.persistentvolume.annotations.pv.kubernetes.io/bound-by-controller",
-            "value": {
-              "stringValue": "yes"
-            }
-          },
-          {
-            "key": "k8s.persistentvolume.labels.example.com/label",
-            "value": {
-              "stringValue": "example-label"
-            }
-          },
-          {
-            "key": "k8s.persistentvolume.labels.type",
-            "value": {
-              "stringValue": "local"
-            }
-          },
-          {
-            "key": "k8s.persistentvolume.name",
-            "value": {
-              "stringValue": "test-pv"
-            }
-          },
-          {
-            "key": "k8s.pod.annotations.test-annotation",
-            "value": {
-              "stringValue": "test-value"
-            }
-          },
-          {
-            "key": "k8s.pod.labels.app",
-            "value": {
-              "stringValue": "test-pod"
-            }
-          },
-          {
-            "key": "k8s.pod.name",
-            "value": {
-              "stringValue": "test-pod"
-            }
-          },
-          {
-            "key": "namespace",
-            "value": {
-              "stringValue": "test-namespace"
-            }
-          },
-          {
-            "key": "net.host.name",
-            "value": {
-              "stringValue": "test-node"
-            }
-          },
-          {
-            "key": "net.host.port",
-            "value": {
-              "stringValue": ""
-            }
-          },
-          {
-            "key": "persistentvolume",
-            "value": {
-              "stringValue": "test-pv"
-            }
-          },
-          {
-            "key": "pod",
-            "value": {
-              "stringValue": "test-pod"
-            }
-          },
-          {
-            "key": "storageclass",
-            "value": {
-              "stringValue": "gp2"
-            }
-          },
-          {
-            "key": "sw.k8s.agent.app.version",
-            "value": {
-              "stringValue": "0.8.1"
-            }
-          },
-          {
-            "key": "sw.k8s.agent.manifest.version",
-            "value": {
-              "stringValue": "2.7.0-alpha.6"
-            }
-          },
-          {
-            "key": "sw.k8s.cluster.uid",
-            "value": {
-              "stringValue": "cluster-uid-123456789"
-            }
-          }
-        ]
-      },
-      "scopeMetrics": [
-        {
-          "metrics": [
-            {
-              "gauge": {
-                "dataPoints": [
-                  {
-                    "asDouble": 1,
-                    "attributes": [
-                      {
-                        "key": "ebs_volume_id",
-                        "value": {
-                          "stringValue": "aws://us-east-1a/vol-0fb83c152e8ad8514"
-                        }
-                      },
-                      {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "http"
-                        }
-                      },
-                      {
-                        "key": "prometheus",
-                        "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
-                        }
-                      },
-                      {
-                        "key": "prometheus_replica",
-                        "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
-                        }
-                      },
-                      {
-                        "key": "service",
-                        "value": {
-                          "stringValue": "test-service"
-                        }
-                      }
-                    ],
-                    "timeUnixNano": "0"
-                  }
-                ]
-              },
-              "name": "k8s.kube_persistentvolume_info"
-            }
-          ],
-          "scope": {}
-        }
-      ]
-    },
-    {
-      "resource": {
-        "attributes": [
-          {
-            "key": "container",
-            "value": {
-              "stringValue": "test-container"
-            }
-          },
-          {
-            "key": "http.scheme",
-            "value": {
-              "stringValue": "http"
-            }
-          },
-          {
-            "key": "k8s.cluster.name",
-            "value": {
-              "stringValue": "cluster name"
-            }
-          },
-          {
-            "key": "k8s.container.name",
-            "value": {
-              "stringValue": "test-container"
-            }
-          },
-          {
-            "key": "k8s.namespace.annotations.description",
-            "value": {
-              "stringValue": "This is a test namespace."
-            }
-          },
-          {
-            "key": "k8s.namespace.labels.app",
-            "value": {
-              "stringValue": "test-app"
-            }
-          },
-          {
-            "key": "k8s.namespace.labels.kubernetes.io/metadata.name",
-            "value": {
-              "stringValue": "test-namespace"
-            }
-          },
-          {
-            "key": "k8s.namespace.labels.purpose",
-            "value": {
-              "stringValue": "testing"
-            }
-          },
-          {
-            "key": "k8s.namespace.name",
-            "value": {
-              "stringValue": "test-namespace"
-            }
-          },
-          {
-            "key": "k8s.persistentvolume.annotations.example.com/annotation",
-            "value": {
-              "stringValue": "example-annotation"
-            }
-          },
-          {
-            "key": "k8s.persistentvolume.annotations.pv.kubernetes.io/bound-by-controller",
-            "value": {
-              "stringValue": "yes"
-            }
-          },
-          {
-            "key": "k8s.persistentvolume.labels.example.com/label",
-            "value": {
-              "stringValue": "example-label"
-            }
-          },
-          {
-            "key": "k8s.persistentvolume.labels.type",
-            "value": {
-              "stringValue": "local"
-            }
-          },
-          {
-            "key": "k8s.persistentvolume.name",
-            "value": {
-              "stringValue": "test-pv"
-            }
-          },
-          {
-            "key": "k8s.pod.annotations.test-annotation",
-            "value": {
-              "stringValue": "test-value"
-            }
-          },
-          {
-            "key": "k8s.pod.labels.app",
-            "value": {
-              "stringValue": "test-pod"
-            }
-          },
-          {
-            "key": "k8s.pod.name",
-            "value": {
-              "stringValue": "test-pod"
-            }
-          },
-          {
-            "key": "namespace",
-            "value": {
-              "stringValue": "test-namespace"
-            }
-          },
-          {
-            "key": "net.host.name",
-            "value": {
-              "stringValue": "test-node"
-            }
-          },
-          {
-            "key": "net.host.port",
-            "value": {
-              "stringValue": ""
-            }
-          },
-          {
-            "key": "persistentvolume",
-            "value": {
-              "stringValue": "test-pv"
-            }
-          },
-          {
-            "key": "pod",
-            "value": {
-              "stringValue": "test-pod"
-            }
-          },
-          {
-            "key": "sw.k8s.agent.app.version",
-            "value": {
-              "stringValue": "0.8.1"
-            }
-          },
-          {
-            "key": "sw.k8s.agent.manifest.version",
-            "value": {
-              "stringValue": "2.7.0-alpha.6"
-            }
-          },
-          {
-            "key": "sw.k8s.cluster.uid",
-            "value": {
-              "stringValue": "cluster-uid-123456789"
-            }
-          }
-        ]
-      },
-      "scopeMetrics": [
-        {
-          "metrics": [
-            {
-              "gauge": {
-                "dataPoints": [
-                  {
-                    "asDouble": 107374182400,
-                    "attributes": [
-                      {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "tcp-model"
-                        }
-                      },
-                      {
-                        "key": "prometheus",
-                        "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
-                        }
-                      },
-                      {
-                        "key": "prometheus_replica",
-                        "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
-                        }
-                      },
-                      {
-                        "key": "service",
-                        "value": {
-                          "stringValue": "test-service"
-                        }
-                      }
-                    ],
-                    "timeUnixNano": "0"
-                  }
-                ]
-              },
-              "name": "k8s.kube_persistentvolume_capacity_bytes"
-            },
-            {
-              "gauge": {
-                "dataPoints": [
-                  {
-                    "asDouble": 0,
-                    "attributes": [
-                      {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "http"
-                        }
-                      },
-                      {
-                        "key": "phase",
-                        "value": {
-                          "stringValue": "Released"
-                        }
-                      },
-                      {
-                        "key": "prometheus",
-                        "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
-                        }
-                      },
-                      {
-                        "key": "prometheus_replica",
-                        "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
-                        }
-                      },
-                      {
-                        "key": "service",
-                        "value": {
-                          "stringValue": "test-service"
-                        }
-                      }
-                    ],
-                    "timeUnixNano": "0"
-                  }
-                ]
-              },
-              "name": "k8s.kube_persistentvolume_status_phase"
-            }
-          ],
-          "scope": {}
-        }
-      ]
-    },
-    {
-      "resource": {
-        "attributes": [
-          {
-            "key": "container",
-            "value": {
-              "stringValue": "test-container"
-            }
-          },
-          {
-            "key": "http.scheme",
-            "value": {
-              "stringValue": "http"
-            }
-          },
-          {
-            "key": "k8s.cluster.name",
-            "value": {
-              "stringValue": "cluster name"
-            }
-          },
-          {
-            "key": "k8s.container.name",
-            "value": {
-              "stringValue": "test-container"
-            }
-          },
-          {
-            "key": "k8s.namespace.annotations.description",
-            "value": {
-              "stringValue": "This is a test namespace."
-            }
-          },
-          {
-            "key": "k8s.namespace.labels.app",
-            "value": {
-              "stringValue": "test-app"
-            }
-          },
-          {
-            "key": "k8s.namespace.labels.kubernetes.io/metadata.name",
-            "value": {
-              "stringValue": "test-namespace"
-            }
-          },
-          {
-            "key": "k8s.namespace.labels.purpose",
-            "value": {
-              "stringValue": "testing"
-            }
-          },
-          {
-            "key": "k8s.namespace.name",
-            "value": {
-              "stringValue": "test-namespace"
-            }
-          },
-          {
-            "key": "k8s.persistentvolume.name",
-            "value": {
-              "stringValue": "pvc-6a8b6907-4bef-4d47-88d6-668cf699e6b0"
-            }
-          },
-          {
-            "key": "k8s.persistentvolumeclaim.annotations.example.com/annotation",
-            "value": {
-              "stringValue": "example-annotation"
-            }
-          },
-          {
-            "key": "k8s.persistentvolumeclaim.annotations.pv.kubernetes.io/bind-completed",
-            "value": {
-              "stringValue": "yes"
-            }
-          },
-          {
-            "key": "k8s.persistentvolumeclaim.annotations.pv.kubernetes.io/bound-by-controller",
-            "value": {
-              "stringValue": "yes"
-            }
-          },
-          {
-            "key": "k8s.persistentvolumeclaim.labels.example.com/label",
-            "value": {
-              "stringValue": "example-label"
-            }
-          },
-          {
-            "key": "k8s.persistentvolumeclaim.name",
-            "value": {
-              "stringValue": "test-pvc"
-            }
-          },
-          {
-            "key": "k8s.pod.annotations.test-annotation",
-            "value": {
-              "stringValue": "test-value"
-            }
-          },
-          {
-            "key": "k8s.pod.labels.app",
-            "value": {
-              "stringValue": "test-pod"
-            }
-          },
-          {
-            "key": "k8s.pod.name",
-            "value": {
-              "stringValue": "test-pod"
-            }
-          },
-          {
-            "key": "namespace",
-            "value": {
-              "stringValue": "test-namespace"
-            }
-          },
-          {
-            "key": "net.host.name",
-            "value": {
-              "stringValue": "test-node"
-            }
-          },
-          {
-            "key": "net.host.port",
-            "value": {
-              "stringValue": ""
-            }
-          },
-          {
-            "key": "persistentvolume",
-            "value": {
-              "stringValue": "pvc-6a8b6907-4bef-4d47-88d6-668cf699e6b0"
-            }
-          },
-          {
-            "key": "persistentvolumeclaim",
-            "value": {
-              "stringValue": "test-pvc"
-            }
-          },
-          {
-            "key": "pod",
-            "value": {
-              "stringValue": "test-pod"
-            }
-          },
-          {
-            "key": "storageclass",
-            "value": {
-              "stringValue": "gp3-xfs-encrypted"
-            }
-          },
-          {
-            "key": "sw.k8s.agent.app.version",
-            "value": {
-              "stringValue": "0.8.1"
-            }
-          },
-          {
-            "key": "sw.k8s.agent.manifest.version",
-            "value": {
-              "stringValue": "2.7.0-alpha.6"
-            }
-          },
-          {
-            "key": "sw.k8s.cluster.uid",
-            "value": {
-              "stringValue": "cluster-uid-123456789"
-            }
-          }
-        ]
-      },
-      "scopeMetrics": [
-        {
-          "metrics": [
-            {
-              "gauge": {
-                "dataPoints": [
-                  {
-                    "asDouble": 1,
-                    "attributes": [
-                      {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "tcp-model"
-                        }
-                      },
-                      {
-                        "key": "prometheus",
-                        "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
-                        }
-                      },
-                      {
-                        "key": "prometheus_replica",
-                        "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
-                        }
-                      },
-                      {
-                        "key": "service",
-                        "value": {
-                          "stringValue": "test-service"
-                        }
-                      },
-                      {
-                        "key": "volumename",
-                        "value": {
-                          "stringValue": "pvc-6a8b6907-4bef-4d47-88d6-668cf699e6b0"
-                        }
-                      }
-                    ],
-                    "timeUnixNano": "0"
-                  }
-                ]
-              },
-              "name": "k8s.kube_persistentvolumeclaim_info"
-            }
-          ],
-          "scope": {}
-        }
-      ]
-    },
-    {
-      "resource": {
-        "attributes": [
-          {
-            "key": "container",
-            "value": {
-              "stringValue": "test-container"
-            }
-          },
-          {
-            "key": "http.scheme",
-            "value": {
-              "stringValue": "http"
-            }
-          },
-          {
-            "key": "k8s.cluster.name",
-            "value": {
-              "stringValue": "cluster name"
-            }
-          },
-          {
-            "key": "k8s.container.name",
-            "value": {
-              "stringValue": "test-container"
-            }
-          },
-          {
-            "key": "k8s.namespace.annotations.description",
-            "value": {
-              "stringValue": "This is a test namespace."
-            }
-          },
-          {
-            "key": "k8s.namespace.labels.app",
-            "value": {
-              "stringValue": "test-app"
-            }
-          },
-          {
-            "key": "k8s.namespace.labels.kubernetes.io/metadata.name",
-            "value": {
-              "stringValue": "test-namespace"
-            }
-          },
-          {
-            "key": "k8s.namespace.labels.purpose",
-            "value": {
-              "stringValue": "testing"
-            }
-          },
-          {
-            "key": "k8s.namespace.name",
-            "value": {
-              "stringValue": "test-namespace"
-            }
-          },
-          {
-            "key": "k8s.persistentvolumeclaim.annotations.example.com/annotation",
-            "value": {
-              "stringValue": "example-annotation"
-            }
-          },
-          {
-            "key": "k8s.persistentvolumeclaim.annotations.pv.kubernetes.io/bind-completed",
-            "value": {
-              "stringValue": "yes"
-            }
-          },
-          {
-            "key": "k8s.persistentvolumeclaim.annotations.pv.kubernetes.io/bound-by-controller",
-            "value": {
-              "stringValue": "yes"
-            }
-          },
-          {
-            "key": "k8s.persistentvolumeclaim.labels.example.com/label",
-            "value": {
-              "stringValue": "example-label"
-            }
-          },
-          {
-            "key": "k8s.persistentvolumeclaim.name",
-            "value": {
-              "stringValue": "test-pvc"
-            }
-          },
-          {
-            "key": "k8s.pod.annotations.test-annotation",
-            "value": {
-              "stringValue": "test-value"
-            }
-          },
-          {
-            "key": "k8s.pod.labels.app",
-            "value": {
-              "stringValue": "test-pod"
-            }
-          },
-          {
-            "key": "k8s.pod.name",
-            "value": {
-              "stringValue": "test-pod"
-            }
-          },
-          {
-            "key": "k8s.pod.uid",
-            "value": {
-              "stringValue": "0eb87a8e-caf5-42f7-8689-a3b36a00232e"
-            }
-          },
-          {
-            "key": "namespace",
-            "value": {
-              "stringValue": "test-namespace"
-            }
-          },
-          {
-            "key": "net.host.name",
-            "value": {
-              "stringValue": "test-node"
-            }
-          },
-          {
-            "key": "net.host.port",
-            "value": {
-              "stringValue": ""
-            }
-          },
-          {
-            "key": "persistentvolumeclaim",
-            "value": {
-              "stringValue": "test-pvc"
-            }
-          },
-          {
-            "key": "pod",
-            "value": {
-              "stringValue": "test-pod"
-            }
-          },
-          {
-            "key": "sw.k8s.agent.app.version",
-            "value": {
-              "stringValue": "0.8.1"
-            }
-          },
-          {
-            "key": "sw.k8s.agent.manifest.version",
-            "value": {
-              "stringValue": "2.7.0-alpha.6"
-            }
-          },
-          {
-            "key": "sw.k8s.cluster.uid",
-            "value": {
-              "stringValue": "cluster-uid-123456789"
-            }
-          },
-          {
-            "key": "uid",
-            "value": {
-              "stringValue": "0eb87a8e-caf5-42f7-8689-a3b36a00232e"
-            }
-          }
-        ]
-      },
-      "scopeMetrics": [
-        {
-          "metrics": [
-            {
-              "gauge": {
-                "dataPoints": [
-                  {
-                    "asDouble": 1,
-                    "attributes": [
-                      {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "http"
-                        }
-                      },
-                      {
-                        "key": "prometheus",
-                        "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
-                        }
-                      },
-                      {
-                        "key": "prometheus_replica",
-                        "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
-                        }
-                      },
-                      {
-                        "key": "service",
-                        "value": {
-                          "stringValue": "test-service"
-                        }
-                      },
-                      {
-                        "key": "volume",
-                        "value": {
-                          "stringValue": "data"
-                        }
-                      }
-                    ],
-                    "timeUnixNano": "0"
-                  }
-                ]
-              },
-              "name": "k8s.kube_pod_spec_volumes_persistentvolumeclaims_info"
-            }
-          ],
-          "scope": {}
-        }
-      ]
-    },
-    {
-      "resource": {
-        "attributes": [
-          {
-            "key": "container",
-            "value": {
-              "stringValue": "test-container"
-            }
-          },
-          {
-            "key": "http.scheme",
-            "value": {
-              "stringValue": "http"
-            }
-          },
-          {
-            "key": "k8s.cluster.name",
-            "value": {
-              "stringValue": "cluster name"
-            }
-          },
-          {
-            "key": "k8s.container.name",
-            "value": {
-              "stringValue": "test-container"
-            }
-          },
-          {
-            "key": "k8s.namespace.annotations.description",
-            "value": {
-              "stringValue": "This is a test namespace."
-            }
-          },
-          {
-            "key": "k8s.namespace.labels.app",
-            "value": {
-              "stringValue": "test-app"
-            }
-          },
-          {
-            "key": "k8s.namespace.labels.kubernetes.io/metadata.name",
-            "value": {
-              "stringValue": "test-namespace"
-            }
-          },
-          {
-            "key": "k8s.namespace.labels.purpose",
-            "value": {
-              "stringValue": "testing"
-            }
-          },
-          {
-            "key": "k8s.namespace.name",
-            "value": {
-              "stringValue": "test-namespace"
-            }
-          },
-          {
-            "key": "k8s.persistentvolumeclaim.annotations.example.com/annotation",
-            "value": {
-              "stringValue": "example-annotation"
-            }
-          },
-          {
-            "key": "k8s.persistentvolumeclaim.annotations.pv.kubernetes.io/bind-completed",
-            "value": {
-              "stringValue": "yes"
-            }
-          },
-          {
-            "key": "k8s.persistentvolumeclaim.annotations.pv.kubernetes.io/bound-by-controller",
-            "value": {
-              "stringValue": "yes"
-            }
-          },
-          {
-            "key": "k8s.persistentvolumeclaim.labels.example.com/label",
-            "value": {
-              "stringValue": "example-label"
-            }
-          },
-          {
-            "key": "k8s.persistentvolumeclaim.name",
-            "value": {
-              "stringValue": "test-pvc"
-            }
-          },
-          {
-            "key": "k8s.pod.annotations.test-annotation",
-            "value": {
-              "stringValue": "test-value"
-            }
-          },
-          {
-            "key": "k8s.pod.labels.app",
-            "value": {
-              "stringValue": "test-pod"
-            }
-          },
-          {
-            "key": "k8s.pod.name",
-            "value": {
-              "stringValue": "test-pod"
-            }
-          },
-          {
-            "key": "namespace",
-            "value": {
-              "stringValue": "test-namespace"
-            }
-          },
-          {
-            "key": "net.host.name",
-            "value": {
-              "stringValue": "test-node"
-            }
-          },
-          {
-            "key": "net.host.port",
-            "value": {
-              "stringValue": ""
-            }
-          },
-          {
-            "key": "persistentvolumeclaim",
-            "value": {
-              "stringValue": "test-pvc"
-            }
-          },
-          {
-            "key": "pod",
-            "value": {
-              "stringValue": "test-pod"
-            }
-          },
-          {
-            "key": "sw.k8s.agent.app.version",
-            "value": {
-              "stringValue": "0.8.1"
-            }
-          },
-          {
-            "key": "sw.k8s.agent.manifest.version",
-            "value": {
-              "stringValue": "2.7.0-alpha.6"
-            }
-          },
-          {
-            "key": "sw.k8s.cluster.uid",
-            "value": {
-              "stringValue": "cluster-uid-123456789"
-            }
-          }
-        ]
-      },
-      "scopeMetrics": [
-        {
-          "metrics": [
-            {
-              "gauge": {
-                "dataPoints": [
-                  {
-                    "asDouble": 107374182400,
-                    "attributes": [
-                      {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "tcp-model"
-                        }
-                      },
-                      {
-                        "key": "prometheus",
-                        "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
-                        }
-                      },
-                      {
-                        "key": "prometheus_replica",
-                        "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
-                        }
-                      },
-                      {
-                        "key": "service",
-                        "value": {
-                          "stringValue": "test-service"
-                        }
-                      }
-                    ],
-                    "timeUnixNano": "0"
-                  }
-                ]
-              },
-              "name": "k8s.kube_persistentvolumeclaim_resource_requests_storage_bytes"
-            },
-            {
-              "gauge": {
-                "dataPoints": [
-                  {
-                    "asDouble": 1,
-                    "attributes": [
-                      {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "http"
-                        }
-                      },
-                      {
-                        "key": "phase",
-                        "value": {
-                          "stringValue": "Bound"
-                        }
-                      },
-                      {
-                        "key": "prometheus",
-                        "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
-                        }
-                      },
-                      {
-                        "key": "prometheus_replica",
-                        "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
-                        }
-                      },
-                      {
-                        "key": "service",
-                        "value": {
-                          "stringValue": "test-service"
-                        }
-                      }
-                    ],
-                    "timeUnixNano": "0"
-                  }
-                ]
-              },
-              "name": "k8s.kube_persistentvolumeclaim_status_phase"
-            }
-          ],
-          "scope": {}
-        }
-      ]
-    },
-    {
-      "resource": {
-        "attributes": [
-          {
-            "key": "container",
-            "value": {
-              "stringValue": "test-container"
-            }
-          },
-          {
-            "key": "http.scheme",
-            "value": {
-              "stringValue": "http"
-            }
-          },
-          {
-            "key": "k8s.cluster.name",
-            "value": {
-              "stringValue": "cluster name"
-            }
-          },
-          {
-            "key": "k8s.container.name",
-            "value": {
-              "stringValue": "test-container"
-            }
-          },
-          {
-            "key": "k8s.namespace.annotations.description",
-            "value": {
-              "stringValue": "This is a test namespace."
-            }
-          },
-          {
-            "key": "k8s.namespace.labels.app",
-            "value": {
-              "stringValue": "test-app"
-            }
-          },
-          {
-            "key": "k8s.namespace.labels.kubernetes.io/metadata.name",
-            "value": {
-              "stringValue": "test-namespace"
-            }
-          },
-          {
-            "key": "k8s.namespace.labels.purpose",
-            "value": {
-              "stringValue": "testing"
-            }
-          },
-          {
-            "key": "k8s.namespace.name",
-            "value": {
-              "stringValue": "test-namespace"
-            }
-          },
-          {
-            "key": "k8s.persistentvolumeclaim.annotations.example.com/annotation",
-            "value": {
-              "stringValue": "example-annotation"
-            }
-          },
-          {
-            "key": "k8s.persistentvolumeclaim.annotations.pv.kubernetes.io/bind-completed",
-            "value": {
-              "stringValue": "yes"
-            }
-          },
-          {
-            "key": "k8s.persistentvolumeclaim.annotations.pv.kubernetes.io/bound-by-controller",
-            "value": {
-              "stringValue": "yes"
-            }
-          },
-          {
-            "key": "k8s.persistentvolumeclaim.labels.example.com/label",
-            "value": {
-              "stringValue": "example-label"
-            }
-          },
-          {
-            "key": "k8s.persistentvolumeclaim.name",
-            "value": {
-              "stringValue": "test-pvc"
-            }
-          },
-          {
-            "key": "k8s.pod.annotations.test-annotation",
-            "value": {
-              "stringValue": "test-value"
-            }
-          },
-          {
-            "key": "k8s.pod.labels.app",
-            "value": {
-              "stringValue": "test-pod"
-            }
-          },
-          {
-            "key": "k8s.pod.name",
-            "value": {
-              "stringValue": "test-pod"
-            }
-          },
-          {
-            "key": "namespace",
-            "value": {
-              "stringValue": "test-namespace"
-            }
-          },
-          {
-            "key": "net.host.name",
-            "value": {
-              "stringValue": "test-node"
-            }
-          },
-          {
-            "key": "net.host.port",
-            "value": {
-              "stringValue": ""
-            }
-          },
-          {
-            "key": "persistentvolumeclaim",
-            "value": {
-              "stringValue": "test-pvc"
-            }
-          },
-          {
-            "key": "pod",
-            "value": {
-              "stringValue": "test-pod"
-            }
-          },
-          {
-            "key": "sw.k8s.agent.app.version",
-            "value": {
-              "stringValue": "0.8.1"
-            }
-          },
-          {
-            "key": "sw.k8s.agent.manifest.version",
-            "value": {
-              "stringValue": "2.7.0-alpha.6"
-            }
-          },
-          {
-            "key": "sw.k8s.cluster.uid",
-            "value": {
-              "stringValue": "cluster-uid-123456789"
-            }
-          },
-          {
-            "key": "sw.k8s.persistentvolumeclaim.status",
-            "value": {
-              "stringValue": "Bound"
-            }
-          }
-        ]
-      },
-      "scopeMetrics": [
-        {
-          "metrics": [
-            {
-              "gauge": {
-                "dataPoints": [
-                  {
-                    "asDouble": 1,
-                    "attributes": [
-                      {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "http"
-                        }
-                      },
-                      {
-                        "key": "prometheus",
-                        "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
-                        }
-                      },
-                      {
-                        "key": "prometheus_replica",
-                        "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
-                        }
-                      },
-                      {
-                        "key": "service",
-                        "value": {
-                          "stringValue": "test-service"
-                        }
-                      }
-                    ],
-                    "timeUnixNano": "0"
-                  }
-                ]
-              },
-              "name": "k8s.persistentvolumeclaim.status.phase"
-            }
-          ],
-          "scope": {}
-        }
-      ]
-    },
-    {
-      "resource": {
-        "attributes": [
-          {
-            "key": "container",
-            "value": {
-              "stringValue": "test-container"
-            }
-          },
-          {
-            "key": "http.scheme",
-            "value": {
-              "stringValue": "http"
-            }
-          },
-          {
-            "key": "k8s.cluster.name",
-            "value": {
-              "stringValue": "cluster name"
-            }
-          },
-          {
-            "key": "k8s.container.name",
-            "value": {
-              "stringValue": "test-container"
-            }
-          },
-          {
-            "key": "k8s.namespace.annotations.description",
-            "value": {
-              "stringValue": "This is a test namespace."
-            }
-          },
-          {
-            "key": "k8s.namespace.labels.app",
-            "value": {
-              "stringValue": "test-app"
-            }
-          },
-          {
-            "key": "k8s.namespace.labels.kubernetes.io/metadata.name",
-            "value": {
-              "stringValue": "test-namespace"
-            }
-          },
-          {
-            "key": "k8s.namespace.labels.purpose",
-            "value": {
-              "stringValue": "testing"
-            }
-          },
-          {
-            "key": "k8s.namespace.name",
-            "value": {
-              "stringValue": "test-namespace"
-            }
-          },
-          {
-            "key": "k8s.pod.annotations.test-annotation",
-            "value": {
-              "stringValue": "test-value"
-            }
-          },
-          {
-            "key": "k8s.pod.labels.app",
-            "value": {
-              "stringValue": "test-pod"
-            }
-          },
-          {
-            "key": "k8s.pod.name",
-            "value": {
-              "stringValue": "test-pod"
-            }
-          },
-          {
-            "key": "k8s.pod.uid",
-            "value": {
-              "stringValue": "03d2b55c-b225-476b-9178-c74f8e5eaba2"
-            }
-          },
-          {
-            "key": "namespace",
-            "value": {
-              "stringValue": "test-namespace"
-            }
-          },
-          {
-            "key": "net.host.name",
-            "value": {
-              "stringValue": "test-node"
-            }
-          },
-          {
-            "key": "net.host.port",
-            "value": {
-              "stringValue": ""
-            }
-          },
-          {
-            "key": "pod",
-            "value": {
-              "stringValue": "test-pod"
-            }
-          },
-          {
-            "key": "sw.k8s.agent.app.version",
-            "value": {
-              "stringValue": "0.8.1"
-            }
-          },
-          {
-            "key": "sw.k8s.agent.manifest.version",
-            "value": {
-              "stringValue": "2.7.0-alpha.6"
-            }
-          },
-          {
-            "key": "sw.k8s.cluster.uid",
-            "value": {
-              "stringValue": "cluster-uid-123456789"
-            }
-          },
-          {
-            "key": "sw.k8s.container.init",
-            "value": {
-              "stringValue": "false"
-            }
-          },
-          {
-            "key": "sw.k8s.container.status",
-            "value": {
-              "stringValue": "running"
-            }
-          },
-          {
-            "key": "uid",
-            "value": {
-              "stringValue": "03d2b55c-b225-476b-9178-c74f8e5eaba2"
-            }
-          }
-        ]
-      },
-      "scopeMetrics": [
-        {
-          "metrics": [
-            {
-              "gauge": {
-                "dataPoints": [
-                  {
-                    "asDouble": 1,
-                    "attributes": [
-                      {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "http"
-                        }
-                      },
-                      {
-                        "key": "prometheus",
-                        "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
-                        }
-                      },
-                      {
-                        "key": "prometheus_replica",
-                        "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
-                        }
-                      },
-                      {
-                        "key": "service",
-                        "value": {
-                          "stringValue": "test-service"
-                        }
-                      }
-                    ],
-                    "timeUnixNano": "0"
-                  }
-                ]
-              },
-              "name": "k8s.container.status"
-            }
-          ],
-          "scope": {}
-        }
-      ]
-    },
-    {
-      "resource": {
-        "attributes": [
-          {
-            "key": "container",
-            "value": {
-              "stringValue": "test-container"
-            }
-          },
-          {
-            "key": "http.scheme",
-            "value": {
-              "stringValue": "http"
-            }
-          },
-          {
-            "key": "k8s.cluster.name",
-            "value": {
-              "stringValue": "cluster name"
-            }
-          },
-          {
-            "key": "k8s.container.name",
-            "value": {
-              "stringValue": "test-container"
-            }
-          },
-          {
-            "key": "k8s.namespace.annotations.description",
-            "value": {
-              "stringValue": "This is a test namespace."
-            }
-          },
-          {
-            "key": "k8s.namespace.labels.app",
-            "value": {
-              "stringValue": "test-app"
-            }
-          },
-          {
-            "key": "k8s.namespace.labels.kubernetes.io/metadata.name",
-            "value": {
-              "stringValue": "test-namespace"
-            }
-          },
-          {
-            "key": "k8s.namespace.labels.purpose",
-            "value": {
-              "stringValue": "testing"
-            }
-          },
-          {
-            "key": "k8s.namespace.name",
-            "value": {
-              "stringValue": "test-namespace"
-            }
-          },
-          {
-            "key": "k8s.pod.annotations.test-annotation",
-            "value": {
-              "stringValue": "test-value"
-            }
-          },
-          {
-            "key": "k8s.pod.labels.app",
-            "value": {
-              "stringValue": "test-pod"
-            }
-          },
-          {
-            "key": "k8s.pod.name",
-            "value": {
-              "stringValue": "test-pod"
-            }
-          },
-          {
-            "key": "k8s.pod.uid",
-            "value": {
-              "stringValue": "03d2b55c-b225-476b-9178-c74f8e5eaba2"
-            }
-          },
-          {
-            "key": "namespace",
-            "value": {
-              "stringValue": "test-namespace"
-            }
-          },
-          {
-            "key": "net.host.name",
-            "value": {
-              "stringValue": "test-node"
-            }
-          },
-          {
-            "key": "net.host.port",
-            "value": {
-              "stringValue": ""
-            }
-          },
-          {
-            "key": "pod",
-            "value": {
-              "stringValue": "test-pod"
-            }
-          },
-          {
-            "key": "sw.k8s.agent.app.version",
-            "value": {
-              "stringValue": "0.8.1"
-            }
-          },
-          {
-            "key": "sw.k8s.agent.manifest.version",
-            "value": {
-              "stringValue": "2.7.0-alpha.6"
-            }
-          },
-          {
-            "key": "sw.k8s.cluster.uid",
-            "value": {
-              "stringValue": "cluster-uid-123456789"
-            }
-          },
-          {
-            "key": "sw.k8s.container.init",
-            "value": {
-              "stringValue": "false"
-            }
-          },
-          {
-            "key": "uid",
-            "value": {
-              "stringValue": "03d2b55c-b225-476b-9178-c74f8e5eaba2"
-            }
-          }
-        ]
-      },
-      "scopeMetrics": [
-        {
-          "metrics": [
-            {
-              "gauge": {
-                "dataPoints": [
-                  {
-                    "asDouble": 1,
-                    "attributes": [
-                      {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "http"
-                        }
-                      },
-                      {
-                        "key": "prometheus",
-                        "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
-                        }
-                      },
-                      {
-                        "key": "prometheus_replica",
-                        "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
-                        }
-                      },
-                      {
-                        "key": "service",
-                        "value": {
-                          "stringValue": "test-service"
-                        }
-                      }
-                    ],
-                    "timeUnixNano": "0"
-                  }
-                ]
-              },
-              "name": "k8s.kube_pod_container_status_ready"
-            },
-            {
-              "name": "k8s.kube_pod_container_status_restarts_total",
-              "sum": {
-                "aggregationTemporality": 2,
-                "dataPoints": [
-                  {
-                    "asDouble": 0,
-                    "attributes": [
-                      {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "http"
-                        }
-                      },
-                      {
-                        "key": "prometheus",
-                        "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
-                        }
-                      },
-                      {
-                        "key": "prometheus_replica",
-                        "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
-                        }
-                      },
-                      {
-                        "key": "service",
-                        "value": {
-                          "stringValue": "test-service"
-                        }
-                      }
-                    ],
-                    "timeUnixNano": "0"
-                  }
-                ],
-                "isMonotonic": true
-              }
-            },
-            {
-              "gauge": {
-                "dataPoints": [
-                  {
-                    "asDouble": 1,
-                    "attributes": [
-                      {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "http"
-                        }
-                      },
-                      {
-                        "key": "prometheus",
-                        "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
-                        }
-                      },
-                      {
-                        "key": "prometheus_replica",
-                        "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
-                        }
-                      },
-                      {
-                        "key": "service",
-                        "value": {
-                          "stringValue": "test-service"
-                        }
-                      }
-                    ],
-                    "timeUnixNano": "0"
-                  }
-                ]
-              },
-              "name": "k8s.kube_pod_container_status_running"
-            },
-            {
-              "gauge": {
-                "dataPoints": [
-                  {
-                    "asDouble": 0,
-                    "attributes": [
-                      {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "http"
-                        }
-                      },
-                      {
-                        "key": "prometheus",
-                        "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
-                        }
-                      },
-                      {
-                        "key": "prometheus_replica",
-                        "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
-                        }
-                      },
-                      {
-                        "key": "service",
-                        "value": {
-                          "stringValue": "test-service"
-                        }
-                      }
-                    ],
-                    "timeUnixNano": "0"
-                  }
-                ]
-              },
-              "name": "k8s.kube_pod_container_status_waiting"
-            }
-          ],
-          "scope": {}
-        }
-      ]
-    },
-    {
-      "resource": {
-        "attributes": [
-          {
-            "key": "container",
-            "value": {
-              "stringValue": "test-container"
-            }
-          },
-          {
-            "key": "http.scheme",
-            "value": {
-              "stringValue": "http"
-            }
-          },
-          {
-            "key": "k8s.cluster.name",
-            "value": {
-              "stringValue": "cluster name"
-            }
-          },
-          {
-            "key": "k8s.container.name",
-            "value": {
-              "stringValue": "test-container"
-            }
-          },
-          {
-            "key": "k8s.namespace.annotations.description",
-            "value": {
-              "stringValue": "This is a test namespace."
-            }
-          },
-          {
-            "key": "k8s.namespace.labels.app",
-            "value": {
-              "stringValue": "test-app"
-            }
-          },
-          {
-            "key": "k8s.namespace.labels.kubernetes.io/metadata.name",
-            "value": {
-              "stringValue": "test-namespace"
-            }
-          },
-          {
-            "key": "k8s.namespace.labels.purpose",
-            "value": {
-              "stringValue": "testing"
-            }
-          },
-          {
-            "key": "k8s.namespace.name",
-            "value": {
-              "stringValue": "test-namespace"
-            }
-          },
-          {
-            "key": "k8s.pod.annotations.test-annotation",
-            "value": {
-              "stringValue": "test-value"
-            }
-          },
-          {
-            "key": "k8s.pod.labels.app",
-            "value": {
-              "stringValue": "test-pod"
-            }
-          },
-          {
-            "key": "k8s.pod.name",
-            "value": {
-              "stringValue": "test-pod"
-            }
-          },
-          {
-            "key": "k8s.pod.uid",
-            "value": {
-              "stringValue": "0eb87a8e-caf5-42f7-8689-a3b36a00232e"
-            }
-          },
-          {
-            "key": "namespace",
-            "value": {
-              "stringValue": "test-namespace"
-            }
-          },
-          {
-            "key": "net.host.name",
-            "value": {
-              "stringValue": "test-node"
-            }
-          },
-          {
-            "key": "net.host.port",
-            "value": {
-              "stringValue": ""
-            }
-          },
-          {
-            "key": "pod",
-            "value": {
-              "stringValue": "test-pod"
-            }
-          },
-          {
-            "key": "sw.k8s.agent.app.version",
-            "value": {
-              "stringValue": "0.8.1"
-            }
-          },
-          {
-            "key": "sw.k8s.agent.manifest.version",
-            "value": {
-              "stringValue": "2.7.0-alpha.6"
-            }
-          },
-          {
-            "key": "sw.k8s.cluster.uid",
-            "value": {
-              "stringValue": "cluster-uid-123456789"
-            }
-          },
-          {
-            "key": "uid",
-            "value": {
-              "stringValue": "0eb87a8e-caf5-42f7-8689-a3b36a00232e"
-            }
-          }
-        ]
-      },
-      "scopeMetrics": [
-        {
-          "metrics": [
-            {
-              "gauge": {
-                "dataPoints": [
-                  {
-                    "asDouble": 1679919168,
-                    "attributes": [
-                      {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "http"
-                        }
-                      },
-                      {
-                        "key": "prometheus",
-                        "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
-                        }
-                      },
-                      {
-                        "key": "prometheus_replica",
-                        "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
-                        }
-                      },
-                      {
-                        "key": "service",
-                        "value": {
-                          "stringValue": "test-service"
-                        }
-                      }
-                    ],
-                    "timeUnixNano": "0"
-                  }
-                ]
-              },
-              "name": "k8s.kube_pod_created"
-            },
-            {
-              "gauge": {
-                "dataPoints": [
-                  {
-                    "asDouble": 0,
-                    "attributes": [
-                      {
-                        "key": "condition",
-                        "value": {
-                          "stringValue": "unknown"
-                        }
-                      },
-                      {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "http"
-                        }
-                      },
-                      {
-                        "key": "prometheus",
-                        "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
-                        }
-                      },
-                      {
-                        "key": "prometheus_replica",
-                        "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
-                        }
-                      },
-                      {
-                        "key": "service",
-                        "value": {
-                          "stringValue": "test-service"
-                        }
-                      }
-                    ],
-                    "timeUnixNano": "0"
-                  }
-                ]
-              },
-              "name": "k8s.kube_pod_status_ready"
-            }
-          ],
-          "scope": {}
-        }
-      ]
-    },
-    {
-      "resource": {
-        "attributes": [
-          {
-            "key": "container",
-            "value": {
-              "stringValue": "test-container"
-            }
-          },
-          {
-            "key": "http.scheme",
-            "value": {
-              "stringValue": "http"
-            }
-          },
-          {
-            "key": "k8s.cluster.name",
-            "value": {
-              "stringValue": "cluster name"
-            }
-          },
-          {
-            "key": "k8s.container.name",
-            "value": {
-              "stringValue": "test-container"
-            }
-          },
-          {
-            "key": "k8s.namespace.annotations.description",
-            "value": {
-              "stringValue": "This is a test namespace."
-            }
-          },
-          {
-            "key": "k8s.namespace.labels.app",
-            "value": {
-              "stringValue": "test-app"
-            }
-          },
-          {
-            "key": "k8s.namespace.labels.kubernetes.io/metadata.name",
-            "value": {
-              "stringValue": "test-namespace"
-            }
-          },
-          {
-            "key": "k8s.namespace.labels.purpose",
-            "value": {
-              "stringValue": "testing"
-            }
-          },
-          {
-            "key": "k8s.namespace.name",
-            "value": {
-              "stringValue": "test-namespace"
-            }
-          },
-          {
-            "key": "k8s.pod.annotations.test-annotation",
-            "value": {
-              "stringValue": "test-value"
-            }
-          },
-          {
-            "key": "k8s.pod.labels.app",
-            "value": {
-              "stringValue": "test-pod"
-            }
-          },
-          {
-            "key": "k8s.pod.name",
-            "value": {
-              "stringValue": "test-pod"
-            }
-          },
-          {
-            "key": "k8s.pod.uid",
-            "value": {
-              "stringValue": "1263fc71-9ca0-468f-aa93-c6aba4e7e7fd"
-            }
-          },
-          {
-            "key": "namespace",
-            "value": {
-              "stringValue": "test-namespace"
-            }
-          },
-          {
-            "key": "net.host.name",
-            "value": {
-              "stringValue": "test-node"
-            }
-          },
-          {
-            "key": "net.host.port",
-            "value": {
-              "stringValue": ""
-            }
-          },
-          {
-            "key": "pod",
-            "value": {
-              "stringValue": "test-pod"
-            }
-          },
-          {
-            "key": "sw.k8s.agent.app.version",
-            "value": {
-              "stringValue": "0.8.1"
-            }
-          },
-          {
-            "key": "sw.k8s.agent.manifest.version",
-            "value": {
-              "stringValue": "2.7.0-alpha.6"
-            }
-          },
-          {
-            "key": "sw.k8s.cluster.uid",
-            "value": {
-              "stringValue": "cluster-uid-123456789"
-            }
-          },
-          {
-            "key": "uid",
-            "value": {
-              "stringValue": "1263fc71-9ca0-468f-aa93-c6aba4e7e7fd"
-            }
-          }
-        ]
-      },
-      "scopeMetrics": [
-        {
-          "metrics": [
-            {
-              "gauge": {
-                "dataPoints": [
-                  {
-                    "asDouble": 1679473328,
-                    "attributes": [
-                      {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "http"
-                        }
-                      },
-                      {
-                        "key": "prometheus",
-                        "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
-                        }
-                      },
-                      {
-                        "key": "prometheus_replica",
-                        "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
-                        }
-                      },
-                      {
-                        "key": "service",
-                        "value": {
-                          "stringValue": "test-service"
-                        }
-                      }
-                    ],
-                    "timeUnixNano": "0"
-                  }
-                ]
-              },
-              "name": "k8s.kube_pod_start_time"
-            }
-          ],
-          "scope": {}
-        }
-      ]
-    },
-    {
-      "resource": {
-        "attributes": [
-          {
-            "key": "container",
-            "value": {
-              "stringValue": "test-container"
-            }
-          },
-          {
-            "key": "http.scheme",
-            "value": {
-              "stringValue": "http"
-            }
-          },
-          {
-            "key": "k8s.cluster.name",
-            "value": {
-              "stringValue": "cluster name"
-            }
-          },
-          {
-            "key": "k8s.container.name",
-            "value": {
-              "stringValue": "test-container"
-            }
-          },
-          {
-            "key": "k8s.namespace.annotations.description",
-            "value": {
-              "stringValue": "This is a test namespace."
-            }
-          },
-          {
-            "key": "k8s.namespace.labels.app",
-            "value": {
-              "stringValue": "test-app"
-            }
-          },
-          {
-            "key": "k8s.namespace.labels.kubernetes.io/metadata.name",
-            "value": {
-              "stringValue": "test-namespace"
-            }
-          },
-          {
-            "key": "k8s.namespace.labels.purpose",
-            "value": {
-              "stringValue": "testing"
-            }
-          },
-          {
-            "key": "k8s.namespace.name",
-            "value": {
-              "stringValue": "test-namespace"
-            }
-          },
-          {
-            "key": "k8s.pod.annotations.test-annotation",
-            "value": {
-              "stringValue": "test-value"
-            }
-          },
-          {
-            "key": "k8s.pod.labels.app",
-            "value": {
-              "stringValue": "test-pod"
-            }
-          },
-          {
-            "key": "k8s.pod.name",
-            "value": {
-              "stringValue": "test-pod"
-            }
-          },
-          {
-            "key": "k8s.pod.uid",
-            "value": {
-              "stringValue": "1f36cbc1-95aa-40ee-8d06-e3dd4cae8b2f"
-            }
-          },
-          {
-            "key": "namespace",
-            "value": {
-              "stringValue": "test-namespace"
-            }
-          },
-          {
-            "key": "net.host.name",
-            "value": {
-              "stringValue": "test-node"
-            }
-          },
-          {
-            "key": "net.host.port",
-            "value": {
-              "stringValue": ""
-            }
-          },
-          {
-            "key": "pod",
-            "value": {
-              "stringValue": "test-pod"
-            }
-          },
-          {
-            "key": "sw.k8s.agent.app.version",
-            "value": {
-              "stringValue": "0.8.1"
-            }
-          },
-          {
-            "key": "sw.k8s.agent.manifest.version",
-            "value": {
-              "stringValue": "2.7.0-alpha.6"
-            }
-          },
-          {
-            "key": "sw.k8s.cluster.uid",
-            "value": {
-              "stringValue": "cluster-uid-123456789"
-            }
-          },
-          {
-            "key": "sw.k8s.container.init",
-            "value": {
-              "stringValue": "false"
-            }
-          },
-          {
-            "key": "uid",
-            "value": {
-              "stringValue": "1f36cbc1-95aa-40ee-8d06-e3dd4cae8b2f"
-            }
-          }
-        ]
-      },
-      "scopeMetrics": [
-        {
-          "metrics": [
-            {
-              "gauge": {
-                "dataPoints": [
-                  {
-                    "asDouble": 0,
-                    "attributes": [
-                      {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "http"
-                        }
-                      },
-                      {
-                        "key": "prometheus",
-                        "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
-                        }
-                      },
-                      {
-                        "key": "prometheus_replica",
-                        "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
-                        }
-                      },
-                      {
-                        "key": "service",
-                        "value": {
-                          "stringValue": "test-service"
-                        }
-                      }
-                    ],
-                    "timeUnixNano": "0"
-                  }
-                ]
-              },
-              "name": "k8s.kube_pod_container_status_terminated"
-            }
-          ],
-          "scope": {}
-        }
-      ]
-    },
-    {
-      "resource": {
-        "attributes": [
-          {
-            "key": "container",
-            "value": {
-              "stringValue": "test-container"
-            }
-          },
-          {
-            "key": "http.scheme",
-            "value": {
-              "stringValue": "http"
-            }
-          },
-          {
-            "key": "k8s.cluster.name",
-            "value": {
-              "stringValue": "cluster name"
-            }
-          },
-          {
-            "key": "k8s.container.name",
-            "value": {
-              "stringValue": "test-container"
-            }
-          },
-          {
-            "key": "k8s.namespace.annotations.description",
-            "value": {
-              "stringValue": "This is a test namespace."
-            }
-          },
-          {
-            "key": "k8s.namespace.labels.app",
-            "value": {
-              "stringValue": "test-app"
-            }
-          },
-          {
-            "key": "k8s.namespace.labels.kubernetes.io/metadata.name",
-            "value": {
-              "stringValue": "test-namespace"
-            }
-          },
-          {
-            "key": "k8s.namespace.labels.purpose",
-            "value": {
-              "stringValue": "testing"
-            }
-          },
-          {
-            "key": "k8s.namespace.name",
-            "value": {
-              "stringValue": "test-namespace"
-            }
-          },
-          {
-            "key": "k8s.pod.annotations.test-annotation",
-            "value": {
-              "stringValue": "test-value"
-            }
-          },
-          {
-            "key": "k8s.pod.labels.app",
-            "value": {
-              "stringValue": "test-pod"
-            }
-          },
-          {
-            "key": "k8s.pod.name",
-            "value": {
-              "stringValue": "test-pod"
-            }
-          },
-          {
-            "key": "k8s.pod.uid",
-            "value": {
-              "stringValue": "2a82ed12-a31a-427a-adb9-d14cf6a4a063"
-            }
-          },
-          {
-            "key": "namespace",
-            "value": {
-              "stringValue": "test-namespace"
-            }
-          },
-          {
-            "key": "net.host.name",
-            "value": {
-              "stringValue": "test-node"
-            }
-          },
-          {
-            "key": "net.host.port",
-            "value": {
-              "stringValue": ""
-            }
-          },
-          {
-            "key": "pod",
-            "value": {
-              "stringValue": "test-pod"
-            }
-          },
-          {
-            "key": "sw.k8s.agent.app.version",
-            "value": {
-              "stringValue": "0.8.1"
-            }
-          },
-          {
-            "key": "sw.k8s.agent.manifest.version",
-            "value": {
-              "stringValue": "2.7.0-alpha.6"
-            }
-          },
-          {
-            "key": "sw.k8s.cluster.uid",
-            "value": {
-              "stringValue": "cluster-uid-123456789"
-            }
-          },
-          {
-            "key": "sw.k8s.container.init",
-            "value": {
-              "stringValue": "true"
-            }
-          },
-          {
-            "key": "uid",
-            "value": {
-              "stringValue": "2a82ed12-a31a-427a-adb9-d14cf6a4a063"
-            }
-          }
-        ]
-      },
-      "scopeMetrics": [
-        {
-          "metrics": [
-            {
-              "gauge": {
-                "dataPoints": [
-                  {
-                    "asDouble": 0.1,
-                    "attributes": [
-                      {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "http"
-                        }
-                      },
-                      {
-                        "key": "prometheus",
-                        "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
-                        }
-                      },
-                      {
-                        "key": "prometheus_replica",
-                        "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
-                        }
-                      },
-                      {
-                        "key": "service",
-                        "value": {
-                          "stringValue": "test-service"
-                        }
-                      }
-                    ],
-                    "timeUnixNano": "0"
-                  }
-                ]
-              },
-              "name": "k8s.kube_pod_init_container_resource_limits_cpu_cores"
-            }
-          ],
-          "scope": {}
-        }
-      ]
-    },
-    {
-      "resource": {
-        "attributes": [
-          {
-            "key": "container",
-            "value": {
-              "stringValue": "test-container"
-            }
-          },
-          {
-            "key": "http.scheme",
-            "value": {
-              "stringValue": "http"
-            }
-          },
-          {
-            "key": "k8s.cluster.name",
-            "value": {
-              "stringValue": "cluster name"
-            }
-          },
-          {
-            "key": "k8s.container.name",
-            "value": {
-              "stringValue": "test-container"
-            }
-          },
-          {
-            "key": "k8s.namespace.annotations.description",
-            "value": {
-              "stringValue": "This is a test namespace."
-            }
-          },
-          {
-            "key": "k8s.namespace.labels.app",
-            "value": {
-              "stringValue": "test-app"
-            }
-          },
-          {
-            "key": "k8s.namespace.labels.kubernetes.io/metadata.name",
-            "value": {
-              "stringValue": "test-namespace"
-            }
-          },
-          {
-            "key": "k8s.namespace.labels.purpose",
-            "value": {
-              "stringValue": "testing"
-            }
-          },
-          {
-            "key": "k8s.namespace.name",
-            "value": {
-              "stringValue": "test-namespace"
-            }
-          },
-          {
-            "key": "k8s.pod.annotations.test-annotation",
-            "value": {
-              "stringValue": "test-value"
-            }
-          },
-          {
-            "key": "k8s.pod.labels.app",
-            "value": {
-              "stringValue": "test-pod"
-            }
-          },
-          {
-            "key": "k8s.pod.name",
-            "value": {
-              "stringValue": "test-pod"
-            }
-          },
-          {
-            "key": "k8s.pod.uid",
-            "value": {
-              "stringValue": "3d89e9f1-b348-45c1-96ce-6a2a1f127084"
-            }
-          },
-          {
-            "key": "namespace",
-            "value": {
-              "stringValue": "test-namespace"
-            }
-          },
-          {
-            "key": "net.host.name",
-            "value": {
-              "stringValue": "test-node"
-            }
-          },
-          {
-            "key": "net.host.port",
-            "value": {
-              "stringValue": ""
-            }
-          },
-          {
-            "key": "pod",
-            "value": {
-              "stringValue": "test-pod"
-            }
-          },
-          {
-            "key": "sw.k8s.agent.app.version",
-            "value": {
-              "stringValue": "0.8.1"
-            }
-          },
-          {
-            "key": "sw.k8s.agent.manifest.version",
-            "value": {
-              "stringValue": "2.7.0-alpha.6"
-            }
-          },
-          {
-            "key": "sw.k8s.cluster.uid",
-            "value": {
-              "stringValue": "cluster-uid-123456789"
-            }
-          },
-          {
-            "key": "sw.k8s.container.init",
-            "value": {
-              "stringValue": "false"
-            }
-          },
-          {
-            "key": "uid",
-            "value": {
-              "stringValue": "3d89e9f1-b348-45c1-96ce-6a2a1f127084"
-            }
-          }
-        ]
-      },
-      "scopeMetrics": [
-        {
-          "metrics": [
-            {
-              "gauge": {
-                "dataPoints": [
-                  {
-                    "asDouble": 1,
-                    "attributes": [
-                      {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "http"
-                        }
-                      },
-                      {
-                        "key": "prometheus",
-                        "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
-                        }
-                      },
-                      {
-                        "key": "prometheus_replica",
-                        "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
-                        }
-                      },
-                      {
-                        "key": "reason",
-                        "value": {
-                          "stringValue": "Error"
-                        }
-                      },
-                      {
-                        "key": "service",
-                        "value": {
-                          "stringValue": "test-service"
-                        }
-                      }
-                    ],
-                    "timeUnixNano": "0"
-                  }
-                ]
-              },
-              "name": "k8s.kube_pod_container_status_last_terminated_reason"
-            }
-          ],
-          "scope": {}
-        }
-      ]
-    },
-    {
-      "resource": {
-        "attributes": [
-          {
-            "key": "container",
-            "value": {
-              "stringValue": "test-container"
-            }
-          },
-          {
-            "key": "http.scheme",
-            "value": {
-              "stringValue": "http"
-            }
-          },
-          {
-            "key": "k8s.cluster.name",
-            "value": {
-              "stringValue": "cluster name"
-            }
-          },
-          {
-            "key": "k8s.container.name",
-            "value": {
-              "stringValue": "test-container"
-            }
-          },
-          {
-            "key": "k8s.namespace.annotations.description",
-            "value": {
-              "stringValue": "This is a test namespace."
-            }
-          },
-          {
-            "key": "k8s.namespace.labels.app",
-            "value": {
-              "stringValue": "test-app"
-            }
-          },
-          {
-            "key": "k8s.namespace.labels.kubernetes.io/metadata.name",
-            "value": {
-              "stringValue": "test-namespace"
-            }
-          },
-          {
-            "key": "k8s.namespace.labels.purpose",
-            "value": {
-              "stringValue": "testing"
-            }
-          },
-          {
-            "key": "k8s.namespace.name",
-            "value": {
-              "stringValue": "test-namespace"
-            }
-          },
-          {
-            "key": "k8s.pod.annotations.test-annotation",
-            "value": {
-              "stringValue": "test-value"
-            }
-          },
-          {
-            "key": "k8s.pod.labels.app",
-            "value": {
-              "stringValue": "test-pod"
-            }
-          },
-          {
-            "key": "k8s.pod.name",
-            "value": {
-              "stringValue": "test-pod"
-            }
-          },
-          {
-            "key": "k8s.pod.uid",
-            "value": {
-              "stringValue": "541e045c-feed-490e-88a6-b33b515bf3cf"
-            }
-          },
-          {
-            "key": "namespace",
-            "value": {
-              "stringValue": "test-namespace"
-            }
-          },
-          {
-            "key": "net.host.name",
-            "value": {
-              "stringValue": "test-node"
-            }
-          },
-          {
-            "key": "net.host.port",
-            "value": {
-              "stringValue": ""
-            }
-          },
-          {
-            "key": "pod",
-            "value": {
-              "stringValue": "test-pod"
-            }
-          },
-          {
-            "key": "sw.k8s.agent.app.version",
-            "value": {
-              "stringValue": "0.8.1"
-            }
-          },
-          {
-            "key": "sw.k8s.agent.manifest.version",
-            "value": {
-              "stringValue": "2.7.0-alpha.6"
-            }
-          },
-          {
-            "key": "sw.k8s.cluster.uid",
-            "value": {
-              "stringValue": "cluster-uid-123456789"
-            }
-          },
-          {
-            "key": "sw.k8s.container.init",
-            "value": {
-              "stringValue": "false"
-            }
-          },
-          {
-            "key": "uid",
-            "value": {
-              "stringValue": "541e045c-feed-490e-88a6-b33b515bf3cf"
-            }
-          }
-        ]
-      },
-      "scopeMetrics": [
-        {
-          "metrics": [
-            {
-              "gauge": {
-                "dataPoints": [
-                  {
-                    "asDouble": 1679916695,
-                    "attributes": [
-                      {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "http"
-                        }
-                      },
-                      {
-                        "key": "prometheus",
-                        "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
-                        }
-                      },
-                      {
-                        "key": "prometheus_replica",
-                        "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
-                        }
-                      },
-                      {
-                        "key": "service",
-                        "value": {
-                          "stringValue": "test-service"
-                        }
-                      }
-                    ],
-                    "timeUnixNano": "0"
-                  }
-                ]
-              },
-              "name": "k8s.kube_pod_container_state_started"
-            }
-          ],
-          "scope": {}
-        }
-      ]
-    },
-    {
-      "resource": {
-        "attributes": [
-          {
-            "key": "container",
-            "value": {
-              "stringValue": "test-container"
-            }
-          },
-          {
-            "key": "http.scheme",
-            "value": {
-              "stringValue": "http"
-            }
-          },
-          {
-            "key": "k8s.cluster.name",
-            "value": {
-              "stringValue": "cluster name"
-            }
-          },
-          {
-            "key": "k8s.container.name",
-            "value": {
-              "stringValue": "test-container"
-            }
-          },
-          {
-            "key": "k8s.namespace.annotations.description",
-            "value": {
-              "stringValue": "This is a test namespace."
-            }
-          },
-          {
-            "key": "k8s.namespace.labels.app",
-            "value": {
-              "stringValue": "test-app"
-            }
-          },
-          {
-            "key": "k8s.namespace.labels.kubernetes.io/metadata.name",
-            "value": {
-              "stringValue": "test-namespace"
-            }
-          },
-          {
-            "key": "k8s.namespace.labels.purpose",
-            "value": {
-              "stringValue": "testing"
-            }
-          },
-          {
-            "key": "k8s.namespace.name",
-            "value": {
-              "stringValue": "test-namespace"
-            }
-          },
-          {
-            "key": "k8s.pod.annotations.test-annotation",
-            "value": {
-              "stringValue": "test-value"
-            }
-          },
-          {
-            "key": "k8s.pod.labels.app",
-            "value": {
-              "stringValue": "test-pod"
-            }
-          },
-          {
-            "key": "k8s.pod.name",
-            "value": {
-              "stringValue": "test-pod"
-            }
-          },
-          {
-            "key": "k8s.pod.uid",
-            "value": {
-              "stringValue": "5808b16d-a1bf-414b-a0d8-3e3ae381a1b7"
-            }
-          },
-          {
-            "key": "namespace",
-            "value": {
-              "stringValue": "test-namespace"
-            }
-          },
-          {
-            "key": "net.host.name",
-            "value": {
-              "stringValue": "test-node"
-            }
-          },
-          {
-            "key": "net.host.port",
-            "value": {
-              "stringValue": ""
-            }
-          },
-          {
-            "key": "pod",
-            "value": {
-              "stringValue": "test-pod"
-            }
-          },
-          {
-            "key": "sw.k8s.agent.app.version",
-            "value": {
-              "stringValue": "0.8.1"
-            }
-          },
-          {
-            "key": "sw.k8s.agent.manifest.version",
-            "value": {
-              "stringValue": "2.7.0-alpha.6"
-            }
-          },
-          {
-            "key": "sw.k8s.cluster.uid",
-            "value": {
-              "stringValue": "cluster-uid-123456789"
-            }
-          },
-          {
-            "key": "uid",
-            "value": {
-              "stringValue": "5808b16d-a1bf-414b-a0d8-3e3ae381a1b7"
-            }
-          }
-        ]
-      },
-      "scopeMetrics": [
-        {
-          "metrics": [
-            {
-              "gauge": {
-                "dataPoints": [
-                  {
-                    "asDouble": 1681221684,
-                    "attributes": [
-                      {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "http"
-                        }
-                      },
-                      {
-                        "key": "prometheus",
-                        "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
-                        }
-                      },
-                      {
-                        "key": "prometheus_replica",
-                        "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
-                        }
-                      },
-                      {
-                        "key": "service",
-                        "value": {
-                          "stringValue": "test-service"
-                        }
-                      }
-                    ],
-                    "timeUnixNano": "0"
-                  }
-                ]
-              },
-              "name": "k8s.kube_pod_completion_time"
-            }
-          ],
-          "scope": {}
-        }
-      ]
-    },
-    {
-      "resource": {
-        "attributes": [
-          {
-            "key": "container",
-            "value": {
-              "stringValue": "test-container"
-            }
-          },
-          {
-            "key": "http.scheme",
-            "value": {
-              "stringValue": "http"
-            }
-          },
-          {
-            "key": "k8s.cluster.name",
-            "value": {
-              "stringValue": "cluster name"
-            }
-          },
-          {
-            "key": "k8s.container.name",
-            "value": {
-              "stringValue": "test-container"
-            }
-          },
-          {
-            "key": "k8s.namespace.annotations.description",
-            "value": {
-              "stringValue": "This is a test namespace."
-            }
-          },
-          {
-            "key": "k8s.namespace.labels.app",
-            "value": {
-              "stringValue": "test-app"
-            }
-          },
-          {
-            "key": "k8s.namespace.labels.kubernetes.io/metadata.name",
-            "value": {
-              "stringValue": "test-namespace"
-            }
-          },
-          {
-            "key": "k8s.namespace.labels.purpose",
-            "value": {
-              "stringValue": "testing"
-            }
-          },
-          {
-            "key": "k8s.namespace.name",
-            "value": {
-              "stringValue": "test-namespace"
-            }
-          },
-          {
-            "key": "k8s.pod.annotations.test-annotation",
-            "value": {
-              "stringValue": "test-value"
-            }
-          },
-          {
-            "key": "k8s.pod.labels.app",
-            "value": {
-              "stringValue": "test-pod"
-            }
-          },
-          {
-            "key": "k8s.pod.name",
-            "value": {
-              "stringValue": "test-pod"
-            }
-          },
-          {
-            "key": "k8s.pod.uid",
-            "value": {
-              "stringValue": "64b6d309-44e3-4a41-8883-c15c7cc9bc4a"
-            }
-          },
-          {
-            "key": "namespace",
-            "value": {
-              "stringValue": "test-namespace"
-            }
-          },
-          {
-            "key": "net.host.name",
-            "value": {
-              "stringValue": "test-node"
-            }
-          },
-          {
-            "key": "net.host.port",
-            "value": {
-              "stringValue": ""
-            }
-          },
-          {
-            "key": "pod",
-            "value": {
-              "stringValue": "test-pod"
-            }
-          },
-          {
-            "key": "sw.k8s.agent.app.version",
-            "value": {
-              "stringValue": "0.8.1"
-            }
-          },
-          {
-            "key": "sw.k8s.agent.manifest.version",
-            "value": {
-              "stringValue": "2.7.0-alpha.6"
-            }
-          },
-          {
-            "key": "sw.k8s.cluster.uid",
-            "value": {
-              "stringValue": "cluster-uid-123456789"
-            }
-          },
-          {
-            "key": "sw.k8s.container.init",
-            "value": {
-              "stringValue": "true"
-            }
-          },
-          {
-            "key": "uid",
-            "value": {
-              "stringValue": "64b6d309-44e3-4a41-8883-c15c7cc9bc4a"
-            }
-          }
-        ]
-      },
-      "scopeMetrics": [
-        {
-          "metrics": [
-            {
-              "gauge": {
-                "dataPoints": [
-                  {
-                    "asDouble": 1,
-                    "attributes": [
-                      {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "http"
-                        }
-                      },
-                      {
-                        "key": "prometheus",
-                        "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
-                        }
-                      },
-                      {
-                        "key": "prometheus_replica",
-                        "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
-                        }
-                      },
-                      {
-                        "key": "service",
-                        "value": {
-                          "stringValue": "test-service"
-                        }
-                      }
-                    ],
-                    "timeUnixNano": "0"
-                  }
-                ]
-              },
-              "name": "k8s.kube_pod_init_container_status_ready"
-            }
-          ],
-          "scope": {}
-        }
-      ]
-    },
-    {
-      "resource": {
-        "attributes": [
-          {
-            "key": "container",
-            "value": {
-              "stringValue": "test-container"
-            }
-          },
-          {
-            "key": "http.scheme",
-            "value": {
-              "stringValue": "http"
-            }
-          },
-          {
-            "key": "k8s.cluster.name",
-            "value": {
-              "stringValue": "cluster name"
-            }
-          },
-          {
-            "key": "k8s.container.name",
-            "value": {
-              "stringValue": "test-container"
-            }
-          },
-          {
-            "key": "k8s.namespace.annotations.description",
-            "value": {
-              "stringValue": "This is a test namespace."
-            }
-          },
-          {
-            "key": "k8s.namespace.labels.app",
-            "value": {
-              "stringValue": "test-app"
-            }
-          },
-          {
-            "key": "k8s.namespace.labels.kubernetes.io/metadata.name",
-            "value": {
-              "stringValue": "test-namespace"
-            }
-          },
-          {
-            "key": "k8s.namespace.labels.purpose",
-            "value": {
-              "stringValue": "testing"
-            }
-          },
-          {
-            "key": "k8s.namespace.name",
-            "value": {
-              "stringValue": "test-namespace"
-            }
-          },
-          {
-            "key": "k8s.pod.annotations.test-annotation",
-            "value": {
-              "stringValue": "test-value"
-            }
-          },
-          {
-            "key": "k8s.pod.labels.app",
-            "value": {
-              "stringValue": "test-pod"
-            }
-          },
-          {
-            "key": "k8s.pod.name",
-            "value": {
-              "stringValue": "test-pod"
-            }
-          },
-          {
-            "key": "k8s.pod.uid",
-            "value": {
-              "stringValue": "71057e83-7723-4db5-a7ca-52ad7904e34d"
-            }
-          },
-          {
-            "key": "namespace",
-            "value": {
-              "stringValue": "test-namespace"
-            }
-          },
-          {
-            "key": "net.host.name",
-            "value": {
-              "stringValue": "test-node"
-            }
-          },
-          {
-            "key": "net.host.port",
-            "value": {
-              "stringValue": ""
-            }
-          },
-          {
-            "key": "pod",
-            "value": {
-              "stringValue": "test-pod"
-            }
-          },
-          {
-            "key": "sw.k8s.agent.app.version",
-            "value": {
-              "stringValue": "0.8.1"
-            }
-          },
-          {
-            "key": "sw.k8s.agent.manifest.version",
-            "value": {
-              "stringValue": "2.7.0-alpha.6"
-            }
-          },
-          {
-            "key": "sw.k8s.cluster.uid",
-            "value": {
-              "stringValue": "cluster-uid-123456789"
-            }
-          },
-          {
-            "key": "sw.k8s.container.init",
-            "value": {
-              "stringValue": "false"
-            }
-          },
-          {
-            "key": "uid",
-            "value": {
-              "stringValue": "71057e83-7723-4db5-a7ca-52ad7904e34d"
-            }
-          }
-        ]
-      },
-      "scopeMetrics": [
-        {
-          "metrics": [
-            {
-              "gauge": {
-                "dataPoints": [
-                  {
-                    "asDouble": 1,
-                    "attributes": [
-                      {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "http"
-                        }
-                      },
-                      {
-                        "key": "prometheus",
-                        "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
-                        }
-                      },
-                      {
-                        "key": "prometheus_replica",
-                        "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
-                        }
-                      },
-                      {
-                        "key": "reason",
-                        "value": {
-                          "stringValue": "Completed"
-                        }
-                      },
-                      {
-                        "key": "service",
-                        "value": {
-                          "stringValue": "test-service"
-                        }
-                      }
-                    ],
-                    "timeUnixNano": "0"
-                  }
-                ]
-              },
-              "name": "k8s.kube_pod_container_status_terminated_reason"
-            }
-          ],
-          "scope": {}
-        }
-      ]
-    },
-    {
-      "resource": {
-        "attributes": [
-          {
-            "key": "container",
-            "value": {
-              "stringValue": "test-container"
-            }
-          },
-          {
-            "key": "http.scheme",
-            "value": {
-              "stringValue": "http"
-            }
-          },
-          {
-            "key": "k8s.cluster.name",
-            "value": {
-              "stringValue": "cluster name"
-            }
-          },
-          {
-            "key": "k8s.container.name",
-            "value": {
-              "stringValue": "test-container"
-            }
-          },
-          {
-            "key": "k8s.namespace.annotations.description",
-            "value": {
-              "stringValue": "This is a test namespace."
-            }
-          },
-          {
-            "key": "k8s.namespace.labels.app",
-            "value": {
-              "stringValue": "test-app"
-            }
-          },
-          {
-            "key": "k8s.namespace.labels.kubernetes.io/metadata.name",
-            "value": {
-              "stringValue": "test-namespace"
-            }
-          },
-          {
-            "key": "k8s.namespace.labels.purpose",
-            "value": {
-              "stringValue": "testing"
-            }
-          },
-          {
-            "key": "k8s.namespace.name",
-            "value": {
-              "stringValue": "test-namespace"
-            }
-          },
-          {
-            "key": "k8s.pod.annotations.test-annotation",
-            "value": {
-              "stringValue": "test-value"
-            }
-          },
-          {
-            "key": "k8s.pod.labels.app",
-            "value": {
-              "stringValue": "test-pod"
-            }
-          },
-          {
-            "key": "k8s.pod.name",
-            "value": {
-              "stringValue": "test-pod"
-            }
-          },
-          {
-            "key": "k8s.pod.uid",
-            "value": {
-              "stringValue": "a920ed2f-477d-4ad7-93d6-3222aabfece2"
-            }
-          },
-          {
-            "key": "namespace",
-            "value": {
-              "stringValue": "test-namespace"
-            }
-          },
-          {
-            "key": "net.host.name",
-            "value": {
-              "stringValue": "test-node"
-            }
-          },
-          {
-            "key": "net.host.port",
-            "value": {
-              "stringValue": ""
-            }
-          },
-          {
-            "key": "pod",
-            "value": {
-              "stringValue": "test-pod"
-            }
-          },
-          {
-            "key": "sw.k8s.agent.app.version",
-            "value": {
-              "stringValue": "0.8.1"
-            }
-          },
-          {
-            "key": "sw.k8s.agent.manifest.version",
-            "value": {
-              "stringValue": "2.7.0-alpha.6"
-            }
-          },
-          {
-            "key": "sw.k8s.cluster.uid",
-            "value": {
-              "stringValue": "cluster-uid-123456789"
-            }
-          },
-          {
-            "key": "sw.k8s.container.init",
-            "value": {
-              "stringValue": "true"
-            }
-          },
-          {
-            "key": "uid",
-            "value": {
-              "stringValue": "a920ed2f-477d-4ad7-93d6-3222aabfece2"
-            }
-          }
-        ]
-      },
-      "scopeMetrics": [
-        {
-          "metrics": [
-            {
-              "gauge": {
-                "dataPoints": [
-                  {
-                    "asDouble": 1073741824,
-                    "attributes": [
-                      {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "http"
-                        }
-                      },
-                      {
-                        "key": "prometheus",
-                        "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
-                        }
-                      },
-                      {
-                        "key": "prometheus_replica",
-                        "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
-                        }
-                      },
-                      {
-                        "key": "service",
-                        "value": {
-                          "stringValue": "test-service"
-                        }
-                      }
-                    ],
-                    "timeUnixNano": "0"
-                  }
-                ]
-              },
-              "name": "k8s.kube_pod_init_container_resource_limits_memory_bytes"
-            },
-            {
-              "name": "k8s.kube_pod_init_container_status_restarts_total",
-              "sum": {
-                "aggregationTemporality": 2,
-                "dataPoints": [
-                  {
-                    "asDouble": 0,
-                    "attributes": [
-                      {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "http"
-                        }
-                      },
-                      {
-                        "key": "prometheus",
-                        "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
-                        }
-                      },
-                      {
-                        "key": "prometheus_replica",
-                        "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
-                        }
-                      },
-                      {
-                        "key": "service",
-                        "value": {
-                          "stringValue": "test-service"
-                        }
-                      }
-                    ],
-                    "timeUnixNano": "0"
-                  }
-                ],
-                "isMonotonic": true
-              }
-            }
-          ],
-          "scope": {}
-        }
-      ]
-    },
-    {
-      "resource": {
-        "attributes": [
-          {
-            "key": "container",
-            "value": {
-              "stringValue": "test-container"
-            }
-          },
-          {
-            "key": "http.scheme",
-            "value": {
-              "stringValue": "http"
-            }
-          },
-          {
-            "key": "k8s.cluster.name",
-            "value": {
-              "stringValue": "cluster name"
-            }
-          },
-          {
-            "key": "k8s.container.name",
-            "value": {
-              "stringValue": "test-container"
-            }
-          },
-          {
-            "key": "k8s.namespace.annotations.description",
-            "value": {
-              "stringValue": "This is a test namespace."
-            }
-          },
-          {
-            "key": "k8s.namespace.labels.app",
-            "value": {
-              "stringValue": "test-app"
-            }
-          },
-          {
-            "key": "k8s.namespace.labels.kubernetes.io/metadata.name",
-            "value": {
-              "stringValue": "test-namespace"
-            }
-          },
-          {
-            "key": "k8s.namespace.labels.purpose",
-            "value": {
-              "stringValue": "testing"
-            }
-          },
-          {
-            "key": "k8s.namespace.name",
-            "value": {
-              "stringValue": "test-namespace"
-            }
-          },
-          {
-            "key": "k8s.pod.annotations.test-annotation",
-            "value": {
-              "stringValue": "test-value"
-            }
-          },
-          {
-            "key": "k8s.pod.labels.app",
-            "value": {
-              "stringValue": "test-pod"
-            }
-          },
-          {
-            "key": "k8s.pod.name",
-            "value": {
-              "stringValue": "test-pod"
-            }
-          },
-          {
-            "key": "k8s.pod.uid",
-            "value": {
-              "stringValue": "bafeef2c-1292-4a5e-a92c-d709480b04b6"
-            }
-          },
-          {
-            "key": "k8s.replicaset.name",
-            "value": {
-              "stringValue": "swi-k8s-otel-collector-swo-k8s-collector-metrics-cf8f6886b"
-            }
-          },
-          {
-            "key": "namespace",
-            "value": {
-              "stringValue": "test-namespace"
-            }
-          },
-          {
-            "key": "net.host.name",
-            "value": {
-              "stringValue": "test-node"
-            }
-          },
-          {
-            "key": "net.host.port",
-            "value": {
-              "stringValue": ""
-            }
-          },
-          {
-            "key": "pod",
-            "value": {
-              "stringValue": "test-pod"
-            }
-          },
-          {
-            "key": "replicaset",
-            "value": {
-              "stringValue": "swi-k8s-otel-collector-swo-k8s-collector-metrics-cf8f6886b"
-            }
-          },
-          {
-            "key": "sw.k8s.agent.app.version",
-            "value": {
-              "stringValue": "0.8.1"
-            }
-          },
-          {
-            "key": "sw.k8s.agent.manifest.version",
-            "value": {
-              "stringValue": "2.7.0-alpha.6"
-            }
-          },
-          {
-            "key": "sw.k8s.cluster.uid",
-            "value": {
-              "stringValue": "cluster-uid-123456789"
-            }
-          },
-          {
-            "key": "uid",
-            "value": {
-              "stringValue": "bafeef2c-1292-4a5e-a92c-d709480b04b6"
-            }
-          }
-        ]
-      },
-      "scopeMetrics": [
-        {
-          "metrics": [
-            {
-              "gauge": {
-                "dataPoints": [
-                  {
-                    "asDouble": 1,
-                    "attributes": [
-                      {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "http"
-                        }
-                      },
-                      {
-                        "key": "owner_is_controller",
-                        "value": {
-                          "stringValue": "true"
-                        }
-                      },
-                      {
-                        "key": "owner_kind",
-                        "value": {
-                          "stringValue": "ReplicaSet"
-                        }
-                      },
-                      {
-                        "key": "prometheus",
-                        "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
-                        }
-                      },
-                      {
-                        "key": "prometheus_replica",
-                        "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
-                        }
-                      },
-                      {
-                        "key": "service",
-                        "value": {
-                          "stringValue": "test-service"
-                        }
-                      }
-                    ],
-                    "timeUnixNano": "0"
-                  }
-                ]
-              },
-              "name": "k8s.kube.pod.owner.replicaset"
-            }
-          ],
-          "scope": {}
-        }
-      ]
-    },
-    {
-      "resource": {
-        "attributes": [
-          {
-            "key": "container",
-            "value": {
-              "stringValue": "test-container"
-            }
-          },
-          {
-            "key": "http.scheme",
-            "value": {
-              "stringValue": "http"
-            }
-          },
-          {
-            "key": "k8s.cluster.name",
-            "value": {
-              "stringValue": "cluster name"
-            }
-          },
-          {
-            "key": "k8s.container.name",
-            "value": {
-              "stringValue": "test-container"
-            }
-          },
-          {
-            "key": "k8s.namespace.annotations.description",
-            "value": {
-              "stringValue": "This is a test namespace."
-            }
-          },
-          {
-            "key": "k8s.namespace.labels.app",
-            "value": {
-              "stringValue": "test-app"
-            }
-          },
-          {
-            "key": "k8s.namespace.labels.kubernetes.io/metadata.name",
-            "value": {
-              "stringValue": "test-namespace"
-            }
-          },
-          {
-            "key": "k8s.namespace.labels.purpose",
-            "value": {
-              "stringValue": "testing"
-            }
-          },
-          {
-            "key": "k8s.namespace.name",
-            "value": {
-              "stringValue": "test-namespace"
-            }
-          },
-          {
-            "key": "k8s.pod.annotations.test-annotation",
-            "value": {
-              "stringValue": "test-value"
-            }
-          },
-          {
-            "key": "k8s.pod.labels.app",
-            "value": {
-              "stringValue": "test-pod"
-            }
-          },
-          {
-            "key": "k8s.pod.name",
-            "value": {
-              "stringValue": "test-pod"
-            }
-          },
-          {
-            "key": "k8s.pod.uid",
-            "value": {
-              "stringValue": "bafeef2c-1292-4a5e-a92c-d709480b04b6"
-            }
-          },
-          {
-            "key": "namespace",
-            "value": {
-              "stringValue": "test-namespace"
-            }
-          },
-          {
-            "key": "net.host.name",
-            "value": {
-              "stringValue": "test-node"
-            }
-          },
-          {
-            "key": "net.host.port",
-            "value": {
-              "stringValue": ""
-            }
-          },
-          {
-            "key": "pod",
-            "value": {
-              "stringValue": "test-pod"
-            }
-          },
-          {
-            "key": "sw.k8s.agent.app.version",
-            "value": {
-              "stringValue": "0.8.1"
-            }
-          },
-          {
-            "key": "sw.k8s.agent.manifest.version",
-            "value": {
-              "stringValue": "2.7.0-alpha.6"
-            }
-          },
-          {
-            "key": "sw.k8s.cluster.uid",
-            "value": {
-              "stringValue": "cluster-uid-123456789"
-            }
-          },
-          {
-            "key": "sw.k8s.container.init",
-            "value": {
-              "stringValue": "false"
-            }
-          },
-          {
-            "key": "sw.k8s.container.status",
-            "value": {
-              "stringValue": "running"
-            }
-          },
-          {
-            "key": "uid",
-            "value": {
-              "stringValue": "bafeef2c-1292-4a5e-a92c-d709480b04b6"
-            }
-          }
-        ]
-      },
-      "scopeMetrics": [
-        {
-          "metrics": [
-            {
-              "gauge": {
-                "dataPoints": [
-                  {
-                    "asDouble": 1,
-                    "attributes": [
-                      {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "http"
-                        }
-                      },
-                      {
-                        "key": "prometheus",
-                        "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
-                        }
-                      },
-                      {
-                        "key": "prometheus_replica",
-                        "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
-                        }
-                      },
-                      {
-                        "key": "service",
-                        "value": {
-                          "stringValue": "test-service"
-                        }
-                      }
-                    ],
-                    "timeUnixNano": "0"
-                  },
-                  {
-                    "asDouble": 1,
-                    "attributes": [
-                      {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "tcp-model"
-                        }
-                      },
-                      {
-                        "key": "prometheus",
-                        "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
-                        }
-                      },
-                      {
-                        "key": "prometheus_replica",
-                        "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
-                        }
-                      },
-                      {
-                        "key": "service",
-                        "value": {
-                          "stringValue": "test-service"
-                        }
-                      }
-                    ],
-                    "timeUnixNano": "0"
-                  }
-                ]
-              },
-              "name": "k8s.container.status"
-            }
-          ],
-          "scope": {}
-        }
-      ]
-    },
-    {
-      "resource": {
-        "attributes": [
-          {
-            "key": "container",
-            "value": {
-              "stringValue": "test-container"
-            }
-          },
-          {
-            "key": "http.scheme",
-            "value": {
-              "stringValue": "http"
-            }
-          },
-          {
-            "key": "k8s.cluster.name",
-            "value": {
-              "stringValue": "cluster name"
-            }
-          },
-          {
-            "key": "k8s.container.name",
-            "value": {
-              "stringValue": "test-container"
-            }
-          },
-          {
-            "key": "k8s.namespace.annotations.description",
-            "value": {
-              "stringValue": "This is a test namespace."
-            }
-          },
-          {
-            "key": "k8s.namespace.labels.app",
-            "value": {
-              "stringValue": "test-app"
-            }
-          },
-          {
-            "key": "k8s.namespace.labels.kubernetes.io/metadata.name",
-            "value": {
-              "stringValue": "test-namespace"
-            }
-          },
-          {
-            "key": "k8s.namespace.labels.purpose",
-            "value": {
-              "stringValue": "testing"
-            }
-          },
-          {
-            "key": "k8s.namespace.name",
-            "value": {
-              "stringValue": "test-namespace"
-            }
-          },
-          {
-            "key": "k8s.pod.annotations.test-annotation",
-            "value": {
-              "stringValue": "test-value"
-            }
-          },
-          {
-            "key": "k8s.pod.labels.app",
-            "value": {
-              "stringValue": "test-pod"
-            }
-          },
-          {
-            "key": "k8s.pod.name",
-            "value": {
-              "stringValue": "test-pod"
-            }
-          },
-          {
-            "key": "k8s.pod.uid",
-            "value": {
-              "stringValue": "bafeef2c-1292-4a5e-a92c-d709480b04b6"
-            }
-          },
-          {
-            "key": "namespace",
-            "value": {
-              "stringValue": "test-namespace"
-            }
-          },
-          {
-            "key": "net.host.name",
-            "value": {
-              "stringValue": "test-node"
-            }
-          },
-          {
-            "key": "net.host.port",
-            "value": {
-              "stringValue": ""
-            }
-          },
-          {
-            "key": "pod",
-            "value": {
-              "stringValue": "test-pod"
-            }
-          },
-          {
-            "key": "sw.k8s.agent.app.version",
-            "value": {
-              "stringValue": "0.8.1"
-            }
-          },
-          {
-            "key": "sw.k8s.agent.manifest.version",
-            "value": {
-              "stringValue": "2.7.0-alpha.6"
-            }
-          },
-          {
-            "key": "sw.k8s.cluster.uid",
-            "value": {
-              "stringValue": "cluster-uid-123456789"
-            }
-          },
-          {
-            "key": "sw.k8s.container.init",
-            "value": {
-              "stringValue": "false"
-            }
-          },
-          {
-            "key": "uid",
-            "value": {
-              "stringValue": "bafeef2c-1292-4a5e-a92c-d709480b04b6"
-            }
-          }
-        ]
-      },
-      "scopeMetrics": [
-        {
-          "metrics": [
-            {
-              "gauge": {
-                "dataPoints": [
-                  {
-                    "asDouble": 1681390530,
-                    "attributes": [
-                      {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "http"
-                        }
-                      },
-                      {
-                        "key": "prometheus",
-                        "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
-                        }
-                      },
-                      {
-                        "key": "prometheus_replica",
-                        "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
-                        }
-                      },
-                      {
-                        "key": "service",
-                        "value": {
-                          "stringValue": "test-service"
-                        }
-                      }
-                    ],
-                    "timeUnixNano": "0"
-                  }
-                ]
-              },
-              "name": "k8s.kube_pod_container_state_started"
-            },
-            {
-              "gauge": {
-                "dataPoints": [
-                  {
-                    "asDouble": 1,
-                    "attributes": [
-                      {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "http"
-                        }
-                      },
-                      {
-                        "key": "prometheus",
-                        "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
-                        }
-                      },
-                      {
-                        "key": "prometheus_replica",
-                        "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
-                        }
-                      },
-                      {
-                        "key": "service",
-                        "value": {
-                          "stringValue": "test-service"
-                        }
-                      }
-                    ],
-                    "timeUnixNano": "0"
-                  }
-                ]
-              },
-              "name": "k8s.kube_pod_container_status_ready"
-            },
-            {
-              "name": "k8s.kube_pod_container_status_restarts_total",
-              "sum": {
-                "aggregationTemporality": 2,
-                "dataPoints": [
-                  {
-                    "asDouble": 0,
-                    "attributes": [
-                      {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "http"
-                        }
-                      },
-                      {
-                        "key": "prometheus",
-                        "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
-                        }
-                      },
-                      {
-                        "key": "prometheus_replica",
-                        "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
-                        }
-                      },
-                      {
-                        "key": "service",
-                        "value": {
-                          "stringValue": "test-service"
-                        }
-                      }
-                    ],
-                    "timeUnixNano": "0"
-                  },
-                  {
-                    "asDouble": 0,
-                    "attributes": [
-                      {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "tcp-model"
-                        }
-                      },
-                      {
-                        "key": "prometheus",
-                        "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
-                        }
-                      },
-                      {
-                        "key": "prometheus_replica",
-                        "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
-                        }
-                      },
-                      {
-                        "key": "service",
-                        "value": {
-                          "stringValue": "test-service"
-                        }
-                      }
-                    ],
-                    "timeUnixNano": "0"
-                  }
-                ],
-                "isMonotonic": true
-              }
-            },
-            {
-              "gauge": {
-                "dataPoints": [
-                  {
-                    "asDouble": 1,
-                    "attributes": [
-                      {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "http"
-                        }
-                      },
-                      {
-                        "key": "prometheus",
-                        "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
-                        }
-                      },
-                      {
-                        "key": "prometheus_replica",
-                        "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
-                        }
-                      },
-                      {
-                        "key": "service",
-                        "value": {
-                          "stringValue": "test-service"
-                        }
-                      }
-                    ],
-                    "timeUnixNano": "0"
-                  },
-                  {
-                    "asDouble": 1,
-                    "attributes": [
-                      {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "tcp-model"
-                        }
-                      },
-                      {
-                        "key": "prometheus",
-                        "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
-                        }
-                      },
-                      {
-                        "key": "prometheus_replica",
-                        "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
-                        }
-                      },
-                      {
-                        "key": "service",
-                        "value": {
-                          "stringValue": "test-service"
-                        }
-                      }
-                    ],
-                    "timeUnixNano": "0"
-                  }
-                ]
-              },
-              "name": "k8s.kube_pod_container_status_running"
-            },
-            {
-              "gauge": {
-                "dataPoints": [
-                  {
-                    "asDouble": 0,
-                    "attributes": [
-                      {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "http"
-                        }
-                      },
-                      {
-                        "key": "prometheus",
-                        "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
-                        }
-                      },
-                      {
-                        "key": "prometheus_replica",
-                        "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
-                        }
-                      },
-                      {
-                        "key": "service",
-                        "value": {
-                          "stringValue": "test-service"
-                        }
-                      }
-                    ],
-                    "timeUnixNano": "0"
-                  }
-                ]
-              },
-              "name": "k8s.kube_pod_container_status_terminated"
-            },
-            {
-              "gauge": {
-                "dataPoints": [
-                  {
-                    "asDouble": 0,
-                    "attributes": [
-                      {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "http"
-                        }
-                      },
-                      {
-                        "key": "prometheus",
-                        "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
-                        }
-                      },
-                      {
-                        "key": "prometheus_replica",
-                        "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
-                        }
-                      },
-                      {
-                        "key": "service",
-                        "value": {
-                          "stringValue": "test-service"
-                        }
-                      }
-                    ],
-                    "timeUnixNano": "0"
-                  }
-                ]
-              },
-              "name": "k8s.kube_pod_container_status_waiting"
-            }
-          ],
-          "scope": {}
-        }
-      ]
-    },
-    {
-      "resource": {
-        "attributes": [
-          {
-            "key": "container",
-            "value": {
-              "stringValue": "test-container"
-            }
-          },
-          {
-            "key": "http.scheme",
-            "value": {
-              "stringValue": "http"
-            }
-          },
-          {
-            "key": "k8s.cluster.name",
-            "value": {
-              "stringValue": "cluster name"
-            }
-          },
-          {
-            "key": "k8s.container.name",
-            "value": {
-              "stringValue": "test-container"
-            }
-          },
-          {
-            "key": "k8s.namespace.annotations.description",
-            "value": {
-              "stringValue": "This is a test namespace."
-            }
-          },
-          {
-            "key": "k8s.namespace.labels.app",
-            "value": {
-              "stringValue": "test-app"
-            }
-          },
-          {
-            "key": "k8s.namespace.labels.kubernetes.io/metadata.name",
-            "value": {
-              "stringValue": "test-namespace"
-            }
-          },
-          {
-            "key": "k8s.namespace.labels.purpose",
-            "value": {
-              "stringValue": "testing"
-            }
-          },
-          {
-            "key": "k8s.namespace.name",
-            "value": {
-              "stringValue": "test-namespace"
-            }
-          },
-          {
-            "key": "k8s.pod.annotations.test-annotation",
-            "value": {
-              "stringValue": "test-value"
-            }
-          },
-          {
-            "key": "k8s.pod.labels.app",
-            "value": {
-              "stringValue": "test-pod"
-            }
-          },
-          {
-            "key": "k8s.pod.name",
-            "value": {
-              "stringValue": "test-pod"
-            }
-          },
-          {
-            "key": "k8s.pod.uid",
-            "value": {
-              "stringValue": "bafeef2c-1292-4a5e-a92c-d709480b04b6"
-            }
-          },
-          {
-            "key": "namespace",
-            "value": {
-              "stringValue": "test-namespace"
-            }
-          },
-          {
-            "key": "net.host.name",
-            "value": {
-              "stringValue": "test-node"
-            }
-          },
-          {
-            "key": "net.host.port",
-            "value": {
-              "stringValue": ""
-            }
-          },
-          {
-            "key": "pod",
-            "value": {
-              "stringValue": "test-pod"
-            }
-          },
-          {
-            "key": "sw.k8s.agent.app.version",
-            "value": {
-              "stringValue": "0.8.1"
-            }
-          },
-          {
-            "key": "sw.k8s.agent.manifest.version",
-            "value": {
-              "stringValue": "2.7.0-alpha.6"
-            }
-          },
-          {
-            "key": "sw.k8s.cluster.uid",
-            "value": {
-              "stringValue": "cluster-uid-123456789"
-            }
-          },
-          {
-            "key": "sw.k8s.container.init",
-            "value": {
-              "stringValue": "true"
-            }
-          },
-          {
-            "key": "sw.k8s.container.status",
-            "value": {
-              "stringValue": "terminated"
-            }
-          },
-          {
-            "key": "uid",
-            "value": {
-              "stringValue": "bafeef2c-1292-4a5e-a92c-d709480b04b6"
-            }
-          }
-        ]
-      },
-      "scopeMetrics": [
-        {
-          "metrics": [
-            {
-              "gauge": {
-                "dataPoints": [
-                  {
-                    "asDouble": 1,
-                    "attributes": [
-                      {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "http"
-                        }
-                      },
-                      {
-                        "key": "prometheus",
-                        "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
-                        }
-                      },
-                      {
-                        "key": "prometheus_replica",
-                        "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
-                        }
-                      },
-                      {
-                        "key": "service",
-                        "value": {
-                          "stringValue": "test-service"
-                        }
-                      }
-                    ],
-                    "timeUnixNano": "0"
-                  }
-                ]
-              },
-              "name": "k8s.container.status"
-            }
-          ],
-          "scope": {}
-        }
-      ]
-    },
-    {
-      "resource": {
-        "attributes": [
-          {
-            "key": "container",
-            "value": {
-              "stringValue": "test-container"
-            }
-          },
-          {
-            "key": "http.scheme",
-            "value": {
-              "stringValue": "http"
-            }
-          },
-          {
-            "key": "k8s.cluster.name",
-            "value": {
-              "stringValue": "cluster name"
-            }
-          },
-          {
-            "key": "k8s.container.name",
-            "value": {
-              "stringValue": "test-container"
-            }
-          },
-          {
-            "key": "k8s.namespace.annotations.description",
-            "value": {
-              "stringValue": "This is a test namespace."
-            }
-          },
-          {
-            "key": "k8s.namespace.labels.app",
-            "value": {
-              "stringValue": "test-app"
-            }
-          },
-          {
-            "key": "k8s.namespace.labels.kubernetes.io/metadata.name",
-            "value": {
-              "stringValue": "test-namespace"
-            }
-          },
-          {
-            "key": "k8s.namespace.labels.purpose",
-            "value": {
-              "stringValue": "testing"
-            }
-          },
-          {
-            "key": "k8s.namespace.name",
-            "value": {
-              "stringValue": "test-namespace"
-            }
-          },
-          {
-            "key": "k8s.pod.annotations.test-annotation",
-            "value": {
-              "stringValue": "test-value"
-            }
-          },
-          {
-            "key": "k8s.pod.labels.app",
-            "value": {
-              "stringValue": "test-pod"
-            }
-          },
-          {
-            "key": "k8s.pod.name",
-            "value": {
-              "stringValue": "test-pod"
-            }
-          },
-          {
-            "key": "k8s.pod.uid",
-            "value": {
-              "stringValue": "bafeef2c-1292-4a5e-a92c-d709480b04b6"
-            }
-          },
-          {
-            "key": "namespace",
-            "value": {
-              "stringValue": "test-namespace"
-            }
-          },
-          {
-            "key": "net.host.name",
-            "value": {
-              "stringValue": "test-node"
-            }
-          },
-          {
-            "key": "net.host.port",
-            "value": {
-              "stringValue": ""
-            }
-          },
-          {
-            "key": "pod",
-            "value": {
-              "stringValue": "test-pod"
-            }
-          },
-          {
-            "key": "sw.k8s.agent.app.version",
-            "value": {
-              "stringValue": "0.8.1"
-            }
-          },
-          {
-            "key": "sw.k8s.agent.manifest.version",
-            "value": {
-              "stringValue": "2.7.0-alpha.6"
-            }
-          },
-          {
-            "key": "sw.k8s.cluster.uid",
-            "value": {
-              "stringValue": "cluster-uid-123456789"
-            }
-          },
-          {
-            "key": "sw.k8s.container.init",
-            "value": {
-              "stringValue": "true"
-            }
-          },
-          {
-            "key": "uid",
-            "value": {
-              "stringValue": "bafeef2c-1292-4a5e-a92c-d709480b04b6"
-            }
-          }
-        ]
-      },
-      "scopeMetrics": [
-        {
-          "metrics": [
-            {
-              "gauge": {
-                "dataPoints": [
-                  {
-                    "asDouble": 1,
-                    "attributes": [
-                      {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "http"
-                        }
-                      },
-                      {
-                        "key": "prometheus",
-                        "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
-                        }
-                      },
-                      {
-                        "key": "prometheus_replica",
-                        "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
-                        }
-                      },
-                      {
-                        "key": "service",
-                        "value": {
-                          "stringValue": "test-service"
-                        }
-                      }
-                    ],
-                    "timeUnixNano": "0"
-                  }
-                ]
-              },
-              "name": "k8s.kube_pod_init_container_status_ready"
-            },
-            {
-              "name": "k8s.kube_pod_init_container_status_restarts_total",
-              "sum": {
-                "aggregationTemporality": 2,
-                "dataPoints": [
-                  {
-                    "asDouble": 0,
-                    "attributes": [
-                      {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "http"
-                        }
-                      },
-                      {
-                        "key": "prometheus",
-                        "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
-                        }
-                      },
-                      {
-                        "key": "prometheus_replica",
-                        "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
-                        }
-                      },
-                      {
-                        "key": "service",
-                        "value": {
-                          "stringValue": "test-service"
-                        }
-                      }
-                    ],
-                    "timeUnixNano": "0"
-                  }
-                ],
-                "isMonotonic": true
-              }
-            },
-            {
-              "gauge": {
-                "dataPoints": [
-                  {
-                    "asDouble": 0,
-                    "attributes": [
-                      {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "http"
-                        }
-                      },
-                      {
-                        "key": "prometheus",
-                        "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
-                        }
-                      },
-                      {
-                        "key": "prometheus_replica",
-                        "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
-                        }
-                      },
-                      {
-                        "key": "service",
-                        "value": {
-                          "stringValue": "test-service"
-                        }
-                      }
-                    ],
-                    "timeUnixNano": "0"
-                  }
-                ]
-              },
-              "name": "k8s.kube_pod_init_container_status_running"
-            },
-            {
-              "gauge": {
-                "dataPoints": [
-                  {
-                    "asDouble": 1,
-                    "attributes": [
-                      {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "http"
-                        }
-                      },
-                      {
-                        "key": "prometheus",
-                        "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
-                        }
-                      },
-                      {
-                        "key": "prometheus_replica",
-                        "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
-                        }
-                      },
-                      {
-                        "key": "service",
-                        "value": {
-                          "stringValue": "test-service"
-                        }
-                      }
-                    ],
-                    "timeUnixNano": "0"
-                  }
-                ]
-              },
-              "name": "k8s.kube_pod_init_container_status_terminated"
-            },
-            {
-              "gauge": {
-                "dataPoints": [
-                  {
-                    "asDouble": 1,
-                    "attributes": [
-                      {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "http"
-                        }
-                      },
-                      {
-                        "key": "prometheus",
-                        "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
-                        }
-                      },
-                      {
-                        "key": "prometheus_replica",
-                        "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
-                        }
-                      },
-                      {
-                        "key": "reason",
-                        "value": {
-                          "stringValue": "Completed"
-                        }
-                      },
-                      {
-                        "key": "service",
-                        "value": {
-                          "stringValue": "test-service"
-                        }
-                      }
-                    ],
-                    "timeUnixNano": "0"
-                  }
-                ]
-              },
-              "name": "k8s.kube_pod_init_container_status_terminated_reason"
-            },
-            {
-              "gauge": {
-                "dataPoints": [
-                  {
-                    "asDouble": 0,
-                    "attributes": [
-                      {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "http"
-                        }
-                      },
-                      {
-                        "key": "prometheus",
-                        "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
-                        }
-                      },
-                      {
-                        "key": "prometheus_replica",
-                        "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
-                        }
-                      },
-                      {
-                        "key": "service",
-                        "value": {
-                          "stringValue": "test-service"
-                        }
-                      }
-                    ],
-                    "timeUnixNano": "0"
-                  }
-                ]
-              },
-              "name": "k8s.kube_pod_init_container_status_waiting"
-            }
-          ],
-          "scope": {}
-        }
-      ]
-    },
-    {
-      "resource": {
-        "attributes": [
-          {
-            "key": "container",
-            "value": {
-              "stringValue": "test-container"
-            }
-          },
-          {
-            "key": "http.scheme",
-            "value": {
-              "stringValue": "http"
-            }
-          },
-          {
-            "key": "k8s.cluster.name",
-            "value": {
-              "stringValue": "cluster name"
-            }
-          },
-          {
-            "key": "k8s.container.name",
-            "value": {
-              "stringValue": "test-container"
-            }
-          },
-          {
-            "key": "k8s.namespace.annotations.description",
-            "value": {
-              "stringValue": "This is a test namespace."
-            }
-          },
-          {
-            "key": "k8s.namespace.labels.app",
-            "value": {
-              "stringValue": "test-app"
-            }
-          },
-          {
-            "key": "k8s.namespace.labels.kubernetes.io/metadata.name",
-            "value": {
-              "stringValue": "test-namespace"
-            }
-          },
-          {
-            "key": "k8s.namespace.labels.purpose",
-            "value": {
-              "stringValue": "testing"
-            }
-          },
-          {
-            "key": "k8s.namespace.name",
-            "value": {
-              "stringValue": "test-namespace"
-            }
-          },
-          {
-            "key": "k8s.pod.annotations.test-annotation",
-            "value": {
-              "stringValue": "test-value"
-            }
-          },
-          {
-            "key": "k8s.pod.labels.app",
-            "value": {
-              "stringValue": "test-pod"
-            }
-          },
-          {
-            "key": "k8s.pod.name",
-            "value": {
-              "stringValue": "test-pod"
-            }
-          },
-          {
-            "key": "k8s.pod.uid",
-            "value": {
-              "stringValue": "bafeef2c-1292-4a5e-a92c-d709480b04b6"
-            }
-          },
-          {
-            "key": "namespace",
-            "value": {
-              "stringValue": "test-namespace"
-            }
-          },
-          {
-            "key": "net.host.name",
-            "value": {
-              "stringValue": "test-node"
-            }
-          },
-          {
-            "key": "net.host.port",
-            "value": {
-              "stringValue": ""
-            }
-          },
-          {
-            "key": "pod",
-            "value": {
-              "stringValue": "test-pod"
-            }
-          },
-          {
-            "key": "sw.k8s.agent.app.version",
-            "value": {
-              "stringValue": "0.8.1"
-            }
-          },
-          {
-            "key": "sw.k8s.agent.manifest.version",
-            "value": {
-              "stringValue": "2.7.0-alpha.6"
-            }
-          },
-          {
-            "key": "sw.k8s.cluster.uid",
-            "value": {
-              "stringValue": "cluster-uid-123456789"
-            }
-          },
-          {
-            "key": "sw.k8s.pod.status",
-            "value": {
-              "stringValue": "Running"
-            }
-          },
-          {
-            "key": "uid",
-            "value": {
-              "stringValue": "bafeef2c-1292-4a5e-a92c-d709480b04b6"
-            }
-          }
-        ]
-      },
-      "scopeMetrics": [
-        {
-          "metrics": [
-            {
-              "gauge": {
-                "dataPoints": [
-                  {
-                    "asDouble": 1,
-                    "attributes": [
-                      {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "http"
-                        }
-                      },
-                      {
-                        "key": "phase",
-                        "value": {
-                          "stringValue": "Running"
-                        }
-                      },
-                      {
-                        "key": "prometheus",
-                        "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
-                        }
-                      },
-                      {
-                        "key": "prometheus_replica",
-                        "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
-                        }
-                      },
-                      {
-                        "key": "service",
-                        "value": {
-                          "stringValue": "test-service"
-                        }
-                      }
-                    ],
-                    "timeUnixNano": "0"
-                  },
-                  {
-                    "asDouble": 1,
-                    "attributes": [
-                      {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "tcp-model"
-                        }
-                      },
-                      {
-                        "key": "phase",
-                        "value": {
-                          "stringValue": "Running"
-                        }
-                      },
-                      {
-                        "key": "prometheus",
-                        "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
-                        }
-                      },
-                      {
-                        "key": "prometheus_replica",
-                        "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
-                        }
-                      },
-                      {
-                        "key": "service",
-                        "value": {
-                          "stringValue": "test-service"
-                        }
-                      }
-                    ],
-                    "timeUnixNano": "0"
-                  }
-                ]
-              },
-              "name": "k8s.kube_pod_status_phase"
-            }
-          ],
-          "scope": {}
-        }
-      ]
-    },
-    {
-      "resource": {
-        "attributes": [
-          {
-            "key": "container",
-            "value": {
-              "stringValue": "test-container"
-            }
-          },
-          {
-            "key": "http.scheme",
-            "value": {
-              "stringValue": "http"
-            }
-          },
-          {
-            "key": "k8s.cluster.name",
-            "value": {
-              "stringValue": "cluster name"
-            }
-          },
-          {
-            "key": "k8s.container.name",
-            "value": {
-              "stringValue": "test-container"
-            }
-          },
-          {
-            "key": "k8s.namespace.annotations.description",
-            "value": {
-              "stringValue": "This is a test namespace."
-            }
-          },
-          {
-            "key": "k8s.namespace.labels.app",
-            "value": {
-              "stringValue": "test-app"
-            }
-          },
-          {
-            "key": "k8s.namespace.labels.kubernetes.io/metadata.name",
-            "value": {
-              "stringValue": "test-namespace"
-            }
-          },
-          {
-            "key": "k8s.namespace.labels.purpose",
-            "value": {
-              "stringValue": "testing"
-            }
-          },
-          {
-            "key": "k8s.namespace.name",
-            "value": {
-              "stringValue": "test-namespace"
-            }
-          },
-          {
-            "key": "k8s.pod.annotations.test-annotation",
-            "value": {
-              "stringValue": "test-value"
-            }
-          },
-          {
-            "key": "k8s.pod.labels.app",
-            "value": {
-              "stringValue": "test-pod"
-            }
-          },
-          {
-            "key": "k8s.pod.name",
-            "value": {
-              "stringValue": "test-pod"
-            }
-          },
-          {
-            "key": "k8s.pod.uid",
-            "value": {
-              "stringValue": "bafeef2c-1292-4a5e-a92c-d709480b04b6"
-            }
-          },
-          {
-            "key": "namespace",
-            "value": {
-              "stringValue": "test-namespace"
-            }
-          },
-          {
-            "key": "net.host.name",
-            "value": {
-              "stringValue": "test-node"
-            }
-          },
-          {
-            "key": "net.host.port",
-            "value": {
-              "stringValue": ""
-            }
-          },
-          {
-            "key": "pod",
-            "value": {
-              "stringValue": "test-pod"
-            }
-          },
-          {
-            "key": "sw.k8s.agent.app.version",
-            "value": {
-              "stringValue": "0.8.1"
-            }
-          },
-          {
-            "key": "sw.k8s.agent.manifest.version",
-            "value": {
-              "stringValue": "2.7.0-alpha.6"
-            }
-          },
-          {
-            "key": "sw.k8s.cluster.uid",
-            "value": {
-              "stringValue": "cluster-uid-123456789"
-            }
-          },
-          {
-            "key": "uid",
-            "value": {
-              "stringValue": "bafeef2c-1292-4a5e-a92c-d709480b04b6"
-            }
-          }
-        ]
-      },
-      "scopeMetrics": [
-        {
-          "metrics": [
-            {
-              "gauge": {
-                "dataPoints": [
-                  {
-                    "asDouble": 1681390527,
-                    "attributes": [
-                      {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "http"
-                        }
-                      },
-                      {
-                        "key": "prometheus",
-                        "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
-                        }
-                      },
-                      {
-                        "key": "prometheus_replica",
-                        "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
-                        }
-                      },
-                      {
-                        "key": "service",
-                        "value": {
-                          "stringValue": "test-service"
-                        }
-                      }
-                    ],
-                    "timeUnixNano": "0"
-                  }
-                ]
-              },
-              "name": "k8s.kube_pod_created"
-            },
-            {
-              "gauge": {
-                "dataPoints": [
-                  {
-                    "asDouble": 1,
-                    "attributes": [
-                      {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "http"
-                        }
-                      },
-                      {
-                        "key": "owner_is_controller",
-                        "value": {
-                          "stringValue": "true"
-                        }
-                      },
-                      {
-                        "key": "owner_kind",
-                        "value": {
-                          "stringValue": "ReplicaSet"
-                        }
-                      },
-                      {
-                        "key": "owner_name",
-                        "value": {
-                          "stringValue": "swi-k8s-otel-collector-swo-k8s-collector-metrics-cf8f6886b"
-                        }
-                      },
-                      {
-                        "key": "prometheus",
-                        "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
-                        }
-                      },
-                      {
-                        "key": "prometheus_replica",
-                        "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
-                        }
-                      },
-                      {
-                        "key": "service",
-                        "value": {
-                          "stringValue": "test-service"
-                        }
-                      }
-                    ],
-                    "timeUnixNano": "0"
-                  }
-                ]
-              },
-              "name": "k8s.kube_pod_owner"
-            },
-            {
-              "gauge": {
-                "dataPoints": [
-                  {
-                    "asDouble": 1681390527,
-                    "attributes": [
-                      {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "http"
-                        }
-                      },
-                      {
-                        "key": "prometheus",
-                        "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
-                        }
-                      },
-                      {
-                        "key": "prometheus_replica",
-                        "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
-                        }
-                      },
-                      {
-                        "key": "service",
-                        "value": {
-                          "stringValue": "test-service"
-                        }
-                      }
-                    ],
-                    "timeUnixNano": "0"
-                  }
-                ]
-              },
-              "name": "k8s.kube_pod_start_time"
-            },
-            {
-              "gauge": {
-                "dataPoints": [
-                  {
-                    "asDouble": 0,
-                    "attributes": [
-                      {
-                        "key": "condition",
-                        "value": {
-                          "stringValue": "false"
-                        }
-                      },
-                      {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "http"
-                        }
-                      },
-                      {
-                        "key": "prometheus",
-                        "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
-                        }
-                      },
-                      {
-                        "key": "prometheus_replica",
-                        "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
-                        }
-                      },
-                      {
-                        "key": "service",
-                        "value": {
-                          "stringValue": "test-service"
-                        }
-                      }
-                    ],
-                    "timeUnixNano": "0"
-                  },
-                  {
-                    "asDouble": 1,
-                    "attributes": [
-                      {
-                        "key": "condition",
-                        "value": {
-                          "stringValue": "true"
-                        }
-                      },
-                      {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "http"
-                        }
-                      },
-                      {
-                        "key": "prometheus",
-                        "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
-                        }
-                      },
-                      {
-                        "key": "prometheus_replica",
-                        "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
-                        }
-                      },
-                      {
-                        "key": "service",
-                        "value": {
-                          "stringValue": "test-service"
-                        }
-                      }
-                    ],
-                    "timeUnixNano": "0"
-                  },
-                  {
-                    "asDouble": 0,
-                    "attributes": [
-                      {
-                        "key": "condition",
-                        "value": {
-                          "stringValue": "unknown"
-                        }
-                      },
-                      {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "http"
-                        }
-                      },
-                      {
-                        "key": "prometheus",
-                        "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
-                        }
-                      },
-                      {
-                        "key": "prometheus_replica",
-                        "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
-                        }
-                      },
-                      {
-                        "key": "service",
-                        "value": {
-                          "stringValue": "test-service"
-                        }
-                      }
-                    ],
-                    "timeUnixNano": "0"
-                  }
-                ]
-              },
-              "name": "k8s.kube_pod_status_ready"
-            }
-          ],
-          "scope": {}
-        }
-      ]
-    },
-    {
-      "resource": {
-        "attributes": [
-          {
-            "key": "container",
-            "value": {
-              "stringValue": "test-container"
-            }
-          },
-          {
-            "key": "http.scheme",
-            "value": {
-              "stringValue": "http"
-            }
-          },
-          {
-            "key": "k8s.cluster.name",
-            "value": {
-              "stringValue": "cluster name"
-            }
-          },
-          {
-            "key": "k8s.container.name",
-            "value": {
-              "stringValue": "test-container"
-            }
-          },
-          {
-            "key": "k8s.namespace.annotations.description",
-            "value": {
-              "stringValue": "This is a test namespace."
-            }
-          },
-          {
-            "key": "k8s.namespace.labels.app",
-            "value": {
-              "stringValue": "test-app"
-            }
-          },
-          {
-            "key": "k8s.namespace.labels.kubernetes.io/metadata.name",
-            "value": {
-              "stringValue": "test-namespace"
-            }
-          },
-          {
-            "key": "k8s.namespace.labels.purpose",
-            "value": {
-              "stringValue": "testing"
-            }
-          },
-          {
-            "key": "k8s.namespace.name",
-            "value": {
-              "stringValue": "test-namespace"
-            }
-          },
-          {
-            "key": "k8s.pod.annotations.test-annotation",
-            "value": {
-              "stringValue": "test-value"
-            }
-          },
-          {
-            "key": "k8s.pod.labels.app",
-            "value": {
-              "stringValue": "test-pod"
-            }
-          },
-          {
-            "key": "k8s.pod.name",
-            "value": {
-              "stringValue": "test-pod"
-            }
-          },
-          {
-            "key": "k8s.pod.uid",
-            "value": {
-              "stringValue": "c7f7a05a-a1b5-4fd0-a611-8e2a0e7acbf6"
-            }
-          },
-          {
-            "key": "namespace",
-            "value": {
-              "stringValue": "test-namespace"
-            }
-          },
-          {
-            "key": "net.host.name",
-            "value": {
-              "stringValue": "test-node"
-            }
-          },
-          {
-            "key": "net.host.port",
-            "value": {
-              "stringValue": ""
-            }
-          },
-          {
-            "key": "pod",
-            "value": {
-              "stringValue": "test-pod"
-            }
-          },
-          {
-            "key": "sw.k8s.agent.app.version",
-            "value": {
-              "stringValue": "0.8.1"
-            }
-          },
-          {
-            "key": "sw.k8s.agent.manifest.version",
-            "value": {
-              "stringValue": "2.7.0-alpha.6"
-            }
-          },
-          {
-            "key": "sw.k8s.cluster.uid",
-            "value": {
-              "stringValue": "cluster-uid-123456789"
-            }
-          },
-          {
-            "key": "sw.k8s.container.init",
-            "value": {
-              "stringValue": "true"
-            }
-          },
-          {
-            "key": "sw.k8s.container.status",
-            "value": {
-              "stringValue": "terminated"
-            }
-          },
-          {
-            "key": "uid",
-            "value": {
-              "stringValue": "c7f7a05a-a1b5-4fd0-a611-8e2a0e7acbf6"
-            }
-          }
-        ]
-      },
-      "scopeMetrics": [
-        {
-          "metrics": [
-            {
-              "gauge": {
-                "dataPoints": [
-                  {
-                    "asDouble": 1,
-                    "attributes": [
-                      {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "http"
-                        }
-                      },
-                      {
-                        "key": "prometheus",
-                        "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
-                        }
-                      },
-                      {
-                        "key": "prometheus_replica",
-                        "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
-                        }
-                      },
-                      {
-                        "key": "service",
-                        "value": {
-                          "stringValue": "test-service"
-                        }
-                      }
-                    ],
-                    "timeUnixNano": "0"
-                  }
-                ]
-              },
-              "name": "k8s.container.status"
-            }
-          ],
-          "scope": {}
-        }
-      ]
-    },
-    {
-      "resource": {
-        "attributes": [
-          {
-            "key": "container",
-            "value": {
-              "stringValue": "test-container"
-            }
-          },
-          {
-            "key": "http.scheme",
-            "value": {
-              "stringValue": "http"
-            }
-          },
-          {
-            "key": "k8s.cluster.name",
-            "value": {
-              "stringValue": "cluster name"
-            }
-          },
-          {
-            "key": "k8s.container.name",
-            "value": {
-              "stringValue": "test-container"
-            }
-          },
-          {
-            "key": "k8s.namespace.annotations.description",
-            "value": {
-              "stringValue": "This is a test namespace."
-            }
-          },
-          {
-            "key": "k8s.namespace.labels.app",
-            "value": {
-              "stringValue": "test-app"
-            }
-          },
-          {
-            "key": "k8s.namespace.labels.kubernetes.io/metadata.name",
-            "value": {
-              "stringValue": "test-namespace"
-            }
-          },
-          {
-            "key": "k8s.namespace.labels.purpose",
-            "value": {
-              "stringValue": "testing"
-            }
-          },
-          {
-            "key": "k8s.namespace.name",
-            "value": {
-              "stringValue": "test-namespace"
-            }
-          },
-          {
-            "key": "k8s.pod.annotations.test-annotation",
-            "value": {
-              "stringValue": "test-value"
-            }
-          },
-          {
-            "key": "k8s.pod.labels.app",
-            "value": {
-              "stringValue": "test-pod"
-            }
-          },
-          {
-            "key": "k8s.pod.name",
-            "value": {
-              "stringValue": "test-pod"
-            }
-          },
-          {
-            "key": "k8s.pod.uid",
-            "value": {
-              "stringValue": "c7f7a05a-a1b5-4fd0-a611-8e2a0e7acbf6"
-            }
-          },
-          {
-            "key": "namespace",
-            "value": {
-              "stringValue": "test-namespace"
-            }
-          },
-          {
-            "key": "net.host.name",
-            "value": {
-              "stringValue": "test-node"
-            }
-          },
-          {
-            "key": "net.host.port",
-            "value": {
-              "stringValue": ""
-            }
-          },
-          {
-            "key": "pod",
-            "value": {
-              "stringValue": "test-pod"
-            }
-          },
-          {
-            "key": "sw.k8s.agent.app.version",
-            "value": {
-              "stringValue": "0.8.1"
-            }
-          },
-          {
-            "key": "sw.k8s.agent.manifest.version",
-            "value": {
-              "stringValue": "2.7.0-alpha.6"
-            }
-          },
-          {
-            "key": "sw.k8s.cluster.uid",
-            "value": {
-              "stringValue": "cluster-uid-123456789"
-            }
-          },
-          {
-            "key": "sw.k8s.container.init",
-            "value": {
-              "stringValue": "true"
-            }
-          },
-          {
-            "key": "uid",
-            "value": {
-              "stringValue": "c7f7a05a-a1b5-4fd0-a611-8e2a0e7acbf6"
-            }
-          }
-        ]
-      },
-      "scopeMetrics": [
-        {
-          "metrics": [
-            {
-              "gauge": {
-                "dataPoints": [
-                  {
-                    "asDouble": 0.25,
-                    "attributes": [
-                      {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "http"
-                        }
-                      },
-                      {
-                        "key": "prometheus",
-                        "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
-                        }
-                      },
-                      {
-                        "key": "prometheus_replica",
-                        "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
-                        }
-                      },
-                      {
-                        "key": "service",
-                        "value": {
-                          "stringValue": "test-service"
-                        }
-                      }
-                    ],
-                    "timeUnixNano": "0"
-                  }
-                ]
-              },
-              "name": "k8s.kube_pod_init_container_resource_requests_cpu_cores"
-            },
-            {
-              "gauge": {
-                "dataPoints": [
-                  {
-                    "asDouble": 67108864,
-                    "attributes": [
-                      {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "http"
-                        }
-                      },
-                      {
-                        "key": "prometheus",
-                        "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
-                        }
-                      },
-                      {
-                        "key": "prometheus_replica",
-                        "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
-                        }
-                      },
-                      {
-                        "key": "service",
-                        "value": {
-                          "stringValue": "test-service"
-                        }
-                      }
-                    ],
-                    "timeUnixNano": "0"
-                  }
-                ]
-              },
-              "name": "k8s.kube_pod_init_container_resource_requests_memory_bytes"
-            },
-            {
-              "gauge": {
-                "dataPoints": [
-                  {
-                    "asDouble": 0,
-                    "attributes": [
-                      {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "http"
-                        }
-                      },
-                      {
-                        "key": "prometheus",
-                        "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
-                        }
-                      },
-                      {
-                        "key": "prometheus_replica",
-                        "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
-                        }
-                      },
-                      {
-                        "key": "service",
-                        "value": {
-                          "stringValue": "test-service"
-                        }
-                      }
-                    ],
-                    "timeUnixNano": "0"
-                  }
-                ]
-              },
-              "name": "k8s.kube_pod_init_container_status_running"
-            },
-            {
-              "gauge": {
-                "dataPoints": [
-                  {
-                    "asDouble": 1,
-                    "attributes": [
-                      {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "http"
-                        }
-                      },
-                      {
-                        "key": "prometheus",
-                        "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
-                        }
-                      },
-                      {
-                        "key": "prometheus_replica",
-                        "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
-                        }
-                      },
-                      {
-                        "key": "service",
-                        "value": {
-                          "stringValue": "test-service"
-                        }
-                      }
-                    ],
-                    "timeUnixNano": "0"
-                  }
-                ]
-              },
-              "name": "k8s.kube_pod_init_container_status_terminated"
-            },
-            {
-              "gauge": {
-                "dataPoints": [
-                  {
-                    "asDouble": 1,
-                    "attributes": [
-                      {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "http"
-                        }
-                      },
-                      {
-                        "key": "prometheus",
-                        "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
-                        }
-                      },
-                      {
-                        "key": "prometheus_replica",
-                        "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
-                        }
-                      },
-                      {
-                        "key": "reason",
-                        "value": {
-                          "stringValue": "Completed"
-                        }
-                      },
-                      {
-                        "key": "service",
-                        "value": {
-                          "stringValue": "test-service"
-                        }
-                      }
-                    ],
-                    "timeUnixNano": "0"
-                  }
-                ]
-              },
-              "name": "k8s.kube_pod_init_container_status_terminated_reason"
-            },
-            {
-              "gauge": {
-                "dataPoints": [
-                  {
-                    "asDouble": 0,
-                    "attributes": [
-                      {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "http"
-                        }
-                      },
-                      {
-                        "key": "prometheus",
-                        "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
-                        }
-                      },
-                      {
-                        "key": "prometheus_replica",
-                        "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
-                        }
-                      },
-                      {
-                        "key": "service",
-                        "value": {
-                          "stringValue": "test-service"
-                        }
-                      }
-                    ],
-                    "timeUnixNano": "0"
-                  }
-                ]
-              },
-              "name": "k8s.kube_pod_init_container_status_waiting"
-            }
-          ],
-          "scope": {}
-        }
-      ]
-    },
-    {
-      "resource": {
-        "attributes": [
-          {
-            "key": "container",
-            "value": {
-              "stringValue": "test-container"
-            }
-          },
-          {
-            "key": "http.scheme",
-            "value": {
-              "stringValue": "http"
-            }
-          },
-          {
-            "key": "k8s.cluster.name",
-            "value": {
-              "stringValue": "cluster name"
-            }
-          },
-          {
-            "key": "k8s.container.name",
-            "value": {
-              "stringValue": "test-container"
-            }
-          },
-          {
-            "key": "k8s.namespace.annotations.description",
-            "value": {
-              "stringValue": "This is a test namespace."
-            }
-          },
-          {
-            "key": "k8s.namespace.labels.app",
-            "value": {
-              "stringValue": "test-app"
-            }
-          },
-          {
-            "key": "k8s.namespace.labels.kubernetes.io/metadata.name",
-            "value": {
-              "stringValue": "test-namespace"
-            }
-          },
-          {
-            "key": "k8s.namespace.labels.purpose",
-            "value": {
-              "stringValue": "testing"
-            }
-          },
-          {
-            "key": "k8s.namespace.name",
-            "value": {
-              "stringValue": "test-namespace"
-            }
-          },
-          {
-            "key": "k8s.pod.annotations.test-annotation",
-            "value": {
-              "stringValue": "test-value"
-            }
-          },
-          {
-            "key": "k8s.pod.labels.app",
-            "value": {
-              "stringValue": "test-pod"
-            }
-          },
-          {
-            "key": "k8s.pod.name",
-            "value": {
-              "stringValue": "test-pod"
-            }
-          },
-          {
-            "key": "k8s.replicaset.annotations.test-annotation",
-            "value": {
-              "stringValue": "test-value"
-            }
-          },
-          {
-            "key": "k8s.replicaset.labels.app",
-            "value": {
-              "stringValue": "test-replicaset"
-            }
-          },
-          {
-            "key": "k8s.replicaset.name",
-            "value": {
-              "stringValue": "test-replicaset"
-            }
-          },
-          {
-            "key": "namespace",
-            "value": {
-              "stringValue": "test-namespace"
-            }
-          },
-          {
-            "key": "net.host.name",
-            "value": {
-              "stringValue": "test-node"
-            }
-          },
-          {
-            "key": "net.host.port",
-            "value": {
-              "stringValue": ""
-            }
-          },
-          {
-            "key": "pod",
-            "value": {
-              "stringValue": "test-pod"
-            }
-          },
-          {
-            "key": "replicaset",
-            "value": {
-              "stringValue": "test-replicaset"
-            }
-          },
-          {
-            "key": "sw.k8s.agent.app.version",
-            "value": {
-              "stringValue": "0.8.1"
-            }
-          },
-          {
-            "key": "sw.k8s.agent.manifest.version",
-            "value": {
-              "stringValue": "2.7.0-alpha.6"
-            }
-          },
-          {
-            "key": "sw.k8s.cluster.uid",
-            "value": {
-              "stringValue": "cluster-uid-123456789"
-            }
-          }
-        ]
-      },
-      "scopeMetrics": [
-        {
-          "metrics": [
-            {
-              "gauge": {
-                "dataPoints": [
-                  {
-                    "asDouble": 1678895204,
-                    "attributes": [
-                      {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "http"
-                        }
-                      },
-                      {
-                        "key": "prometheus",
-                        "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
-                        }
-                      },
-                      {
-                        "key": "prometheus_replica",
-                        "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
-                        }
-                      },
-                      {
-                        "key": "service",
-                        "value": {
-                          "stringValue": "test-service"
-                        }
-                      }
-                    ],
-                    "timeUnixNano": "0"
-                  }
-                ]
-              },
-              "name": "k8s.kube_replicaset_created"
-            },
-            {
-              "gauge": {
-                "dataPoints": [
-                  {
-                    "asDouble": 1,
-                    "attributes": [
-                      {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "http"
-                        }
-                      },
-                      {
-                        "key": "owner_is_controller",
-                        "value": {
-                          "stringValue": "true"
-                        }
-                      },
-                      {
-                        "key": "owner_kind",
-                        "value": {
-                          "stringValue": "Deployment"
-                        }
-                      },
-                      {
-                        "key": "owner_name",
-                        "value": {
-                          "stringValue": "core-c1"
-                        }
-                      },
-                      {
-                        "key": "prometheus",
-                        "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
-                        }
-                      },
-                      {
-                        "key": "prometheus_replica",
-                        "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
-                        }
-                      },
-                      {
-                        "key": "service",
-                        "value": {
-                          "stringValue": "test-service"
-                        }
-                      }
-                    ],
-                    "timeUnixNano": "0"
-                  },
-                  {
-                    "asDouble": 1,
-                    "attributes": [
-                      {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "http"
-                        }
-                      },
-                      {
-                        "key": "owner_is_controller",
-                        "value": {
-                          "stringValue": "true"
-                        }
-                      },
-                      {
-                        "key": "owner_kind",
-                        "value": {
-                          "stringValue": "Deployment"
-                        }
-                      },
-                      {
-                        "key": "owner_name",
-                        "value": {
-                          "stringValue": "swi-k8s-otel-collector-swo-k8s-collector-metrics"
-                        }
-                      },
-                      {
-                        "key": "prometheus",
-                        "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
-                        }
-                      },
-                      {
-                        "key": "prometheus_replica",
-                        "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
-                        }
-                      },
-                      {
-                        "key": "service",
-                        "value": {
-                          "stringValue": "test-service"
-                        }
-                      }
-                    ],
-                    "timeUnixNano": "0"
-                  }
-                ]
-              },
-              "name": "k8s.kube_replicaset_owner"
-            },
-            {
-              "gauge": {
-                "dataPoints": [
-                  {
-                    "asDouble": 0,
-                    "attributes": [
-                      {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "http"
-                        }
-                      },
-                      {
-                        "key": "prometheus",
-                        "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
-                        }
-                      },
-                      {
-                        "key": "prometheus_replica",
-                        "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
-                        }
-                      },
-                      {
-                        "key": "service",
-                        "value": {
-                          "stringValue": "test-service"
-                        }
-                      }
-                    ],
-                    "timeUnixNano": "0"
-                  }
-                ]
-              },
-              "name": "k8s.kube_replicaset_spec_replicas"
-            },
-            {
-              "gauge": {
-                "dataPoints": [
-                  {
-                    "asDouble": 0,
-                    "attributes": [
-                      {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "http"
-                        }
-                      },
-                      {
-                        "key": "prometheus",
-                        "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
-                        }
-                      },
-                      {
-                        "key": "prometheus_replica",
-                        "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
-                        }
-                      },
-                      {
-                        "key": "service",
-                        "value": {
-                          "stringValue": "test-service"
-                        }
-                      }
-                    ],
-                    "timeUnixNano": "0"
-                  }
-                ]
-              },
-              "name": "k8s.kube_replicaset_status_ready_replicas"
-            },
-            {
-              "gauge": {
-                "dataPoints": [
-                  {
-                    "asDouble": 0,
-                    "attributes": [
-                      {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "http"
-                        }
-                      },
-                      {
-                        "key": "prometheus",
-                        "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
-                        }
-                      },
-                      {
-                        "key": "prometheus_replica",
-                        "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
-                        }
-                      },
-                      {
-                        "key": "service",
-                        "value": {
-                          "stringValue": "test-service"
-                        }
-                      }
-                    ],
-                    "timeUnixNano": "0"
-                  }
-                ]
-              },
-              "name": "k8s.kube_replicaset_status_replicas"
-            }
-          ],
-          "scope": {}
-        }
-      ]
-    },
-    {
-      "resource": {
-        "attributes": [
-          {
-            "key": "container",
-            "value": {
-              "stringValue": "test-container"
-            }
-          },
-          {
-            "key": "http.scheme",
-            "value": {
-              "stringValue": "http"
-            }
-          },
-          {
-            "key": "k8s.cluster.name",
-            "value": {
-              "stringValue": "cluster name"
-            }
-          },
-          {
-            "key": "k8s.container.name",
-            "value": {
-              "stringValue": "test-container"
-            }
-          },
-          {
-            "key": "k8s.namespace.annotations.description",
-            "value": {
-              "stringValue": "This is a test namespace."
-            }
-          },
-          {
-            "key": "k8s.namespace.labels.app",
-            "value": {
-              "stringValue": "test-app"
-            }
-          },
-          {
-            "key": "k8s.namespace.labels.kubernetes.io/metadata.name",
-            "value": {
-              "stringValue": "test-namespace"
-            }
-          },
-          {
-            "key": "k8s.namespace.labels.purpose",
-            "value": {
-              "stringValue": "testing"
-            }
-          },
-          {
-            "key": "k8s.namespace.name",
-            "value": {
-              "stringValue": "test-namespace"
-            }
-          },
-          {
-            "key": "k8s.pod.annotations.test-annotation",
-            "value": {
-              "stringValue": "test-value"
-            }
-          },
-          {
-            "key": "k8s.pod.labels.app",
-            "value": {
-              "stringValue": "test-pod"
-            }
-          },
-          {
-            "key": "k8s.pod.name",
-            "value": {
-              "stringValue": "test-pod"
-            }
-          },
-          {
-            "key": "k8s.replicaset.name",
-            "value": {
-              "stringValue": "swi-k8s-otel-collector-swo-k8s-collector-metrics-cf8f6886b"
-            }
-          },
-          {
-            "key": "namespace",
-            "value": {
-              "stringValue": "test-namespace"
-            }
-          },
-          {
-            "key": "net.host.name",
-            "value": {
-              "stringValue": "test-node"
-            }
-          },
-          {
-            "key": "net.host.port",
-            "value": {
-              "stringValue": ""
-            }
-          },
-          {
-            "key": "pod",
-            "value": {
-              "stringValue": "test-pod"
-            }
-          },
-          {
-            "key": "replicaset",
-            "value": {
-              "stringValue": "swi-k8s-otel-collector-swo-k8s-collector-metrics-cf8f6886b"
-            }
-          },
-          {
-            "key": "sw.k8s.agent.app.version",
-            "value": {
-              "stringValue": "0.8.1"
-            }
-          },
-          {
-            "key": "sw.k8s.agent.manifest.version",
-            "value": {
-              "stringValue": "2.7.0-alpha.6"
-            }
-          },
-          {
-            "key": "sw.k8s.cluster.uid",
-            "value": {
-              "stringValue": "cluster-uid-123456789"
-            }
-          }
-        ]
-      },
-      "scopeMetrics": [
-        {
-          "metrics": [
-            {
-              "gauge": {
-                "dataPoints": [
-                  {
-                    "asDouble": 1,
-                    "attributes": [
-                      {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "tcp-model"
-                        }
-                      },
-                      {
-                        "key": "owner_is_controller",
-                        "value": {
-                          "stringValue": "true"
-                        }
-                      },
-                      {
-                        "key": "owner_kind",
-                        "value": {
-                          "stringValue": "ReplicaSet"
-                        }
-                      },
-                      {
-                        "key": "prometheus",
-                        "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
-                        }
-                      },
-                      {
-                        "key": "prometheus_replica",
-                        "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
-                        }
-                      },
-                      {
-                        "key": "service",
-                        "value": {
-                          "stringValue": "test-service"
-                        }
-                      }
-                    ],
-                    "timeUnixNano": "0"
-                  }
-                ]
-              },
-              "name": "k8s.kube.pod.owner.replicaset"
-            }
-          ],
-          "scope": {}
-        }
-      ]
-    },
-    {
-      "resource": {
-        "attributes": [
-          {
-            "key": "container",
-            "value": {
-              "stringValue": "test-container"
-            }
-          },
-          {
-            "key": "http.scheme",
-            "value": {
-              "stringValue": "http"
-            }
-          },
-          {
-            "key": "k8s.cluster.name",
-            "value": {
-              "stringValue": "cluster name"
-            }
-          },
-          {
-            "key": "k8s.container.name",
-            "value": {
-              "stringValue": "test-container"
-            }
-          },
-          {
-            "key": "k8s.namespace.annotations.description",
-            "value": {
-              "stringValue": "This is a test namespace."
-            }
-          },
-          {
-            "key": "k8s.namespace.labels.app",
-            "value": {
-              "stringValue": "test-app"
-            }
-          },
-          {
-            "key": "k8s.namespace.labels.kubernetes.io/metadata.name",
-            "value": {
-              "stringValue": "test-namespace"
-            }
-          },
-          {
-            "key": "k8s.namespace.labels.purpose",
-            "value": {
-              "stringValue": "testing"
-            }
-          },
-          {
-            "key": "k8s.namespace.name",
-            "value": {
-              "stringValue": "test-namespace"
-            }
-          },
-          {
-            "key": "k8s.pod.annotations.test-annotation",
-            "value": {
-              "stringValue": "test-value"
-            }
-          },
-          {
-            "key": "k8s.pod.labels.app",
-            "value": {
-              "stringValue": "test-pod"
-            }
-          },
-          {
-            "key": "k8s.pod.name",
-            "value": {
-              "stringValue": "test-pod"
-            }
-          },
-          {
-            "key": "k8s.statefulset.annotations.test-annotation",
-            "value": {
-              "stringValue": "test-value"
-            }
-          },
-          {
-            "key": "k8s.statefulset.labels.app",
-            "value": {
-              "stringValue": "test-statefulset"
-            }
-          },
-          {
-            "key": "k8s.statefulset.name",
-            "value": {
-              "stringValue": "test-statefulset"
-            }
-          },
-          {
-            "key": "namespace",
-            "value": {
-              "stringValue": "test-namespace"
-            }
-          },
-          {
-            "key": "net.host.name",
-            "value": {
-              "stringValue": "test-node"
-            }
-          },
-          {
-            "key": "net.host.port",
-            "value": {
-              "stringValue": ""
-            }
-          },
-          {
-            "key": "pod",
-            "value": {
-              "stringValue": "test-pod"
-            }
-          },
-          {
-            "key": "statefulset",
-            "value": {
-              "stringValue": "test-statefulset"
-            }
-          },
-          {
-            "key": "sw.k8s.agent.app.version",
-            "value": {
-              "stringValue": "0.8.1"
-            }
-          },
-          {
-            "key": "sw.k8s.agent.manifest.version",
-            "value": {
-              "stringValue": "2.7.0-alpha.6"
-            }
-          },
-          {
-            "key": "sw.k8s.cluster.uid",
-            "value": {
-              "stringValue": "cluster-uid-123456789"
-            }
-          }
-        ]
-      },
-      "scopeMetrics": [
-        {
-          "metrics": [
-            {
-              "gauge": {
-                "dataPoints": [
-                  {
-                    "asDouble": 1645144985,
-                    "attributes": [
-                      {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "http"
-                        }
-                      },
-                      {
-                        "key": "prometheus",
-                        "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
-                        }
-                      },
-                      {
-                        "key": "prometheus_replica",
-                        "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
-                        }
-                      },
-                      {
-                        "key": "service",
-                        "value": {
-                          "stringValue": "test-service"
-                        }
-                      }
-                    ],
-                    "timeUnixNano": "0"
-                  }
-                ]
-              },
-              "name": "k8s.kube_statefulset_created"
-            },
-            {
-              "gauge": {
-                "dataPoints": [
-                  {
-                    "asDouble": 1,
-                    "attributes": [
-                      {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "http"
-                        }
-                      },
-                      {
-                        "key": "prometheus",
-                        "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
-                        }
-                      },
-                      {
-                        "key": "prometheus_replica",
-                        "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
-                        }
-                      },
-                      {
-                        "key": "service",
-                        "value": {
-                          "stringValue": "test-service"
-                        }
-                      }
-                    ],
-                    "timeUnixNano": "0"
-                  }
-                ]
-              },
-              "name": "k8s.kube_statefulset_labels"
-            },
-            {
-              "gauge": {
-                "dataPoints": [
-                  {
-                    "asDouble": 3,
-                    "attributes": [
-                      {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "http"
-                        }
-                      },
-                      {
-                        "key": "prometheus",
-                        "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
-                        }
-                      },
-                      {
-                        "key": "prometheus_replica",
-                        "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
-                        }
-                      },
-                      {
-                        "key": "service",
-                        "value": {
-                          "stringValue": "test-service"
-                        }
-                      }
-                    ],
-                    "timeUnixNano": "0"
-                  }
-                ]
-              },
-              "name": "k8s.kube_statefulset_replicas"
-            },
-            {
-              "gauge": {
-                "dataPoints": [
-                  {
-                    "asDouble": 3,
-                    "attributes": [
-                      {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "http"
-                        }
-                      },
-                      {
-                        "key": "prometheus",
-                        "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
-                        }
-                      },
-                      {
-                        "key": "prometheus_replica",
-                        "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
-                        }
-                      },
-                      {
-                        "key": "service",
-                        "value": {
-                          "stringValue": "test-service"
-                        }
-                      }
-                    ],
-                    "timeUnixNano": "0"
-                  }
-                ]
-              },
-              "name": "k8s.kube_statefulset_status_replicas_current"
-            },
-            {
-              "gauge": {
-                "dataPoints": [
-                  {
-                    "asDouble": 1,
-                    "attributes": [
-                      {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "http"
-                        }
-                      },
-                      {
-                        "key": "prometheus",
-                        "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
-                        }
-                      },
-                      {
-                        "key": "prometheus_replica",
-                        "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
-                        }
-                      },
-                      {
-                        "key": "service",
-                        "value": {
-                          "stringValue": "test-service"
-                        }
-                      }
-                    ],
-                    "timeUnixNano": "0"
-                  }
-                ]
-              },
-              "name": "k8s.kube_statefulset_status_replicas_ready"
-            },
-            {
-              "gauge": {
-                "dataPoints": [
-                  {
-                    "asDouble": 1,
-                    "attributes": [
-                      {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "http"
-                        }
-                      },
-                      {
-                        "key": "prometheus",
-                        "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
-                        }
-                      },
-                      {
-                        "key": "prometheus_replica",
-                        "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
-                        }
-                      },
-                      {
-                        "key": "service",
-                        "value": {
-                          "stringValue": "test-service"
-                        }
-                      }
-                    ],
-                    "timeUnixNano": "0"
-                  }
-                ]
-              },
-              "name": "k8s.kube_statefulset_status_replicas_updated"
-            }
-          ],
-          "scope": {}
-        }
-      ]
-    },
-    {
-      "resource": {
-        "attributes": [
-          {
-            "key": "container",
-            "value": {
-              "stringValue": "test-container"
-            }
-          },
-          {
-            "key": "http.scheme",
-            "value": {
-              "stringValue": "http"
-            }
-          },
-          {
-            "key": "k8s.cluster.name",
-            "value": {
-              "stringValue": "cluster name"
-            }
-          },
-          {
-            "key": "k8s.container.name",
-            "value": {
-              "stringValue": "test-container"
-            }
-          },
-          {
-            "key": "k8s.namespace.annotations.description",
-            "value": {
-              "stringValue": "This is a test namespace."
-            }
-          },
-          {
-            "key": "k8s.namespace.labels.app",
-            "value": {
-              "stringValue": "test-app"
-            }
-          },
-          {
-            "key": "k8s.namespace.labels.kubernetes.io/metadata.name",
-            "value": {
-              "stringValue": "test-namespace"
-            }
-          },
-          {
-            "key": "k8s.namespace.labels.purpose",
-            "value": {
-              "stringValue": "testing"
-            }
-          },
-          {
-            "key": "k8s.namespace.name",
-            "value": {
-              "stringValue": "test-namespace"
-            }
-          },
-          {
-            "key": "k8s.pod.annotations.test-annotation",
-            "value": {
-              "stringValue": "test-value"
-            }
-          },
-          {
-            "key": "k8s.pod.labels.app",
-            "value": {
-              "stringValue": "test-pod"
-            }
-          },
-          {
-            "key": "k8s.pod.name",
-            "value": {
-              "stringValue": "test-pod"
-            }
-          },
-          {
-            "key": "namespace",
-            "value": {
-              "stringValue": "test-namespace"
-            }
-          },
-          {
-            "key": "net.host.name",
-            "value": {
-              "stringValue": "test-node"
-            }
-          },
-          {
-            "key": "net.host.port",
-            "value": {
-              "stringValue": ""
-            }
-          },
-          {
-            "key": "pod",
-            "value": {
-              "stringValue": "test-pod"
-            }
-          },
-          {
-            "key": "sw.k8s.agent.app.version",
-            "value": {
-              "stringValue": "0.8.1"
-            }
-          },
-          {
-            "key": "sw.k8s.agent.manifest.version",
-            "value": {
-              "stringValue": "2.7.0-alpha.6"
-            }
-          },
-          {
-            "key": "sw.k8s.cluster.uid",
-            "value": {
-              "stringValue": "cluster-uid-123456789"
-            }
-          }
-        ]
-      },
-      "scopeMetrics": [
-        {
-          "metrics": [
-            {
-              "gauge": {
-                "dataPoints": [
-                  {
-                    "asDouble": 0,
-                    "startTimeUnixNano": "0",
-                    "timeUnixNano": "0"
-                  }
-                ]
-              },
-              "name": "k8s.container.fs.iops"
-            },
-            {
-              "gauge": {
-                "dataPoints": [
-                  {
-                    "asDouble": 0,
-                    "startTimeUnixNano": "0",
-                    "timeUnixNano": "0"
-                  }
-                ]
-              },
-              "name": "k8s.container.fs.throughput"
-            },
-            {
-              "gauge": {
-                "dataPoints": [
-                  {
-                    "asDouble": 1648847018,
-                    "attributes": [
-                      {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "http"
-                        }
-                      },
-                      {
-                        "key": "prometheus",
-                        "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
-                        }
-                      },
-                      {
-                        "key": "prometheus_replica",
-                        "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
-                        }
-                      },
-                      {
-                        "key": "service",
-                        "value": {
-                          "stringValue": "test-service"
-                        }
-                      }
-                    ],
-                    "timeUnixNano": "0"
-                  }
-                ]
-              },
-              "name": "k8s.kube_namespace_created"
-            },
-            {
-              "gauge": {
-                "dataPoints": [
-                  {
-                    "asDouble": 1,
-                    "attributes": [
-                      {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "tcp-model"
-                        }
-                      },
-                      {
-                        "key": "owner_is_controller",
-                        "value": {
-                          "stringValue": "true"
-                        }
-                      },
-                      {
-                        "key": "owner_kind",
-                        "value": {
-                          "stringValue": "DaemonSet"
-                        }
-                      },
-                      {
-                        "key": "owner_name",
-                        "value": {
-                          "stringValue": "spire-spiffe-csi-driver"
-                        }
-                      },
-                      {
-                        "key": "prometheus",
-                        "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
-                        }
-                      },
-                      {
-                        "key": "prometheus_replica",
-                        "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
-                        }
-                      },
-                      {
-                        "key": "service",
-                        "value": {
-                          "stringValue": "test-service"
-                        }
-                      }
-                    ],
-                    "timeUnixNano": "0"
-                  },
-                  {
-                    "asDouble": 1,
-                    "attributes": [
-                      {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "tcp-model"
-                        }
-                      },
-                      {
-                        "key": "owner_is_controller",
-                        "value": {
-                          "stringValue": "true"
-                        }
-                      },
-                      {
-                        "key": "owner_kind",
-                        "value": {
-                          "stringValue": "ReplicaSet"
-                        }
-                      },
-                      {
-                        "key": "owner_name",
-                        "value": {
-                          "stringValue": "swi-k8s-otel-collector-swo-k8s-collector-metrics-cf8f6886b"
-                        }
-                      },
-                      {
-                        "key": "prometheus",
-                        "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
-                        }
-                      },
-                      {
-                        "key": "prometheus_replica",
-                        "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
-                        }
-                      },
-                      {
-                        "key": "service",
-                        "value": {
-                          "stringValue": "test-service"
-                        }
-                      }
-                    ],
-                    "timeUnixNano": "0"
-                  }
-                ]
-              },
-              "name": "k8s.kube_pod_owner"
-            },
-            {
-              "gauge": {
-                "dataPoints": [
-                  {
-                    "asDouble": 100,
-                    "attributes": [
-                      {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "http"
-                        }
-                      },
-                      {
-                        "key": "prometheus",
-                        "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
-                        }
-                      },
-                      {
-                        "key": "prometheus_replica",
-                        "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
-                        }
-                      },
-                      {
-                        "key": "resource",
-                        "value": {
-                          "stringValue": "pods"
-                        }
-                      },
-                      {
-                        "key": "resourcequota",
-                        "value": {
-                          "stringValue": "gatekeeper-critical-pods"
-                        }
-                      },
-                      {
-                        "key": "service",
-                        "value": {
-                          "stringValue": "test-service"
-                        }
-                      },
-                      {
-                        "key": "type",
-                        "value": {
-                          "stringValue": "hard"
-                        }
-                      }
-                    ],
-                    "timeUnixNano": "0"
-                  }
-                ]
-              },
-              "name": "k8s.kube_resourcequota"
-            }
-          ],
-          "scope": {}
-        }
-      ]
-    },
-    {
-      "resource": {
-        "attributes": [
-          {
-            "key": "container",
-            "value": {
-              "stringValue": "test-container"
-            }
-          },
-          {
-            "key": "http.scheme",
-            "value": {
-              "stringValue": "http"
-            }
-          },
-          {
-            "key": "k8s.cluster.name",
-            "value": {
-              "stringValue": "cluster name"
-            }
-          },
-          {
-            "key": "k8s.container.name",
-            "value": {
-              "stringValue": "test-container"
-            }
-          },
-          {
-            "key": "k8s.namespace.annotations.description",
-            "value": {
-              "stringValue": "This is a test namespace."
-            }
-          },
-          {
-            "key": "k8s.namespace.labels.app",
-            "value": {
-              "stringValue": "test-app"
-            }
-          },
-          {
-            "key": "k8s.namespace.labels.kubernetes.io/metadata.name",
-            "value": {
-              "stringValue": "test-namespace"
-            }
-          },
-          {
-            "key": "k8s.namespace.labels.purpose",
-            "value": {
-              "stringValue": "testing"
-            }
-          },
-          {
-            "key": "k8s.namespace.name",
-            "value": {
-              "stringValue": "test-namespace"
-            }
-          },
-          {
-            "key": "k8s.pod.annotations.test-annotation",
-            "value": {
-              "stringValue": "test-value"
-            }
-          },
-          {
-            "key": "k8s.pod.labels.app",
-            "value": {
-              "stringValue": "test-pod"
-            }
-          },
-          {
-            "key": "k8s.pod.name",
-            "value": {
-              "stringValue": "test-pod"
-            }
-          },
-          {
-            "key": "namespace",
-            "value": {
-              "stringValue": "test-namespace"
-            }
-          },
-          {
-            "key": "net.host.name",
-            "value": {
-              "stringValue": "test-node"
-            }
-          },
-          {
-            "key": "net.host.port",
-            "value": {
-              "stringValue": ""
-            }
-          },
-          {
-            "key": "pod",
-            "value": {
-              "stringValue": "test-pod"
-            }
-          },
-          {
-            "key": "sw.k8s.agent.app.version",
-            "value": {
-              "stringValue": "0.8.1"
-            }
-          },
-          {
-            "key": "sw.k8s.agent.manifest.version",
-            "value": {
-              "stringValue": "2.7.0-alpha.6"
-            }
-          },
-          {
-            "key": "sw.k8s.cluster.uid",
-            "value": {
-              "stringValue": "cluster-uid-123456789"
-            }
-          },
-          {
-            "key": "sw.k8s.namespace.status",
-            "value": {
-              "stringValue": "Active"
-            }
-          }
-        ]
-      },
-      "scopeMetrics": [
-        {
-          "metrics": [
-            {
-              "gauge": {
-                "dataPoints": [
-                  {
-                    "asDouble": 1,
-                    "attributes": [
-                      {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "http"
-                        }
-                      },
-                      {
-                        "key": "phase",
-                        "value": {
-                          "stringValue": "Active"
-                        }
-                      },
-                      {
-                        "key": "prometheus",
-                        "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
-                        }
-                      },
-                      {
-                        "key": "prometheus_replica",
-                        "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
-                        }
-                      },
-                      {
-                        "key": "service",
-                        "value": {
-                          "stringValue": "test-service"
-                        }
-                      }
-                    ],
-                    "timeUnixNano": "0"
-                  }
-                ]
-              },
-              "name": "k8s.kube_namespace_status_phase"
-            }
-          ],
-          "scope": {}
-        }
-      ]
-    },
-    {
-      "resource": {
-        "attributes": [
-          {
             "key": "http.scheme",
             "value": {
               "stringValue": "http"
@@ -21466,6 +21688,143 @@
             "key": "k8s.node.name",
             "value": {
               "stringValue": "test-node"
+            }
+          },
+          {
+            "key": "k8s.pod.annotations.test-annotation",
+            "value": {
+              "stringValue": "test-value"
+            }
+          },
+          {
+            "key": "k8s.pod.labels.app",
+            "value": {
+              "stringValue": "test-pod"
+            }
+          },
+          {
+            "key": "k8s.pod.name",
+            "value": {
+              "stringValue": "test-pod"
+            }
+          },
+          {
+            "key": "namespace",
+            "value": {
+              "stringValue": "test-namespace"
+            }
+          },
+          {
+            "key": "net.host.name",
+            "value": {
+              "stringValue": "test-node"
+            }
+          },
+          {
+            "key": "net.host.port",
+            "value": {
+              "stringValue": ""
+            }
+          },
+          {
+            "key": "pod",
+            "value": {
+              "stringValue": "test-pod"
+            }
+          },
+          {
+            "key": "sw.k8s.agent.app.version",
+            "value": {
+              "stringValue": "0.8.1"
+            }
+          },
+          {
+            "key": "sw.k8s.agent.manifest.version",
+            "value": {
+              "stringValue": "2.7.0-alpha.6"
+            }
+          },
+          {
+            "key": "sw.k8s.cluster.uid",
+            "value": {
+              "stringValue": "cluster-uid-123456789"
+            }
+          }
+        ]
+      },
+      "scopeMetrics": [
+        {
+          "metrics": [
+            {
+              "gauge": {
+                "dataPoints": [
+                  {
+                    "asDouble": 2,
+                    "timeUnixNano": "0"
+                  }
+                ]
+              },
+              "name": "k8s.pod.containers"
+            },
+            {
+              "gauge": {
+                "dataPoints": [
+                  {
+                    "asDouble": 3,
+                    "timeUnixNano": "0"
+                  }
+                ]
+              },
+              "name": "k8s.pod.containers.running"
+            }
+          ],
+          "scope": {}
+        }
+      ]
+    },
+    {
+      "resource": {
+        "attributes": [
+          {
+            "key": "http.scheme",
+            "value": {
+              "stringValue": "http"
+            }
+          },
+          {
+            "key": "k8s.cluster.name",
+            "value": {
+              "stringValue": "cluster name"
+            }
+          },
+          {
+            "key": "k8s.namespace.annotations.description",
+            "value": {
+              "stringValue": "This is a test namespace."
+            }
+          },
+          {
+            "key": "k8s.namespace.labels.app",
+            "value": {
+              "stringValue": "test-app"
+            }
+          },
+          {
+            "key": "k8s.namespace.labels.kubernetes.io/metadata.name",
+            "value": {
+              "stringValue": "test-namespace"
+            }
+          },
+          {
+            "key": "k8s.namespace.labels.purpose",
+            "value": {
+              "stringValue": "testing"
+            }
+          },
+          {
+            "key": "k8s.namespace.name",
+            "value": {
+              "stringValue": "test-namespace"
             }
           },
           {
@@ -22596,60 +22955,6 @@
             }
           },
           {
-            "key": "k8s.namespace.annotations.description",
-            "value": {
-              "stringValue": "This is a test namespace."
-            }
-          },
-          {
-            "key": "k8s.namespace.labels.app",
-            "value": {
-              "stringValue": "test-app"
-            }
-          },
-          {
-            "key": "k8s.namespace.labels.kubernetes.io/metadata.name",
-            "value": {
-              "stringValue": "test-namespace"
-            }
-          },
-          {
-            "key": "k8s.namespace.labels.purpose",
-            "value": {
-              "stringValue": "testing"
-            }
-          },
-          {
-            "key": "k8s.namespace.name",
-            "value": {
-              "stringValue": "test-namespace"
-            }
-          },
-          {
-            "key": "k8s.pod.annotations.test-annotation",
-            "value": {
-              "stringValue": "test-value"
-            }
-          },
-          {
-            "key": "k8s.pod.labels.app",
-            "value": {
-              "stringValue": "test-pod"
-            }
-          },
-          {
-            "key": "k8s.pod.name",
-            "value": {
-              "stringValue": "test-pod"
-            }
-          },
-          {
-            "key": "namespace",
-            "value": {
-              "stringValue": "test-namespace"
-            }
-          },
-          {
             "key": "net.host.name",
             "value": {
               "stringValue": "test-node"
@@ -22659,12 +22964,6 @@
             "key": "net.host.port",
             "value": {
               "stringValue": ""
-            }
-          },
-          {
-            "key": "pod",
-            "value": {
-              "stringValue": "test-pod"
             }
           },
           {
@@ -22690,6 +22989,50 @@
       "scopeMetrics": [
         {
           "metrics": [
+            {
+              "gauge": {
+                "dataPoints": [
+                  {
+                    "asDouble": 31.78,
+                    "timeUnixNano": "0"
+                  }
+                ]
+              },
+              "name": "k8s.cluster.cpu.allocatable"
+            },
+            {
+              "gauge": {
+                "dataPoints": [
+                  {
+                    "asDouble": 32,
+                    "timeUnixNano": "0"
+                  }
+                ]
+              },
+              "name": "k8s.cluster.cpu.capacity"
+            },
+            {
+              "gauge": {
+                "dataPoints": [
+                  {
+                    "asDouble": 126595563520,
+                    "timeUnixNano": "0"
+                  }
+                ]
+              },
+              "name": "k8s.cluster.memory.allocatable"
+            },
+            {
+              "gauge": {
+                "dataPoints": [
+                  {
+                    "asDouble": 132738121728,
+                    "timeUnixNano": "0"
+                  }
+                ]
+              },
+              "name": "k8s.cluster.memory.capacity"
+            },
             {
               "gauge": {
                 "dataPoints": [
@@ -22699,80 +23042,74 @@
                   }
                 ]
               },
-              "name": "k8s.pod.containers"
+              "name": "k8s.cluster.nodes"
             },
             {
               "gauge": {
                 "dataPoints": [
                   {
-                    "asDouble": 3,
+                    "asDouble": 2,
                     "timeUnixNano": "0"
                   }
                 ]
               },
-              "name": "k8s.pod.containers.running"
-            }
-          ],
-          "scope": {}
-        }
-      ]
-    },
-    {
-      "resource": {
-        "attributes": [
-          {
-            "key": "http.scheme",
-            "value": {
-              "stringValue": "http"
-            }
-          },
-          {
-            "key": "k8s.cluster.name",
-            "value": {
-              "stringValue": "cluster name"
-            }
-          },
-          {
-            "key": "k8s.node.name",
-            "value": {
-              "stringValue": "test-node"
-            }
-          },
-          {
-            "key": "net.host.name",
-            "value": {
-              "stringValue": "test-node"
-            }
-          },
-          {
-            "key": "net.host.port",
-            "value": {
-              "stringValue": ""
-            }
-          },
-          {
-            "key": "sw.k8s.agent.app.version",
-            "value": {
-              "stringValue": "0.8.1"
-            }
-          },
-          {
-            "key": "sw.k8s.agent.manifest.version",
-            "value": {
-              "stringValue": "2.7.0-alpha.6"
-            }
-          },
-          {
-            "key": "sw.k8s.cluster.uid",
-            "value": {
-              "stringValue": "cluster-uid-123456789"
-            }
-          }
-        ]
-      },
-      "scopeMetrics": [
-        {
-          "metrics": [
+              "name": "k8s.cluster.nodes.ready"
+            },
+            {
+              "gauge": {
+                "dataPoints": [
+                  {
+                    "asDouble": 1,
+                    "timeUnixNano": "0"
+                  }
+                ]
+              },
+              "name": "k8s.cluster.nodes.ready.avg"
+            },
+            {
+              "gauge": {
+                "dataPoints": [
+                  {
+                    "asDouble": 2,
+                    "timeUnixNano": "0"
+                  }
+                ]
+              },
+              "name": "k8s.cluster.pods"
+            },
+            {
+              "gauge": {
+                "dataPoints": [
+                  {
+                    "asDouble": 2,
+                    "timeUnixNano": "0"
+                  }
+                ]
+              },
+              "name": "k8s.cluster.pods.running"
+            },
+            {
+              "gauge": {
+                "dataPoints": [
+                  {
+                    "asDouble": 0.1,
+                    "timeUnixNano": "0"
+                  }
+                ]
+              },
+              "name": "k8s.cluster.spec.cpu.requests"
+            },
+            {
+              "gauge": {
+                "dataPoints": [
+                  {
+                    "asDouble": 6442450944,
+                    "timeUnixNano": "0"
+                  }
+                ]
+              },
+              "name": "k8s.cluster.spec.memory.requests"
+            },
             {
               "gauge": {
                 "dataPoints": [
@@ -36370,182 +36707,6 @@
                 ]
               },
               "name": "k8s.node.pods"
-            }
-          ],
-          "scope": {}
-        }
-      ]
-    },
-    {
-      "resource": {
-        "attributes": [
-          {
-            "key": "http.scheme",
-            "value": {
-              "stringValue": "http"
-            }
-          },
-          {
-            "key": "k8s.cluster.name",
-            "value": {
-              "stringValue": "cluster name"
-            }
-          },
-          {
-            "key": "net.host.name",
-            "value": {
-              "stringValue": "test-node"
-            }
-          },
-          {
-            "key": "net.host.port",
-            "value": {
-              "stringValue": ""
-            }
-          },
-          {
-            "key": "sw.k8s.agent.app.version",
-            "value": {
-              "stringValue": "0.8.1"
-            }
-          },
-          {
-            "key": "sw.k8s.agent.manifest.version",
-            "value": {
-              "stringValue": "2.7.0-alpha.6"
-            }
-          },
-          {
-            "key": "sw.k8s.cluster.uid",
-            "value": {
-              "stringValue": "cluster-uid-123456789"
-            }
-          }
-        ]
-      },
-      "scopeMetrics": [
-        {
-          "metrics": [
-            {
-              "gauge": {
-                "dataPoints": [
-                  {
-                    "asDouble": 31.78,
-                    "timeUnixNano": "0"
-                  }
-                ]
-              },
-              "name": "k8s.cluster.cpu.allocatable"
-            },
-            {
-              "gauge": {
-                "dataPoints": [
-                  {
-                    "asDouble": 32,
-                    "timeUnixNano": "0"
-                  }
-                ]
-              },
-              "name": "k8s.cluster.cpu.capacity"
-            },
-            {
-              "gauge": {
-                "dataPoints": [
-                  {
-                    "asDouble": 126595563520,
-                    "timeUnixNano": "0"
-                  }
-                ]
-              },
-              "name": "k8s.cluster.memory.allocatable"
-            },
-            {
-              "gauge": {
-                "dataPoints": [
-                  {
-                    "asDouble": 132738121728,
-                    "timeUnixNano": "0"
-                  }
-                ]
-              },
-              "name": "k8s.cluster.memory.capacity"
-            },
-            {
-              "gauge": {
-                "dataPoints": [
-                  {
-                    "asDouble": 2,
-                    "timeUnixNano": "0"
-                  }
-                ]
-              },
-              "name": "k8s.cluster.nodes"
-            },
-            {
-              "gauge": {
-                "dataPoints": [
-                  {
-                    "asDouble": 2,
-                    "timeUnixNano": "0"
-                  }
-                ]
-              },
-              "name": "k8s.cluster.nodes.ready"
-            },
-            {
-              "gauge": {
-                "dataPoints": [
-                  {
-                    "asDouble": 1,
-                    "timeUnixNano": "0"
-                  }
-                ]
-              },
-              "name": "k8s.cluster.nodes.ready.avg"
-            },
-            {
-              "gauge": {
-                "dataPoints": [
-                  {
-                    "asDouble": 2,
-                    "timeUnixNano": "0"
-                  }
-                ]
-              },
-              "name": "k8s.cluster.pods"
-            },
-            {
-              "gauge": {
-                "dataPoints": [
-                  {
-                    "asDouble": 2,
-                    "timeUnixNano": "0"
-                  }
-                ]
-              },
-              "name": "k8s.cluster.pods.running"
-            },
-            {
-              "gauge": {
-                "dataPoints": [
-                  {
-                    "asDouble": 0.1,
-                    "timeUnixNano": "0"
-                  }
-                ]
-              },
-              "name": "k8s.cluster.spec.cpu.requests"
-            },
-            {
-              "gauge": {
-                "dataPoints": [
-                  {
-                    "asDouble": 6442450944,
-                    "timeUnixNano": "0"
-                  }
-                ]
-              },
-              "name": "k8s.cluster.spec.memory.requests"
             }
           ],
           "scope": {}

--- a/tests/integration/expected_output.json
+++ b/tests/integration/expected_output.json
@@ -150,7 +150,7 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "2.7.0-alpha.5"
+              "stringValue": "2.7.0-alpha.6"
             }
           },
           {
@@ -374,7 +374,7 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "2.7.0-alpha.5"
+              "stringValue": "2.7.0-alpha.6"
             }
           },
           {
@@ -610,7 +610,7 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "2.7.0-alpha.5"
+              "stringValue": "2.7.0-alpha.6"
             }
           },
           {
@@ -846,7 +846,7 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "2.7.0-alpha.5"
+              "stringValue": "2.7.0-alpha.6"
             }
           },
           {
@@ -1082,7 +1082,7 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "2.7.0-alpha.5"
+              "stringValue": "2.7.0-alpha.6"
             }
           },
           {
@@ -1318,7 +1318,7 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "2.7.0-alpha.5"
+              "stringValue": "2.7.0-alpha.6"
             }
           },
           {
@@ -1530,7 +1530,7 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "2.7.0-alpha.5"
+              "stringValue": "2.7.0-alpha.6"
             }
           },
           {
@@ -1784,7 +1784,7 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "2.7.0-alpha.5"
+              "stringValue": "2.7.0-alpha.6"
             }
           },
           {
@@ -2044,7 +2044,7 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "2.7.0-alpha.5"
+              "stringValue": "2.7.0-alpha.6"
             }
           },
           {
@@ -2292,7 +2292,7 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "2.7.0-alpha.5"
+              "stringValue": "2.7.0-alpha.6"
             }
           },
           {
@@ -2510,7 +2510,7 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "2.7.0-alpha.5"
+              "stringValue": "2.7.0-alpha.6"
             }
           },
           {
@@ -2710,7 +2710,7 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "2.7.0-alpha.5"
+              "stringValue": "2.7.0-alpha.6"
             }
           },
           {
@@ -3206,7 +3206,7 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "2.7.0-alpha.5"
+              "stringValue": "2.7.0-alpha.6"
             }
           },
           {
@@ -3418,7 +3418,7 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "2.7.0-alpha.5"
+              "stringValue": "2.7.0-alpha.6"
             }
           },
           {
@@ -3618,7 +3618,7 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "2.7.0-alpha.5"
+              "stringValue": "2.7.0-alpha.6"
             }
           },
           {
@@ -4513,7 +4513,7 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "2.7.0-alpha.5"
+              "stringValue": "2.7.0-alpha.6"
             }
           },
           {
@@ -4992,7 +4992,7 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "2.7.0-alpha.5"
+              "stringValue": "2.7.0-alpha.6"
             }
           },
           {
@@ -5198,7 +5198,7 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "2.7.0-alpha.5"
+              "stringValue": "2.7.0-alpha.6"
             }
           },
           {
@@ -5530,7 +5530,7 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "2.7.0-alpha.5"
+              "stringValue": "2.7.0-alpha.6"
             }
           },
           {
@@ -5813,7 +5813,7 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "2.7.0-alpha.5"
+              "stringValue": "2.7.0-alpha.6"
             }
           },
           {
@@ -6741,7 +6741,7 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "2.7.0-alpha.5"
+              "stringValue": "2.7.0-alpha.6"
             }
           },
           {
@@ -6955,7 +6955,7 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "2.7.0-alpha.5"
+              "stringValue": "2.7.0-alpha.6"
             }
           },
           {
@@ -7155,7 +7155,7 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "2.7.0-alpha.5"
+              "stringValue": "2.7.0-alpha.6"
             }
           },
           {
@@ -7725,7 +7725,7 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "2.7.0-alpha.5"
+              "stringValue": "2.7.0-alpha.6"
             }
           },
           {
@@ -7919,7 +7919,7 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "2.7.0-alpha.5"
+              "stringValue": "2.7.0-alpha.6"
             }
           },
           {
@@ -8113,7 +8113,7 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "2.7.0-alpha.5"
+              "stringValue": "2.7.0-alpha.6"
             }
           },
           {
@@ -8822,7 +8822,7 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "2.7.0-alpha.5"
+              "stringValue": "2.7.0-alpha.6"
             }
           },
           {
@@ -9083,7 +9083,7 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "2.7.0-alpha.5"
+              "stringValue": "2.7.0-alpha.6"
             }
           },
           {
@@ -9338,7 +9338,7 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "2.7.0-alpha.5"
+              "stringValue": "2.7.0-alpha.6"
             }
           },
           {
@@ -13289,7 +13289,7 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "2.7.0-alpha.5"
+              "stringValue": "2.7.0-alpha.6"
             }
           },
           {
@@ -13561,7 +13561,7 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "2.7.0-alpha.5"
+              "stringValue": "2.7.0-alpha.6"
             }
           },
           {
@@ -13779,7 +13779,7 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "2.7.0-alpha.5"
+              "stringValue": "2.7.0-alpha.6"
             }
           },
           {
@@ -13985,7 +13985,7 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "2.7.0-alpha.5"
+              "stringValue": "2.7.0-alpha.6"
             }
           },
           {
@@ -14246,7 +14246,7 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "2.7.0-alpha.5"
+              "stringValue": "2.7.0-alpha.6"
             }
           },
           {
@@ -14458,7 +14458,7 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "2.7.0-alpha.5"
+              "stringValue": "2.7.0-alpha.6"
             }
           },
           {
@@ -14670,7 +14670,7 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "2.7.0-alpha.5"
+              "stringValue": "2.7.0-alpha.6"
             }
           },
           {
@@ -14913,7 +14913,7 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "2.7.0-alpha.5"
+              "stringValue": "2.7.0-alpha.6"
             }
           },
           {
@@ -15089,7 +15089,7 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "2.7.0-alpha.5"
+              "stringValue": "2.7.0-alpha.6"
             }
           },
           {
@@ -15277,7 +15277,7 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "2.7.0-alpha.5"
+              "stringValue": "2.7.0-alpha.6"
             }
           },
           {
@@ -15572,7 +15572,7 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "2.7.0-alpha.5"
+              "stringValue": "2.7.0-alpha.6"
             }
           },
           {
@@ -15791,7 +15791,7 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "2.7.0-alpha.5"
+              "stringValue": "2.7.0-alpha.6"
             }
           },
           {
@@ -15967,7 +15967,7 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "2.7.0-alpha.5"
+              "stringValue": "2.7.0-alpha.6"
             }
           },
           {
@@ -16149,7 +16149,7 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "2.7.0-alpha.5"
+              "stringValue": "2.7.0-alpha.6"
             }
           },
           {
@@ -16331,7 +16331,7 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "2.7.0-alpha.5"
+              "stringValue": "2.7.0-alpha.6"
             }
           },
           {
@@ -16519,7 +16519,7 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "2.7.0-alpha.5"
+              "stringValue": "2.7.0-alpha.6"
             }
           },
           {
@@ -16701,7 +16701,7 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "2.7.0-alpha.5"
+              "stringValue": "2.7.0-alpha.6"
             }
           },
           {
@@ -16877,7 +16877,7 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "2.7.0-alpha.5"
+              "stringValue": "2.7.0-alpha.6"
             }
           },
           {
@@ -17059,7 +17059,7 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "2.7.0-alpha.5"
+              "stringValue": "2.7.0-alpha.6"
             }
           },
           {
@@ -17247,7 +17247,7 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "2.7.0-alpha.5"
+              "stringValue": "2.7.0-alpha.6"
             }
           },
           {
@@ -17480,7 +17480,7 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "2.7.0-alpha.5"
+              "stringValue": "2.7.0-alpha.6"
             }
           },
           {
@@ -17668,7 +17668,7 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "2.7.0-alpha.5"
+              "stringValue": "2.7.0-alpha.6"
             }
           },
           {
@@ -17886,7 +17886,7 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "2.7.0-alpha.5"
+              "stringValue": "2.7.0-alpha.6"
             }
           },
           {
@@ -18315,7 +18315,7 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "2.7.0-alpha.5"
+              "stringValue": "2.7.0-alpha.6"
             }
           },
           {
@@ -18503,7 +18503,7 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "2.7.0-alpha.5"
+              "stringValue": "2.7.0-alpha.6"
             }
           },
           {
@@ -18878,7 +18878,7 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "2.7.0-alpha.5"
+              "stringValue": "2.7.0-alpha.6"
             }
           },
           {
@@ -19102,7 +19102,7 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "2.7.0-alpha.5"
+              "stringValue": "2.7.0-alpha.6"
             }
           },
           {
@@ -19485,7 +19485,7 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "2.7.0-alpha.5"
+              "stringValue": "2.7.0-alpha.6"
             }
           },
           {
@@ -19673,7 +19673,7 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "2.7.0-alpha.5"
+              "stringValue": "2.7.0-alpha.6"
             }
           },
           {
@@ -20064,7 +20064,7 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "2.7.0-alpha.5"
+              "stringValue": "2.7.0-alpha.6"
             }
           },
           {
@@ -20454,7 +20454,7 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "2.7.0-alpha.5"
+              "stringValue": "2.7.0-alpha.6"
             }
           },
           {
@@ -20654,7 +20654,7 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "2.7.0-alpha.5"
+              "stringValue": "2.7.0-alpha.6"
             }
           },
           {
@@ -21003,7 +21003,7 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "2.7.0-alpha.5"
+              "stringValue": "2.7.0-alpha.6"
             }
           },
           {
@@ -21349,7 +21349,7 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "2.7.0-alpha.5"
+              "stringValue": "2.7.0-alpha.6"
             }
           },
           {
@@ -21519,7 +21519,7 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "2.7.0-alpha.5"
+              "stringValue": "2.7.0-alpha.6"
             }
           },
           {
@@ -22676,7 +22676,7 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "2.7.0-alpha.5"
+              "stringValue": "2.7.0-alpha.6"
             }
           },
           {
@@ -22759,7 +22759,7 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "2.7.0-alpha.5"
+              "stringValue": "2.7.0-alpha.6"
             }
           },
           {
@@ -36412,7 +36412,7 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "2.7.0-alpha.5"
+              "stringValue": "2.7.0-alpha.6"
             }
           },
           {

--- a/tests/integration/test_utils.py
+++ b/tests/integration/test_utils.py
@@ -115,6 +115,26 @@ def sort_attributes(element):
         element["attributes"] = sorted(
             element["attributes"], key=lambda a: a["key"])
 
+def sanitize_attributes(element):
+    if "attributes" in element:
+        # Exclude node attributes as they comes from real cluster so it is not predictable in integrations test to match them
+        exclude_prefixes = ['k8s.node.annotations', 'k8s.node.labels']
+
+        filtered_attributes = [
+            attr for attr in element["attributes"]
+            if all(not attr["key"].startswith(prefix) for prefix in exclude_prefixes)
+        ]
+
+        # Sort the remaining attributes
+        element["attributes"] = sorted(
+            filtered_attributes, key=lambda a: a["key"]
+        )
+
+        # 'k8s.node.name' also comes from real cluster so sanitize it to `test-node` to make it predictable
+        for attr in element["attributes"]:
+            if attr["key"] == "k8s.node.name":
+                attr["value"] = {"stringValue": "test-node"}
+
 def sort_datapoints(metric):
     metric["dataPoints"] = sorted(
         metric["dataPoints"], key=datapoint_sorting_key)
@@ -124,6 +144,7 @@ def process_metric_type(metric):
     if "dataPoints" in metric:
         for dp in metric["dataPoints"]:
             remove_time_in_datapoint(dp)
+            sanitize_attributes(dp)
             sort_attributes(dp)
         sort_datapoints(metric)
 
@@ -183,6 +204,7 @@ def get_merged_json(content):
 
     # Sort the result and set timeStamps to 0 to make it easier to compare
     for resource in result["resourceMetrics"]:
+        sanitize_attributes(resource["resource"])
         sort_attributes(resource["resource"])
         for scope in resource["scopeMetrics"]:
             scope["scope"] = {}


### PR DESCRIPTION
`k8s.node.name` attributes from metrics often includes host name and not actual node name (they differ in case of Fargate). So I am setting the same mechanism we already previously did for Events. To remove `k8s.node.name` attribute if it does not match actual node name. 

In the same time I added instrumentation of `k8s.node.name` which should cover cases when it does not exists.
