### PR TITLE
NH-62317 removing syslog attributes

### DIFF
--- a/deploy/helm/CHANGELOG.md
+++ b/deploy/helm/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+- Changing log message attributes to respect OTEL log format
+
 ## [2.8.0-alpha.2] - 2023-09-14
 
 ### Added

--- a/deploy/helm/logs-collector-config.yaml
+++ b/deploy/helm/logs-collector-config.yaml
@@ -29,7 +29,7 @@ processors:
       - k8s.namespace.name
       - k8s.pod.name
       - k8s.pod.uid
-      - host.hostname
+      - host.name
       - service.name
 
 
@@ -98,12 +98,8 @@ processors:
     log_statements:
       - context: log
         statements:
-          - set( attributes["syslog.facility"], 1 )
-          - set( attributes["syslog.version"], 1 )
-          - set( attributes["host.hostname"], attributes["k8s.pod.name"])
+          - set( attributes["host.name"], attributes["k8s.pod.name"])
           - set( attributes["service.name"], attributes["k8s.container.name"])
-          - set( attributes["syslog.procid"], attributes["run_id"])
-          - set( attributes["syslog.msgid"], attributes["stream"])
 
   batch:
 {{ toYaml .Values.otel.logs.batch | indent 4 }}
@@ -232,9 +228,8 @@ receivers:
       - type: move
         from: attributes.pod_name
         to: attributes["k8s.pod.name"]
-      - type: move
-        from: attributes.run_id
-        to: attributes["run_id"]
+      - type: remove
+        field: attributes.run_id
       - type: move
         from: attributes.uid
         to: attributes["k8s.pod.uid"]

--- a/deploy/helm/tests/__snapshot__/logs-collector-config-map-windows_test.yaml.snap
+++ b/deploy/helm/tests/__snapshot__/logs-collector-config-map-windows_test.yaml.snap
@@ -34,7 +34,7 @@ Logs config for windows nodes should match snapshot when using default values:
           - k8s.namespace.name
           - k8s.pod.name
           - k8s.pod.uid
-          - host.hostname
+          - host.name
           - service.name
         memory_limiter:
           check_interval: 1s
@@ -65,12 +65,8 @@ Logs config for windows nodes should match snapshot when using default values:
           log_statements:
           - context: log
             statements:
-            - set( attributes["syslog.facility"], 1 )
-            - set( attributes["syslog.version"], 1 )
-            - set( attributes["host.hostname"], attributes["k8s.pod.name"])
+            - set( attributes["host.name"], attributes["k8s.pod.name"])
             - set( attributes["service.name"], attributes["k8s.container.name"])
-            - set( attributes["syslog.procid"], attributes["run_id"])
-            - set( attributes["syslog.msgid"], attributes["stream"])
       receivers:
         filelog:
           encoding: utf-8
@@ -156,9 +152,8 @@ Logs config for windows nodes should match snapshot when using default values:
           - from: attributes.pod_name
             to: attributes["k8s.pod.name"]
             type: move
-          - from: attributes.run_id
-            to: attributes["run_id"]
-            type: move
+          - field: attributes.run_id
+            type: remove
           - from: attributes.uid
             to: attributes["k8s.pod.uid"]
             type: move

--- a/deploy/helm/tests/__snapshot__/logs-collector-config-map_test.yaml.snap
+++ b/deploy/helm/tests/__snapshot__/logs-collector-config-map_test.yaml.snap
@@ -34,7 +34,7 @@ Logs config should match snapshot when using default values:
           - k8s.namespace.name
           - k8s.pod.name
           - k8s.pod.uid
-          - host.hostname
+          - host.name
           - service.name
         memory_limiter:
           check_interval: 1s
@@ -85,12 +85,8 @@ Logs config should match snapshot when using default values:
           log_statements:
           - context: log
             statements:
-            - set( attributes["syslog.facility"], 1 )
-            - set( attributes["syslog.version"], 1 )
-            - set( attributes["host.hostname"], attributes["k8s.pod.name"])
+            - set( attributes["host.name"], attributes["k8s.pod.name"])
             - set( attributes["service.name"], attributes["k8s.container.name"])
-            - set( attributes["syslog.procid"], attributes["run_id"])
-            - set( attributes["syslog.msgid"], attributes["stream"])
       receivers:
         filelog:
           encoding: utf-8
@@ -176,9 +172,8 @@ Logs config should match snapshot when using default values:
           - from: attributes.pod_name
             to: attributes["k8s.pod.name"]
             type: move
-          - from: attributes.run_id
-            to: attributes["run_id"]
-            type: move
+          - field: attributes.run_id
+            type: remove
           - from: attributes.uid
             to: attributes["k8s.pod.uid"]
             type: move


### PR DESCRIPTION
Syslog attributes should not be necessary anymore according to  https://swicloud.atlassian.net/wiki/spaces/SP/pages/3706519849/TIP-8+Minimal+Otel+Log+Support