### PR TITLE
NH-57036: Fixing usage metrics on Fargate nodes

### DIFF
--- a/deploy/helm/CHANGELOG.md
+++ b/deploy/helm/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Fixed
+- Usage metrics for Fargate nodes
+
 ## [2.7.0-alpha.7] - 2023-08-30
 
 ### Fixed

--- a/deploy/helm/metrics-collector-config.yaml
+++ b/deploy/helm/metrics-collector-config.yaml
@@ -31,6 +31,11 @@ processors:
     metric_statements:
       - context: datapoint
         statements:
+          - set(attributes["k8s.node.name"], attributes["node"]) where IsMatch(metric.name, "^(container_.*)|(kube_node_.*)|(kube_pod_info)|(kube_pod_container_resource_requests)|(kube_pod_container_resource_limits)|(kube_pod_init_container_resource_requests)|(kube_pod_init_container_resource_limits)$") == true and attributes["k8s.node.name"] == nil
+{{- if not .Values.aws_fargate.enabled }}
+          - set(attributes["k8s.node.name"], attributes["kubernetes_io_hostname"]) where IsMatch(metric.name, "^(container_.*)|(kube_node_.*)|(kube_pod_info)|(kube_pod_container_resource_requests)|(kube_pod_container_resource_limits)|(kube_pod_init_container_resource_requests)|(kube_pod_init_container_resource_limits)$") == true and attributes["k8s.node.name"] == nil
+{{- end }}
+          - set(attributes["k8s.node.name"], resource.attributes["service.instance.id"]) where IsMatch(metric.name, "^(container_.*)|(kube_node_.*)|(kube_pod_info)|(kube_pod_container_resource_requests)|(kube_pod_container_resource_limits)|(kube_pod_init_container_resource_requests)|(kube_pod_init_container_resource_limits)$") == true and attributes["k8s.node.name"] == nil
           - convert_gauge_to_sum("cumulative", true) where IsMatch(metric.name, "^.*_total$") == true
           - set(attributes["job_condition"], "Active") where IsMatch(metric.name, "^.*kube_job_status_active$") == true and value_double > 0
           - set(attributes["job_condition"], "Failed") where IsMatch(metric.name, "^.*kube_job_failed$") == true and IsMatch(attributes["condition"], "^true$") == true and value_double > 0
@@ -49,32 +54,6 @@ processors:
     metrics:
       datapoint:
       - 'attributes["container"] == "POD" and IsMatch(metric.name, "container_network_.*|k8s.container.*") == true'
-
-
-  # unify attributes
-  attributes/unify_node_attribute:
-    include:
-      match_type: regexp
-      metric_names:
-        - container_.*
-        - kube_node_.*
-        - kube_pod_info
-        - kube_pod_container_resource_requests
-        - kube_pod_container_resource_limits
-        - kube_pod_init_container_resource_requests
-        - kube_pod_init_container_resource_limits
-    actions:
-      - key: k8s.node.name
-        from_attribute: node
-        action: insert
-{{- if not .Values.aws_fargate.enabled }}
-      - key: k8s.node.name
-        from_attribute: kubernetes_io_hostname
-        action: insert
-{{- end }}
-      - key: k8s.node.name
-        from_attribute: service.instance.id
-        action: insert
 
   attributes/unify_volume_attribute:
     include:
@@ -1483,7 +1462,6 @@ service:
         - filter/receiver
         - transform
         - filter/remove_internal        
-        - attributes/unify_node_attribute
         - attributes/unify_volume_attribute        
         - attributes/identify_init_container
         - attributes/identify_standard_container

--- a/deploy/helm/tests/__snapshot__/metrics-collector-config-map-fargate_test.yaml.snap
+++ b/deploy/helm/tests/__snapshot__/metrics-collector-config-map-fargate_test.yaml.snap
@@ -334,24 +334,6 @@ Metrics config should match snapshot when using default values:
             match_type: regexp
             metric_names:
             - .*
-        attributes/unify_node_attribute:
-          actions:
-          - action: insert
-            from_attribute: node
-            key: k8s.node.name
-          - action: insert
-            from_attribute: service.instance.id
-            key: k8s.node.name
-          include:
-            match_type: regexp
-            metric_names:
-            - container_.*
-            - kube_node_.*
-            - kube_pod_info
-            - kube_pod_container_resource_requests
-            - kube_pod_container_resource_limits
-            - kube_pod_init_container_resource_requests
-            - kube_pod_init_container_resource_limits
         attributes/unify_volume_attribute:
           actions:
           - action: insert
@@ -1902,6 +1884,12 @@ Metrics config should match snapshot when using default values:
           metric_statements:
           - context: datapoint
             statements:
+            - set(attributes["k8s.node.name"], attributes["node"]) where IsMatch(metric.name,
+              "^(container_.*)|(kube_node_.*)|(kube_pod_info)|(kube_pod_container_resource_requests)|(kube_pod_container_resource_limits)|(kube_pod_init_container_resource_requests)|(kube_pod_init_container_resource_limits)$")
+              == true and attributes["k8s.node.name"] == nil
+            - set(attributes["k8s.node.name"], resource.attributes["service.instance.id"])
+              where IsMatch(metric.name, "^(container_.*)|(kube_node_.*)|(kube_pod_info)|(kube_pod_container_resource_requests)|(kube_pod_container_resource_limits)|(kube_pod_init_container_resource_requests)|(kube_pod_init_container_resource_limits)$")
+              == true and attributes["k8s.node.name"] == nil
             - convert_gauge_to_sum("cumulative", true) where IsMatch(metric.name, "^.*_total$")
               == true
             - set(attributes["job_condition"], "Active") where IsMatch(metric.name, "^.*kube_job_status_active$")
@@ -1988,7 +1976,6 @@ Metrics config should match snapshot when using default values:
             - filter/receiver
             - transform
             - filter/remove_internal
-            - attributes/unify_node_attribute
             - attributes/unify_volume_attribute
             - attributes/identify_init_container
             - attributes/identify_standard_container

--- a/deploy/helm/tests/__snapshot__/metrics-collector-config-map_test.yaml.snap
+++ b/deploy/helm/tests/__snapshot__/metrics-collector-config-map_test.yaml.snap
@@ -334,27 +334,6 @@ Metrics config should match snapshot when using default values:
             match_type: regexp
             metric_names:
             - .*
-        attributes/unify_node_attribute:
-          actions:
-          - action: insert
-            from_attribute: node
-            key: k8s.node.name
-          - action: insert
-            from_attribute: kubernetes_io_hostname
-            key: k8s.node.name
-          - action: insert
-            from_attribute: service.instance.id
-            key: k8s.node.name
-          include:
-            match_type: regexp
-            metric_names:
-            - container_.*
-            - kube_node_.*
-            - kube_pod_info
-            - kube_pod_container_resource_requests
-            - kube_pod_container_resource_limits
-            - kube_pod_init_container_resource_requests
-            - kube_pod_init_container_resource_limits
         attributes/unify_volume_attribute:
           actions:
           - action: insert
@@ -1905,6 +1884,15 @@ Metrics config should match snapshot when using default values:
           metric_statements:
           - context: datapoint
             statements:
+            - set(attributes["k8s.node.name"], attributes["node"]) where IsMatch(metric.name,
+              "^(container_.*)|(kube_node_.*)|(kube_pod_info)|(kube_pod_container_resource_requests)|(kube_pod_container_resource_limits)|(kube_pod_init_container_resource_requests)|(kube_pod_init_container_resource_limits)$")
+              == true and attributes["k8s.node.name"] == nil
+            - set(attributes["k8s.node.name"], attributes["kubernetes_io_hostname"]) where
+              IsMatch(metric.name, "^(container_.*)|(kube_node_.*)|(kube_pod_info)|(kube_pod_container_resource_requests)|(kube_pod_container_resource_limits)|(kube_pod_init_container_resource_requests)|(kube_pod_init_container_resource_limits)$")
+              == true and attributes["k8s.node.name"] == nil
+            - set(attributes["k8s.node.name"], resource.attributes["service.instance.id"])
+              where IsMatch(metric.name, "^(container_.*)|(kube_node_.*)|(kube_pod_info)|(kube_pod_container_resource_requests)|(kube_pod_container_resource_limits)|(kube_pod_init_container_resource_requests)|(kube_pod_init_container_resource_limits)$")
+              == true and attributes["k8s.node.name"] == nil
             - convert_gauge_to_sum("cumulative", true) where IsMatch(metric.name, "^.*_total$")
               == true
             - set(attributes["job_condition"], "Active") where IsMatch(metric.name, "^.*kube_job_status_active$")
@@ -1991,7 +1979,6 @@ Metrics config should match snapshot when using default values:
             - filter/receiver
             - transform
             - filter/remove_internal
-            - attributes/unify_node_attribute
             - attributes/unify_volume_attribute
             - attributes/identify_init_container
             - attributes/identify_standard_container

--- a/tests/integration/expected_output.json
+++ b/tests/integration/expected_output.json
@@ -23355,6 +23355,127 @@
               "gauge": {
                 "dataPoints": [
                   {
+                    "asDouble": 31.78,
+                    "timeUnixNano": "0"
+                  }
+                ]
+              },
+              "name": "k8s.cluster.cpu.allocatable"
+            },
+            {
+              "gauge": {
+                "dataPoints": [
+                  {
+                    "asDouble": 32,
+                    "timeUnixNano": "0"
+                  }
+                ]
+              },
+              "name": "k8s.cluster.cpu.capacity"
+            },
+            {
+              "gauge": {
+                "dataPoints": [
+                  {
+                    "asDouble": 126595563520,
+                    "timeUnixNano": "0"
+                  }
+                ]
+              },
+              "name": "k8s.cluster.memory.allocatable"
+            },
+            {
+              "gauge": {
+                "dataPoints": [
+                  {
+                    "asDouble": 132738121728,
+                    "timeUnixNano": "0"
+                  }
+                ]
+              },
+              "name": "k8s.cluster.memory.capacity"
+            },
+            {
+              "gauge": {
+                "dataPoints": [
+                  {
+                    "asDouble": 2,
+                    "timeUnixNano": "0"
+                  }
+                ]
+              },
+              "name": "k8s.cluster.nodes"
+            },
+            {
+              "gauge": {
+                "dataPoints": [
+                  {
+                    "asDouble": 2,
+                    "timeUnixNano": "0"
+                  }
+                ]
+              },
+              "name": "k8s.cluster.nodes.ready"
+            },
+            {
+              "gauge": {
+                "dataPoints": [
+                  {
+                    "asDouble": 1,
+                    "timeUnixNano": "0"
+                  }
+                ]
+              },
+              "name": "k8s.cluster.nodes.ready.avg"
+            },
+            {
+              "gauge": {
+                "dataPoints": [
+                  {
+                    "asDouble": 2,
+                    "timeUnixNano": "0"
+                  }
+                ]
+              },
+              "name": "k8s.cluster.pods"
+            },
+            {
+              "gauge": {
+                "dataPoints": [
+                  {
+                    "asDouble": 2,
+                    "timeUnixNano": "0"
+                  }
+                ]
+              },
+              "name": "k8s.cluster.pods.running"
+            },
+            {
+              "gauge": {
+                "dataPoints": [
+                  {
+                    "asDouble": 0.1,
+                    "timeUnixNano": "0"
+                  }
+                ]
+              },
+              "name": "k8s.cluster.spec.cpu.requests"
+            },
+            {
+              "gauge": {
+                "dataPoints": [
+                  {
+                    "asDouble": 6442450944,
+                    "timeUnixNano": "0"
+                  }
+                ]
+              },
+              "name": "k8s.cluster.spec.memory.requests"
+            },
+            {
+              "gauge": {
+                "dataPoints": [
+                  {
                     "asDouble": 0,
                     "attributes": [
                       {

--- a/tests/integration/expected_output.json
+++ b/tests/integration/expected_output.json
@@ -4505,6 +4505,12 @@
             }
           },
           {
+            "key": "k8s.node.name",
+            "value": {
+              "stringValue": "test-node"
+            }
+          },
+          {
             "key": "k8s.pod.annotations.test-annotation",
             "value": {
               "stringValue": "test-value"
@@ -4707,73 +4713,6 @@
               }
             },
             {
-              "gauge": {
-                "dataPoints": [
-                  {
-                    "asDouble": 12288,
-                    "attributes": [
-                      {
-                        "key": "device",
-                        "value": {
-                          "stringValue": "/dev/nvme0n1p1"
-                        }
-                      },
-                      {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "https-metrics"
-                        }
-                      },
-                      {
-                        "key": "id",
-                        "value": {
-                          "stringValue": "/kubepods/burstable/pod03d2b55c-b225-476b-9178-c74f8e5eaba2/b569246357457b8e4212a8e1a655442561648908c07e6343be2df710f0b4b067"
-                        }
-                      },
-                      {
-                        "key": "metrics_path",
-                        "value": {
-                          "stringValue": "/metrics/cadvisor"
-                        }
-                      },
-                      {
-                        "key": "name",
-                        "value": {
-                          "stringValue": "k8s_admin-tools_temporal-admintools-9f5d799c8-7t7jv_temporal-system_03d2b55c-b225-476b-9178-c74f8e5eaba2_0"
-                        }
-                      },
-                      {
-                        "key": "node",
-                        "value": {
-                          "stringValue": "test-node"
-                        }
-                      },
-                      {
-                        "key": "prometheus",
-                        "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
-                        }
-                      },
-                      {
-                        "key": "prometheus_replica",
-                        "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
-                        }
-                      },
-                      {
-                        "key": "service",
-                        "value": {
-                          "stringValue": "test-service"
-                        }
-                      }
-                    ],
-                    "timeUnixNano": "0"
-                  }
-                ]
-              },
-              "name": "k8s.container_fs_usage_bytes"
-            },
-            {
               "name": "k8s.container_fs_writes_total",
               "sum": {
                 "aggregationTemporality": 2,
@@ -4841,6 +4780,212 @@
                 ],
                 "isMonotonic": true
               }
+            }
+          ],
+          "scope": {}
+        }
+      ]
+    },
+    {
+      "resource": {
+        "attributes": [
+          {
+            "key": "container",
+            "value": {
+              "stringValue": "test-container"
+            }
+          },
+          {
+            "key": "http.scheme",
+            "value": {
+              "stringValue": "http"
+            }
+          },
+          {
+            "key": "image",
+            "value": {
+              "stringValue": "915014598477.dkr.ecr.us-east-1.amazonaws.com/external/docker.io/temporalio/admin-tools@sha256:69e9f218ec37d8ef0ed793e2cc1a73dedbb62f545c9e1b858afffedba36fdd66"
+            }
+          },
+          {
+            "key": "k8s.cluster.name",
+            "value": {
+              "stringValue": "cluster name"
+            }
+          },
+          {
+            "key": "k8s.container.image.name",
+            "value": {
+              "stringValue": "915014598477.dkr.ecr.us-east-1.amazonaws.com/external/docker.io/temporalio/admin-tools@sha256:69e9f218ec37d8ef0ed793e2cc1a73dedbb62f545c9e1b858afffedba36fdd66"
+            }
+          },
+          {
+            "key": "k8s.container.name",
+            "value": {
+              "stringValue": "test-container"
+            }
+          },
+          {
+            "key": "k8s.namespace.annotations.description",
+            "value": {
+              "stringValue": "This is a test namespace."
+            }
+          },
+          {
+            "key": "k8s.namespace.labels.app",
+            "value": {
+              "stringValue": "test-app"
+            }
+          },
+          {
+            "key": "k8s.namespace.labels.kubernetes.io/metadata.name",
+            "value": {
+              "stringValue": "test-namespace"
+            }
+          },
+          {
+            "key": "k8s.namespace.labels.purpose",
+            "value": {
+              "stringValue": "testing"
+            }
+          },
+          {
+            "key": "k8s.namespace.name",
+            "value": {
+              "stringValue": "test-namespace"
+            }
+          },
+          {
+            "key": "k8s.pod.annotations.test-annotation",
+            "value": {
+              "stringValue": "test-value"
+            }
+          },
+          {
+            "key": "k8s.pod.labels.app",
+            "value": {
+              "stringValue": "test-pod"
+            }
+          },
+          {
+            "key": "k8s.pod.name",
+            "value": {
+              "stringValue": "test-pod"
+            }
+          },
+          {
+            "key": "namespace",
+            "value": {
+              "stringValue": "test-namespace"
+            }
+          },
+          {
+            "key": "net.host.name",
+            "value": {
+              "stringValue": "test-node"
+            }
+          },
+          {
+            "key": "net.host.port",
+            "value": {
+              "stringValue": ""
+            }
+          },
+          {
+            "key": "pod",
+            "value": {
+              "stringValue": "test-pod"
+            }
+          },
+          {
+            "key": "sw.k8s.agent.app.version",
+            "value": {
+              "stringValue": "0.8.1"
+            }
+          },
+          {
+            "key": "sw.k8s.agent.manifest.version",
+            "value": {
+              "stringValue": "2.7.0-alpha.7"
+            }
+          },
+          {
+            "key": "sw.k8s.cluster.uid",
+            "value": {
+              "stringValue": "cluster-uid-123456789"
+            }
+          }
+        ]
+      },
+      "scopeMetrics": [
+        {
+          "metrics": [
+            {
+              "gauge": {
+                "dataPoints": [
+                  {
+                    "asDouble": 12288,
+                    "attributes": [
+                      {
+                        "key": "device",
+                        "value": {
+                          "stringValue": "/dev/nvme0n1p1"
+                        }
+                      },
+                      {
+                        "key": "endpoint",
+                        "value": {
+                          "stringValue": "https-metrics"
+                        }
+                      },
+                      {
+                        "key": "id",
+                        "value": {
+                          "stringValue": "/kubepods/burstable/pod03d2b55c-b225-476b-9178-c74f8e5eaba2/b569246357457b8e4212a8e1a655442561648908c07e6343be2df710f0b4b067"
+                        }
+                      },
+                      {
+                        "key": "metrics_path",
+                        "value": {
+                          "stringValue": "/metrics/cadvisor"
+                        }
+                      },
+                      {
+                        "key": "name",
+                        "value": {
+                          "stringValue": "k8s_admin-tools_temporal-admintools-9f5d799c8-7t7jv_temporal-system_03d2b55c-b225-476b-9178-c74f8e5eaba2_0"
+                        }
+                      },
+                      {
+                        "key": "node",
+                        "value": {
+                          "stringValue": "test-node"
+                        }
+                      },
+                      {
+                        "key": "prometheus",
+                        "value": {
+                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
+                        }
+                      },
+                      {
+                        "key": "prometheus_replica",
+                        "value": {
+                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
+                        }
+                      },
+                      {
+                        "key": "service",
+                        "value": {
+                          "stringValue": "test-service"
+                        }
+                      }
+                    ],
+                    "timeUnixNano": "0"
+                  }
+                ]
+              },
+              "name": "k8s.container_fs_usage_bytes"
             },
             {
               "gauge": {
@@ -5504,6 +5649,12 @@
             }
           },
           {
+            "key": "k8s.node.name",
+            "value": {
+              "stringValue": "test-node"
+            }
+          },
+          {
             "key": "k8s.pod.annotations.test-annotation",
             "value": {
               "stringValue": "test-value"
@@ -5778,6 +5929,12 @@
             "key": "k8s.namespace.name",
             "value": {
               "stringValue": "test-namespace"
+            }
+          },
+          {
+            "key": "k8s.node.name",
+            "value": {
+              "stringValue": "test-node"
             }
           },
           {
@@ -6181,73 +6338,6 @@
               }
             },
             {
-              "gauge": {
-                "dataPoints": [
-                  {
-                    "asDouble": 540672,
-                    "attributes": [
-                      {
-                        "key": "device",
-                        "value": {
-                          "stringValue": "/dev/nvme0n1p1"
-                        }
-                      },
-                      {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "https-metrics"
-                        }
-                      },
-                      {
-                        "key": "id",
-                        "value": {
-                          "stringValue": "/kubepods/burstable/podbafeef2c-1292-4a5e-a92c-d709480b04b6/86a84e64dded58918633fc9d1dd89a3f769d25143dd2da4273516d013df5862a"
-                        }
-                      },
-                      {
-                        "key": "metrics_path",
-                        "value": {
-                          "stringValue": "/metrics/cadvisor"
-                        }
-                      },
-                      {
-                        "key": "name",
-                        "value": {
-                          "stringValue": "k8s_swi-opentelemetry-collector_swi-k8s-otel-collector-swo-k8s-collector-metrics-cf8f6886bwt88g_prometheus-system_bafeef2c-1292-4a5e-a92c-d709480b04b6_0"
-                        }
-                      },
-                      {
-                        "key": "node",
-                        "value": {
-                          "stringValue": "test-node"
-                        }
-                      },
-                      {
-                        "key": "prometheus",
-                        "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
-                        }
-                      },
-                      {
-                        "key": "prometheus_replica",
-                        "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
-                        }
-                      },
-                      {
-                        "key": "service",
-                        "value": {
-                          "stringValue": "test-service"
-                        }
-                      }
-                    ],
-                    "timeUnixNano": "0"
-                  }
-                ]
-              },
-              "name": "k8s.container_fs_usage_bytes"
-            },
-            {
               "name": "k8s.container_fs_writes_bytes_total",
               "sum": {
                 "aggregationTemporality": 2,
@@ -6444,6 +6534,212 @@
                 ],
                 "isMonotonic": true
               }
+            }
+          ],
+          "scope": {}
+        }
+      ]
+    },
+    {
+      "resource": {
+        "attributes": [
+          {
+            "key": "container",
+            "value": {
+              "stringValue": "test-container"
+            }
+          },
+          {
+            "key": "http.scheme",
+            "value": {
+              "stringValue": "http"
+            }
+          },
+          {
+            "key": "image",
+            "value": {
+              "stringValue": "sha256:8423d5a81606084300d223d734589c7264ca789ff6908875cf62178ead6a6154"
+            }
+          },
+          {
+            "key": "k8s.cluster.name",
+            "value": {
+              "stringValue": "cluster name"
+            }
+          },
+          {
+            "key": "k8s.container.image.name",
+            "value": {
+              "stringValue": "sha256:8423d5a81606084300d223d734589c7264ca789ff6908875cf62178ead6a6154"
+            }
+          },
+          {
+            "key": "k8s.container.name",
+            "value": {
+              "stringValue": "test-container"
+            }
+          },
+          {
+            "key": "k8s.namespace.annotations.description",
+            "value": {
+              "stringValue": "This is a test namespace."
+            }
+          },
+          {
+            "key": "k8s.namespace.labels.app",
+            "value": {
+              "stringValue": "test-app"
+            }
+          },
+          {
+            "key": "k8s.namespace.labels.kubernetes.io/metadata.name",
+            "value": {
+              "stringValue": "test-namespace"
+            }
+          },
+          {
+            "key": "k8s.namespace.labels.purpose",
+            "value": {
+              "stringValue": "testing"
+            }
+          },
+          {
+            "key": "k8s.namespace.name",
+            "value": {
+              "stringValue": "test-namespace"
+            }
+          },
+          {
+            "key": "k8s.pod.annotations.test-annotation",
+            "value": {
+              "stringValue": "test-value"
+            }
+          },
+          {
+            "key": "k8s.pod.labels.app",
+            "value": {
+              "stringValue": "test-pod"
+            }
+          },
+          {
+            "key": "k8s.pod.name",
+            "value": {
+              "stringValue": "test-pod"
+            }
+          },
+          {
+            "key": "namespace",
+            "value": {
+              "stringValue": "test-namespace"
+            }
+          },
+          {
+            "key": "net.host.name",
+            "value": {
+              "stringValue": "test-node"
+            }
+          },
+          {
+            "key": "net.host.port",
+            "value": {
+              "stringValue": ""
+            }
+          },
+          {
+            "key": "pod",
+            "value": {
+              "stringValue": "test-pod"
+            }
+          },
+          {
+            "key": "sw.k8s.agent.app.version",
+            "value": {
+              "stringValue": "0.8.1"
+            }
+          },
+          {
+            "key": "sw.k8s.agent.manifest.version",
+            "value": {
+              "stringValue": "2.7.0-alpha.7"
+            }
+          },
+          {
+            "key": "sw.k8s.cluster.uid",
+            "value": {
+              "stringValue": "cluster-uid-123456789"
+            }
+          }
+        ]
+      },
+      "scopeMetrics": [
+        {
+          "metrics": [
+            {
+              "gauge": {
+                "dataPoints": [
+                  {
+                    "asDouble": 540672,
+                    "attributes": [
+                      {
+                        "key": "device",
+                        "value": {
+                          "stringValue": "/dev/nvme0n1p1"
+                        }
+                      },
+                      {
+                        "key": "endpoint",
+                        "value": {
+                          "stringValue": "https-metrics"
+                        }
+                      },
+                      {
+                        "key": "id",
+                        "value": {
+                          "stringValue": "/kubepods/burstable/podbafeef2c-1292-4a5e-a92c-d709480b04b6/86a84e64dded58918633fc9d1dd89a3f769d25143dd2da4273516d013df5862a"
+                        }
+                      },
+                      {
+                        "key": "metrics_path",
+                        "value": {
+                          "stringValue": "/metrics/cadvisor"
+                        }
+                      },
+                      {
+                        "key": "name",
+                        "value": {
+                          "stringValue": "k8s_swi-opentelemetry-collector_swi-k8s-otel-collector-swo-k8s-collector-metrics-cf8f6886bwt88g_prometheus-system_bafeef2c-1292-4a5e-a92c-d709480b04b6_0"
+                        }
+                      },
+                      {
+                        "key": "node",
+                        "value": {
+                          "stringValue": "test-node"
+                        }
+                      },
+                      {
+                        "key": "prometheus",
+                        "value": {
+                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
+                        }
+                      },
+                      {
+                        "key": "prometheus_replica",
+                        "value": {
+                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
+                        }
+                      },
+                      {
+                        "key": "service",
+                        "value": {
+                          "stringValue": "test-service"
+                        }
+                      }
+                    ],
+                    "timeUnixNano": "0"
+                  }
+                ]
+              },
+              "name": "k8s.container_fs_usage_bytes"
             },
             {
               "gauge": {
@@ -14137,80 +14433,6 @@
               "gauge": {
                 "dataPoints": [
                   {
-                    "asDouble": 0.25,
-                    "attributes": [
-                      {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "http"
-                        }
-                      },
-                      {
-                        "key": "prometheus",
-                        "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
-                        }
-                      },
-                      {
-                        "key": "prometheus_replica",
-                        "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
-                        }
-                      },
-                      {
-                        "key": "service",
-                        "value": {
-                          "stringValue": "test-service"
-                        }
-                      }
-                    ],
-                    "timeUnixNano": "0"
-                  }
-                ]
-              },
-              "name": "k8s.kube_pod_init_container_resource_requests_cpu_cores"
-            },
-            {
-              "gauge": {
-                "dataPoints": [
-                  {
-                    "asDouble": 67108864,
-                    "attributes": [
-                      {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "http"
-                        }
-                      },
-                      {
-                        "key": "prometheus",
-                        "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
-                        }
-                      },
-                      {
-                        "key": "prometheus_replica",
-                        "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
-                        }
-                      },
-                      {
-                        "key": "service",
-                        "value": {
-                          "stringValue": "test-service"
-                        }
-                      }
-                    ],
-                    "timeUnixNano": "0"
-                  }
-                ]
-              },
-              "name": "k8s.kube_pod_init_container_resource_requests_memory_bytes"
-            },
-            {
-              "gauge": {
-                "dataPoints": [
-                  {
                     "asDouble": 0,
                     "attributes": [
                       {
@@ -15475,18 +15697,6 @@
       "scopeMetrics": [
         {
           "metrics": [
-            {
-              "gauge": {
-                "dataPoints": [
-                  {
-                    "asDouble": 0,
-                    "startTimeUnixNano": "0",
-                    "timeUnixNano": "0"
-                  }
-                ]
-              },
-              "name": "k8s.container.fs.iops"
-            },
             {
               "gauge": {
                 "dataPoints": [
@@ -16954,6 +17164,225 @@
                 ]
               },
               "name": "k8s.kube_pod_container_resource_requests"
+            }
+          ],
+          "scope": {}
+        }
+      ]
+    },
+    {
+      "resource": {
+        "attributes": [
+          {
+            "key": "container",
+            "value": {
+              "stringValue": "test-container"
+            }
+          },
+          {
+            "key": "http.scheme",
+            "value": {
+              "stringValue": "http"
+            }
+          },
+          {
+            "key": "k8s.cluster.name",
+            "value": {
+              "stringValue": "cluster name"
+            }
+          },
+          {
+            "key": "k8s.container.name",
+            "value": {
+              "stringValue": "test-container"
+            }
+          },
+          {
+            "key": "k8s.namespace.annotations.description",
+            "value": {
+              "stringValue": "This is a test namespace."
+            }
+          },
+          {
+            "key": "k8s.namespace.labels.app",
+            "value": {
+              "stringValue": "test-app"
+            }
+          },
+          {
+            "key": "k8s.namespace.labels.kubernetes.io/metadata.name",
+            "value": {
+              "stringValue": "test-namespace"
+            }
+          },
+          {
+            "key": "k8s.namespace.labels.purpose",
+            "value": {
+              "stringValue": "testing"
+            }
+          },
+          {
+            "key": "k8s.namespace.name",
+            "value": {
+              "stringValue": "test-namespace"
+            }
+          },
+          {
+            "key": "k8s.pod.annotations.test-annotation",
+            "value": {
+              "stringValue": "test-value"
+            }
+          },
+          {
+            "key": "k8s.pod.labels.app",
+            "value": {
+              "stringValue": "test-pod"
+            }
+          },
+          {
+            "key": "k8s.pod.name",
+            "value": {
+              "stringValue": "test-pod"
+            }
+          },
+          {
+            "key": "k8s.pod.uid",
+            "value": {
+              "stringValue": "c7f7a05a-a1b5-4fd0-a611-8e2a0e7acbf6"
+            }
+          },
+          {
+            "key": "namespace",
+            "value": {
+              "stringValue": "test-namespace"
+            }
+          },
+          {
+            "key": "net.host.name",
+            "value": {
+              "stringValue": "test-node"
+            }
+          },
+          {
+            "key": "net.host.port",
+            "value": {
+              "stringValue": ""
+            }
+          },
+          {
+            "key": "pod",
+            "value": {
+              "stringValue": "test-pod"
+            }
+          },
+          {
+            "key": "sw.k8s.agent.app.version",
+            "value": {
+              "stringValue": "0.8.1"
+            }
+          },
+          {
+            "key": "sw.k8s.agent.manifest.version",
+            "value": {
+              "stringValue": "2.7.0-alpha.7"
+            }
+          },
+          {
+            "key": "sw.k8s.cluster.uid",
+            "value": {
+              "stringValue": "cluster-uid-123456789"
+            }
+          },
+          {
+            "key": "sw.k8s.container.init",
+            "value": {
+              "stringValue": "true"
+            }
+          },
+          {
+            "key": "uid",
+            "value": {
+              "stringValue": "c7f7a05a-a1b5-4fd0-a611-8e2a0e7acbf6"
+            }
+          }
+        ]
+      },
+      "scopeMetrics": [
+        {
+          "metrics": [
+            {
+              "gauge": {
+                "dataPoints": [
+                  {
+                    "asDouble": 0.25,
+                    "attributes": [
+                      {
+                        "key": "endpoint",
+                        "value": {
+                          "stringValue": "http"
+                        }
+                      },
+                      {
+                        "key": "prometheus",
+                        "value": {
+                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
+                        }
+                      },
+                      {
+                        "key": "prometheus_replica",
+                        "value": {
+                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
+                        }
+                      },
+                      {
+                        "key": "service",
+                        "value": {
+                          "stringValue": "test-service"
+                        }
+                      }
+                    ],
+                    "timeUnixNano": "0"
+                  }
+                ]
+              },
+              "name": "k8s.kube_pod_init_container_resource_requests_cpu_cores"
+            },
+            {
+              "gauge": {
+                "dataPoints": [
+                  {
+                    "asDouble": 67108864,
+                    "attributes": [
+                      {
+                        "key": "endpoint",
+                        "value": {
+                          "stringValue": "http"
+                        }
+                      },
+                      {
+                        "key": "prometheus",
+                        "value": {
+                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
+                        }
+                      },
+                      {
+                        "key": "prometheus_replica",
+                        "value": {
+                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
+                        }
+                      },
+                      {
+                        "key": "service",
+                        "value": {
+                          "stringValue": "test-service"
+                        }
+                      }
+                    ],
+                    "timeUnixNano": "0"
+                  }
+                ]
+              },
+              "name": "k8s.kube_pod_init_container_resource_requests_memory_bytes"
             }
           ],
           "scope": {}
@@ -21759,143 +22188,6 @@
               "gauge": {
                 "dataPoints": [
                   {
-                    "asDouble": 2,
-                    "timeUnixNano": "0"
-                  }
-                ]
-              },
-              "name": "k8s.pod.containers"
-            },
-            {
-              "gauge": {
-                "dataPoints": [
-                  {
-                    "asDouble": 3,
-                    "timeUnixNano": "0"
-                  }
-                ]
-              },
-              "name": "k8s.pod.containers.running"
-            }
-          ],
-          "scope": {}
-        }
-      ]
-    },
-    {
-      "resource": {
-        "attributes": [
-          {
-            "key": "http.scheme",
-            "value": {
-              "stringValue": "http"
-            }
-          },
-          {
-            "key": "k8s.cluster.name",
-            "value": {
-              "stringValue": "cluster name"
-            }
-          },
-          {
-            "key": "k8s.namespace.annotations.description",
-            "value": {
-              "stringValue": "This is a test namespace."
-            }
-          },
-          {
-            "key": "k8s.namespace.labels.app",
-            "value": {
-              "stringValue": "test-app"
-            }
-          },
-          {
-            "key": "k8s.namespace.labels.kubernetes.io/metadata.name",
-            "value": {
-              "stringValue": "test-namespace"
-            }
-          },
-          {
-            "key": "k8s.namespace.labels.purpose",
-            "value": {
-              "stringValue": "testing"
-            }
-          },
-          {
-            "key": "k8s.namespace.name",
-            "value": {
-              "stringValue": "test-namespace"
-            }
-          },
-          {
-            "key": "k8s.pod.annotations.test-annotation",
-            "value": {
-              "stringValue": "test-value"
-            }
-          },
-          {
-            "key": "k8s.pod.labels.app",
-            "value": {
-              "stringValue": "test-pod"
-            }
-          },
-          {
-            "key": "k8s.pod.name",
-            "value": {
-              "stringValue": "test-pod"
-            }
-          },
-          {
-            "key": "namespace",
-            "value": {
-              "stringValue": "test-namespace"
-            }
-          },
-          {
-            "key": "net.host.name",
-            "value": {
-              "stringValue": "test-node"
-            }
-          },
-          {
-            "key": "net.host.port",
-            "value": {
-              "stringValue": ""
-            }
-          },
-          {
-            "key": "pod",
-            "value": {
-              "stringValue": "test-pod"
-            }
-          },
-          {
-            "key": "sw.k8s.agent.app.version",
-            "value": {
-              "stringValue": "0.8.1"
-            }
-          },
-          {
-            "key": "sw.k8s.agent.manifest.version",
-            "value": {
-              "stringValue": "2.7.0-alpha.7"
-            }
-          },
-          {
-            "key": "sw.k8s.cluster.uid",
-            "value": {
-              "stringValue": "cluster-uid-123456789"
-            }
-          }
-        ]
-      },
-      "scopeMetrics": [
-        {
-          "metrics": [
-            {
-              "gauge": {
-                "dataPoints": [
-                  {
                     "asDouble": 0,
                     "attributes": [
                       {
@@ -22496,6 +22788,155 @@
               "gauge": {
                 "dataPoints": [
                   {
+                    "asDouble": 2,
+                    "timeUnixNano": "0"
+                  }
+                ]
+              },
+              "name": "k8s.pod.containers"
+            },
+            {
+              "gauge": {
+                "dataPoints": [
+                  {
+                    "asDouble": 3,
+                    "timeUnixNano": "0"
+                  }
+                ]
+              },
+              "name": "k8s.pod.containers.running"
+            },
+            {
+              "gauge": {
+                "dataPoints": [
+                  {
+                    "asDouble": 0,
+                    "startTimeUnixNano": "0",
+                    "timeUnixNano": "0"
+                  }
+                ]
+              },
+              "name": "k8s.pod.cpu.usage.seconds.rate"
+            }
+          ],
+          "scope": {}
+        }
+      ]
+    },
+    {
+      "resource": {
+        "attributes": [
+          {
+            "key": "http.scheme",
+            "value": {
+              "stringValue": "http"
+            }
+          },
+          {
+            "key": "k8s.cluster.name",
+            "value": {
+              "stringValue": "cluster name"
+            }
+          },
+          {
+            "key": "k8s.namespace.annotations.description",
+            "value": {
+              "stringValue": "This is a test namespace."
+            }
+          },
+          {
+            "key": "k8s.namespace.labels.app",
+            "value": {
+              "stringValue": "test-app"
+            }
+          },
+          {
+            "key": "k8s.namespace.labels.kubernetes.io/metadata.name",
+            "value": {
+              "stringValue": "test-namespace"
+            }
+          },
+          {
+            "key": "k8s.namespace.labels.purpose",
+            "value": {
+              "stringValue": "testing"
+            }
+          },
+          {
+            "key": "k8s.namespace.name",
+            "value": {
+              "stringValue": "test-namespace"
+            }
+          },
+          {
+            "key": "k8s.pod.annotations.test-annotation",
+            "value": {
+              "stringValue": "test-value"
+            }
+          },
+          {
+            "key": "k8s.pod.labels.app",
+            "value": {
+              "stringValue": "test-pod"
+            }
+          },
+          {
+            "key": "k8s.pod.name",
+            "value": {
+              "stringValue": "test-pod"
+            }
+          },
+          {
+            "key": "namespace",
+            "value": {
+              "stringValue": "test-namespace"
+            }
+          },
+          {
+            "key": "net.host.name",
+            "value": {
+              "stringValue": "test-node"
+            }
+          },
+          {
+            "key": "net.host.port",
+            "value": {
+              "stringValue": ""
+            }
+          },
+          {
+            "key": "pod",
+            "value": {
+              "stringValue": "test-pod"
+            }
+          },
+          {
+            "key": "sw.k8s.agent.app.version",
+            "value": {
+              "stringValue": "0.8.1"
+            }
+          },
+          {
+            "key": "sw.k8s.agent.manifest.version",
+            "value": {
+              "stringValue": "2.7.0-alpha.7"
+            }
+          },
+          {
+            "key": "sw.k8s.cluster.uid",
+            "value": {
+              "stringValue": "cluster-uid-123456789"
+            }
+          }
+        ]
+      },
+      "scopeMetrics": [
+        {
+          "metrics": [
+            {
+              "gauge": {
+                "dataPoints": [
+                  {
                     "asDouble": 2037620736,
                     "attributes": [
                       {
@@ -22722,18 +23163,6 @@
                   }
                 ]
               },
-              "name": "k8s.pod.cpu.usage.seconds.rate"
-            },
-            {
-              "gauge": {
-                "dataPoints": [
-                  {
-                    "asDouble": 0,
-                    "startTimeUnixNano": "0",
-                    "timeUnixNano": "0"
-                  }
-                ]
-              },
               "name": "k8s.pod.fs.iops"
             },
             {
@@ -22743,14 +23172,7 @@
                     "asDouble": 0,
                     "startTimeUnixNano": "0",
                     "timeUnixNano": "0"
-                  }
-                ]
-              },
-              "name": "k8s.pod.fs.reads.bytes.rate"
-            },
-            {
-              "gauge": {
-                "dataPoints": [
+                  },
                   {
                     "asDouble": 0,
                     "startTimeUnixNano": "0",
@@ -22764,48 +23186,12 @@
               "gauge": {
                 "dataPoints": [
                   {
-                    "asDouble": 0,
-                    "startTimeUnixNano": "0",
-                    "timeUnixNano": "0"
-                  }
-                ]
-              },
-              "name": "k8s.pod.fs.throughput"
-            },
-            {
-              "gauge": {
-                "dataPoints": [
-                  {
                     "asDouble": 552960,
                     "timeUnixNano": "0"
                   }
                 ]
               },
               "name": "k8s.pod.fs.usage.bytes"
-            },
-            {
-              "gauge": {
-                "dataPoints": [
-                  {
-                    "asDouble": 0,
-                    "startTimeUnixNano": "0",
-                    "timeUnixNano": "0"
-                  }
-                ]
-              },
-              "name": "k8s.pod.fs.writes.bytes.rate"
-            },
-            {
-              "gauge": {
-                "dataPoints": [
-                  {
-                    "asDouble": 0,
-                    "startTimeUnixNano": "0",
-                    "timeUnixNano": "0"
-                  }
-                ]
-              },
-              "name": "k8s.pod.fs.writes.rate"
             },
             {
               "gauge": {
@@ -22841,30 +23227,6 @@
                 ]
               },
               "name": "k8s.pod.network.bytes_transmitted"
-            },
-            {
-              "gauge": {
-                "dataPoints": [
-                  {
-                    "asDouble": 0,
-                    "startTimeUnixNano": "0",
-                    "timeUnixNano": "0"
-                  }
-                ]
-              },
-              "name": "k8s.pod.network.packets_received"
-            },
-            {
-              "gauge": {
-                "dataPoints": [
-                  {
-                    "asDouble": 0,
-                    "startTimeUnixNano": "0",
-                    "timeUnixNano": "0"
-                  }
-                ]
-              },
-              "name": "k8s.pod.network.packets_transmitted"
             },
             {
               "gauge": {
@@ -22989,127 +23351,6 @@
       "scopeMetrics": [
         {
           "metrics": [
-            {
-              "gauge": {
-                "dataPoints": [
-                  {
-                    "asDouble": 31.78,
-                    "timeUnixNano": "0"
-                  }
-                ]
-              },
-              "name": "k8s.cluster.cpu.allocatable"
-            },
-            {
-              "gauge": {
-                "dataPoints": [
-                  {
-                    "asDouble": 32,
-                    "timeUnixNano": "0"
-                  }
-                ]
-              },
-              "name": "k8s.cluster.cpu.capacity"
-            },
-            {
-              "gauge": {
-                "dataPoints": [
-                  {
-                    "asDouble": 126595563520,
-                    "timeUnixNano": "0"
-                  }
-                ]
-              },
-              "name": "k8s.cluster.memory.allocatable"
-            },
-            {
-              "gauge": {
-                "dataPoints": [
-                  {
-                    "asDouble": 132738121728,
-                    "timeUnixNano": "0"
-                  }
-                ]
-              },
-              "name": "k8s.cluster.memory.capacity"
-            },
-            {
-              "gauge": {
-                "dataPoints": [
-                  {
-                    "asDouble": 2,
-                    "timeUnixNano": "0"
-                  }
-                ]
-              },
-              "name": "k8s.cluster.nodes"
-            },
-            {
-              "gauge": {
-                "dataPoints": [
-                  {
-                    "asDouble": 2,
-                    "timeUnixNano": "0"
-                  }
-                ]
-              },
-              "name": "k8s.cluster.nodes.ready"
-            },
-            {
-              "gauge": {
-                "dataPoints": [
-                  {
-                    "asDouble": 1,
-                    "timeUnixNano": "0"
-                  }
-                ]
-              },
-              "name": "k8s.cluster.nodes.ready.avg"
-            },
-            {
-              "gauge": {
-                "dataPoints": [
-                  {
-                    "asDouble": 2,
-                    "timeUnixNano": "0"
-                  }
-                ]
-              },
-              "name": "k8s.cluster.pods"
-            },
-            {
-              "gauge": {
-                "dataPoints": [
-                  {
-                    "asDouble": 2,
-                    "timeUnixNano": "0"
-                  }
-                ]
-              },
-              "name": "k8s.cluster.pods.running"
-            },
-            {
-              "gauge": {
-                "dataPoints": [
-                  {
-                    "asDouble": 0.1,
-                    "timeUnixNano": "0"
-                  }
-                ]
-              },
-              "name": "k8s.cluster.spec.cpu.requests"
-            },
-            {
-              "gauge": {
-                "dataPoints": [
-                  {
-                    "asDouble": 6442450944,
-                    "timeUnixNano": "0"
-                  }
-                ]
-              },
-              "name": "k8s.cluster.spec.memory.requests"
-            },
             {
               "gauge": {
                 "dataPoints": [
@@ -36546,18 +36787,6 @@
                 ]
               },
               "name": "k8s.node.fs.iops"
-            },
-            {
-              "gauge": {
-                "dataPoints": [
-                  {
-                    "asDouble": 0,
-                    "startTimeUnixNano": "0",
-                    "timeUnixNano": "0"
-                  }
-                ]
-              },
-              "name": "k8s.node.fs.throughput"
             },
             {
               "gauge": {


### PR DESCRIPTION
copying resource attribute `service.instance.id` to attribute `k8s.node.name` on Fargate nodes should do the work. Hopefully nothing else is broken by that..