### PR TITLE
Optimizing docker layers, having all binaries for journalctl in one

### DIFF
--- a/build/docker/Dockerfile
+++ b/build/docker/Dockerfile
@@ -23,13 +23,7 @@ FROM debian:11.7@sha256:432f545c6ba13b79e2681f4cc4858788b0ab099fc1cca799cc0fae46
 RUN apt update
 RUN apt install -y systemd
 
-FROM scratch
-
-ARG USER_UID=10001
-USER ${USER_UID}
-
-COPY --from=prep /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
-COPY --from=builder /src/swi-k8s-opentelemetry-collector /swi-otelcol
+FROM scratch as journalbinaries
 
 # dynamically linked libraries that are required for journalctl and the journalctl binary itself
 #   use `ldd /bin/journalctl` to get dynamically linked libraries from the binary
@@ -59,6 +53,15 @@ COPY --from=journal /lib/x86_64-linux-gnu/libaudit.so.1 /lib/x86_64-linux-gnu/li
 COPY --from=journal /usr/lib/x86_64-linux-gnu/libpcre2-8.so.0 /usr/lib/x86_64-linux-gnu/libpcre2-8.so.0
 COPY --from=journal /lib/x86_64-linux-gnu/libcap-ng.so.0 /lib/x86_64-linux-gnu/libcap-ng.so.0
 COPY --from=journal /bin/journalctl /bin/journalctl
+
+FROM scratch
+
+ARG USER_UID=10001
+USER ${USER_UID}
+
+COPY --from=prep /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
+COPY --from=builder /src/swi-k8s-opentelemetry-collector /swi-otelcol
+COPY --from=journalbinaries / /
 
 ENTRYPOINT ["/swi-otelcol"]
 CMD ["--config=/opt/default-config.yaml"]


### PR DESCRIPTION
each COPY in end image has separate layer, so adding extra stage and merging all COPY commands into single layer