### PR TITLE
NH-53106: Fixing usage metrics

### DIFF
--- a/deploy/helm/CHANGELOG.md
+++ b/deploy/helm/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## [2.7.0-alpha.7] - 2023-08-30
+
+### Fixed
+- Usage metrics for nodes
+
 ## [2.7.0-alpha.6] - 2023-08-28
 
 ### Changed

--- a/deploy/helm/Chart.yaml
+++ b/deploy/helm/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: swo-k8s-collector
-version: 2.7.0-alpha.6
+version: 2.7.0-alpha.7
 appVersion: "0.8.1"
 description: SolarWinds Kubernetes Integration
 keywords:

--- a/deploy/helm/metrics-collector-config.yaml
+++ b/deploy/helm/metrics-collector-config.yaml
@@ -67,8 +67,13 @@ processors:
       - key: k8s.node.name
         from_attribute: node
         action: insert
+{{- if not .Values.aws_fargate.enabled }}
       - key: k8s.node.name
-        from_attribute: instance
+        from_attribute: kubernetes_io_hostname
+        action: insert
+{{- end }}
+      - key: k8s.node.name
+        from_attribute: service.instance.id
         action: insert
 
   attributes/unify_volume_attribute:

--- a/deploy/helm/tests/__snapshot__/logs-fargate-config-map_test.yaml.snap
+++ b/deploy/helm/tests/__snapshot__/logs-fargate-config-map_test.yaml.snap
@@ -24,7 +24,7 @@ Fargate logging ConfigMap spec should include additional filters when they are c
           Match *
           Add sw.k8s.cluster.uid <CLUSTER_UID>
           Add sw.k8s.log.type container
-          Add sw.k8s.agent.manifest.version "2.7.0-alpha.6"
+          Add sw.k8s.agent.manifest.version "2.7.0-alpha.7"
     flb_log_cw: "false"
     output.conf: |
       [OUTPUT]
@@ -64,7 +64,7 @@ Fargate logging ConfigMap spec should match snapshot when Fargate logging is ena
           Match *
           Add sw.k8s.cluster.uid <CLUSTER_UID>
           Add sw.k8s.log.type container
-          Add sw.k8s.agent.manifest.version "2.7.0-alpha.6"
+          Add sw.k8s.agent.manifest.version "2.7.0-alpha.7"
     flb_log_cw: "false"
     output.conf: |
       [OUTPUT]

--- a/deploy/helm/tests/__snapshot__/metrics-collector-config-map-fargate_test.yaml.snap
+++ b/deploy/helm/tests/__snapshot__/metrics-collector-config-map-fargate_test.yaml.snap
@@ -340,9 +340,6 @@ Metrics config should match snapshot when using default values:
             from_attribute: node
             key: k8s.node.name
           - action: insert
-            from_attribute: kubernetes_io_hostname
-            key: k8s.node.name
-          - action: insert
             from_attribute: service.instance.id
             key: k8s.node.name
           include:

--- a/deploy/helm/tests/metrics-collector-config-map-fargate_test.yaml
+++ b/deploy/helm/tests/metrics-collector-config-map-fargate_test.yaml
@@ -1,0 +1,12 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/helm-unittest/helm-unittest/main/schema/helm-testsuite.json
+suite: Test for metrics-collector-config-map
+templates:
+  - metrics-collector-config-map.yaml
+tests:
+  - it: Metrics config should match snapshot when using default values
+    template: metrics-collector-config-map.yaml
+    set:
+      aws_fargate.enabled: true
+    asserts:
+      - matchSnapshot:
+          path: data

--- a/tests/integration/expected_output.json
+++ b/tests/integration/expected_output.json
@@ -156,7 +156,7 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "2.7.0-alpha.6"
+              "stringValue": "2.7.0-alpha.7"
             }
           },
           {
@@ -392,7 +392,7 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "2.7.0-alpha.6"
+              "stringValue": "2.7.0-alpha.7"
             }
           },
           {
@@ -634,7 +634,7 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "2.7.0-alpha.6"
+              "stringValue": "2.7.0-alpha.7"
             }
           },
           {
@@ -876,7 +876,7 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "2.7.0-alpha.6"
+              "stringValue": "2.7.0-alpha.7"
             }
           },
           {
@@ -1118,7 +1118,7 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "2.7.0-alpha.6"
+              "stringValue": "2.7.0-alpha.7"
             }
           },
           {
@@ -1360,7 +1360,7 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "2.7.0-alpha.6"
+              "stringValue": "2.7.0-alpha.7"
             }
           },
           {
@@ -1566,7 +1566,7 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "2.7.0-alpha.6"
+              "stringValue": "2.7.0-alpha.7"
             }
           },
           {
@@ -1814,7 +1814,7 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "2.7.0-alpha.6"
+              "stringValue": "2.7.0-alpha.7"
             }
           },
           {
@@ -2068,7 +2068,7 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "2.7.0-alpha.6"
+              "stringValue": "2.7.0-alpha.7"
             }
           },
           {
@@ -2310,7 +2310,7 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "2.7.0-alpha.6"
+              "stringValue": "2.7.0-alpha.7"
             }
           },
           {
@@ -2534,7 +2534,7 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "2.7.0-alpha.6"
+              "stringValue": "2.7.0-alpha.7"
             }
           },
           {
@@ -2740,7 +2740,7 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "2.7.0-alpha.6"
+              "stringValue": "2.7.0-alpha.7"
             }
           },
           {
@@ -3242,7 +3242,7 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "2.7.0-alpha.6"
+              "stringValue": "2.7.0-alpha.7"
             }
           },
           {
@@ -3460,7 +3460,7 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "2.7.0-alpha.6"
+              "stringValue": "2.7.0-alpha.7"
             }
           },
           {
@@ -3666,7 +3666,7 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "2.7.0-alpha.6"
+              "stringValue": "2.7.0-alpha.7"
             }
           },
           {
@@ -4555,7 +4555,7 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "2.7.0-alpha.6"
+              "stringValue": "2.7.0-alpha.7"
             }
           },
           {
@@ -5028,7 +5028,7 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "2.7.0-alpha.6"
+              "stringValue": "2.7.0-alpha.7"
             }
           },
           {
@@ -5228,7 +5228,7 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "2.7.0-alpha.6"
+              "stringValue": "2.7.0-alpha.7"
             }
           },
           {
@@ -5554,7 +5554,7 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "2.7.0-alpha.6"
+              "stringValue": "2.7.0-alpha.7"
             }
           },
           {
@@ -5831,7 +5831,7 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "2.7.0-alpha.6"
+              "stringValue": "2.7.0-alpha.7"
             }
           },
           {
@@ -6753,7 +6753,7 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "2.7.0-alpha.6"
+              "stringValue": "2.7.0-alpha.7"
             }
           },
           {
@@ -6961,7 +6961,7 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "2.7.0-alpha.6"
+              "stringValue": "2.7.0-alpha.7"
             }
           },
           {
@@ -7167,7 +7167,7 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "2.7.0-alpha.6"
+              "stringValue": "2.7.0-alpha.7"
             }
           },
           {
@@ -7779,7 +7779,7 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "2.7.0-alpha.6"
+              "stringValue": "2.7.0-alpha.7"
             }
           },
           {
@@ -8015,7 +8015,7 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "2.7.0-alpha.6"
+              "stringValue": "2.7.0-alpha.7"
             }
           },
           {
@@ -8233,7 +8233,7 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "2.7.0-alpha.6"
+              "stringValue": "2.7.0-alpha.7"
             }
           },
           {
@@ -8506,7 +8506,7 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "2.7.0-alpha.6"
+              "stringValue": "2.7.0-alpha.7"
             }
           },
           {
@@ -8736,7 +8736,7 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "2.7.0-alpha.6"
+              "stringValue": "2.7.0-alpha.7"
             }
           },
           {
@@ -8960,7 +8960,7 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "2.7.0-alpha.6"
+              "stringValue": "2.7.0-alpha.7"
             }
           },
           {
@@ -9215,7 +9215,7 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "2.7.0-alpha.6"
+              "stringValue": "2.7.0-alpha.7"
             }
           },
           {
@@ -9403,7 +9403,7 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "2.7.0-alpha.6"
+              "stringValue": "2.7.0-alpha.7"
             }
           },
           {
@@ -9597,7 +9597,7 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "2.7.0-alpha.6"
+              "stringValue": "2.7.0-alpha.7"
             }
           },
           {
@@ -9898,7 +9898,7 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "2.7.0-alpha.6"
+              "stringValue": "2.7.0-alpha.7"
             }
           },
           {
@@ -10123,7 +10123,7 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "2.7.0-alpha.6"
+              "stringValue": "2.7.0-alpha.7"
             }
           },
           {
@@ -10305,7 +10305,7 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "2.7.0-alpha.6"
+              "stringValue": "2.7.0-alpha.7"
             }
           },
           {
@@ -10493,7 +10493,7 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "2.7.0-alpha.6"
+              "stringValue": "2.7.0-alpha.7"
             }
           },
           {
@@ -10681,7 +10681,7 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "2.7.0-alpha.6"
+              "stringValue": "2.7.0-alpha.7"
             }
           },
           {
@@ -10875,7 +10875,7 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "2.7.0-alpha.6"
+              "stringValue": "2.7.0-alpha.7"
             }
           },
           {
@@ -11063,7 +11063,7 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "2.7.0-alpha.6"
+              "stringValue": "2.7.0-alpha.7"
             }
           },
           {
@@ -11245,7 +11245,7 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "2.7.0-alpha.6"
+              "stringValue": "2.7.0-alpha.7"
             }
           },
           {
@@ -11433,7 +11433,7 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "2.7.0-alpha.6"
+              "stringValue": "2.7.0-alpha.7"
             }
           },
           {
@@ -11627,7 +11627,7 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "2.7.0-alpha.6"
+              "stringValue": "2.7.0-alpha.7"
             }
           },
           {
@@ -11866,7 +11866,7 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "2.7.0-alpha.6"
+              "stringValue": "2.7.0-alpha.7"
             }
           },
           {
@@ -12060,7 +12060,7 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "2.7.0-alpha.6"
+              "stringValue": "2.7.0-alpha.7"
             }
           },
           {
@@ -12284,7 +12284,7 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "2.7.0-alpha.6"
+              "stringValue": "2.7.0-alpha.7"
             }
           },
           {
@@ -12719,7 +12719,7 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "2.7.0-alpha.6"
+              "stringValue": "2.7.0-alpha.7"
             }
           },
           {
@@ -12913,7 +12913,7 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "2.7.0-alpha.6"
+              "stringValue": "2.7.0-alpha.7"
             }
           },
           {
@@ -13294,7 +13294,7 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "2.7.0-alpha.6"
+              "stringValue": "2.7.0-alpha.7"
             }
           },
           {
@@ -13524,7 +13524,7 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "2.7.0-alpha.6"
+              "stringValue": "2.7.0-alpha.7"
             }
           },
           {
@@ -13913,7 +13913,7 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "2.7.0-alpha.6"
+              "stringValue": "2.7.0-alpha.7"
             }
           },
           {
@@ -14107,7 +14107,7 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "2.7.0-alpha.6"
+              "stringValue": "2.7.0-alpha.7"
             }
           },
           {
@@ -14504,7 +14504,7 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "2.7.0-alpha.6"
+              "stringValue": "2.7.0-alpha.7"
             }
           },
           {
@@ -14900,7 +14900,7 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "2.7.0-alpha.6"
+              "stringValue": "2.7.0-alpha.7"
             }
           },
           {
@@ -15106,7 +15106,7 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "2.7.0-alpha.6"
+              "stringValue": "2.7.0-alpha.7"
             }
           },
           {
@@ -15461,7 +15461,7 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "2.7.0-alpha.6"
+              "stringValue": "2.7.0-alpha.7"
             }
           },
           {
@@ -15813,7 +15813,7 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "2.7.0-alpha.6"
+              "stringValue": "2.7.0-alpha.7"
             }
           },
           {
@@ -15995,7 +15995,7 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "2.7.0-alpha.6"
+              "stringValue": "2.7.0-alpha.7"
             }
           },
           {
@@ -16183,7 +16183,7 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "2.7.0-alpha.6"
+              "stringValue": "2.7.0-alpha.7"
             }
           },
           {
@@ -16371,7 +16371,7 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "2.7.0-alpha.6"
+              "stringValue": "2.7.0-alpha.7"
             }
           },
           {
@@ -17074,7 +17074,7 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "2.7.0-alpha.6"
+              "stringValue": "2.7.0-alpha.7"
             }
           },
           {
@@ -17329,7 +17329,7 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "2.7.0-alpha.6"
+              "stringValue": "2.7.0-alpha.7"
             }
           },
           {
@@ -17578,7 +17578,7 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "2.7.0-alpha.6"
+              "stringValue": "2.7.0-alpha.7"
             }
           },
           {
@@ -21523,7 +21523,7 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "2.7.0-alpha.6"
+              "stringValue": "2.7.0-alpha.7"
             }
           },
           {
@@ -21741,7 +21741,7 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "2.7.0-alpha.6"
+              "stringValue": "2.7.0-alpha.7"
             }
           },
           {
@@ -21878,7 +21878,7 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "2.7.0-alpha.6"
+              "stringValue": "2.7.0-alpha.7"
             }
           },
           {
@@ -22975,7 +22975,7 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "2.7.0-alpha.6"
+              "stringValue": "2.7.0-alpha.7"
             }
           },
           {


### PR DESCRIPTION
* renamed `instance` to `service.instance.id` as for some time `instance` no longer goes from prometheusreciever (see BREAKING CHANGES of https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/CHANGELOG.md#v0470) 
* `kubernetes_io_hostname` must be ignored on Fargate nodes so adding condition there
* `service.instance.id` fallback should cover non-fargate nodes in Fargate cluster. On EKS it should always contain real node
* presence of `kubernetes_io_hostname` in non-fargate cluster should cover most of the use cases where `service.instance.id` is malformed (e.q. docker-desktop when there is ip address instead of real node name)