### PR TITLE
NH-54277: Adding Windows image tag

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,1 +1,2 @@
+.git
 tests/integration/actual.json

--- a/.github/workflows/buildAndDeploy.yml
+++ b/.github/workflows/buildAndDeploy.yml
@@ -64,6 +64,34 @@ jobs:
           name: image
           path: swi-k8s-opentelemetry-collector.tar
           retention-days: 2
+  
+  build_and_test_windows:
+    runs-on: windows-2022
+    if: github.event_name == 'release' && github.event.action == 'published' && !contains(github.ref, 'swo-k8s-collector')
+    outputs:
+      image_tag: ${{ steps.generate-tag.outputs.value }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Generate docker image tag
+        id: generate-tag
+        run: echo "::set-output name=value::v${{ github.run_number }}-$(git rev-parse --short HEAD)"
+
+      - name: Build
+        run: docker build -t swi-k8s-opentelemetry-collector:${{ steps.generate-tag.outputs.value }}-nanoserver-ltsc2022 -f build/docker/Dockerfile.Windows . 
+
+      - name: Save image
+        if: github.event_name == 'release' && github.event.action == 'published' && !contains(github.ref, 'swo-k8s-collector')
+        run: |
+          docker save --output swi-k8s-opentelemetry-collector-windows.tar swi-k8s-opentelemetry-collector:${{ steps.generate-tag.outputs.value }}-nanoserver-ltsc2022
+
+      - uses: actions/upload-artifact@v3
+        if: github.event_name == 'release' && github.event.action == 'published' && !contains(github.ref, 'swo-k8s-collector')
+        with:
+          name: image
+          path: swi-k8s-opentelemetry-collector-windows.tar
+          retention-days: 2
 
   # Verify whether Helm chart works with image published in DockerHub
   helm_e2e:
@@ -262,6 +290,37 @@ jobs:
       - name: Push as specific
         run: docker push ${{ env.DOCKERHUB_IMAGE }}:${{ steps.vars.outputs.tag }}
 
-      # Temporarily disabled
-      # - name: Push as latest
-      #   run: docker push ${{ env.DOCKERHUB_IMAGE }}:latest
+  deploy_dockerhub_windows:
+    runs-on: windows-2022
+    needs: build_and_test_windows
+    name: Deploy to docker hub Windows
+    if: github.event_name == 'release' && github.event.action == 'published' && !contains(github.ref, 'swo-k8s-collector')
+    environment:
+      name: production
+      url: https://hub.docker.com/repository/docker/solarwinds/swi-opentelemetry-collector
+    steps:
+      - uses: actions/download-artifact@v3
+        with:
+          name: image
+
+      - name: Get image tag
+        id: vars
+        run: echo ::set-output name=tag::${GITHUB_REF#refs/*/}
+
+      - name: Load image
+        run: |
+          docker load --input swi-k8s-opentelemetry-collector-windows.tar
+
+      - name: Tag images
+        run: |
+          docker tag swi-k8s-opentelemetry-collector:${{ needs.build_and_test.outputs.image_tag }}-nanoserver-ltsc2022 ${{ env.DOCKERHUB_IMAGE }}:${{ steps.vars.outputs.tag }}-nanoserver-ltsc2022
+
+      - name: Docker login
+        env:
+          DOCKER_HUB_CI_PASSWORD: ${{ secrets.DOCKER_HUB_CI_PASSWORD }}
+          DOCKER_HUB_CI_USER: ${{ secrets.DOCKER_HUB_CI_USER }}
+        run: echo "$DOCKER_HUB_CI_PASSWORD" | docker login -u "$DOCKER_HUB_CI_USER" --password-stdin
+
+      - name: Push as specific
+        run: docker push ${{ env.DOCKERHUB_IMAGE }}:${{ steps.vars.outputs.tag }}-nanoserver-ltsc2022
+

--- a/build/docker/Dockerfile.Windows
+++ b/build/docker/Dockerfile.Windows
@@ -1,0 +1,21 @@
+FROM docker.io/library/golang:1.21.0-nanoserver-ltsc2022@sha256:d08dfe442c8d0dbd180c883198dbcf881e47f8a48ecd301c2d015b64c665da69 as base
+WORKDIR /src
+COPY ["./src/", "./src/"]
+
+FROM base as builder
+
+COPY /build/swi-k8s-opentelemetry-collector.yaml /src/swi-k8s-opentelemetry-collector.yaml
+RUN go install go.opentelemetry.io/collector/cmd/builder@v0.81.0
+
+ARG CGO_ENABLED=0
+ARG GOEXPERIMENT=boringcrypto
+
+RUN /go/bin/builder --config ./swi-k8s-opentelemetry-collector.yaml --output-path ./
+
+FROM mcr.microsoft.com/windows/nanoserver:ltsc2022
+
+COPY --from=builder /src/swi-k8s-opentelemetry-collector /swi-otelcol.exe
+ENTRYPOINT ["swi-otelcol.exe"]
+CMD ["--config=c:/config/default-config.yaml"]
+
+


### PR DESCRIPTION
* Added separate publishing Job for windows image
* Windows is going to be build only in event of release. The image is not needed for any other part of the workflow and we can quite rely on the Go that if the build of OTEL fails on Windows it would have failed on Linux as well
