### PR TITLE
NH-47025: Update dependencies

### DIFF
--- a/build/docker/Dockerfile
+++ b/build/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM docker.io/library/golang:1.20.7-bullseye@sha256:74b09b3b6fa5aa542df8ef974cb745eb477be72f6fcf821517fb410aff532b00 as base
+FROM docker.io/library/golang:1.21.0-bullseye@sha256:316fa84a843ee467ff08a7bba40472f7004f9f9bcf002cd9bc8fd3d385bfe89d as base
 WORKDIR /src
 COPY ["./src/", "./src/"]
 

--- a/build/docker/structure-test.yaml
+++ b/build/docker/structure-test.yaml
@@ -18,4 +18,4 @@ commandTests:
   - name: "swi-otelcol is working in the image"
     command: "/swi-otelcol"
     args: ["-v"]
-    expectedOutput: ["swi-k8s-opentelemetry-collector version 0.8.1"]
+    expectedOutput: ["swi-k8s-opentelemetry-collector version 0.8.2"]

--- a/build/swi-k8s-opentelemetry-collector.yaml
+++ b/build/swi-k8s-opentelemetry-collector.yaml
@@ -2,7 +2,7 @@ dist:
   name: swi-k8s-opentelemetry-collector
   description: "SolarWinds distribution for OpenTelemetry"
   otelcol_version: "0.81.0"
-  version: "0.8.1"
+  version: "0.8.2"
 exporters:
   - gomod: go.opentelemetry.io/collector/exporter/otlpexporter v0.81.0
 
@@ -37,3 +37,8 @@ extensions:
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/extension/storage v0.81.0
     import: "github.com/open-telemetry/opentelemetry-collector-contrib/extension/storage/filestorage"
   - gomod: go.opentelemetry.io/collector/extension/ballastextension v0.81.0
+
+replaces:
+  - github.com/jaegertracing/jaeger => github.com/jaegertracing/jaeger v1.47
+  - golang.org/x/net => golang.org/x/net v0.13.0
+  - github.com/aws/aws-sdk-go => github.com/aws/aws-sdk-go v1.44.333


### PR DESCRIPTION
Updating:
* go build image to `1.21.0`
* `jaegertracing/jaeger` to `v1.47`
* `golang.org/x/net` to `v0.13.0`
* `aws-sdk-go` to `v1.44.333`

Marking the new image as `0.8.2`