### PR TITLE
NH-60899: Unexport attributes

### DIFF
--- a/deploy/helm/CHANGELOG.md
+++ b/deploy/helm/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Detection of Node name for Fargate Nodes's metrics
 
+### Removed
+
+- Removed attributes `net.host.name`, `net.host.port`, `http.scheme`, `prometheus`, `prometheus_replica` and `endpoint` from exported metrics
+
 ## [2.8.0-alpha.3] - 2023-10-06
 
 ### Changed

--- a/deploy/helm/metrics-collector-config.yaml
+++ b/deploy/helm/metrics-collector-config.yaml
@@ -1299,6 +1299,15 @@ processors:
           - delete_key(resource.attributes, "sw.k8s.cronjob.found")
           - delete_key(resource.attributes, "sw.k8s.node.found")
 
+  attributes/remove_prometheus_attributes:
+    actions:
+      - key: endpoint
+        action: delete
+      - key: prometheus
+        action: delete
+      - key: prometheus_replica
+        action: delete
+
   resource/events:
     attributes:
       # Collector and Manifest version
@@ -1486,6 +1495,7 @@ service:
         - filter/receiver
         - transform
         - filter/remove_internal        
+        - attributes/remove_prometheus_attributes
         - attributes/unify_node_attribute
         - transform/unify_node_attribute
         - attributes/unify_volume_attribute        

--- a/deploy/helm/metrics-collector-config.yaml
+++ b/deploy/helm/metrics-collector-config.yaml
@@ -1129,14 +1129,14 @@ processors:
       - key: service.instance.id
         action: delete
 
-      - key: host.name
+      - key: net.host.name
         action: delete
 
-      - key: port
+      - key: net.host.port
         action: delete
 
-      - key: scheme
-        action: delete 
+      - key: http.scheme
+        action: delete
 
       # Collector and Manifest version
       - key: sw.k8s.agent.manifest.version

--- a/deploy/helm/tests/__snapshot__/metrics-collector-config-map-fargate_test.yaml.snap
+++ b/deploy/helm/tests/__snapshot__/metrics-collector-config-map-fargate_test.yaml.snap
@@ -325,6 +325,14 @@ Metrics config should match snapshot when using default values:
             match_type: regexp
             metric_names:
             - kube_pod_container_.*
+        attributes/remove_prometheus_attributes:
+          actions:
+          - action: delete
+            key: endpoint
+          - action: delete
+            key: prometheus
+          - action: delete
+            key: prometheus_replica
         attributes/remove_temp:
           actions:
           - action: delete
@@ -1616,11 +1624,11 @@ Metrics config should match snapshot when using default values:
           - action: delete
             key: service.instance.id
           - action: delete
-            key: host.name
+            key: net.host.name
           - action: delete
-            key: port
+            key: net.host.port
           - action: delete
-            key: scheme
+            key: http.scheme
           - action: insert
             key: sw.k8s.agent.manifest.version
             value: ${MANIFEST_VERSION}
@@ -1992,6 +2000,7 @@ Metrics config should match snapshot when using default values:
             - filter/receiver
             - transform
             - filter/remove_internal
+            - attributes/remove_prometheus_attributes
             - attributes/unify_node_attribute
             - transform/unify_node_attribute
             - attributes/unify_volume_attribute

--- a/deploy/helm/tests/__snapshot__/metrics-collector-config-map_test.yaml.snap
+++ b/deploy/helm/tests/__snapshot__/metrics-collector-config-map_test.yaml.snap
@@ -325,6 +325,14 @@ Metrics config should match snapshot when using default values:
             match_type: regexp
             metric_names:
             - kube_pod_container_.*
+        attributes/remove_prometheus_attributes:
+          actions:
+          - action: delete
+            key: endpoint
+          - action: delete
+            key: prometheus
+          - action: delete
+            key: prometheus_replica
         attributes/remove_temp:
           actions:
           - action: delete
@@ -1619,11 +1627,11 @@ Metrics config should match snapshot when using default values:
           - action: delete
             key: service.instance.id
           - action: delete
-            key: host.name
+            key: net.host.name
           - action: delete
-            key: port
+            key: net.host.port
           - action: delete
-            key: scheme
+            key: http.scheme
           - action: insert
             key: sw.k8s.agent.manifest.version
             value: ${MANIFEST_VERSION}
@@ -1995,6 +2003,7 @@ Metrics config should match snapshot when using default values:
             - filter/receiver
             - transform
             - filter/remove_internal
+            - attributes/remove_prometheus_attributes
             - attributes/unify_node_attribute
             - transform/unify_node_attribute
             - attributes/unify_volume_attribute

--- a/tests/integration/expected_output.json
+++ b/tests/integration/expected_output.json
@@ -16,12 +16,6 @@
             }
           },
           {
-            "key": "http.scheme",
-            "value": {
-              "stringValue": "http"
-            }
-          },
-          {
             "key": "k8s.cluster.name",
             "value": {
               "stringValue": "cluster name"
@@ -121,18 +115,6 @@
             "key": "namespace",
             "value": {
               "stringValue": "test-namespace"
-            }
-          },
-          {
-            "key": "net.host.name",
-            "value": {
-              "stringValue": "test-node"
-            }
-          },
-          {
-            "key": "net.host.port",
-            "value": {
-              "stringValue": ""
             }
           },
           {
@@ -258,12 +240,6 @@
             }
           },
           {
-            "key": "http.scheme",
-            "value": {
-              "stringValue": "http"
-            }
-          },
-          {
             "key": "image",
             "value": {
               "stringValue": "registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.6.2"
@@ -363,18 +339,6 @@
             "key": "namespace",
             "value": {
               "stringValue": "test-namespace"
-            }
-          },
-          {
-            "key": "net.host.name",
-            "value": {
-              "stringValue": "test-node"
-            }
-          },
-          {
-            "key": "net.host.port",
-            "value": {
-              "stringValue": ""
             }
           },
           {
@@ -500,12 +464,6 @@
             }
           },
           {
-            "key": "http.scheme",
-            "value": {
-              "stringValue": "http"
-            }
-          },
-          {
             "key": "image",
             "value": {
               "stringValue": "busybox:latest"
@@ -605,18 +563,6 @@
             "key": "namespace",
             "value": {
               "stringValue": "test-namespace"
-            }
-          },
-          {
-            "key": "net.host.name",
-            "value": {
-              "stringValue": "test-node"
-            }
-          },
-          {
-            "key": "net.host.port",
-            "value": {
-              "stringValue": ""
             }
           },
           {
@@ -742,12 +688,6 @@
             }
           },
           {
-            "key": "http.scheme",
-            "value": {
-              "stringValue": "http"
-            }
-          },
-          {
             "key": "image",
             "value": {
               "stringValue": "solarwinds/swi-opentelemetry-collector:0.5.0"
@@ -847,18 +787,6 @@
             "key": "namespace",
             "value": {
               "stringValue": "test-namespace"
-            }
-          },
-          {
-            "key": "net.host.name",
-            "value": {
-              "stringValue": "test-node"
-            }
-          },
-          {
-            "key": "net.host.port",
-            "value": {
-              "stringValue": ""
             }
           },
           {
@@ -984,12 +912,6 @@
             }
           },
           {
-            "key": "http.scheme",
-            "value": {
-              "stringValue": "http"
-            }
-          },
-          {
             "key": "image",
             "value": {
               "stringValue": "busybox:1.29.2"
@@ -1089,18 +1011,6 @@
             "key": "namespace",
             "value": {
               "stringValue": "test-namespace"
-            }
-          },
-          {
-            "key": "net.host.name",
-            "value": {
-              "stringValue": "test-node"
-            }
-          },
-          {
-            "key": "net.host.port",
-            "value": {
-              "stringValue": ""
             }
           },
           {
@@ -1226,12 +1136,6 @@
             }
           },
           {
-            "key": "http.scheme",
-            "value": {
-              "stringValue": "http"
-            }
-          },
-          {
             "key": "image",
             "value": {
               "stringValue": "fullstorydev/grpcurl:latest"
@@ -1334,18 +1238,6 @@
             }
           },
           {
-            "key": "net.host.name",
-            "value": {
-              "stringValue": "test-node"
-            }
-          },
-          {
-            "key": "net.host.port",
-            "value": {
-              "stringValue": ""
-            }
-          },
-          {
             "key": "pod",
             "value": {
               "stringValue": "test-pod"
@@ -1444,12 +1336,6 @@
             }
           },
           {
-            "key": "http.scheme",
-            "value": {
-              "stringValue": "http"
-            }
-          },
-          {
             "key": "internal_ip",
             "value": {
               "stringValue": "172.22.0.106"
@@ -1525,18 +1411,6 @@
             "key": "namespace",
             "value": {
               "stringValue": "test-namespace"
-            }
-          },
-          {
-            "key": "net.host.name",
-            "value": {
-              "stringValue": "test-node"
-            }
-          },
-          {
-            "key": "net.host.port",
-            "value": {
-              "stringValue": ""
             }
           },
           {
@@ -1692,12 +1566,6 @@
             }
           },
           {
-            "key": "http.scheme",
-            "value": {
-              "stringValue": "http"
-            }
-          },
-          {
             "key": "internal_ip",
             "value": {
               "stringValue": "172.22.2.84"
@@ -1773,18 +1641,6 @@
             "key": "namespace",
             "value": {
               "stringValue": "test-namespace"
-            }
-          },
-          {
-            "key": "net.host.name",
-            "value": {
-              "stringValue": "test-node"
-            }
-          },
-          {
-            "key": "net.host.port",
-            "value": {
-              "stringValue": ""
             }
           },
           {
@@ -1958,12 +1814,6 @@
             }
           },
           {
-            "key": "http.scheme",
-            "value": {
-              "stringValue": "http"
-            }
-          },
-          {
             "key": "k8s.cluster.name",
             "value": {
               "stringValue": "cluster name"
@@ -2033,18 +1883,6 @@
             "key": "namespace",
             "value": {
               "stringValue": "test-namespace"
-            }
-          },
-          {
-            "key": "net.host.name",
-            "value": {
-              "stringValue": "test-node"
-            }
-          },
-          {
-            "key": "net.host.port",
-            "value": {
-              "stringValue": ""
             }
           },
           {
@@ -2200,12 +2038,6 @@
             }
           },
           {
-            "key": "http.scheme",
-            "value": {
-              "stringValue": "http"
-            }
-          },
-          {
             "key": "k8s.cluster.name",
             "value": {
               "stringValue": "cluster name"
@@ -2275,18 +2107,6 @@
             "key": "namespace",
             "value": {
               "stringValue": "test-namespace"
-            }
-          },
-          {
-            "key": "net.host.name",
-            "value": {
-              "stringValue": "test-node"
-            }
-          },
-          {
-            "key": "net.host.port",
-            "value": {
-              "stringValue": ""
             }
           },
           {
@@ -2424,12 +2244,6 @@
             }
           },
           {
-            "key": "http.scheme",
-            "value": {
-              "stringValue": "http"
-            }
-          },
-          {
             "key": "k8s.cluster.name",
             "value": {
               "stringValue": "cluster name"
@@ -2505,18 +2319,6 @@
             "key": "namespace",
             "value": {
               "stringValue": "test-namespace"
-            }
-          },
-          {
-            "key": "net.host.name",
-            "value": {
-              "stringValue": "test-node"
-            }
-          },
-          {
-            "key": "net.host.port",
-            "value": {
-              "stringValue": ""
             }
           },
           {
@@ -2618,12 +2420,6 @@
             }
           },
           {
-            "key": "http.scheme",
-            "value": {
-              "stringValue": "http"
-            }
-          },
-          {
             "key": "k8s.cluster.name",
             "value": {
               "stringValue": "cluster name"
@@ -2711,18 +2507,6 @@
             "key": "namespace",
             "value": {
               "stringValue": "test-namespace"
-            }
-          },
-          {
-            "key": "net.host.name",
-            "value": {
-              "stringValue": "test-node"
-            }
-          },
-          {
-            "key": "net.host.port",
-            "value": {
-              "stringValue": ""
             }
           },
           {
@@ -3108,12 +2892,6 @@
             }
           },
           {
-            "key": "http.scheme",
-            "value": {
-              "stringValue": "http"
-            }
-          },
-          {
             "key": "k8s.cluster.name",
             "value": {
               "stringValue": "cluster name"
@@ -3210,18 +2988,6 @@
             }
           },
           {
-            "key": "net.host.name",
-            "value": {
-              "stringValue": "test-node"
-            }
-          },
-          {
-            "key": "net.host.port",
-            "value": {
-              "stringValue": ""
-            }
-          },
-          {
             "key": "pod",
             "value": {
               "stringValue": "test-pod"
@@ -3323,12 +3089,6 @@
             "key": "deployment",
             "value": {
               "stringValue": "swi-k8s-otel-collector-swo-k8s-collector-metrics"
-            }
-          },
-          {
-            "key": "http.scheme",
-            "value": {
-              "stringValue": "http"
             }
           },
           {
@@ -3428,18 +3188,6 @@
             }
           },
           {
-            "key": "net.host.name",
-            "value": {
-              "stringValue": "test-node"
-            }
-          },
-          {
-            "key": "net.host.port",
-            "value": {
-              "stringValue": ""
-            }
-          },
-          {
             "key": "pod",
             "value": {
               "stringValue": "test-pod"
@@ -3544,12 +3292,6 @@
             }
           },
           {
-            "key": "http.scheme",
-            "value": {
-              "stringValue": "http"
-            }
-          },
-          {
             "key": "k8s.cluster.name",
             "value": {
               "stringValue": "cluster name"
@@ -3637,18 +3379,6 @@
             "key": "namespace",
             "value": {
               "stringValue": "test-namespace"
-            }
-          },
-          {
-            "key": "net.host.name",
-            "value": {
-              "stringValue": "test-node"
-            }
-          },
-          {
-            "key": "net.host.port",
-            "value": {
-              "stringValue": ""
             }
           },
           {
@@ -4445,12 +4175,6 @@
             }
           },
           {
-            "key": "http.scheme",
-            "value": {
-              "stringValue": "http"
-            }
-          },
-          {
             "key": "image",
             "value": {
               "stringValue": "915014598477.dkr.ecr.us-east-1.amazonaws.com/external/docker.io/temporalio/admin-tools@sha256:69e9f218ec37d8ef0ed793e2cc1a73dedbb62f545c9e1b858afffedba36fdd66"
@@ -4526,18 +4250,6 @@
             "key": "namespace",
             "value": {
               "stringValue": "test-namespace"
-            }
-          },
-          {
-            "key": "net.host.name",
-            "value": {
-              "stringValue": "test-node"
-            }
-          },
-          {
-            "key": "net.host.port",
-            "value": {
-              "stringValue": ""
             }
           },
           {
@@ -4918,12 +4630,6 @@
             }
           },
           {
-            "key": "http.scheme",
-            "value": {
-              "stringValue": "http"
-            }
-          },
-          {
             "key": "image",
             "value": {
               "stringValue": "915014598477.dkr.ecr.us-east-1.amazonaws.com/external/docker.io/temporalio/server@sha256:1ecfc4b2cb425b93c1f74ab7288ac190982f039ac65789da3a97377bed706348"
@@ -4999,18 +4705,6 @@
             "key": "namespace",
             "value": {
               "stringValue": "test-namespace"
-            }
-          },
-          {
-            "key": "net.host.name",
-            "value": {
-              "stringValue": "test-node"
-            }
-          },
-          {
-            "key": "net.host.port",
-            "value": {
-              "stringValue": ""
             }
           },
           {
@@ -5118,12 +4812,6 @@
             }
           },
           {
-            "key": "http.scheme",
-            "value": {
-              "stringValue": "http"
-            }
-          },
-          {
             "key": "image",
             "value": {
               "stringValue": "915014598477.dkr.ecr.us-east-1.amazonaws.com/nighthawk/alerting_management@sha256:11138b16b634ffbc60ceb1c9c99a93faab82d0b74c1204157c2ee2068f3395b8"
@@ -5199,18 +4887,6 @@
             "key": "namespace",
             "value": {
               "stringValue": "test-namespace"
-            }
-          },
-          {
-            "key": "net.host.name",
-            "value": {
-              "stringValue": "test-node"
-            }
-          },
-          {
-            "key": "net.host.port",
-            "value": {
-              "stringValue": ""
             }
           },
           {
@@ -5444,12 +5120,6 @@
             }
           },
           {
-            "key": "http.scheme",
-            "value": {
-              "stringValue": "http"
-            }
-          },
-          {
             "key": "image",
             "value": {
               "stringValue": "915014598477.dkr.ecr.us-east-1.amazonaws.com/nighthawk/alerting_state_manager@sha256:aa7e6b9e69e8acceb8e6754832324ddf6d6f339101493816e0311ccfeae2c3dd"
@@ -5525,18 +5195,6 @@
             "key": "namespace",
             "value": {
               "stringValue": "test-namespace"
-            }
-          },
-          {
-            "key": "net.host.name",
-            "value": {
-              "stringValue": "test-node"
-            }
-          },
-          {
-            "key": "net.host.port",
-            "value": {
-              "stringValue": ""
             }
           },
           {
@@ -5721,12 +5379,6 @@
             }
           },
           {
-            "key": "http.scheme",
-            "value": {
-              "stringValue": "http"
-            }
-          },
-          {
             "key": "image",
             "value": {
               "stringValue": "sha256:8423d5a81606084300d223d734589c7264ca789ff6908875cf62178ead6a6154"
@@ -5802,18 +5454,6 @@
             "key": "namespace",
             "value": {
               "stringValue": "test-namespace"
-            }
-          },
-          {
-            "key": "net.host.name",
-            "value": {
-              "stringValue": "test-node"
-            }
-          },
-          {
-            "key": "net.host.port",
-            "value": {
-              "stringValue": ""
             }
           },
           {
@@ -6643,12 +6283,6 @@
             }
           },
           {
-            "key": "http.scheme",
-            "value": {
-              "stringValue": "http"
-            }
-          },
-          {
             "key": "image",
             "value": {
               "stringValue": "sha256:90c7349d6e210794df9fb6a022050325400daae2fa23b833be91293aae2e4e78"
@@ -6724,18 +6358,6 @@
             "key": "namespace",
             "value": {
               "stringValue": "test-namespace"
-            }
-          },
-          {
-            "key": "net.host.name",
-            "value": {
-              "stringValue": "test-node"
-            }
-          },
-          {
-            "key": "net.host.port",
-            "value": {
-              "stringValue": ""
             }
           },
           {
@@ -6851,12 +6473,6 @@
             }
           },
           {
-            "key": "http.scheme",
-            "value": {
-              "stringValue": "http"
-            }
-          },
-          {
             "key": "image",
             "value": {
               "stringValue": "sha256:971d0489e081e4422f45606ed2b08506243c46c47305f2476fd6b8cd92fd9a49"
@@ -6932,18 +6548,6 @@
             "key": "namespace",
             "value": {
               "stringValue": "test-namespace"
-            }
-          },
-          {
-            "key": "net.host.name",
-            "value": {
-              "stringValue": "test-node"
-            }
-          },
-          {
-            "key": "net.host.port",
-            "value": {
-              "stringValue": ""
             }
           },
           {
@@ -7051,12 +6655,6 @@
             }
           },
           {
-            "key": "http.scheme",
-            "value": {
-              "stringValue": "http"
-            }
-          },
-          {
             "key": "job_name",
             "value": {
               "stringValue": "test-job-name"
@@ -7138,18 +6736,6 @@
             "key": "namespace",
             "value": {
               "stringValue": "test-namespace"
-            }
-          },
-          {
-            "key": "net.host.name",
-            "value": {
-              "stringValue": "test-node"
-            }
-          },
-          {
-            "key": "net.host.port",
-            "value": {
-              "stringValue": ""
             }
           },
           {
@@ -7627,12 +7213,6 @@
             }
           },
           {
-            "key": "http.scheme",
-            "value": {
-              "stringValue": "http"
-            }
-          },
-          {
             "key": "k8s.cluster.name",
             "value": {
               "stringValue": "cluster name"
@@ -7738,18 +7318,6 @@
             "key": "namespace",
             "value": {
               "stringValue": "test-namespace"
-            }
-          },
-          {
-            "key": "net.host.name",
-            "value": {
-              "stringValue": "test-node"
-            }
-          },
-          {
-            "key": "net.host.port",
-            "value": {
-              "stringValue": ""
             }
           },
           {
@@ -7869,12 +7437,6 @@
             }
           },
           {
-            "key": "http.scheme",
-            "value": {
-              "stringValue": "http"
-            }
-          },
-          {
             "key": "k8s.cluster.name",
             "value": {
               "stringValue": "cluster name"
@@ -7974,18 +7536,6 @@
             "key": "namespace",
             "value": {
               "stringValue": "test-namespace"
-            }
-          },
-          {
-            "key": "net.host.name",
-            "value": {
-              "stringValue": "test-node"
-            }
-          },
-          {
-            "key": "net.host.port",
-            "value": {
-              "stringValue": ""
             }
           },
           {
@@ -8093,12 +7643,6 @@
             }
           },
           {
-            "key": "http.scheme",
-            "value": {
-              "stringValue": "http"
-            }
-          },
-          {
             "key": "k8s.cluster.name",
             "value": {
               "stringValue": "cluster name"
@@ -8198,18 +7742,6 @@
             "key": "namespace",
             "value": {
               "stringValue": "test-namespace"
-            }
-          },
-          {
-            "key": "net.host.name",
-            "value": {
-              "stringValue": "test-node"
-            }
-          },
-          {
-            "key": "net.host.port",
-            "value": {
-              "stringValue": ""
             }
           },
           {
@@ -8348,12 +7880,6 @@
             }
           },
           {
-            "key": "http.scheme",
-            "value": {
-              "stringValue": "http"
-            }
-          },
-          {
             "key": "k8s.cluster.name",
             "value": {
               "stringValue": "cluster name"
@@ -8459,18 +7985,6 @@
             "key": "namespace",
             "value": {
               "stringValue": "test-namespace"
-            }
-          },
-          {
-            "key": "net.host.name",
-            "value": {
-              "stringValue": "test-node"
-            }
-          },
-          {
-            "key": "net.host.port",
-            "value": {
-              "stringValue": ""
             }
           },
           {
@@ -8590,12 +8104,6 @@
             }
           },
           {
-            "key": "http.scheme",
-            "value": {
-              "stringValue": "http"
-            }
-          },
-          {
             "key": "k8s.cluster.name",
             "value": {
               "stringValue": "cluster name"
@@ -8704,18 +8212,6 @@
             }
           },
           {
-            "key": "net.host.name",
-            "value": {
-              "stringValue": "test-node"
-            }
-          },
-          {
-            "key": "net.host.port",
-            "value": {
-              "stringValue": ""
-            }
-          },
-          {
             "key": "persistentvolumeclaim",
             "value": {
               "stringValue": "test-pvc"
@@ -8820,12 +8316,6 @@
             }
           },
           {
-            "key": "http.scheme",
-            "value": {
-              "stringValue": "http"
-            }
-          },
-          {
             "key": "k8s.cluster.name",
             "value": {
               "stringValue": "cluster name"
@@ -8925,18 +8415,6 @@
             "key": "namespace",
             "value": {
               "stringValue": "test-namespace"
-            }
-          },
-          {
-            "key": "net.host.name",
-            "value": {
-              "stringValue": "test-node"
-            }
-          },
-          {
-            "key": "net.host.port",
-            "value": {
-              "stringValue": ""
             }
           },
           {
@@ -9075,12 +8553,6 @@
             }
           },
           {
-            "key": "http.scheme",
-            "value": {
-              "stringValue": "http"
-            }
-          },
-          {
             "key": "k8s.cluster.name",
             "value": {
               "stringValue": "cluster name"
@@ -9183,18 +8655,6 @@
             }
           },
           {
-            "key": "net.host.name",
-            "value": {
-              "stringValue": "test-node"
-            }
-          },
-          {
-            "key": "net.host.port",
-            "value": {
-              "stringValue": ""
-            }
-          },
-          {
             "key": "persistentvolumeclaim",
             "value": {
               "stringValue": "test-pvc"
@@ -9293,12 +8753,6 @@
             }
           },
           {
-            "key": "http.scheme",
-            "value": {
-              "stringValue": "http"
-            }
-          },
-          {
             "key": "k8s.cluster.name",
             "value": {
               "stringValue": "cluster name"
@@ -9374,18 +8828,6 @@
             "key": "namespace",
             "value": {
               "stringValue": "test-namespace"
-            }
-          },
-          {
-            "key": "net.host.name",
-            "value": {
-              "stringValue": "test-node"
-            }
-          },
-          {
-            "key": "net.host.port",
-            "value": {
-              "stringValue": ""
             }
           },
           {
@@ -9487,12 +8929,6 @@
             }
           },
           {
-            "key": "http.scheme",
-            "value": {
-              "stringValue": "http"
-            }
-          },
-          {
             "key": "k8s.cluster.name",
             "value": {
               "stringValue": "cluster name"
@@ -9568,18 +9004,6 @@
             "key": "namespace",
             "value": {
               "stringValue": "test-namespace"
-            }
-          },
-          {
-            "key": "net.host.name",
-            "value": {
-              "stringValue": "test-node"
-            }
-          },
-          {
-            "key": "net.host.port",
-            "value": {
-              "stringValue": ""
             }
           },
           {
@@ -9788,12 +9212,6 @@
             }
           },
           {
-            "key": "http.scheme",
-            "value": {
-              "stringValue": "http"
-            }
-          },
-          {
             "key": "k8s.cluster.name",
             "value": {
               "stringValue": "cluster name"
@@ -9869,18 +9287,6 @@
             "key": "namespace",
             "value": {
               "stringValue": "test-namespace"
-            }
-          },
-          {
-            "key": "net.host.name",
-            "value": {
-              "stringValue": "test-node"
-            }
-          },
-          {
-            "key": "net.host.port",
-            "value": {
-              "stringValue": ""
             }
           },
           {
@@ -10013,12 +9419,6 @@
             }
           },
           {
-            "key": "http.scheme",
-            "value": {
-              "stringValue": "http"
-            }
-          },
-          {
             "key": "k8s.cluster.name",
             "value": {
               "stringValue": "cluster name"
@@ -10094,18 +9494,6 @@
             "key": "namespace",
             "value": {
               "stringValue": "test-namespace"
-            }
-          },
-          {
-            "key": "net.host.name",
-            "value": {
-              "stringValue": "test-node"
-            }
-          },
-          {
-            "key": "net.host.port",
-            "value": {
-              "stringValue": ""
             }
           },
           {
@@ -10195,12 +9583,6 @@
             }
           },
           {
-            "key": "http.scheme",
-            "value": {
-              "stringValue": "http"
-            }
-          },
-          {
             "key": "k8s.cluster.name",
             "value": {
               "stringValue": "cluster name"
@@ -10276,18 +9658,6 @@
             "key": "namespace",
             "value": {
               "stringValue": "test-namespace"
-            }
-          },
-          {
-            "key": "net.host.name",
-            "value": {
-              "stringValue": "test-node"
-            }
-          },
-          {
-            "key": "net.host.port",
-            "value": {
-              "stringValue": ""
             }
           },
           {
@@ -10383,12 +9753,6 @@
             }
           },
           {
-            "key": "http.scheme",
-            "value": {
-              "stringValue": "http"
-            }
-          },
-          {
             "key": "k8s.cluster.name",
             "value": {
               "stringValue": "cluster name"
@@ -10464,18 +9828,6 @@
             "key": "namespace",
             "value": {
               "stringValue": "test-namespace"
-            }
-          },
-          {
-            "key": "net.host.name",
-            "value": {
-              "stringValue": "test-node"
-            }
-          },
-          {
-            "key": "net.host.port",
-            "value": {
-              "stringValue": ""
             }
           },
           {
@@ -10577,12 +9929,6 @@
             }
           },
           {
-            "key": "http.scheme",
-            "value": {
-              "stringValue": "http"
-            }
-          },
-          {
             "key": "k8s.cluster.name",
             "value": {
               "stringValue": "cluster name"
@@ -10658,18 +10004,6 @@
             "key": "namespace",
             "value": {
               "stringValue": "test-namespace"
-            }
-          },
-          {
-            "key": "net.host.name",
-            "value": {
-              "stringValue": "test-node"
-            }
-          },
-          {
-            "key": "net.host.port",
-            "value": {
-              "stringValue": ""
             }
           },
           {
@@ -10765,12 +10099,6 @@
             }
           },
           {
-            "key": "http.scheme",
-            "value": {
-              "stringValue": "http"
-            }
-          },
-          {
             "key": "k8s.cluster.name",
             "value": {
               "stringValue": "cluster name"
@@ -10846,18 +10174,6 @@
             "key": "namespace",
             "value": {
               "stringValue": "test-namespace"
-            }
-          },
-          {
-            "key": "net.host.name",
-            "value": {
-              "stringValue": "test-node"
-            }
-          },
-          {
-            "key": "net.host.port",
-            "value": {
-              "stringValue": ""
             }
           },
           {
@@ -10947,12 +10263,6 @@
             }
           },
           {
-            "key": "http.scheme",
-            "value": {
-              "stringValue": "http"
-            }
-          },
-          {
             "key": "k8s.cluster.name",
             "value": {
               "stringValue": "cluster name"
@@ -11028,18 +10338,6 @@
             "key": "namespace",
             "value": {
               "stringValue": "test-namespace"
-            }
-          },
-          {
-            "key": "net.host.name",
-            "value": {
-              "stringValue": "test-node"
-            }
-          },
-          {
-            "key": "net.host.port",
-            "value": {
-              "stringValue": ""
             }
           },
           {
@@ -11135,12 +10433,6 @@
             }
           },
           {
-            "key": "http.scheme",
-            "value": {
-              "stringValue": "http"
-            }
-          },
-          {
             "key": "k8s.cluster.name",
             "value": {
               "stringValue": "cluster name"
@@ -11216,18 +10508,6 @@
             "key": "namespace",
             "value": {
               "stringValue": "test-namespace"
-            }
-          },
-          {
-            "key": "net.host.name",
-            "value": {
-              "stringValue": "test-node"
-            }
-          },
-          {
-            "key": "net.host.port",
-            "value": {
-              "stringValue": ""
             }
           },
           {
@@ -11329,12 +10609,6 @@
             }
           },
           {
-            "key": "http.scheme",
-            "value": {
-              "stringValue": "http"
-            }
-          },
-          {
             "key": "k8s.cluster.name",
             "value": {
               "stringValue": "cluster name"
@@ -11410,18 +10684,6 @@
             "key": "namespace",
             "value": {
               "stringValue": "test-namespace"
-            }
-          },
-          {
-            "key": "net.host.name",
-            "value": {
-              "stringValue": "test-node"
-            }
-          },
-          {
-            "key": "net.host.port",
-            "value": {
-              "stringValue": ""
             }
           },
           {
@@ -11519,12 +10781,6 @@
             }
           },
           {
-            "key": "http.scheme",
-            "value": {
-              "stringValue": "http"
-            }
-          },
-          {
             "key": "k8s.cluster.name",
             "value": {
               "stringValue": "cluster name"
@@ -11606,18 +10862,6 @@
             "key": "namespace",
             "value": {
               "stringValue": "test-namespace"
-            }
-          },
-          {
-            "key": "net.host.name",
-            "value": {
-              "stringValue": "test-node"
-            }
-          },
-          {
-            "key": "net.host.port",
-            "value": {
-              "stringValue": ""
             }
           },
           {
@@ -11725,12 +10969,6 @@
             }
           },
           {
-            "key": "http.scheme",
-            "value": {
-              "stringValue": "http"
-            }
-          },
-          {
             "key": "k8s.cluster.name",
             "value": {
               "stringValue": "cluster name"
@@ -11806,18 +11044,6 @@
             "key": "namespace",
             "value": {
               "stringValue": "test-namespace"
-            }
-          },
-          {
-            "key": "net.host.name",
-            "value": {
-              "stringValue": "test-node"
-            }
-          },
-          {
-            "key": "net.host.port",
-            "value": {
-              "stringValue": ""
             }
           },
           {
@@ -11949,12 +11175,6 @@
             }
           },
           {
-            "key": "http.scheme",
-            "value": {
-              "stringValue": "http"
-            }
-          },
-          {
             "key": "k8s.cluster.name",
             "value": {
               "stringValue": "cluster name"
@@ -12030,18 +11250,6 @@
             "key": "namespace",
             "value": {
               "stringValue": "test-namespace"
-            }
-          },
-          {
-            "key": "net.host.name",
-            "value": {
-              "stringValue": "test-node"
-            }
-          },
-          {
-            "key": "net.host.port",
-            "value": {
-              "stringValue": ""
             }
           },
           {
@@ -12384,12 +11592,6 @@
             }
           },
           {
-            "key": "http.scheme",
-            "value": {
-              "stringValue": "http"
-            }
-          },
-          {
             "key": "k8s.cluster.name",
             "value": {
               "stringValue": "cluster name"
@@ -12465,18 +11667,6 @@
             "key": "namespace",
             "value": {
               "stringValue": "test-namespace"
-            }
-          },
-          {
-            "key": "net.host.name",
-            "value": {
-              "stringValue": "test-node"
-            }
-          },
-          {
-            "key": "net.host.port",
-            "value": {
-              "stringValue": ""
             }
           },
           {
@@ -12578,12 +11768,6 @@
             }
           },
           {
-            "key": "http.scheme",
-            "value": {
-              "stringValue": "http"
-            }
-          },
-          {
             "key": "k8s.cluster.name",
             "value": {
               "stringValue": "cluster name"
@@ -12659,18 +11843,6 @@
             "key": "namespace",
             "value": {
               "stringValue": "test-namespace"
-            }
-          },
-          {
-            "key": "net.host.name",
-            "value": {
-              "stringValue": "test-node"
-            }
-          },
-          {
-            "key": "net.host.port",
-            "value": {
-              "stringValue": ""
             }
           },
           {
@@ -12959,12 +12131,6 @@
             }
           },
           {
-            "key": "http.scheme",
-            "value": {
-              "stringValue": "http"
-            }
-          },
-          {
             "key": "k8s.cluster.name",
             "value": {
               "stringValue": "cluster name"
@@ -13040,18 +12206,6 @@
             "key": "namespace",
             "value": {
               "stringValue": "test-namespace"
-            }
-          },
-          {
-            "key": "net.host.name",
-            "value": {
-              "stringValue": "test-node"
-            }
-          },
-          {
-            "key": "net.host.port",
-            "value": {
-              "stringValue": ""
             }
           },
           {
@@ -13189,12 +12343,6 @@
             }
           },
           {
-            "key": "http.scheme",
-            "value": {
-              "stringValue": "http"
-            }
-          },
-          {
             "key": "k8s.cluster.name",
             "value": {
               "stringValue": "cluster name"
@@ -13270,18 +12418,6 @@
             "key": "namespace",
             "value": {
               "stringValue": "test-namespace"
-            }
-          },
-          {
-            "key": "net.host.name",
-            "value": {
-              "stringValue": "test-node"
-            }
-          },
-          {
-            "key": "net.host.port",
-            "value": {
-              "stringValue": ""
             }
           },
           {
@@ -13578,12 +12714,6 @@
             }
           },
           {
-            "key": "http.scheme",
-            "value": {
-              "stringValue": "http"
-            }
-          },
-          {
             "key": "k8s.cluster.name",
             "value": {
               "stringValue": "cluster name"
@@ -13659,18 +12789,6 @@
             "key": "namespace",
             "value": {
               "stringValue": "test-namespace"
-            }
-          },
-          {
-            "key": "net.host.name",
-            "value": {
-              "stringValue": "test-node"
-            }
-          },
-          {
-            "key": "net.host.port",
-            "value": {
-              "stringValue": ""
             }
           },
           {
@@ -13772,12 +12890,6 @@
             }
           },
           {
-            "key": "http.scheme",
-            "value": {
-              "stringValue": "http"
-            }
-          },
-          {
             "key": "k8s.cluster.name",
             "value": {
               "stringValue": "cluster name"
@@ -13853,18 +12965,6 @@
             "key": "namespace",
             "value": {
               "stringValue": "test-namespace"
-            }
-          },
-          {
-            "key": "net.host.name",
-            "value": {
-              "stringValue": "test-node"
-            }
-          },
-          {
-            "key": "net.host.port",
-            "value": {
-              "stringValue": ""
             }
           },
           {
@@ -14077,12 +13177,6 @@
             }
           },
           {
-            "key": "http.scheme",
-            "value": {
-              "stringValue": "http"
-            }
-          },
-          {
             "key": "k8s.cluster.name",
             "value": {
               "stringValue": "cluster name"
@@ -14170,18 +13264,6 @@
             "key": "namespace",
             "value": {
               "stringValue": "test-namespace"
-            }
-          },
-          {
-            "key": "net.host.name",
-            "value": {
-              "stringValue": "test-node"
-            }
-          },
-          {
-            "key": "net.host.port",
-            "value": {
-              "stringValue": ""
             }
           },
           {
@@ -14485,12 +13567,6 @@
             }
           },
           {
-            "key": "http.scheme",
-            "value": {
-              "stringValue": "http"
-            }
-          },
-          {
             "key": "k8s.cluster.name",
             "value": {
               "stringValue": "cluster name"
@@ -14566,18 +13642,6 @@
             "key": "namespace",
             "value": {
               "stringValue": "test-namespace"
-            }
-          },
-          {
-            "key": "net.host.name",
-            "value": {
-              "stringValue": "test-node"
-            }
-          },
-          {
-            "key": "net.host.port",
-            "value": {
-              "stringValue": ""
             }
           },
           {
@@ -14679,12 +13743,6 @@
             }
           },
           {
-            "key": "http.scheme",
-            "value": {
-              "stringValue": "http"
-            }
-          },
-          {
             "key": "k8s.cluster.name",
             "value": {
               "stringValue": "cluster name"
@@ -14772,18 +13830,6 @@
             "key": "namespace",
             "value": {
               "stringValue": "test-namespace"
-            }
-          },
-          {
-            "key": "net.host.name",
-            "value": {
-              "stringValue": "test-node"
-            }
-          },
-          {
-            "key": "net.host.port",
-            "value": {
-              "stringValue": ""
             }
           },
           {
@@ -15058,12 +14104,6 @@
             }
           },
           {
-            "key": "http.scheme",
-            "value": {
-              "stringValue": "http"
-            }
-          },
-          {
             "key": "k8s.cluster.name",
             "value": {
               "stringValue": "cluster name"
@@ -15133,18 +14173,6 @@
             "key": "namespace",
             "value": {
               "stringValue": "test-namespace"
-            }
-          },
-          {
-            "key": "net.host.name",
-            "value": {
-              "stringValue": "test-node"
-            }
-          },
-          {
-            "key": "net.host.port",
-            "value": {
-              "stringValue": ""
             }
           },
           {
@@ -15410,12 +14438,6 @@
             }
           },
           {
-            "key": "http.scheme",
-            "value": {
-              "stringValue": "http"
-            }
-          },
-          {
             "key": "k8s.cluster.name",
             "value": {
               "stringValue": "cluster name"
@@ -15485,18 +14507,6 @@
             "key": "namespace",
             "value": {
               "stringValue": "test-namespace"
-            }
-          },
-          {
-            "key": "net.host.name",
-            "value": {
-              "stringValue": "test-node"
-            }
-          },
-          {
-            "key": "net.host.port",
-            "value": {
-              "stringValue": ""
             }
           },
           {
@@ -15592,12 +14602,6 @@
             }
           },
           {
-            "key": "http.scheme",
-            "value": {
-              "stringValue": "http"
-            }
-          },
-          {
             "key": "k8s.cluster.name",
             "value": {
               "stringValue": "cluster name"
@@ -15667,18 +14671,6 @@
             "key": "namespace",
             "value": {
               "stringValue": "test-namespace"
-            }
-          },
-          {
-            "key": "net.host.name",
-            "value": {
-              "stringValue": "test-node"
-            }
-          },
-          {
-            "key": "net.host.port",
-            "value": {
-              "stringValue": ""
             }
           },
           {
@@ -16252,12 +15244,6 @@
             }
           },
           {
-            "key": "http.scheme",
-            "value": {
-              "stringValue": "http"
-            }
-          },
-          {
             "key": "k8s.cluster.name",
             "value": {
               "stringValue": "cluster name"
@@ -16327,18 +15313,6 @@
             "key": "namespace",
             "value": {
               "stringValue": "test-namespace"
-            }
-          },
-          {
-            "key": "net.host.name",
-            "value": {
-              "stringValue": "test-node"
-            }
-          },
-          {
-            "key": "net.host.port",
-            "value": {
-              "stringValue": ""
             }
           },
           {
@@ -16507,12 +15481,6 @@
             }
           },
           {
-            "key": "http.scheme",
-            "value": {
-              "stringValue": "http"
-            }
-          },
-          {
             "key": "k8s.cluster.name",
             "value": {
               "stringValue": "cluster name"
@@ -16582,18 +15550,6 @@
             "key": "namespace",
             "value": {
               "stringValue": "test-namespace"
-            }
-          },
-          {
-            "key": "net.host.name",
-            "value": {
-              "stringValue": "test-node"
-            }
-          },
-          {
-            "key": "net.host.port",
-            "value": {
-              "stringValue": ""
             }
           },
           {
@@ -16762,12 +15718,6 @@
             }
           },
           {
-            "key": "http.scheme",
-            "value": {
-              "stringValue": "http"
-            }
-          },
-          {
             "key": "k8s.cluster.name",
             "value": {
               "stringValue": "cluster name"
@@ -16831,18 +15781,6 @@
             "key": "namespace",
             "value": {
               "stringValue": "test-namespace"
-            }
-          },
-          {
-            "key": "net.host.name",
-            "value": {
-              "stringValue": "test-node"
-            }
-          },
-          {
-            "key": "net.host.port",
-            "value": {
-              "stringValue": ""
             }
           },
           {
@@ -20707,12 +19645,6 @@
             }
           },
           {
-            "key": "http.scheme",
-            "value": {
-              "stringValue": "http"
-            }
-          },
-          {
             "key": "k8s.cluster.name",
             "value": {
               "stringValue": "cluster name"
@@ -20776,18 +19708,6 @@
             "key": "namespace",
             "value": {
               "stringValue": "test-namespace"
-            }
-          },
-          {
-            "key": "net.host.name",
-            "value": {
-              "stringValue": "test-node"
-            }
-          },
-          {
-            "key": "net.host.port",
-            "value": {
-              "stringValue": ""
             }
           },
           {
@@ -20925,12 +19845,6 @@
       "resource": {
         "attributes": [
           {
-            "key": "http.scheme",
-            "value": {
-              "stringValue": "http"
-            }
-          },
-          {
             "key": "k8s.cluster.name",
             "value": {
               "stringValue": "cluster name"
@@ -20997,18 +19911,6 @@
             }
           },
           {
-            "key": "net.host.name",
-            "value": {
-              "stringValue": "test-node"
-            }
-          },
-          {
-            "key": "net.host.port",
-            "value": {
-              "stringValue": ""
-            }
-          },
-          {
             "key": "pod",
             "value": {
               "stringValue": "test-pod"
@@ -21068,12 +19970,6 @@
       "resource": {
         "attributes": [
           {
-            "key": "http.scheme",
-            "value": {
-              "stringValue": "http"
-            }
-          },
-          {
             "key": "k8s.cluster.name",
             "value": {
               "stringValue": "cluster name"
@@ -21131,18 +20027,6 @@
             "key": "namespace",
             "value": {
               "stringValue": "test-namespace"
-            }
-          },
-          {
-            "key": "net.host.name",
-            "value": {
-              "stringValue": "test-node"
-            }
-          },
-          {
-            "key": "net.host.port",
-            "value": {
-              "stringValue": ""
             }
           },
           {
@@ -22225,27 +21109,9 @@
       "resource": {
         "attributes": [
           {
-            "key": "http.scheme",
-            "value": {
-              "stringValue": "http"
-            }
-          },
-          {
             "key": "k8s.cluster.name",
             "value": {
               "stringValue": "cluster name"
-            }
-          },
-          {
-            "key": "net.host.name",
-            "value": {
-              "stringValue": "test-node"
-            }
-          },
-          {
-            "key": "net.host.port",
-            "value": {
-              "stringValue": ""
             }
           },
           {
@@ -35979,6 +34845,54 @@
               },
               "name": "k8s.node.network.transmit_packets_dropped"
             },
+            {
+              "gauge": {
+                "dataPoints": [
+                  {
+                    "asDouble": 2,
+                    "timeUnixNano": "0"
+                  }
+                ]
+              },
+              "name": "k8s.node.pods"
+            }
+          ],
+          "scope": {}
+        }
+      ]
+    },
+    {
+      "resource": {
+        "attributes": [
+          {
+            "key": "k8s.cluster.name",
+            "value": {
+              "stringValue": "cluster name"
+            }
+          },
+          {
+            "key": "sw.k8s.agent.app.version",
+            "value": {
+              "stringValue": "0.8.3"
+            }
+          },
+          {
+            "key": "sw.k8s.agent.manifest.version",
+            "value": {
+              "stringValue": "2.8.0-alpha.3"
+            }
+          },
+          {
+            "key": "sw.k8s.cluster.uid",
+            "value": {
+              "stringValue": "cluster-uid-123456789"
+            }
+          }
+        ]
+      },
+      "scopeMetrics": [
+        {
+          "metrics": [
             {
               "gauge": {
                 "dataPoints": [

--- a/tests/integration/expected_output.json
+++ b/tests/integration/expected_output.json
@@ -165,24 +165,6 @@
                     "asDouble": 1,
                     "attributes": [
                       {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "http"
-                        }
-                      },
-                      {
-                        "key": "prometheus",
-                        "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
-                        }
-                      },
-                      {
-                        "key": "prometheus_replica",
-                        "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
-                        }
-                      },
-                      {
                         "key": "service",
                         "value": {
                           "stringValue": "test-service"
@@ -388,24 +370,6 @@
                   {
                     "asDouble": 1,
                     "attributes": [
-                      {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "http"
-                        }
-                      },
-                      {
-                        "key": "prometheus",
-                        "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
-                        }
-                      },
-                      {
-                        "key": "prometheus_replica",
-                        "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
-                        }
-                      },
                       {
                         "key": "service",
                         "value": {
@@ -613,24 +577,6 @@
                     "asDouble": 1,
                     "attributes": [
                       {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "http"
-                        }
-                      },
-                      {
-                        "key": "prometheus",
-                        "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
-                        }
-                      },
-                      {
-                        "key": "prometheus_replica",
-                        "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
-                        }
-                      },
-                      {
                         "key": "service",
                         "value": {
                           "stringValue": "test-service"
@@ -836,24 +782,6 @@
                   {
                     "asDouble": 1,
                     "attributes": [
-                      {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "http"
-                        }
-                      },
-                      {
-                        "key": "prometheus",
-                        "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
-                        }
-                      },
-                      {
-                        "key": "prometheus_replica",
-                        "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
-                        }
-                      },
                       {
                         "key": "service",
                         "value": {
@@ -1061,24 +989,6 @@
                     "asDouble": 1,
                     "attributes": [
                       {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "http"
-                        }
-                      },
-                      {
-                        "key": "prometheus",
-                        "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
-                        }
-                      },
-                      {
-                        "key": "prometheus_replica",
-                        "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
-                        }
-                      },
-                      {
                         "key": "service",
                         "value": {
                           "stringValue": "test-service"
@@ -1285,24 +1195,6 @@
                     "asDouble": 1,
                     "attributes": [
                       {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "http"
-                        }
-                      },
-                      {
-                        "key": "prometheus",
-                        "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
-                        }
-                      },
-                      {
-                        "key": "prometheus_replica",
-                        "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
-                        }
-                      },
-                      {
                         "key": "service",
                         "value": {
                           "stringValue": "test-service"
@@ -1491,12 +1383,6 @@
                     "asDouble": 1,
                     "attributes": [
                       {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "http"
-                        }
-                      },
-                      {
                         "key": "kernel_version",
                         "value": {
                           "stringValue": "5.4.231-137.341.amzn2.x86_64"
@@ -1512,18 +1398,6 @@
                         "key": "node",
                         "value": {
                           "stringValue": "test-node"
-                        }
-                      },
-                      {
-                        "key": "prometheus",
-                        "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
-                        }
-                      },
-                      {
-                        "key": "prometheus_replica",
-                        "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
                         }
                       },
                       {
@@ -1721,12 +1595,6 @@
                     "asDouble": 1,
                     "attributes": [
                       {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "http"
-                        }
-                      },
-                      {
                         "key": "kernel_version",
                         "value": {
                           "stringValue": "5.4.231-137.341.amzn2.x86_64"
@@ -1742,18 +1610,6 @@
                         "key": "node",
                         "value": {
                           "stringValue": "test-node"
-                        }
-                      },
-                      {
-                        "key": "prometheus",
-                        "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
-                        }
-                      },
-                      {
-                        "key": "prometheus_replica",
-                        "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
                         }
                       },
                       {
@@ -1963,27 +1819,9 @@
                     "asDouble": 1,
                     "attributes": [
                       {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "http"
-                        }
-                      },
-                      {
                         "key": "node",
                         "value": {
                           "stringValue": "test-node"
-                        }
-                      },
-                      {
-                        "key": "prometheus",
-                        "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
-                        }
-                      },
-                      {
-                        "key": "prometheus_replica",
-                        "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
                         }
                       },
                       {
@@ -2187,27 +2025,9 @@
                     "asDouble": 1,
                     "attributes": [
                       {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "http"
-                        }
-                      },
-                      {
                         "key": "node",
                         "value": {
                           "stringValue": "test-node"
-                        }
-                      },
-                      {
-                        "key": "prometheus",
-                        "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
-                        }
-                      },
-                      {
-                        "key": "prometheus_replica",
-                        "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
                         }
                       },
                       {
@@ -2357,12 +2177,6 @@
                     "asDouble": 1,
                     "attributes": [
                       {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "tcp-model"
-                        }
-                      },
-                      {
                         "key": "owner_is_controller",
                         "value": {
                           "stringValue": "true"
@@ -2372,18 +2186,6 @@
                         "key": "owner_kind",
                         "value": {
                           "stringValue": "DaemonSet"
-                        }
-                      },
-                      {
-                        "key": "prometheus",
-                        "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
-                        }
-                      },
-                      {
-                        "key": "prometheus_replica",
-                        "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
                         }
                       },
                       {
@@ -2545,24 +2347,6 @@
                     "asDouble": 1675156340,
                     "attributes": [
                       {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "http"
-                        }
-                      },
-                      {
-                        "key": "prometheus",
-                        "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
-                        }
-                      },
-                      {
-                        "key": "prometheus_replica",
-                        "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
-                        }
-                      },
-                      {
                         "key": "service",
                         "value": {
                           "stringValue": "test-service"
@@ -2581,24 +2365,6 @@
                   {
                     "asDouble": 1,
                     "attributes": [
-                      {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "http"
-                        }
-                      },
-                      {
-                        "key": "prometheus",
-                        "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
-                        }
-                      },
-                      {
-                        "key": "prometheus_replica",
-                        "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
-                        }
-                      },
                       {
                         "key": "service",
                         "value": {
@@ -2619,24 +2385,6 @@
                     "asDouble": 48,
                     "attributes": [
                       {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "http"
-                        }
-                      },
-                      {
-                        "key": "prometheus",
-                        "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
-                        }
-                      },
-                      {
-                        "key": "prometheus_replica",
-                        "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
-                        }
-                      },
-                      {
                         "key": "service",
                         "value": {
                           "stringValue": "test-service"
@@ -2655,24 +2403,6 @@
                   {
                     "asDouble": 48,
                     "attributes": [
-                      {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "http"
-                        }
-                      },
-                      {
-                        "key": "prometheus",
-                        "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
-                        }
-                      },
-                      {
-                        "key": "prometheus_replica",
-                        "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
-                        }
-                      },
                       {
                         "key": "service",
                         "value": {
@@ -2693,24 +2423,6 @@
                     "asDouble": 48,
                     "attributes": [
                       {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "http"
-                        }
-                      },
-                      {
-                        "key": "prometheus",
-                        "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
-                        }
-                      },
-                      {
-                        "key": "prometheus_replica",
-                        "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
-                        }
-                      },
-                      {
                         "key": "service",
                         "value": {
                           "stringValue": "test-service"
@@ -2729,24 +2441,6 @@
                   {
                     "asDouble": 0,
                     "attributes": [
-                      {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "http"
-                        }
-                      },
-                      {
-                        "key": "prometheus",
-                        "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
-                        }
-                      },
-                      {
-                        "key": "prometheus_replica",
-                        "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
-                        }
-                      },
                       {
                         "key": "service",
                         "value": {
@@ -2767,24 +2461,6 @@
                     "asDouble": 48,
                     "attributes": [
                       {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "http"
-                        }
-                      },
-                      {
-                        "key": "prometheus",
-                        "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
-                        }
-                      },
-                      {
-                        "key": "prometheus_replica",
-                        "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
-                        }
-                      },
-                      {
                         "key": "service",
                         "value": {
                           "stringValue": "test-service"
@@ -2804,24 +2480,6 @@
                     "asDouble": 0,
                     "attributes": [
                       {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "http"
-                        }
-                      },
-                      {
-                        "key": "prometheus",
-                        "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
-                        }
-                      },
-                      {
-                        "key": "prometheus_replica",
-                        "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
-                        }
-                      },
-                      {
                         "key": "service",
                         "value": {
                           "stringValue": "test-service"
@@ -2840,24 +2498,6 @@
                   {
                     "asDouble": 48,
                     "attributes": [
-                      {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "http"
-                        }
-                      },
-                      {
-                        "key": "prometheus",
-                        "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
-                        }
-                      },
-                      {
-                        "key": "prometheus_replica",
-                        "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
-                        }
-                      },
                       {
                         "key": "service",
                         "value": {
@@ -3029,12 +2669,6 @@
                     "asDouble": 1,
                     "attributes": [
                       {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "http"
-                        }
-                      },
-                      {
                         "key": "owner_is_controller",
                         "value": {
                           "stringValue": "true"
@@ -3044,18 +2678,6 @@
                         "key": "owner_kind",
                         "value": {
                           "stringValue": "Deployment"
-                        }
-                      },
-                      {
-                        "key": "prometheus",
-                        "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
-                        }
-                      },
-                      {
-                        "key": "prometheus_replica",
-                        "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
                         }
                       },
                       {
@@ -3229,12 +2851,6 @@
                     "asDouble": 1,
                     "attributes": [
                       {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "http"
-                        }
-                      },
-                      {
                         "key": "owner_is_controller",
                         "value": {
                           "stringValue": "true"
@@ -3244,18 +2860,6 @@
                         "key": "owner_kind",
                         "value": {
                           "stringValue": "Deployment"
-                        }
-                      },
-                      {
-                        "key": "prometheus",
-                        "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
-                        }
-                      },
-                      {
-                        "key": "prometheus_replica",
-                        "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
                         }
                       },
                       {
@@ -3423,24 +3027,6 @@
                         }
                       },
                       {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "http"
-                        }
-                      },
-                      {
-                        "key": "prometheus",
-                        "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
-                        }
-                      },
-                      {
-                        "key": "prometheus_replica",
-                        "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
-                        }
-                      },
-                      {
                         "key": "service",
                         "value": {
                           "stringValue": "test-service"
@@ -3472,24 +3058,6 @@
                         }
                       },
                       {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "http"
-                        }
-                      },
-                      {
-                        "key": "prometheus",
-                        "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
-                        }
-                      },
-                      {
-                        "key": "prometheus_replica",
-                        "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
-                        }
-                      },
-                      {
                         "key": "service",
                         "value": {
                           "stringValue": "test-service"
@@ -3515,24 +3083,6 @@
                     "asDouble": 1675156340,
                     "attributes": [
                       {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "http"
-                        }
-                      },
-                      {
-                        "key": "prometheus",
-                        "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
-                        }
-                      },
-                      {
-                        "key": "prometheus_replica",
-                        "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
-                        }
-                      },
-                      {
                         "key": "service",
                         "value": {
                           "stringValue": "test-service"
@@ -3551,24 +3101,6 @@
                   {
                     "asDouble": 1,
                     "attributes": [
-                      {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "http"
-                        }
-                      },
-                      {
-                        "key": "prometheus",
-                        "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
-                        }
-                      },
-                      {
-                        "key": "prometheus_replica",
-                        "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
-                        }
-                      },
                       {
                         "key": "service",
                         "value": {
@@ -3589,24 +3121,6 @@
                     "asDouble": 0,
                     "attributes": [
                       {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "http"
-                        }
-                      },
-                      {
-                        "key": "prometheus",
-                        "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
-                        }
-                      },
-                      {
-                        "key": "prometheus_replica",
-                        "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
-                        }
-                      },
-                      {
                         "key": "service",
                         "value": {
                           "stringValue": "test-service"
@@ -3626,24 +3140,6 @@
                     "asDouble": 1,
                     "attributes": [
                       {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "http"
-                        }
-                      },
-                      {
-                        "key": "prometheus",
-                        "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
-                        }
-                      },
-                      {
-                        "key": "prometheus_replica",
-                        "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
-                        }
-                      },
-                      {
                         "key": "service",
                         "value": {
                           "stringValue": "test-service"
@@ -3655,24 +3151,6 @@
                   {
                     "asDouble": 1,
                     "attributes": [
-                      {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "tcp-model"
-                        }
-                      },
-                      {
-                        "key": "prometheus",
-                        "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
-                        }
-                      },
-                      {
-                        "key": "prometheus_replica",
-                        "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
-                        }
-                      },
                       {
                         "key": "service",
                         "value": {
@@ -3696,24 +3174,6 @@
                         "key": "condition",
                         "value": {
                           "stringValue": "Available"
-                        }
-                      },
-                      {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "http"
-                        }
-                      },
-                      {
-                        "key": "prometheus",
-                        "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
-                        }
-                      },
-                      {
-                        "key": "prometheus_replica",
-                        "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
                         }
                       },
                       {
@@ -3741,24 +3201,6 @@
                         }
                       },
                       {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "http"
-                        }
-                      },
-                      {
-                        "key": "prometheus",
-                        "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
-                        }
-                      },
-                      {
-                        "key": "prometheus_replica",
-                        "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
-                        }
-                      },
-                      {
                         "key": "service",
                         "value": {
                           "stringValue": "test-service"
@@ -3780,24 +3222,6 @@
                         "key": "condition",
                         "value": {
                           "stringValue": "Available"
-                        }
-                      },
-                      {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "http"
-                        }
-                      },
-                      {
-                        "key": "prometheus",
-                        "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
-                        }
-                      },
-                      {
-                        "key": "prometheus_replica",
-                        "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
                         }
                       },
                       {
@@ -3825,24 +3249,6 @@
                         }
                       },
                       {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "http"
-                        }
-                      },
-                      {
-                        "key": "prometheus",
-                        "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
-                        }
-                      },
-                      {
-                        "key": "prometheus_replica",
-                        "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
-                        }
-                      },
-                      {
                         "key": "service",
                         "value": {
                           "stringValue": "test-service"
@@ -3867,24 +3273,6 @@
                         }
                       },
                       {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "http"
-                        }
-                      },
-                      {
-                        "key": "prometheus",
-                        "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
-                        }
-                      },
-                      {
-                        "key": "prometheus_replica",
-                        "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
-                        }
-                      },
-                      {
                         "key": "service",
                         "value": {
                           "stringValue": "test-service"
@@ -3906,24 +3294,6 @@
                         "key": "condition",
                         "value": {
                           "stringValue": "Progressing"
-                        }
-                      },
-                      {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "http"
-                        }
-                      },
-                      {
-                        "key": "prometheus",
-                        "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
-                        }
-                      },
-                      {
-                        "key": "prometheus_replica",
-                        "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
                         }
                       },
                       {
@@ -3952,24 +3322,6 @@
                     "asDouble": 1,
                     "attributes": [
                       {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "http"
-                        }
-                      },
-                      {
-                        "key": "prometheus",
-                        "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
-                        }
-                      },
-                      {
-                        "key": "prometheus_replica",
-                        "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
-                        }
-                      },
-                      {
                         "key": "service",
                         "value": {
                           "stringValue": "test-service"
@@ -3989,24 +3341,6 @@
                     "asDouble": 1,
                     "attributes": [
                       {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "http"
-                        }
-                      },
-                      {
-                        "key": "prometheus",
-                        "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
-                        }
-                      },
-                      {
-                        "key": "prometheus_replica",
-                        "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
-                        }
-                      },
-                      {
                         "key": "service",
                         "value": {
                           "stringValue": "test-service"
@@ -4018,24 +3352,6 @@
                   {
                     "asDouble": 1,
                     "attributes": [
-                      {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "tcp-model"
-                        }
-                      },
-                      {
-                        "key": "prometheus",
-                        "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
-                        }
-                      },
-                      {
-                        "key": "prometheus_replica",
-                        "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
-                        }
-                      },
                       {
                         "key": "service",
                         "value": {
@@ -4056,24 +3372,6 @@
                     "asDouble": 1,
                     "attributes": [
                       {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "http"
-                        }
-                      },
-                      {
-                        "key": "prometheus",
-                        "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
-                        }
-                      },
-                      {
-                        "key": "prometheus_replica",
-                        "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
-                        }
-                      },
-                      {
                         "key": "service",
                         "value": {
                           "stringValue": "test-service"
@@ -4093,24 +3391,6 @@
                     "asDouble": 0,
                     "attributes": [
                       {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "http"
-                        }
-                      },
-                      {
-                        "key": "prometheus",
-                        "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
-                        }
-                      },
-                      {
-                        "key": "prometheus_replica",
-                        "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
-                        }
-                      },
-                      {
                         "key": "service",
                         "value": {
                           "stringValue": "test-service"
@@ -4129,24 +3409,6 @@
                   {
                     "asDouble": 1,
                     "attributes": [
-                      {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "http"
-                        }
-                      },
-                      {
-                        "key": "prometheus",
-                        "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
-                        }
-                      },
-                      {
-                        "key": "prometheus_replica",
-                        "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
-                        }
-                      },
                       {
                         "key": "service",
                         "value": {
@@ -4294,12 +3556,6 @@
                         }
                       },
                       {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "https-metrics"
-                        }
-                      },
-                      {
                         "key": "id",
                         "value": {
                           "stringValue": "/kubepods/burstable/pod03d2b55c-b225-476b-9178-c74f8e5eaba2/b569246357457b8e4212a8e1a655442561648908c07e6343be2df710f0b4b067"
@@ -4321,18 +3577,6 @@
                         "key": "node",
                         "value": {
                           "stringValue": "test-node"
-                        }
-                      },
-                      {
-                        "key": "prometheus",
-                        "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
-                        }
-                      },
-                      {
-                        "key": "prometheus_replica",
-                        "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
                         }
                       },
                       {
@@ -4364,12 +3608,6 @@
                         }
                       },
                       {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "https-metrics"
-                        }
-                      },
-                      {
                         "key": "id",
                         "value": {
                           "stringValue": "/kubepods/burstable/pod03d2b55c-b225-476b-9178-c74f8e5eaba2/b569246357457b8e4212a8e1a655442561648908c07e6343be2df710f0b4b067"
@@ -4391,18 +3629,6 @@
                         "key": "node",
                         "value": {
                           "stringValue": "test-node"
-                        }
-                      },
-                      {
-                        "key": "prometheus",
-                        "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
-                        }
-                      },
-                      {
-                        "key": "prometheus_replica",
-                        "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
                         }
                       },
                       {
@@ -4431,12 +3657,6 @@
                         }
                       },
                       {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "https-metrics"
-                        }
-                      },
-                      {
                         "key": "id",
                         "value": {
                           "stringValue": "/kubepods/burstable/pod03d2b55c-b225-476b-9178-c74f8e5eaba2/b569246357457b8e4212a8e1a655442561648908c07e6343be2df710f0b4b067"
@@ -4458,18 +3678,6 @@
                         "key": "node",
                         "value": {
                           "stringValue": "test-node"
-                        }
-                      },
-                      {
-                        "key": "prometheus",
-                        "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
-                        }
-                      },
-                      {
-                        "key": "prometheus_replica",
-                        "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
                         }
                       },
                       {
@@ -4500,12 +3708,6 @@
                         }
                       },
                       {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "https-metrics"
-                        }
-                      },
-                      {
                         "key": "id",
                         "value": {
                           "stringValue": "/kubepods/burstable/pod03d2b55c-b225-476b-9178-c74f8e5eaba2/b569246357457b8e4212a8e1a655442561648908c07e6343be2df710f0b4b067"
@@ -4527,18 +3729,6 @@
                         "key": "node",
                         "value": {
                           "stringValue": "test-node"
-                        }
-                      },
-                      {
-                        "key": "prometheus",
-                        "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
-                        }
-                      },
-                      {
-                        "key": "prometheus_replica",
-                        "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
                         }
                       },
                       {
@@ -4561,12 +3751,6 @@
                     "asDouble": 100000,
                     "attributes": [
                       {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "https-metrics"
-                        }
-                      },
-                      {
                         "key": "id",
                         "value": {
                           "stringValue": "/kubepods/burstable/pod03d2b55c-b225-476b-9178-c74f8e5eaba2/b569246357457b8e4212a8e1a655442561648908c07e6343be2df710f0b4b067"
@@ -4588,18 +3772,6 @@
                         "key": "node",
                         "value": {
                           "stringValue": "test-node"
-                        }
-                      },
-                      {
-                        "key": "prometheus",
-                        "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
-                        }
-                      },
-                      {
-                        "key": "prometheus_replica",
-                        "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
                         }
                       },
                       {
@@ -4743,12 +3915,6 @@
                     "asDouble": 42266624,
                     "attributes": [
                       {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "https-metrics"
-                        }
-                      },
-                      {
                         "key": "id",
                         "value": {
                           "stringValue": "/kubepods/burstable/podda98d120-3439-4c96-a0ff-a67749a268b5/162dda5dbbea3eb335679b99848024f3e6ce6766709f8724b2128c4c11824d5b"
@@ -4770,18 +3936,6 @@
                         "key": "node",
                         "value": {
                           "stringValue": "test-node"
-                        }
-                      },
-                      {
-                        "key": "prometheus",
-                        "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
-                        }
-                      },
-                      {
-                        "key": "prometheus_replica",
-                        "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
                         }
                       },
                       {
@@ -4927,12 +4081,6 @@
                     "asDouble": 550377,
                     "attributes": [
                       {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "https-metrics"
-                        }
-                      },
-                      {
                         "key": "id",
                         "value": {
                           "stringValue": "/kubepods/burstable/pod7590868f-fb43-40c5-b750-9306fa11571e/1e14a072d677f6b31ac2a09a68d14ac5c788663a660979980da066a919fe7e84"
@@ -4954,18 +4102,6 @@
                         "key": "node",
                         "value": {
                           "stringValue": "test-node"
-                        }
-                      },
-                      {
-                        "key": "prometheus",
-                        "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
-                        }
-                      },
-                      {
-                        "key": "prometheus_replica",
-                        "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
                         }
                       },
                       {
@@ -4990,12 +4126,6 @@
                     "asDouble": 20702,
                     "attributes": [
                       {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "https-metrics"
-                        }
-                      },
-                      {
                         "key": "id",
                         "value": {
                           "stringValue": "/kubepods/burstable/pod7590868f-fb43-40c5-b750-9306fa11571e/1e14a072d677f6b31ac2a09a68d14ac5c788663a660979980da066a919fe7e84"
@@ -5017,18 +4147,6 @@
                         "key": "node",
                         "value": {
                           "stringValue": "test-node"
-                        }
-                      },
-                      {
-                        "key": "prometheus",
-                        "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
-                        }
-                      },
-                      {
-                        "key": "prometheus_replica",
-                        "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
                         }
                       },
                       {
@@ -5051,12 +4169,6 @@
                     "asDouble": 100000,
                     "attributes": [
                       {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "https-metrics"
-                        }
-                      },
-                      {
                         "key": "id",
                         "value": {
                           "stringValue": "/kubepods/burstable/pod7590868f-fb43-40c5-b750-9306fa11571e/1e14a072d677f6b31ac2a09a68d14ac5c788663a660979980da066a919fe7e84"
@@ -5078,18 +4190,6 @@
                         "key": "node",
                         "value": {
                           "stringValue": "test-node"
-                        }
-                      },
-                      {
-                        "key": "prometheus",
-                        "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
-                        }
-                      },
-                      {
-                        "key": "prometheus_replica",
-                        "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
                         }
                       },
                       {
@@ -5241,12 +4341,6 @@
                         }
                       },
                       {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "https-metrics"
-                        }
-                      },
-                      {
                         "key": "id",
                         "value": {
                           "stringValue": "/kubepods/burstable/pod86586cab-5b42-4084-a56e-b1520bd171a9/c6bdd9e7503d57f9b171a8a4174834aa9a58ece0a00015a7d9c24a75fe525e3c"
@@ -5268,18 +4362,6 @@
                         "key": "node",
                         "value": {
                           "stringValue": "test-node"
-                        }
-                      },
-                      {
-                        "key": "prometheus",
-                        "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
-                        }
-                      },
-                      {
-                        "key": "prometheus_replica",
-                        "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
                         }
                       },
                       {
@@ -5310,12 +4392,6 @@
                         }
                       },
                       {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "https-metrics"
-                        }
-                      },
-                      {
                         "key": "id",
                         "value": {
                           "stringValue": "/kubepods/burstable/pod86586cab-5b42-4084-a56e-b1520bd171a9/c6bdd9e7503d57f9b171a8a4174834aa9a58ece0a00015a7d9c24a75fe525e3c"
@@ -5337,18 +4413,6 @@
                         "key": "node",
                         "value": {
                           "stringValue": "test-node"
-                        }
-                      },
-                      {
-                        "key": "prometheus",
-                        "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
-                        }
-                      },
-                      {
-                        "key": "prometheus_replica",
-                        "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
                         }
                       },
                       {
@@ -5498,12 +4562,6 @@
                         }
                       },
                       {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "https-metrics"
-                        }
-                      },
-                      {
                         "key": "id",
                         "value": {
                           "stringValue": "/kubepods/burstable/podbafeef2c-1292-4a5e-a92c-d709480b04b6/86a84e64dded58918633fc9d1dd89a3f769d25143dd2da4273516d013df5862a"
@@ -5525,18 +4583,6 @@
                         "key": "node",
                         "value": {
                           "stringValue": "test-node"
-                        }
-                      },
-                      {
-                        "key": "prometheus",
-                        "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
-                        }
-                      },
-                      {
-                        "key": "prometheus_replica",
-                        "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
                         }
                       },
                       {
@@ -5568,12 +4614,6 @@
                         }
                       },
                       {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "https-metrics"
-                        }
-                      },
-                      {
                         "key": "id",
                         "value": {
                           "stringValue": "/kubepods/burstable/podbafeef2c-1292-4a5e-a92c-d709480b04b6/86a84e64dded58918633fc9d1dd89a3f769d25143dd2da4273516d013df5862a"
@@ -5595,18 +4635,6 @@
                         "key": "node",
                         "value": {
                           "stringValue": "test-node"
-                        }
-                      },
-                      {
-                        "key": "prometheus",
-                        "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
-                        }
-                      },
-                      {
-                        "key": "prometheus_replica",
-                        "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
                         }
                       },
                       {
@@ -5637,12 +4665,6 @@
                         }
                       },
                       {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "https-metrics"
-                        }
-                      },
-                      {
                         "key": "id",
                         "value": {
                           "stringValue": "/kubepods/burstable/podbafeef2c-1292-4a5e-a92c-d709480b04b6/86a84e64dded58918633fc9d1dd89a3f769d25143dd2da4273516d013df5862a"
@@ -5664,18 +4686,6 @@
                         "key": "node",
                         "value": {
                           "stringValue": "test-node"
-                        }
-                      },
-                      {
-                        "key": "prometheus",
-                        "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
-                        }
-                      },
-                      {
-                        "key": "prometheus_replica",
-                        "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
                         }
                       },
                       {
@@ -5706,12 +4716,6 @@
                         }
                       },
                       {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "https-metrics"
-                        }
-                      },
-                      {
                         "key": "id",
                         "value": {
                           "stringValue": "/kubepods/burstable/podbafeef2c-1292-4a5e-a92c-d709480b04b6/86a84e64dded58918633fc9d1dd89a3f769d25143dd2da4273516d013df5862a"
@@ -5733,18 +4737,6 @@
                         "key": "node",
                         "value": {
                           "stringValue": "test-node"
-                        }
-                      },
-                      {
-                        "key": "prometheus",
-                        "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
-                        }
-                      },
-                      {
-                        "key": "prometheus_replica",
-                        "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
                         }
                       },
                       {
@@ -5766,12 +4758,6 @@
                         }
                       },
                       {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "https-metrics"
-                        }
-                      },
-                      {
                         "key": "id",
                         "value": {
                           "stringValue": "/kubepods/burstable/podbafeef2c-1292-4a5e-a92c-d709480b04b6/86a84e64dded58918633fc9d1dd89a3f769d25143dd2da4273516d013df5862a"
@@ -5793,18 +4779,6 @@
                         "key": "node",
                         "value": {
                           "stringValue": "test-node"
-                        }
-                      },
-                      {
-                        "key": "prometheus",
-                        "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
-                        }
-                      },
-                      {
-                        "key": "prometheus_replica",
-                        "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
                         }
                       },
                       {
@@ -5833,12 +4807,6 @@
                         }
                       },
                       {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "https-metrics"
-                        }
-                      },
-                      {
                         "key": "id",
                         "value": {
                           "stringValue": "/kubepods/burstable/podbafeef2c-1292-4a5e-a92c-d709480b04b6/86a84e64dded58918633fc9d1dd89a3f769d25143dd2da4273516d013df5862a"
@@ -5860,18 +4828,6 @@
                         "key": "node",
                         "value": {
                           "stringValue": "test-node"
-                        }
-                      },
-                      {
-                        "key": "prometheus",
-                        "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
-                        }
-                      },
-                      {
-                        "key": "prometheus_replica",
-                        "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
                         }
                       },
                       {
@@ -5902,12 +4858,6 @@
                         }
                       },
                       {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "https-metrics"
-                        }
-                      },
-                      {
                         "key": "id",
                         "value": {
                           "stringValue": "/kubepods/burstable/podbafeef2c-1292-4a5e-a92c-d709480b04b6/86a84e64dded58918633fc9d1dd89a3f769d25143dd2da4273516d013df5862a"
@@ -5929,18 +4879,6 @@
                         "key": "node",
                         "value": {
                           "stringValue": "test-node"
-                        }
-                      },
-                      {
-                        "key": "prometheus",
-                        "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
-                        }
-                      },
-                      {
-                        "key": "prometheus_replica",
-                        "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
                         }
                       },
                       {
@@ -5971,12 +4909,6 @@
                         }
                       },
                       {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "https-metrics"
-                        }
-                      },
-                      {
                         "key": "id",
                         "value": {
                           "stringValue": "/kubepods/burstable/podbafeef2c-1292-4a5e-a92c-d709480b04b6/86a84e64dded58918633fc9d1dd89a3f769d25143dd2da4273516d013df5862a"
@@ -5998,18 +4930,6 @@
                         "key": "node",
                         "value": {
                           "stringValue": "test-node"
-                        }
-                      },
-                      {
-                        "key": "prometheus",
-                        "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
-                        }
-                      },
-                      {
-                        "key": "prometheus_replica",
-                        "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
                         }
                       },
                       {
@@ -6031,12 +4951,6 @@
                         }
                       },
                       {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "https-metrics"
-                        }
-                      },
-                      {
                         "key": "id",
                         "value": {
                           "stringValue": "/kubepods/burstable/podbafeef2c-1292-4a5e-a92c-d709480b04b6/86a84e64dded58918633fc9d1dd89a3f769d25143dd2da4273516d013df5862a"
@@ -6058,18 +4972,6 @@
                         "key": "node",
                         "value": {
                           "stringValue": "test-node"
-                        }
-                      },
-                      {
-                        "key": "prometheus",
-                        "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
-                        }
-                      },
-                      {
-                        "key": "prometheus_replica",
-                        "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
                         }
                       },
                       {
@@ -6092,12 +4994,6 @@
                     "asDouble": 2036076544,
                     "attributes": [
                       {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "https-metrics"
-                        }
-                      },
-                      {
                         "key": "id",
                         "value": {
                           "stringValue": "/kubepods/burstable/podbafeef2c-1292-4a5e-a92c-d709480b04b6/86a84e64dded58918633fc9d1dd89a3f769d25143dd2da4273516d013df5862a"
@@ -6119,18 +5015,6 @@
                         "key": "node",
                         "value": {
                           "stringValue": "test-node"
-                        }
-                      },
-                      {
-                        "key": "prometheus",
-                        "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
-                        }
-                      },
-                      {
-                        "key": "prometheus_replica",
-                        "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
                         }
                       },
                       {
@@ -6153,12 +5037,6 @@
                     "asDouble": 100000,
                     "attributes": [
                       {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "https-metrics"
-                        }
-                      },
-                      {
                         "key": "id",
                         "value": {
                           "stringValue": "/kubepods/burstable/podbafeef2c-1292-4a5e-a92c-d709480b04b6/86a84e64dded58918633fc9d1dd89a3f769d25143dd2da4273516d013df5862a"
@@ -6180,18 +5058,6 @@
                         "key": "node",
                         "value": {
                           "stringValue": "test-node"
-                        }
-                      },
-                      {
-                        "key": "prometheus",
-                        "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
-                        }
-                      },
-                      {
-                        "key": "prometheus_replica",
-                        "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
                         }
                       },
                       {
@@ -6214,12 +5080,6 @@
                     "asDouble": 3221225472,
                     "attributes": [
                       {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "https-metrics"
-                        }
-                      },
-                      {
                         "key": "id",
                         "value": {
                           "stringValue": "/kubepods/burstable/podbafeef2c-1292-4a5e-a92c-d709480b04b6/86a84e64dded58918633fc9d1dd89a3f769d25143dd2da4273516d013df5862a"
@@ -6241,18 +5101,6 @@
                         "key": "node",
                         "value": {
                           "stringValue": "test-node"
-                        }
-                      },
-                      {
-                        "key": "prometheus",
-                        "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
-                        }
-                      },
-                      {
-                        "key": "prometheus_replica",
-                        "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
                         }
                       },
                       {
@@ -6404,12 +5252,6 @@
                         }
                       },
                       {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "https-metrics"
-                        }
-                      },
-                      {
                         "key": "id",
                         "value": {
                           "stringValue": "/kubepods/burstable/pode7c539fd-351f-4f2e-a2d9-9a5c6fe69b78/d10b04fe42ee52263efe5b77a3764ac1d775afd100f5b7e52f995a8e00cd9665"
@@ -6431,18 +5273,6 @@
                         "key": "node",
                         "value": {
                           "stringValue": "test-node"
-                        }
-                      },
-                      {
-                        "key": "prometheus",
-                        "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
-                        }
-                      },
-                      {
-                        "key": "prometheus_replica",
-                        "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
                         }
                       },
                       {
@@ -6586,12 +5416,6 @@
                     "asDouble": 1073741824,
                     "attributes": [
                       {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "https-metrics"
-                        }
-                      },
-                      {
                         "key": "id",
                         "value": {
                           "stringValue": "/kubepods/burstable/pod1f59980a-6857-4530-9da3-ce5981261e5f/ba11f8492c5cf24d35dc6a96f9dde23f72e62691ef63cc725ba7738af38c2d5b"
@@ -6613,18 +5437,6 @@
                         "key": "node",
                         "value": {
                           "stringValue": "test-node"
-                        }
-                      },
-                      {
-                        "key": "prometheus",
-                        "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
-                        }
-                      },
-                      {
-                        "key": "prometheus_replica",
-                        "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
                         }
                       },
                       {
@@ -6780,24 +5592,6 @@
                         }
                       },
                       {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "http"
-                        }
-                      },
-                      {
-                        "key": "prometheus",
-                        "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
-                        }
-                      },
-                      {
-                        "key": "prometheus_replica",
-                        "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
-                        }
-                      },
-                      {
                         "key": "service",
                         "value": {
                           "stringValue": "test-service"
@@ -6816,24 +5610,6 @@
                   {
                     "asDouble": 1667941087,
                     "attributes": [
-                      {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "http"
-                        }
-                      },
-                      {
-                        "key": "prometheus",
-                        "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
-                        }
-                      },
-                      {
-                        "key": "prometheus_replica",
-                        "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
-                        }
-                      },
                       {
                         "key": "service",
                         "value": {
@@ -6854,24 +5630,6 @@
                     "asDouble": 1,
                     "attributes": [
                       {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "http"
-                        }
-                      },
-                      {
-                        "key": "prometheus",
-                        "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
-                        }
-                      },
-                      {
-                        "key": "prometheus_replica",
-                        "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
-                        }
-                      },
-                      {
                         "key": "service",
                         "value": {
                           "stringValue": "test-service"
@@ -6891,12 +5649,6 @@
                     "asDouble": 1,
                     "attributes": [
                       {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "http"
-                        }
-                      },
-                      {
                         "key": "owner_is_controller",
                         "value": {
                           "stringValue": "<none>"
@@ -6912,18 +5664,6 @@
                         "key": "owner_name",
                         "value": {
                           "stringValue": "<none>"
-                        }
-                      },
-                      {
-                        "key": "prometheus",
-                        "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
-                        }
-                      },
-                      {
-                        "key": "prometheus_replica",
-                        "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
                         }
                       },
                       {
@@ -6946,24 +5686,6 @@
                     "asDouble": 1,
                     "attributes": [
                       {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "http"
-                        }
-                      },
-                      {
-                        "key": "prometheus",
-                        "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
-                        }
-                      },
-                      {
-                        "key": "prometheus_replica",
-                        "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
-                        }
-                      },
-                      {
                         "key": "service",
                         "value": {
                           "stringValue": "test-service"
@@ -6982,24 +5704,6 @@
                   {
                     "asDouble": 1,
                     "attributes": [
-                      {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "http"
-                        }
-                      },
-                      {
-                        "key": "prometheus",
-                        "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
-                        }
-                      },
-                      {
-                        "key": "prometheus_replica",
-                        "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
-                        }
-                      },
                       {
                         "key": "service",
                         "value": {
@@ -7020,24 +5724,6 @@
                     "asDouble": 0,
                     "attributes": [
                       {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "http"
-                        }
-                      },
-                      {
-                        "key": "prometheus",
-                        "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
-                        }
-                      },
-                      {
-                        "key": "prometheus_replica",
-                        "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
-                        }
-                      },
-                      {
                         "key": "service",
                         "value": {
                           "stringValue": "test-service"
@@ -7056,24 +5742,6 @@
                   {
                     "asDouble": 1675437568,
                     "attributes": [
-                      {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "http"
-                        }
-                      },
-                      {
-                        "key": "prometheus",
-                        "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
-                        }
-                      },
-                      {
-                        "key": "prometheus_replica",
-                        "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
-                        }
-                      },
                       {
                         "key": "service",
                         "value": {
@@ -7094,24 +5762,6 @@
                     "asDouble": 0,
                     "attributes": [
                       {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "http"
-                        }
-                      },
-                      {
-                        "key": "prometheus",
-                        "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
-                        }
-                      },
-                      {
-                        "key": "prometheus_replica",
-                        "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
-                        }
-                      },
-                      {
                         "key": "service",
                         "value": {
                           "stringValue": "test-service"
@@ -7131,24 +5781,6 @@
                     "asDouble": 1675437559,
                     "attributes": [
                       {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "http"
-                        }
-                      },
-                      {
-                        "key": "prometheus",
-                        "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
-                        }
-                      },
-                      {
-                        "key": "prometheus_replica",
-                        "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
-                        }
-                      },
-                      {
                         "key": "service",
                         "value": {
                           "stringValue": "test-service"
@@ -7167,24 +5799,6 @@
                   {
                     "asDouble": 1,
                     "attributes": [
-                      {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "http"
-                        }
-                      },
-                      {
-                        "key": "prometheus",
-                        "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
-                        }
-                      },
-                      {
-                        "key": "prometheus_replica",
-                        "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
-                        }
-                      },
                       {
                         "key": "service",
                         "value": {
@@ -7386,27 +6000,9 @@
                         }
                       },
                       {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "http"
-                        }
-                      },
-                      {
                         "key": "name",
                         "value": {
                           "stringValue": "data-zookeeper-2"
-                        }
-                      },
-                      {
-                        "key": "prometheus",
-                        "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
-                        }
-                      },
-                      {
-                        "key": "prometheus_replica",
-                        "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
                         }
                       },
                       {
@@ -7598,24 +6194,6 @@
                         }
                       },
                       {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "http"
-                        }
-                      },
-                      {
-                        "key": "prometheus",
-                        "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
-                        }
-                      },
-                      {
-                        "key": "prometheus_replica",
-                        "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
-                        }
-                      },
-                      {
                         "key": "service",
                         "value": {
                           "stringValue": "test-service"
@@ -7792,24 +6370,6 @@
                     "asDouble": 107374182400,
                     "attributes": [
                       {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "tcp-model"
-                        }
-                      },
-                      {
-                        "key": "prometheus",
-                        "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
-                        }
-                      },
-                      {
-                        "key": "prometheus_replica",
-                        "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
-                        }
-                      },
-                      {
                         "key": "service",
                         "value": {
                           "stringValue": "test-service"
@@ -7829,27 +6389,9 @@
                     "asDouble": 0,
                     "attributes": [
                       {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "http"
-                        }
-                      },
-                      {
                         "key": "phase",
                         "value": {
                           "stringValue": "Released"
-                        }
-                      },
-                      {
-                        "key": "prometheus",
-                        "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
-                        }
-                      },
-                      {
-                        "key": "prometheus_replica",
-                        "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
                         }
                       },
                       {
@@ -8053,24 +6595,6 @@
                     "asDouble": 1,
                     "attributes": [
                       {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "tcp-model"
-                        }
-                      },
-                      {
-                        "key": "prometheus",
-                        "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
-                        }
-                      },
-                      {
-                        "key": "prometheus_replica",
-                        "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
-                        }
-                      },
-                      {
                         "key": "service",
                         "value": {
                           "stringValue": "test-service"
@@ -8265,24 +6789,6 @@
                     "asDouble": 1,
                     "attributes": [
                       {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "http"
-                        }
-                      },
-                      {
-                        "key": "prometheus",
-                        "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
-                        }
-                      },
-                      {
-                        "key": "prometheus_replica",
-                        "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
-                        }
-                      },
-                      {
                         "key": "service",
                         "value": {
                           "stringValue": "test-service"
@@ -8465,24 +6971,6 @@
                     "asDouble": 107374182400,
                     "attributes": [
                       {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "tcp-model"
-                        }
-                      },
-                      {
-                        "key": "prometheus",
-                        "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
-                        }
-                      },
-                      {
-                        "key": "prometheus_replica",
-                        "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
-                        }
-                      },
-                      {
                         "key": "service",
                         "value": {
                           "stringValue": "test-service"
@@ -8502,27 +6990,9 @@
                     "asDouble": 1,
                     "attributes": [
                       {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "http"
-                        }
-                      },
-                      {
                         "key": "phase",
                         "value": {
                           "stringValue": "Bound"
-                        }
-                      },
-                      {
-                        "key": "prometheus",
-                        "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
-                        }
-                      },
-                      {
-                        "key": "prometheus_replica",
-                        "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
                         }
                       },
                       {
@@ -8708,24 +7178,6 @@
                     "asDouble": 1,
                     "attributes": [
                       {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "http"
-                        }
-                      },
-                      {
-                        "key": "prometheus",
-                        "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
-                        }
-                      },
-                      {
-                        "key": "prometheus_replica",
-                        "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
-                        }
-                      },
-                      {
                         "key": "service",
                         "value": {
                           "stringValue": "test-service"
@@ -8884,24 +7336,6 @@
                     "asDouble": 1,
                     "attributes": [
                       {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "http"
-                        }
-                      },
-                      {
-                        "key": "prometheus",
-                        "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
-                        }
-                      },
-                      {
-                        "key": "prometheus_replica",
-                        "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
-                        }
-                      },
-                      {
                         "key": "service",
                         "value": {
                           "stringValue": "test-service"
@@ -9054,24 +7488,6 @@
                     "asDouble": 1,
                     "attributes": [
                       {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "http"
-                        }
-                      },
-                      {
-                        "key": "prometheus",
-                        "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
-                        }
-                      },
-                      {
-                        "key": "prometheus_replica",
-                        "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
-                        }
-                      },
-                      {
                         "key": "service",
                         "value": {
                           "stringValue": "test-service"
@@ -9093,24 +7509,6 @@
                     "asDouble": 0,
                     "attributes": [
                       {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "http"
-                        }
-                      },
-                      {
-                        "key": "prometheus",
-                        "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
-                        }
-                      },
-                      {
-                        "key": "prometheus_replica",
-                        "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
-                        }
-                      },
-                      {
                         "key": "service",
                         "value": {
                           "stringValue": "test-service"
@@ -9130,24 +7528,6 @@
                     "asDouble": 1,
                     "attributes": [
                       {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "http"
-                        }
-                      },
-                      {
-                        "key": "prometheus",
-                        "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
-                        }
-                      },
-                      {
-                        "key": "prometheus_replica",
-                        "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
-                        }
-                      },
-                      {
                         "key": "service",
                         "value": {
                           "stringValue": "test-service"
@@ -9166,24 +7546,6 @@
                   {
                     "asDouble": 0,
                     "attributes": [
-                      {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "http"
-                        }
-                      },
-                      {
-                        "key": "prometheus",
-                        "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
-                        }
-                      },
-                      {
-                        "key": "prometheus_replica",
-                        "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
-                        }
-                      },
                       {
                         "key": "service",
                         "value": {
@@ -9331,24 +7693,6 @@
                     "asDouble": 1679919168,
                     "attributes": [
                       {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "http"
-                        }
-                      },
-                      {
-                        "key": "prometheus",
-                        "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
-                        }
-                      },
-                      {
-                        "key": "prometheus_replica",
-                        "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
-                        }
-                      },
-                      {
                         "key": "service",
                         "value": {
                           "stringValue": "test-service"
@@ -9371,24 +7715,6 @@
                         "key": "condition",
                         "value": {
                           "stringValue": "unknown"
-                        }
-                      },
-                      {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "http"
-                        }
-                      },
-                      {
-                        "key": "prometheus",
-                        "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
-                        }
-                      },
-                      {
-                        "key": "prometheus_replica",
-                        "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
                         }
                       },
                       {
@@ -9537,24 +7863,6 @@
                   {
                     "asDouble": 1679473328,
                     "attributes": [
-                      {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "http"
-                        }
-                      },
-                      {
-                        "key": "prometheus",
-                        "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
-                        }
-                      },
-                      {
-                        "key": "prometheus_replica",
-                        "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
-                        }
-                      },
                       {
                         "key": "service",
                         "value": {
@@ -9708,24 +8016,6 @@
                     "asDouble": 0,
                     "attributes": [
                       {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "http"
-                        }
-                      },
-                      {
-                        "key": "prometheus",
-                        "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
-                        }
-                      },
-                      {
-                        "key": "prometheus_replica",
-                        "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
-                        }
-                      },
-                      {
                         "key": "service",
                         "value": {
                           "stringValue": "test-service"
@@ -9877,24 +8167,6 @@
                   {
                     "asDouble": 1,
                     "attributes": [
-                      {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "http"
-                        }
-                      },
-                      {
-                        "key": "prometheus",
-                        "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
-                        }
-                      },
-                      {
-                        "key": "prometheus_replica",
-                        "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
-                        }
-                      },
                       {
                         "key": "reason",
                         "value": {
@@ -10054,24 +8326,6 @@
                     "asDouble": 1679916695,
                     "attributes": [
                       {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "http"
-                        }
-                      },
-                      {
-                        "key": "prometheus",
-                        "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
-                        }
-                      },
-                      {
-                        "key": "prometheus_replica",
-                        "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
-                        }
-                      },
-                      {
                         "key": "service",
                         "value": {
                           "stringValue": "test-service"
@@ -10217,24 +8471,6 @@
                   {
                     "asDouble": 1681221684,
                     "attributes": [
-                      {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "http"
-                        }
-                      },
-                      {
-                        "key": "prometheus",
-                        "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
-                        }
-                      },
-                      {
-                        "key": "prometheus_replica",
-                        "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
-                        }
-                      },
                       {
                         "key": "service",
                         "value": {
@@ -10388,24 +8624,6 @@
                     "asDouble": 1,
                     "attributes": [
                       {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "http"
-                        }
-                      },
-                      {
-                        "key": "prometheus",
-                        "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
-                        }
-                      },
-                      {
-                        "key": "prometheus_replica",
-                        "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
-                        }
-                      },
-                      {
                         "key": "service",
                         "value": {
                           "stringValue": "test-service"
@@ -10557,24 +8775,6 @@
                   {
                     "asDouble": 1,
                     "attributes": [
-                      {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "http"
-                        }
-                      },
-                      {
-                        "key": "prometheus",
-                        "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
-                        }
-                      },
-                      {
-                        "key": "prometheus_replica",
-                        "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
-                        }
-                      },
                       {
                         "key": "reason",
                         "value": {
@@ -10736,24 +8936,6 @@
                     "asDouble": 0,
                     "attributes": [
                       {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "http"
-                        }
-                      },
-                      {
-                        "key": "prometheus",
-                        "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
-                        }
-                      },
-                      {
-                        "key": "prometheus_replica",
-                        "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
-                        }
-                      },
-                      {
                         "key": "service",
                         "value": {
                           "stringValue": "test-service"
@@ -10912,12 +9094,6 @@
                     "asDouble": 1,
                     "attributes": [
                       {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "http"
-                        }
-                      },
-                      {
                         "key": "owner_is_controller",
                         "value": {
                           "stringValue": "true"
@@ -10927,18 +9103,6 @@
                         "key": "owner_kind",
                         "value": {
                           "stringValue": "ReplicaSet"
-                        }
-                      },
-                      {
-                        "key": "prometheus",
-                        "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
-                        }
-                      },
-                      {
-                        "key": "prometheus_replica",
-                        "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
                         }
                       },
                       {
@@ -11100,54 +9264,6 @@
                     "asDouble": 1,
                     "attributes": [
                       {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "http"
-                        }
-                      },
-                      {
-                        "key": "prometheus",
-                        "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
-                        }
-                      },
-                      {
-                        "key": "prometheus_replica",
-                        "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
-                        }
-                      },
-                      {
-                        "key": "service",
-                        "value": {
-                          "stringValue": "test-service"
-                        }
-                      }
-                    ],
-                    "timeUnixNano": "0"
-                  },
-                  {
-                    "asDouble": 1,
-                    "attributes": [
-                      {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "tcp-model"
-                        }
-                      },
-                      {
-                        "key": "prometheus",
-                        "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
-                        }
-                      },
-                      {
-                        "key": "prometheus_replica",
-                        "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
-                        }
-                      },
-                      {
                         "key": "service",
                         "value": {
                           "stringValue": "test-service"
@@ -11300,24 +9416,6 @@
                     "asDouble": 1681390530,
                     "attributes": [
                       {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "http"
-                        }
-                      },
-                      {
-                        "key": "prometheus",
-                        "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
-                        }
-                      },
-                      {
-                        "key": "prometheus_replica",
-                        "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
-                        }
-                      },
-                      {
                         "key": "service",
                         "value": {
                           "stringValue": "test-service"
@@ -11336,24 +9434,6 @@
                   {
                     "asDouble": 1,
                     "attributes": [
-                      {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "http"
-                        }
-                      },
-                      {
-                        "key": "prometheus",
-                        "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
-                        }
-                      },
-                      {
-                        "key": "prometheus_replica",
-                        "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
-                        }
-                      },
                       {
                         "key": "service",
                         "value": {
@@ -11376,24 +9456,6 @@
                     "asDouble": 0,
                     "attributes": [
                       {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "http"
-                        }
-                      },
-                      {
-                        "key": "prometheus",
-                        "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
-                        }
-                      },
-                      {
-                        "key": "prometheus_replica",
-                        "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
-                        }
-                      },
-                      {
                         "key": "service",
                         "value": {
                           "stringValue": "test-service"
@@ -11405,24 +9467,6 @@
                   {
                     "asDouble": 0,
                     "attributes": [
-                      {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "tcp-model"
-                        }
-                      },
-                      {
-                        "key": "prometheus",
-                        "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
-                        }
-                      },
-                      {
-                        "key": "prometheus_replica",
-                        "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
-                        }
-                      },
                       {
                         "key": "service",
                         "value": {
@@ -11443,24 +9487,6 @@
                     "asDouble": 1,
                     "attributes": [
                       {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "http"
-                        }
-                      },
-                      {
-                        "key": "prometheus",
-                        "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
-                        }
-                      },
-                      {
-                        "key": "prometheus_replica",
-                        "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
-                        }
-                      },
-                      {
                         "key": "service",
                         "value": {
                           "stringValue": "test-service"
@@ -11472,24 +9498,6 @@
                   {
                     "asDouble": 1,
                     "attributes": [
-                      {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "tcp-model"
-                        }
-                      },
-                      {
-                        "key": "prometheus",
-                        "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
-                        }
-                      },
-                      {
-                        "key": "prometheus_replica",
-                        "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
-                        }
-                      },
                       {
                         "key": "service",
                         "value": {
@@ -11510,24 +9518,6 @@
                     "asDouble": 0,
                     "attributes": [
                       {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "http"
-                        }
-                      },
-                      {
-                        "key": "prometheus",
-                        "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
-                        }
-                      },
-                      {
-                        "key": "prometheus_replica",
-                        "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
-                        }
-                      },
-                      {
                         "key": "service",
                         "value": {
                           "stringValue": "test-service"
@@ -11546,24 +9536,6 @@
                   {
                     "asDouble": 0,
                     "attributes": [
-                      {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "http"
-                        }
-                      },
-                      {
-                        "key": "prometheus",
-                        "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
-                        }
-                      },
-                      {
-                        "key": "prometheus_replica",
-                        "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
-                        }
-                      },
                       {
                         "key": "service",
                         "value": {
@@ -11723,24 +9695,6 @@
                     "asDouble": 1,
                     "attributes": [
                       {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "http"
-                        }
-                      },
-                      {
-                        "key": "prometheus",
-                        "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
-                        }
-                      },
-                      {
-                        "key": "prometheus_replica",
-                        "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
-                        }
-                      },
-                      {
                         "key": "service",
                         "value": {
                           "stringValue": "test-service"
@@ -11893,24 +9847,6 @@
                     "asDouble": 1,
                     "attributes": [
                       {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "http"
-                        }
-                      },
-                      {
-                        "key": "prometheus",
-                        "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
-                        }
-                      },
-                      {
-                        "key": "prometheus_replica",
-                        "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
-                        }
-                      },
-                      {
                         "key": "service",
                         "value": {
                           "stringValue": "test-service"
@@ -11932,24 +9868,6 @@
                     "asDouble": 0,
                     "attributes": [
                       {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "http"
-                        }
-                      },
-                      {
-                        "key": "prometheus",
-                        "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
-                        }
-                      },
-                      {
-                        "key": "prometheus_replica",
-                        "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
-                        }
-                      },
-                      {
                         "key": "service",
                         "value": {
                           "stringValue": "test-service"
@@ -11968,24 +9886,6 @@
                   {
                     "asDouble": 0,
                     "attributes": [
-                      {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "http"
-                        }
-                      },
-                      {
-                        "key": "prometheus",
-                        "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
-                        }
-                      },
-                      {
-                        "key": "prometheus_replica",
-                        "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
-                        }
-                      },
                       {
                         "key": "service",
                         "value": {
@@ -12006,24 +9906,6 @@
                     "asDouble": 1,
                     "attributes": [
                       {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "http"
-                        }
-                      },
-                      {
-                        "key": "prometheus",
-                        "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
-                        }
-                      },
-                      {
-                        "key": "prometheus_replica",
-                        "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
-                        }
-                      },
-                      {
                         "key": "service",
                         "value": {
                           "stringValue": "test-service"
@@ -12042,24 +9924,6 @@
                   {
                     "asDouble": 1,
                     "attributes": [
-                      {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "http"
-                        }
-                      },
-                      {
-                        "key": "prometheus",
-                        "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
-                        }
-                      },
-                      {
-                        "key": "prometheus_replica",
-                        "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
-                        }
-                      },
                       {
                         "key": "reason",
                         "value": {
@@ -12085,24 +9949,6 @@
                   {
                     "asDouble": 0,
                     "attributes": [
-                      {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "http"
-                        }
-                      },
-                      {
-                        "key": "prometheus",
-                        "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
-                        }
-                      },
-                      {
-                        "key": "prometheus_replica",
-                        "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
-                        }
-                      },
                       {
                         "key": "service",
                         "value": {
@@ -12256,27 +10102,9 @@
                     "asDouble": 1,
                     "attributes": [
                       {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "http"
-                        }
-                      },
-                      {
                         "key": "phase",
                         "value": {
                           "stringValue": "Running"
-                        }
-                      },
-                      {
-                        "key": "prometheus",
-                        "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
-                        }
-                      },
-                      {
-                        "key": "prometheus_replica",
-                        "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
                         }
                       },
                       {
@@ -12292,27 +10120,9 @@
                     "asDouble": 1,
                     "attributes": [
                       {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "tcp-model"
-                        }
-                      },
-                      {
                         "key": "phase",
                         "value": {
                           "stringValue": "Running"
-                        }
-                      },
-                      {
-                        "key": "prometheus",
-                        "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
-                        }
-                      },
-                      {
-                        "key": "prometheus_replica",
-                        "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
                         }
                       },
                       {
@@ -12462,24 +10272,6 @@
                     "asDouble": 1681390527,
                     "attributes": [
                       {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "http"
-                        }
-                      },
-                      {
-                        "key": "prometheus",
-                        "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
-                        }
-                      },
-                      {
-                        "key": "prometheus_replica",
-                        "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
-                        }
-                      },
-                      {
                         "key": "service",
                         "value": {
                           "stringValue": "test-service"
@@ -12499,12 +10291,6 @@
                     "asDouble": 1,
                     "attributes": [
                       {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "http"
-                        }
-                      },
-                      {
                         "key": "owner_is_controller",
                         "value": {
                           "stringValue": "true"
@@ -12520,18 +10306,6 @@
                         "key": "owner_name",
                         "value": {
                           "stringValue": "swi-k8s-otel-collector-swo-k8s-collector-metrics-cf8f6886b"
-                        }
-                      },
-                      {
-                        "key": "prometheus",
-                        "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
-                        }
-                      },
-                      {
-                        "key": "prometheus_replica",
-                        "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
                         }
                       },
                       {
@@ -12553,24 +10327,6 @@
                   {
                     "asDouble": 1681390527,
                     "attributes": [
-                      {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "http"
-                        }
-                      },
-                      {
-                        "key": "prometheus",
-                        "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
-                        }
-                      },
-                      {
-                        "key": "prometheus_replica",
-                        "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
-                        }
-                      },
                       {
                         "key": "service",
                         "value": {
@@ -12597,24 +10353,6 @@
                         }
                       },
                       {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "http"
-                        }
-                      },
-                      {
-                        "key": "prometheus",
-                        "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
-                        }
-                      },
-                      {
-                        "key": "prometheus_replica",
-                        "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
-                        }
-                      },
-                      {
                         "key": "service",
                         "value": {
                           "stringValue": "test-service"
@@ -12633,24 +10371,6 @@
                         }
                       },
                       {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "http"
-                        }
-                      },
-                      {
-                        "key": "prometheus",
-                        "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
-                        }
-                      },
-                      {
-                        "key": "prometheus_replica",
-                        "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
-                        }
-                      },
-                      {
                         "key": "service",
                         "value": {
                           "stringValue": "test-service"
@@ -12666,24 +10386,6 @@
                         "key": "condition",
                         "value": {
                           "stringValue": "unknown"
-                        }
-                      },
-                      {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "http"
-                        }
-                      },
-                      {
-                        "key": "prometheus",
-                        "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
-                        }
-                      },
-                      {
-                        "key": "prometheus_replica",
-                        "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
                         }
                       },
                       {
@@ -12845,24 +10547,6 @@
                     "asDouble": 1,
                     "attributes": [
                       {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "http"
-                        }
-                      },
-                      {
-                        "key": "prometheus",
-                        "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
-                        }
-                      },
-                      {
-                        "key": "prometheus_replica",
-                        "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
-                        }
-                      },
-                      {
                         "key": "service",
                         "value": {
                           "stringValue": "test-service"
@@ -13015,24 +10699,6 @@
                     "asDouble": 0,
                     "attributes": [
                       {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "http"
-                        }
-                      },
-                      {
-                        "key": "prometheus",
-                        "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
-                        }
-                      },
-                      {
-                        "key": "prometheus_replica",
-                        "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
-                        }
-                      },
-                      {
                         "key": "service",
                         "value": {
                           "stringValue": "test-service"
@@ -13052,24 +10718,6 @@
                     "asDouble": 1,
                     "attributes": [
                       {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "http"
-                        }
-                      },
-                      {
-                        "key": "prometheus",
-                        "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
-                        }
-                      },
-                      {
-                        "key": "prometheus_replica",
-                        "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
-                        }
-                      },
-                      {
                         "key": "service",
                         "value": {
                           "stringValue": "test-service"
@@ -13088,24 +10736,6 @@
                   {
                     "asDouble": 1,
                     "attributes": [
-                      {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "http"
-                        }
-                      },
-                      {
-                        "key": "prometheus",
-                        "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
-                        }
-                      },
-                      {
-                        "key": "prometheus_replica",
-                        "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
-                        }
-                      },
                       {
                         "key": "reason",
                         "value": {
@@ -13131,24 +10761,6 @@
                   {
                     "asDouble": 0,
                     "attributes": [
-                      {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "http"
-                        }
-                      },
-                      {
-                        "key": "prometheus",
-                        "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
-                        }
-                      },
-                      {
-                        "key": "prometheus_replica",
-                        "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
-                        }
-                      },
                       {
                         "key": "service",
                         "value": {
@@ -13308,24 +10920,6 @@
                     "asDouble": 1678895204,
                     "attributes": [
                       {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "http"
-                        }
-                      },
-                      {
-                        "key": "prometheus",
-                        "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
-                        }
-                      },
-                      {
-                        "key": "prometheus_replica",
-                        "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
-                        }
-                      },
-                      {
                         "key": "service",
                         "value": {
                           "stringValue": "test-service"
@@ -13345,12 +10939,6 @@
                     "asDouble": 1,
                     "attributes": [
                       {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "http"
-                        }
-                      },
-                      {
                         "key": "owner_is_controller",
                         "value": {
                           "stringValue": "true"
@@ -13369,18 +10957,6 @@
                         }
                       },
                       {
-                        "key": "prometheus",
-                        "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
-                        }
-                      },
-                      {
-                        "key": "prometheus_replica",
-                        "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
-                        }
-                      },
-                      {
                         "key": "service",
                         "value": {
                           "stringValue": "test-service"
@@ -13392,12 +10968,6 @@
                   {
                     "asDouble": 1,
                     "attributes": [
-                      {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "http"
-                        }
-                      },
                       {
                         "key": "owner_is_controller",
                         "value": {
@@ -13414,18 +10984,6 @@
                         "key": "owner_name",
                         "value": {
                           "stringValue": "swi-k8s-otel-collector-swo-k8s-collector-metrics"
-                        }
-                      },
-                      {
-                        "key": "prometheus",
-                        "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
-                        }
-                      },
-                      {
-                        "key": "prometheus_replica",
-                        "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
                         }
                       },
                       {
@@ -13448,24 +11006,6 @@
                     "asDouble": 0,
                     "attributes": [
                       {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "http"
-                        }
-                      },
-                      {
-                        "key": "prometheus",
-                        "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
-                        }
-                      },
-                      {
-                        "key": "prometheus_replica",
-                        "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
-                        }
-                      },
-                      {
                         "key": "service",
                         "value": {
                           "stringValue": "test-service"
@@ -13485,24 +11025,6 @@
                     "asDouble": 0,
                     "attributes": [
                       {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "http"
-                        }
-                      },
-                      {
-                        "key": "prometheus",
-                        "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
-                        }
-                      },
-                      {
-                        "key": "prometheus_replica",
-                        "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
-                        }
-                      },
-                      {
                         "key": "service",
                         "value": {
                           "stringValue": "test-service"
@@ -13521,24 +11043,6 @@
                   {
                     "asDouble": 0,
                     "attributes": [
-                      {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "http"
-                        }
-                      },
-                      {
-                        "key": "prometheus",
-                        "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
-                        }
-                      },
-                      {
-                        "key": "prometheus_replica",
-                        "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
-                        }
-                      },
                       {
                         "key": "service",
                         "value": {
@@ -13686,12 +11190,6 @@
                     "asDouble": 1,
                     "attributes": [
                       {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "tcp-model"
-                        }
-                      },
-                      {
                         "key": "owner_is_controller",
                         "value": {
                           "stringValue": "true"
@@ -13701,18 +11199,6 @@
                         "key": "owner_kind",
                         "value": {
                           "stringValue": "ReplicaSet"
-                        }
-                      },
-                      {
-                        "key": "prometheus",
-                        "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
-                        }
-                      },
-                      {
-                        "key": "prometheus_replica",
-                        "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
                         }
                       },
                       {
@@ -13874,24 +11360,6 @@
                     "asDouble": 1645144985,
                     "attributes": [
                       {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "http"
-                        }
-                      },
-                      {
-                        "key": "prometheus",
-                        "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
-                        }
-                      },
-                      {
-                        "key": "prometheus_replica",
-                        "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
-                        }
-                      },
-                      {
                         "key": "service",
                         "value": {
                           "stringValue": "test-service"
@@ -13910,24 +11378,6 @@
                   {
                     "asDouble": 1,
                     "attributes": [
-                      {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "http"
-                        }
-                      },
-                      {
-                        "key": "prometheus",
-                        "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
-                        }
-                      },
-                      {
-                        "key": "prometheus_replica",
-                        "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
-                        }
-                      },
                       {
                         "key": "service",
                         "value": {
@@ -13948,24 +11398,6 @@
                     "asDouble": 3,
                     "attributes": [
                       {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "http"
-                        }
-                      },
-                      {
-                        "key": "prometheus",
-                        "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
-                        }
-                      },
-                      {
-                        "key": "prometheus_replica",
-                        "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
-                        }
-                      },
-                      {
                         "key": "service",
                         "value": {
                           "stringValue": "test-service"
@@ -13984,24 +11416,6 @@
                   {
                     "asDouble": 3,
                     "attributes": [
-                      {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "http"
-                        }
-                      },
-                      {
-                        "key": "prometheus",
-                        "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
-                        }
-                      },
-                      {
-                        "key": "prometheus_replica",
-                        "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
-                        }
-                      },
                       {
                         "key": "service",
                         "value": {
@@ -14022,24 +11436,6 @@
                     "asDouble": 1,
                     "attributes": [
                       {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "http"
-                        }
-                      },
-                      {
-                        "key": "prometheus",
-                        "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
-                        }
-                      },
-                      {
-                        "key": "prometheus_replica",
-                        "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
-                        }
-                      },
-                      {
                         "key": "service",
                         "value": {
                           "stringValue": "test-service"
@@ -14058,24 +11454,6 @@
                   {
                     "asDouble": 1,
                     "attributes": [
-                      {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "http"
-                        }
-                      },
-                      {
-                        "key": "prometheus",
-                        "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
-                        }
-                      },
-                      {
-                        "key": "prometheus_replica",
-                        "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
-                        }
-                      },
                       {
                         "key": "service",
                         "value": {
@@ -14235,24 +11613,6 @@
                     "asDouble": 1648847018,
                     "attributes": [
                       {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "http"
-                        }
-                      },
-                      {
-                        "key": "prometheus",
-                        "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
-                        }
-                      },
-                      {
-                        "key": "prometheus_replica",
-                        "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
-                        }
-                      },
-                      {
                         "key": "service",
                         "value": {
                           "stringValue": "test-service"
@@ -14272,12 +11632,6 @@
                     "asDouble": 1,
                     "attributes": [
                       {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "tcp-model"
-                        }
-                      },
-                      {
                         "key": "owner_is_controller",
                         "value": {
                           "stringValue": "true"
@@ -14296,18 +11650,6 @@
                         }
                       },
                       {
-                        "key": "prometheus",
-                        "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
-                        }
-                      },
-                      {
-                        "key": "prometheus_replica",
-                        "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
-                        }
-                      },
-                      {
                         "key": "service",
                         "value": {
                           "stringValue": "test-service"
@@ -14319,12 +11661,6 @@
                   {
                     "asDouble": 1,
                     "attributes": [
-                      {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "tcp-model"
-                        }
-                      },
                       {
                         "key": "owner_is_controller",
                         "value": {
@@ -14341,18 +11677,6 @@
                         "key": "owner_name",
                         "value": {
                           "stringValue": "swi-k8s-otel-collector-swo-k8s-collector-metrics-cf8f6886b"
-                        }
-                      },
-                      {
-                        "key": "prometheus",
-                        "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
-                        }
-                      },
-                      {
-                        "key": "prometheus_replica",
-                        "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
                         }
                       },
                       {
@@ -14374,24 +11698,6 @@
                   {
                     "asDouble": 100,
                     "attributes": [
-                      {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "http"
-                        }
-                      },
-                      {
-                        "key": "prometheus",
-                        "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
-                        }
-                      },
-                      {
-                        "key": "prometheus_replica",
-                        "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
-                        }
-                      },
                       {
                         "key": "resource",
                         "value": {
@@ -14551,27 +11857,9 @@
                     "asDouble": 1,
                     "attributes": [
                       {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "http"
-                        }
-                      },
-                      {
                         "key": "phase",
                         "value": {
                           "stringValue": "Active"
-                        }
-                      },
-                      {
-                        "key": "prometheus",
-                        "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
-                        }
-                      },
-                      {
-                        "key": "prometheus_replica",
-                        "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
                         }
                       },
                       {
@@ -14721,27 +12009,9 @@
                     "asDouble": 0.1,
                     "attributes": [
                       {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "tcp-model"
-                        }
-                      },
-                      {
                         "key": "node",
                         "value": {
                           "stringValue": "test-node"
-                        }
-                      },
-                      {
-                        "key": "prometheus",
-                        "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
-                        }
-                      },
-                      {
-                        "key": "prometheus_replica",
-                        "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
                         }
                       },
                       {
@@ -14776,75 +12046,9 @@
                     "asDouble": 3221225472,
                     "attributes": [
                       {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "http"
-                        }
-                      },
-                      {
                         "key": "node",
                         "value": {
                           "stringValue": "test-node"
-                        }
-                      },
-                      {
-                        "key": "prometheus",
-                        "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
-                        }
-                      },
-                      {
-                        "key": "prometheus_replica",
-                        "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
-                        }
-                      },
-                      {
-                        "key": "resource",
-                        "value": {
-                          "stringValue": "memory"
-                        }
-                      },
-                      {
-                        "key": "service",
-                        "value": {
-                          "stringValue": "test-service"
-                        }
-                      },
-                      {
-                        "key": "unit",
-                        "value": {
-                          "stringValue": "byte"
-                        }
-                      }
-                    ],
-                    "timeUnixNano": "0"
-                  },
-                  {
-                    "asDouble": 3221225472,
-                    "attributes": [
-                      {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "tcp-model"
-                        }
-                      },
-                      {
-                        "key": "node",
-                        "value": {
-                          "stringValue": "test-node"
-                        }
-                      },
-                      {
-                        "key": "prometheus",
-                        "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
-                        }
-                      },
-                      {
-                        "key": "prometheus_replica",
-                        "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
                         }
                       },
                       {
@@ -14879,75 +12083,9 @@
                     "asDouble": 3221225472,
                     "attributes": [
                       {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "http"
-                        }
-                      },
-                      {
                         "key": "node",
                         "value": {
                           "stringValue": "test-node"
-                        }
-                      },
-                      {
-                        "key": "prometheus",
-                        "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
-                        }
-                      },
-                      {
-                        "key": "prometheus_replica",
-                        "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
-                        }
-                      },
-                      {
-                        "key": "resource",
-                        "value": {
-                          "stringValue": "memory"
-                        }
-                      },
-                      {
-                        "key": "service",
-                        "value": {
-                          "stringValue": "test-service"
-                        }
-                      },
-                      {
-                        "key": "unit",
-                        "value": {
-                          "stringValue": "byte"
-                        }
-                      }
-                    ],
-                    "timeUnixNano": "0"
-                  },
-                  {
-                    "asDouble": 3221225472,
-                    "attributes": [
-                      {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "tcp-model"
-                        }
-                      },
-                      {
-                        "key": "node",
-                        "value": {
-                          "stringValue": "test-node"
-                        }
-                      },
-                      {
-                        "key": "prometheus",
-                        "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
-                        }
-                      },
-                      {
-                        "key": "prometheus_replica",
-                        "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
                         }
                       },
                       {
@@ -14979,78 +12117,12 @@
               "gauge": {
                 "dataPoints": [
                   {
-                    "asDouble": 3221225472,
-                    "attributes": [
-                      {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "http"
-                        }
-                      },
-                      {
-                        "key": "node",
-                        "value": {
-                          "stringValue": "test-node"
-                        }
-                      },
-                      {
-                        "key": "prometheus",
-                        "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
-                        }
-                      },
-                      {
-                        "key": "prometheus_replica",
-                        "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
-                        }
-                      },
-                      {
-                        "key": "resource",
-                        "value": {
-                          "stringValue": "memory"
-                        }
-                      },
-                      {
-                        "key": "service",
-                        "value": {
-                          "stringValue": "test-service"
-                        }
-                      },
-                      {
-                        "key": "unit",
-                        "value": {
-                          "stringValue": "byte"
-                        }
-                      }
-                    ],
-                    "timeUnixNano": "0"
-                  },
-                  {
                     "asDouble": 0.1,
                     "attributes": [
                       {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "tcp-model"
-                        }
-                      },
-                      {
                         "key": "node",
                         "value": {
                           "stringValue": "test-node"
-                        }
-                      },
-                      {
-                        "key": "prometheus",
-                        "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
-                        }
-                      },
-                      {
-                        "key": "prometheus_replica",
-                        "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
                         }
                       },
                       {
@@ -15078,27 +12150,39 @@
                     "asDouble": 3221225472,
                     "attributes": [
                       {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "tcp-model"
-                        }
-                      },
-                      {
                         "key": "node",
                         "value": {
                           "stringValue": "test-node"
                         }
                       },
                       {
-                        "key": "prometheus",
+                        "key": "resource",
                         "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
+                          "stringValue": "memory"
                         }
                       },
                       {
-                        "key": "prometheus_replica",
+                        "key": "service",
                         "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
+                          "stringValue": "test-service"
+                        }
+                      },
+                      {
+                        "key": "unit",
+                        "value": {
+                          "stringValue": "byte"
+                        }
+                      }
+                    ],
+                    "timeUnixNano": "0"
+                  },
+                  {
+                    "asDouble": 3221225472,
+                    "attributes": [
+                      {
+                        "key": "node",
+                        "value": {
+                          "stringValue": "test-node"
                         }
                       },
                       {
@@ -15133,27 +12217,9 @@
                     "asDouble": 3221225472,
                     "attributes": [
                       {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "http"
-                        }
-                      },
-                      {
                         "key": "node",
                         "value": {
                           "stringValue": "test-node"
-                        }
-                      },
-                      {
-                        "key": "prometheus",
-                        "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
-                        }
-                      },
-                      {
-                        "key": "prometheus_replica",
-                        "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
                         }
                       },
                       {
@@ -15181,27 +12247,9 @@
                     "asDouble": 3221225472,
                     "attributes": [
                       {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "tcp-model"
-                        }
-                      },
-                      {
                         "key": "node",
                         "value": {
                           "stringValue": "test-node"
-                        }
-                      },
-                      {
-                        "key": "prometheus",
-                        "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
-                        }
-                      },
-                      {
-                        "key": "prometheus_replica",
-                        "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
                         }
                       },
                       {
@@ -15363,27 +12411,9 @@
                     "asDouble": 0.1,
                     "attributes": [
                       {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "http"
-                        }
-                      },
-                      {
                         "key": "node",
                         "value": {
                           "stringValue": "test-node"
-                        }
-                      },
-                      {
-                        "key": "prometheus",
-                        "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
-                        }
-                      },
-                      {
-                        "key": "prometheus_replica",
-                        "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
                         }
                       },
                       {
@@ -15418,27 +12448,9 @@
                     "asDouble": 0.1,
                     "attributes": [
                       {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "http"
-                        }
-                      },
-                      {
                         "key": "node",
                         "value": {
                           "stringValue": "test-node"
-                        }
-                      },
-                      {
-                        "key": "prometheus",
-                        "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
-                        }
-                      },
-                      {
-                        "key": "prometheus_replica",
-                        "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
                         }
                       },
                       {
@@ -15600,27 +12612,9 @@
                     "asDouble": 5368709120,
                     "attributes": [
                       {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "http"
-                        }
-                      },
-                      {
                         "key": "node",
                         "value": {
                           "stringValue": "test-node"
-                        }
-                      },
-                      {
-                        "key": "prometheus",
-                        "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
-                        }
-                      },
-                      {
-                        "key": "prometheus_replica",
-                        "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
                         }
                       },
                       {
@@ -15655,27 +12649,9 @@
                     "asDouble": 5368709120,
                     "attributes": [
                       {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "http"
-                        }
-                      },
-                      {
                         "key": "node",
                         "value": {
                           "stringValue": "test-node"
-                        }
-                      },
-                      {
-                        "key": "prometheus",
-                        "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
-                        }
-                      },
-                      {
-                        "key": "prometheus_replica",
-                        "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
                         }
                       },
                       {
@@ -15819,27 +12795,9 @@
                     "asDouble": 1679916076,
                     "attributes": [
                       {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "http"
-                        }
-                      },
-                      {
                         "key": "node",
                         "value": {
                           "stringValue": "test-node"
-                        }
-                      },
-                      {
-                        "key": "prometheus",
-                        "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
-                        }
-                      },
-                      {
-                        "key": "prometheus_replica",
-                        "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
                         }
                       },
                       {
@@ -15862,27 +12820,9 @@
                     "asDouble": 0,
                     "attributes": [
                       {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "http"
-                        }
-                      },
-                      {
                         "key": "node",
                         "value": {
                           "stringValue": "test-node"
-                        }
-                      },
-                      {
-                        "key": "prometheus",
-                        "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
-                        }
-                      },
-                      {
-                        "key": "prometheus_replica",
-                        "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
                         }
                       },
                       {
@@ -15905,27 +12845,39 @@
                     "asDouble": 39,
                     "attributes": [
                       {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "http"
-                        }
-                      },
-                      {
                         "key": "node",
                         "value": {
                           "stringValue": "test-node"
                         }
                       },
                       {
-                        "key": "prometheus",
+                        "key": "resource",
                         "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
+                          "stringValue": "attachable_volumes_aws_ebs"
                         }
                       },
                       {
-                        "key": "prometheus_replica",
+                        "key": "service",
                         "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
+                          "stringValue": "test-service"
+                        }
+                      },
+                      {
+                        "key": "unit",
+                        "value": {
+                          "stringValue": "byte"
+                        }
+                      }
+                    ],
+                    "timeUnixNano": "0"
+                  },
+                  {
+                    "asDouble": 39,
+                    "attributes": [
+                      {
+                        "key": "node",
+                        "value": {
+                          "stringValue": "test-node"
                         }
                       },
                       {
@@ -15953,27 +12905,39 @@
                     "asDouble": 15.89,
                     "attributes": [
                       {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "http"
-                        }
-                      },
-                      {
                         "key": "node",
                         "value": {
                           "stringValue": "test-node"
                         }
                       },
                       {
-                        "key": "prometheus",
+                        "key": "resource",
                         "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
+                          "stringValue": "cpu"
                         }
                       },
                       {
-                        "key": "prometheus_replica",
+                        "key": "service",
                         "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
+                          "stringValue": "test-service"
+                        }
+                      },
+                      {
+                        "key": "unit",
+                        "value": {
+                          "stringValue": "core"
+                        }
+                      }
+                    ],
+                    "timeUnixNano": "0"
+                  },
+                  {
+                    "asDouble": 15.89,
+                    "attributes": [
+                      {
+                        "key": "node",
+                        "value": {
+                          "stringValue": "test-node"
                         }
                       },
                       {
@@ -16001,27 +12965,39 @@
                     "asDouble": 288825207124,
                     "attributes": [
                       {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "http"
-                        }
-                      },
-                      {
                         "key": "node",
                         "value": {
                           "stringValue": "test-node"
                         }
                       },
                       {
-                        "key": "prometheus",
+                        "key": "resource",
                         "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
+                          "stringValue": "ephemeral_storage"
                         }
                       },
                       {
-                        "key": "prometheus_replica",
+                        "key": "service",
                         "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
+                          "stringValue": "test-service"
+                        }
+                      },
+                      {
+                        "key": "unit",
+                        "value": {
+                          "stringValue": "byte"
+                        }
+                      }
+                    ],
+                    "timeUnixNano": "0"
+                  },
+                  {
+                    "asDouble": 288825207124,
+                    "attributes": [
+                      {
+                        "key": "node",
+                        "value": {
+                          "stringValue": "test-node"
                         }
                       },
                       {
@@ -16049,27 +13025,9 @@
                     "asDouble": 0,
                     "attributes": [
                       {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "http"
-                        }
-                      },
-                      {
                         "key": "node",
                         "value": {
                           "stringValue": "test-node"
-                        }
-                      },
-                      {
-                        "key": "prometheus",
-                        "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
-                        }
-                      },
-                      {
-                        "key": "prometheus_replica",
-                        "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
                         }
                       },
                       {
@@ -16097,11 +13055,35 @@
                     "asDouble": 0,
                     "attributes": [
                       {
-                        "key": "endpoint",
+                        "key": "node",
                         "value": {
-                          "stringValue": "http"
+                          "stringValue": "test-node"
                         }
                       },
+                      {
+                        "key": "resource",
+                        "value": {
+                          "stringValue": "hugepages_1Gi"
+                        }
+                      },
+                      {
+                        "key": "service",
+                        "value": {
+                          "stringValue": "test-service"
+                        }
+                      },
+                      {
+                        "key": "unit",
+                        "value": {
+                          "stringValue": "byte"
+                        }
+                      }
+                    ],
+                    "timeUnixNano": "0"
+                  },
+                  {
+                    "asDouble": 0,
+                    "attributes": [
                       {
                         "key": "node",
                         "value": {
@@ -16109,15 +13091,33 @@
                         }
                       },
                       {
-                        "key": "prometheus",
+                        "key": "resource",
                         "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
+                          "stringValue": "hugepages_2Mi"
                         }
                       },
                       {
-                        "key": "prometheus_replica",
+                        "key": "service",
                         "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
+                          "stringValue": "test-service"
+                        }
+                      },
+                      {
+                        "key": "unit",
+                        "value": {
+                          "stringValue": "byte"
+                        }
+                      }
+                    ],
+                    "timeUnixNano": "0"
+                  },
+                  {
+                    "asDouble": 0,
+                    "attributes": [
+                      {
+                        "key": "node",
+                        "value": {
+                          "stringValue": "test-node"
                         }
                       },
                       {
@@ -16145,27 +13145,39 @@
                     "asDouble": 63297781760,
                     "attributes": [
                       {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "http"
-                        }
-                      },
-                      {
                         "key": "node",
                         "value": {
                           "stringValue": "test-node"
                         }
                       },
                       {
-                        "key": "prometheus",
+                        "key": "resource",
                         "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
+                          "stringValue": "memory"
                         }
                       },
                       {
-                        "key": "prometheus_replica",
+                        "key": "service",
                         "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
+                          "stringValue": "test-service"
+                        }
+                      },
+                      {
+                        "key": "unit",
+                        "value": {
+                          "stringValue": "byte"
+                        }
+                      }
+                    ],
+                    "timeUnixNano": "0"
+                  },
+                  {
+                    "asDouble": 63297781760,
+                    "attributes": [
+                      {
+                        "key": "node",
+                        "value": {
+                          "stringValue": "test-node"
                         }
                       },
                       {
@@ -16193,27 +13205,9 @@
                     "asDouble": 234,
                     "attributes": [
                       {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "http"
-                        }
-                      },
-                      {
                         "key": "node",
                         "value": {
                           "stringValue": "test-node"
-                        }
-                      },
-                      {
-                        "key": "prometheus",
-                        "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
-                        }
-                      },
-                      {
-                        "key": "prometheus_replica",
-                        "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
                         }
                       },
                       {
@@ -16238,318 +13232,12 @@
                     "timeUnixNano": "0"
                   },
                   {
-                    "asDouble": 39,
-                    "attributes": [
-                      {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "tcp-model"
-                        }
-                      },
-                      {
-                        "key": "node",
-                        "value": {
-                          "stringValue": "test-node"
-                        }
-                      },
-                      {
-                        "key": "prometheus",
-                        "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
-                        }
-                      },
-                      {
-                        "key": "prometheus_replica",
-                        "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
-                        }
-                      },
-                      {
-                        "key": "resource",
-                        "value": {
-                          "stringValue": "attachable_volumes_aws_ebs"
-                        }
-                      },
-                      {
-                        "key": "service",
-                        "value": {
-                          "stringValue": "test-service"
-                        }
-                      },
-                      {
-                        "key": "unit",
-                        "value": {
-                          "stringValue": "byte"
-                        }
-                      }
-                    ],
-                    "timeUnixNano": "0"
-                  },
-                  {
-                    "asDouble": 15.89,
-                    "attributes": [
-                      {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "tcp-model"
-                        }
-                      },
-                      {
-                        "key": "node",
-                        "value": {
-                          "stringValue": "test-node"
-                        }
-                      },
-                      {
-                        "key": "prometheus",
-                        "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
-                        }
-                      },
-                      {
-                        "key": "prometheus_replica",
-                        "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
-                        }
-                      },
-                      {
-                        "key": "resource",
-                        "value": {
-                          "stringValue": "cpu"
-                        }
-                      },
-                      {
-                        "key": "service",
-                        "value": {
-                          "stringValue": "test-service"
-                        }
-                      },
-                      {
-                        "key": "unit",
-                        "value": {
-                          "stringValue": "core"
-                        }
-                      }
-                    ],
-                    "timeUnixNano": "0"
-                  },
-                  {
-                    "asDouble": 288825207124,
-                    "attributes": [
-                      {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "tcp-model"
-                        }
-                      },
-                      {
-                        "key": "node",
-                        "value": {
-                          "stringValue": "test-node"
-                        }
-                      },
-                      {
-                        "key": "prometheus",
-                        "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
-                        }
-                      },
-                      {
-                        "key": "prometheus_replica",
-                        "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
-                        }
-                      },
-                      {
-                        "key": "resource",
-                        "value": {
-                          "stringValue": "ephemeral_storage"
-                        }
-                      },
-                      {
-                        "key": "service",
-                        "value": {
-                          "stringValue": "test-service"
-                        }
-                      },
-                      {
-                        "key": "unit",
-                        "value": {
-                          "stringValue": "byte"
-                        }
-                      }
-                    ],
-                    "timeUnixNano": "0"
-                  },
-                  {
-                    "asDouble": 0,
-                    "attributes": [
-                      {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "tcp-model"
-                        }
-                      },
-                      {
-                        "key": "node",
-                        "value": {
-                          "stringValue": "test-node"
-                        }
-                      },
-                      {
-                        "key": "prometheus",
-                        "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
-                        }
-                      },
-                      {
-                        "key": "prometheus_replica",
-                        "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
-                        }
-                      },
-                      {
-                        "key": "resource",
-                        "value": {
-                          "stringValue": "hugepages_1Gi"
-                        }
-                      },
-                      {
-                        "key": "service",
-                        "value": {
-                          "stringValue": "test-service"
-                        }
-                      },
-                      {
-                        "key": "unit",
-                        "value": {
-                          "stringValue": "byte"
-                        }
-                      }
-                    ],
-                    "timeUnixNano": "0"
-                  },
-                  {
-                    "asDouble": 0,
-                    "attributes": [
-                      {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "tcp-model"
-                        }
-                      },
-                      {
-                        "key": "node",
-                        "value": {
-                          "stringValue": "test-node"
-                        }
-                      },
-                      {
-                        "key": "prometheus",
-                        "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
-                        }
-                      },
-                      {
-                        "key": "prometheus_replica",
-                        "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
-                        }
-                      },
-                      {
-                        "key": "resource",
-                        "value": {
-                          "stringValue": "hugepages_2Mi"
-                        }
-                      },
-                      {
-                        "key": "service",
-                        "value": {
-                          "stringValue": "test-service"
-                        }
-                      },
-                      {
-                        "key": "unit",
-                        "value": {
-                          "stringValue": "byte"
-                        }
-                      }
-                    ],
-                    "timeUnixNano": "0"
-                  },
-                  {
-                    "asDouble": 63297781760,
-                    "attributes": [
-                      {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "tcp-model"
-                        }
-                      },
-                      {
-                        "key": "node",
-                        "value": {
-                          "stringValue": "test-node"
-                        }
-                      },
-                      {
-                        "key": "prometheus",
-                        "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
-                        }
-                      },
-                      {
-                        "key": "prometheus_replica",
-                        "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
-                        }
-                      },
-                      {
-                        "key": "resource",
-                        "value": {
-                          "stringValue": "memory"
-                        }
-                      },
-                      {
-                        "key": "service",
-                        "value": {
-                          "stringValue": "test-service"
-                        }
-                      },
-                      {
-                        "key": "unit",
-                        "value": {
-                          "stringValue": "byte"
-                        }
-                      }
-                    ],
-                    "timeUnixNano": "0"
-                  },
-                  {
                     "asDouble": 234,
                     "attributes": [
                       {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "tcp-model"
-                        }
-                      },
-                      {
                         "key": "node",
                         "value": {
                           "stringValue": "test-node"
-                        }
-                      },
-                      {
-                        "key": "prometheus",
-                        "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
-                        }
-                      },
-                      {
-                        "key": "prometheus_replica",
-                        "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
                         }
                       },
                       {
@@ -16584,27 +13272,39 @@
                     "asDouble": 39,
                     "attributes": [
                       {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "http"
-                        }
-                      },
-                      {
                         "key": "node",
                         "value": {
                           "stringValue": "test-node"
                         }
                       },
                       {
-                        "key": "prometheus",
+                        "key": "resource",
                         "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
+                          "stringValue": "attachable_volumes_aws_ebs"
                         }
                       },
                       {
-                        "key": "prometheus_replica",
+                        "key": "service",
                         "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
+                          "stringValue": "test-service"
+                        }
+                      },
+                      {
+                        "key": "unit",
+                        "value": {
+                          "stringValue": "byte"
+                        }
+                      }
+                    ],
+                    "timeUnixNano": "0"
+                  },
+                  {
+                    "asDouble": 39,
+                    "attributes": [
+                      {
+                        "key": "node",
+                        "value": {
+                          "stringValue": "test-node"
                         }
                       },
                       {
@@ -16632,27 +13332,39 @@
                     "asDouble": 16,
                     "attributes": [
                       {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "http"
-                        }
-                      },
-                      {
                         "key": "node",
                         "value": {
                           "stringValue": "test-node"
                         }
                       },
                       {
-                        "key": "prometheus",
+                        "key": "resource",
                         "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
+                          "stringValue": "cpu"
                         }
                       },
                       {
-                        "key": "prometheus_replica",
+                        "key": "service",
                         "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
+                          "stringValue": "test-service"
+                        }
+                      },
+                      {
+                        "key": "unit",
+                        "value": {
+                          "stringValue": "core"
+                        }
+                      }
+                    ],
+                    "timeUnixNano": "0"
+                  },
+                  {
+                    "asDouble": 16,
+                    "attributes": [
+                      {
+                        "key": "node",
+                        "value": {
+                          "stringValue": "test-node"
                         }
                       },
                       {
@@ -16680,27 +13392,39 @@
                     "asDouble": 322109943808,
                     "attributes": [
                       {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "http"
-                        }
-                      },
-                      {
                         "key": "node",
                         "value": {
                           "stringValue": "test-node"
                         }
                       },
                       {
-                        "key": "prometheus",
+                        "key": "resource",
                         "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
+                          "stringValue": "ephemeral_storage"
                         }
                       },
                       {
-                        "key": "prometheus_replica",
+                        "key": "service",
                         "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
+                          "stringValue": "test-service"
+                        }
+                      },
+                      {
+                        "key": "unit",
+                        "value": {
+                          "stringValue": "byte"
+                        }
+                      }
+                    ],
+                    "timeUnixNano": "0"
+                  },
+                  {
+                    "asDouble": 322109943808,
+                    "attributes": [
+                      {
+                        "key": "node",
+                        "value": {
+                          "stringValue": "test-node"
                         }
                       },
                       {
@@ -16728,27 +13452,9 @@
                     "asDouble": 0,
                     "attributes": [
                       {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "http"
-                        }
-                      },
-                      {
                         "key": "node",
                         "value": {
                           "stringValue": "test-node"
-                        }
-                      },
-                      {
-                        "key": "prometheus",
-                        "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
-                        }
-                      },
-                      {
-                        "key": "prometheus_replica",
-                        "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
                         }
                       },
                       {
@@ -16776,11 +13482,35 @@
                     "asDouble": 0,
                     "attributes": [
                       {
-                        "key": "endpoint",
+                        "key": "node",
                         "value": {
-                          "stringValue": "http"
+                          "stringValue": "test-node"
                         }
                       },
+                      {
+                        "key": "resource",
+                        "value": {
+                          "stringValue": "hugepages_1Gi"
+                        }
+                      },
+                      {
+                        "key": "service",
+                        "value": {
+                          "stringValue": "test-service"
+                        }
+                      },
+                      {
+                        "key": "unit",
+                        "value": {
+                          "stringValue": "byte"
+                        }
+                      }
+                    ],
+                    "timeUnixNano": "0"
+                  },
+                  {
+                    "asDouble": 0,
+                    "attributes": [
                       {
                         "key": "node",
                         "value": {
@@ -16788,15 +13518,33 @@
                         }
                       },
                       {
-                        "key": "prometheus",
+                        "key": "resource",
                         "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
+                          "stringValue": "hugepages_2Mi"
                         }
                       },
                       {
-                        "key": "prometheus_replica",
+                        "key": "service",
                         "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
+                          "stringValue": "test-service"
+                        }
+                      },
+                      {
+                        "key": "unit",
+                        "value": {
+                          "stringValue": "byte"
+                        }
+                      }
+                    ],
+                    "timeUnixNano": "0"
+                  },
+                  {
+                    "asDouble": 0,
+                    "attributes": [
+                      {
+                        "key": "node",
+                        "value": {
+                          "stringValue": "test-node"
                         }
                       },
                       {
@@ -16824,27 +13572,39 @@
                     "asDouble": 66369060864,
                     "attributes": [
                       {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "http"
-                        }
-                      },
-                      {
                         "key": "node",
                         "value": {
                           "stringValue": "test-node"
                         }
                       },
                       {
-                        "key": "prometheus",
+                        "key": "resource",
                         "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
+                          "stringValue": "memory"
                         }
                       },
                       {
-                        "key": "prometheus_replica",
+                        "key": "service",
                         "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
+                          "stringValue": "test-service"
+                        }
+                      },
+                      {
+                        "key": "unit",
+                        "value": {
+                          "stringValue": "byte"
+                        }
+                      }
+                    ],
+                    "timeUnixNano": "0"
+                  },
+                  {
+                    "asDouble": 66369060864,
+                    "attributes": [
+                      {
+                        "key": "node",
+                        "value": {
+                          "stringValue": "test-node"
                         }
                       },
                       {
@@ -16872,27 +13632,9 @@
                     "asDouble": 234,
                     "attributes": [
                       {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "http"
-                        }
-                      },
-                      {
                         "key": "node",
                         "value": {
                           "stringValue": "test-node"
-                        }
-                      },
-                      {
-                        "key": "prometheus",
-                        "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
-                        }
-                      },
-                      {
-                        "key": "prometheus_replica",
-                        "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
                         }
                       },
                       {
@@ -16917,318 +13659,12 @@
                     "timeUnixNano": "0"
                   },
                   {
-                    "asDouble": 39,
-                    "attributes": [
-                      {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "tcp-model"
-                        }
-                      },
-                      {
-                        "key": "node",
-                        "value": {
-                          "stringValue": "test-node"
-                        }
-                      },
-                      {
-                        "key": "prometheus",
-                        "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
-                        }
-                      },
-                      {
-                        "key": "prometheus_replica",
-                        "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
-                        }
-                      },
-                      {
-                        "key": "resource",
-                        "value": {
-                          "stringValue": "attachable_volumes_aws_ebs"
-                        }
-                      },
-                      {
-                        "key": "service",
-                        "value": {
-                          "stringValue": "test-service"
-                        }
-                      },
-                      {
-                        "key": "unit",
-                        "value": {
-                          "stringValue": "byte"
-                        }
-                      }
-                    ],
-                    "timeUnixNano": "0"
-                  },
-                  {
-                    "asDouble": 16,
-                    "attributes": [
-                      {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "tcp-model"
-                        }
-                      },
-                      {
-                        "key": "node",
-                        "value": {
-                          "stringValue": "test-node"
-                        }
-                      },
-                      {
-                        "key": "prometheus",
-                        "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
-                        }
-                      },
-                      {
-                        "key": "prometheus_replica",
-                        "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
-                        }
-                      },
-                      {
-                        "key": "resource",
-                        "value": {
-                          "stringValue": "cpu"
-                        }
-                      },
-                      {
-                        "key": "service",
-                        "value": {
-                          "stringValue": "test-service"
-                        }
-                      },
-                      {
-                        "key": "unit",
-                        "value": {
-                          "stringValue": "core"
-                        }
-                      }
-                    ],
-                    "timeUnixNano": "0"
-                  },
-                  {
-                    "asDouble": 322109943808,
-                    "attributes": [
-                      {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "tcp-model"
-                        }
-                      },
-                      {
-                        "key": "node",
-                        "value": {
-                          "stringValue": "test-node"
-                        }
-                      },
-                      {
-                        "key": "prometheus",
-                        "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
-                        }
-                      },
-                      {
-                        "key": "prometheus_replica",
-                        "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
-                        }
-                      },
-                      {
-                        "key": "resource",
-                        "value": {
-                          "stringValue": "ephemeral_storage"
-                        }
-                      },
-                      {
-                        "key": "service",
-                        "value": {
-                          "stringValue": "test-service"
-                        }
-                      },
-                      {
-                        "key": "unit",
-                        "value": {
-                          "stringValue": "byte"
-                        }
-                      }
-                    ],
-                    "timeUnixNano": "0"
-                  },
-                  {
-                    "asDouble": 0,
-                    "attributes": [
-                      {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "tcp-model"
-                        }
-                      },
-                      {
-                        "key": "node",
-                        "value": {
-                          "stringValue": "test-node"
-                        }
-                      },
-                      {
-                        "key": "prometheus",
-                        "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
-                        }
-                      },
-                      {
-                        "key": "prometheus_replica",
-                        "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
-                        }
-                      },
-                      {
-                        "key": "resource",
-                        "value": {
-                          "stringValue": "hugepages_1Gi"
-                        }
-                      },
-                      {
-                        "key": "service",
-                        "value": {
-                          "stringValue": "test-service"
-                        }
-                      },
-                      {
-                        "key": "unit",
-                        "value": {
-                          "stringValue": "byte"
-                        }
-                      }
-                    ],
-                    "timeUnixNano": "0"
-                  },
-                  {
-                    "asDouble": 0,
-                    "attributes": [
-                      {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "tcp-model"
-                        }
-                      },
-                      {
-                        "key": "node",
-                        "value": {
-                          "stringValue": "test-node"
-                        }
-                      },
-                      {
-                        "key": "prometheus",
-                        "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
-                        }
-                      },
-                      {
-                        "key": "prometheus_replica",
-                        "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
-                        }
-                      },
-                      {
-                        "key": "resource",
-                        "value": {
-                          "stringValue": "hugepages_2Mi"
-                        }
-                      },
-                      {
-                        "key": "service",
-                        "value": {
-                          "stringValue": "test-service"
-                        }
-                      },
-                      {
-                        "key": "unit",
-                        "value": {
-                          "stringValue": "byte"
-                        }
-                      }
-                    ],
-                    "timeUnixNano": "0"
-                  },
-                  {
-                    "asDouble": 66369060864,
-                    "attributes": [
-                      {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "tcp-model"
-                        }
-                      },
-                      {
-                        "key": "node",
-                        "value": {
-                          "stringValue": "test-node"
-                        }
-                      },
-                      {
-                        "key": "prometheus",
-                        "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
-                        }
-                      },
-                      {
-                        "key": "prometheus_replica",
-                        "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
-                        }
-                      },
-                      {
-                        "key": "resource",
-                        "value": {
-                          "stringValue": "memory"
-                        }
-                      },
-                      {
-                        "key": "service",
-                        "value": {
-                          "stringValue": "test-service"
-                        }
-                      },
-                      {
-                        "key": "unit",
-                        "value": {
-                          "stringValue": "byte"
-                        }
-                      }
-                    ],
-                    "timeUnixNano": "0"
-                  },
-                  {
                     "asDouble": 234,
                     "attributes": [
                       {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "tcp-model"
-                        }
-                      },
-                      {
                         "key": "node",
                         "value": {
                           "stringValue": "test-node"
-                        }
-                      },
-                      {
-                        "key": "prometheus",
-                        "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
-                        }
-                      },
-                      {
-                        "key": "prometheus_replica",
-                        "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
                         }
                       },
                       {
@@ -17269,27 +13705,39 @@
                         }
                       },
                       {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "http"
-                        }
-                      },
-                      {
                         "key": "node",
                         "value": {
                           "stringValue": "test-node"
                         }
                       },
                       {
-                        "key": "prometheus",
+                        "key": "service",
                         "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
+                          "stringValue": "test-service"
                         }
                       },
                       {
-                        "key": "prometheus_replica",
+                        "key": "status",
                         "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
+                          "stringValue": "false"
+                        }
+                      }
+                    ],
+                    "timeUnixNano": "0"
+                  },
+                  {
+                    "asDouble": 1,
+                    "attributes": [
+                      {
+                        "key": "condition",
+                        "value": {
+                          "stringValue": "DiskPressure"
+                        }
+                      },
+                      {
+                        "key": "node",
+                        "value": {
+                          "stringValue": "test-node"
                         }
                       },
                       {
@@ -17317,27 +13765,9 @@
                         }
                       },
                       {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "http"
-                        }
-                      },
-                      {
                         "key": "node",
                         "value": {
                           "stringValue": "test-node"
-                        }
-                      },
-                      {
-                        "key": "prometheus",
-                        "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
-                        }
-                      },
-                      {
-                        "key": "prometheus_replica",
-                        "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
                         }
                       },
                       {
@@ -17365,123 +13795,9 @@
                         }
                       },
                       {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "http"
-                        }
-                      },
-                      {
                         "key": "node",
                         "value": {
                           "stringValue": "test-node"
-                        }
-                      },
-                      {
-                        "key": "prometheus",
-                        "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
-                        }
-                      },
-                      {
-                        "key": "prometheus_replica",
-                        "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
-                        }
-                      },
-                      {
-                        "key": "service",
-                        "value": {
-                          "stringValue": "test-service"
-                        }
-                      },
-                      {
-                        "key": "status",
-                        "value": {
-                          "stringValue": "unknown"
-                        }
-                      }
-                    ],
-                    "timeUnixNano": "0"
-                  },
-                  {
-                    "asDouble": 1,
-                    "attributes": [
-                      {
-                        "key": "condition",
-                        "value": {
-                          "stringValue": "DiskPressure"
-                        }
-                      },
-                      {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "tcp-model"
-                        }
-                      },
-                      {
-                        "key": "node",
-                        "value": {
-                          "stringValue": "test-node"
-                        }
-                      },
-                      {
-                        "key": "prometheus",
-                        "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
-                        }
-                      },
-                      {
-                        "key": "prometheus_replica",
-                        "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
-                        }
-                      },
-                      {
-                        "key": "service",
-                        "value": {
-                          "stringValue": "test-service"
-                        }
-                      },
-                      {
-                        "key": "status",
-                        "value": {
-                          "stringValue": "false"
-                        }
-                      }
-                    ],
-                    "timeUnixNano": "0"
-                  },
-                  {
-                    "asDouble": 0,
-                    "attributes": [
-                      {
-                        "key": "condition",
-                        "value": {
-                          "stringValue": "DiskPressure"
-                        }
-                      },
-                      {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "tcp-model"
-                        }
-                      },
-                      {
-                        "key": "node",
-                        "value": {
-                          "stringValue": "test-node"
-                        }
-                      },
-                      {
-                        "key": "prometheus",
-                        "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
-                        }
-                      },
-                      {
-                        "key": "prometheus_replica",
-                        "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
                         }
                       },
                       {
@@ -17509,27 +13825,39 @@
                         }
                       },
                       {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "tcp-model"
-                        }
-                      },
-                      {
                         "key": "node",
                         "value": {
                           "stringValue": "test-node"
                         }
                       },
                       {
-                        "key": "prometheus",
+                        "key": "service",
                         "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
+                          "stringValue": "test-service"
                         }
                       },
                       {
-                        "key": "prometheus_replica",
+                        "key": "status",
                         "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
+                          "stringValue": "unknown"
+                        }
+                      }
+                    ],
+                    "timeUnixNano": "0"
+                  },
+                  {
+                    "asDouble": 0,
+                    "attributes": [
+                      {
+                        "key": "condition",
+                        "value": {
+                          "stringValue": "DiskPressure"
+                        }
+                      },
+                      {
+                        "key": "node",
+                        "value": {
+                          "stringValue": "test-node"
                         }
                       },
                       {
@@ -17557,27 +13885,39 @@
                         }
                       },
                       {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "http"
-                        }
-                      },
-                      {
                         "key": "node",
                         "value": {
                           "stringValue": "test-node"
                         }
                       },
                       {
-                        "key": "prometheus",
+                        "key": "service",
                         "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
+                          "stringValue": "test-service"
                         }
                       },
                       {
-                        "key": "prometheus_replica",
+                        "key": "status",
                         "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
+                          "stringValue": "false"
+                        }
+                      }
+                    ],
+                    "timeUnixNano": "0"
+                  },
+                  {
+                    "asDouble": 1,
+                    "attributes": [
+                      {
+                        "key": "condition",
+                        "value": {
+                          "stringValue": "MemoryPressure"
+                        }
+                      },
+                      {
+                        "key": "node",
+                        "value": {
+                          "stringValue": "test-node"
                         }
                       },
                       {
@@ -17605,27 +13945,9 @@
                         }
                       },
                       {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "http"
-                        }
-                      },
-                      {
                         "key": "node",
                         "value": {
                           "stringValue": "test-node"
-                        }
-                      },
-                      {
-                        "key": "prometheus",
-                        "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
-                        }
-                      },
-                      {
-                        "key": "prometheus_replica",
-                        "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
                         }
                       },
                       {
@@ -17653,123 +13975,9 @@
                         }
                       },
                       {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "http"
-                        }
-                      },
-                      {
                         "key": "node",
                         "value": {
                           "stringValue": "test-node"
-                        }
-                      },
-                      {
-                        "key": "prometheus",
-                        "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
-                        }
-                      },
-                      {
-                        "key": "prometheus_replica",
-                        "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
-                        }
-                      },
-                      {
-                        "key": "service",
-                        "value": {
-                          "stringValue": "test-service"
-                        }
-                      },
-                      {
-                        "key": "status",
-                        "value": {
-                          "stringValue": "unknown"
-                        }
-                      }
-                    ],
-                    "timeUnixNano": "0"
-                  },
-                  {
-                    "asDouble": 1,
-                    "attributes": [
-                      {
-                        "key": "condition",
-                        "value": {
-                          "stringValue": "MemoryPressure"
-                        }
-                      },
-                      {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "tcp-model"
-                        }
-                      },
-                      {
-                        "key": "node",
-                        "value": {
-                          "stringValue": "test-node"
-                        }
-                      },
-                      {
-                        "key": "prometheus",
-                        "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
-                        }
-                      },
-                      {
-                        "key": "prometheus_replica",
-                        "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
-                        }
-                      },
-                      {
-                        "key": "service",
-                        "value": {
-                          "stringValue": "test-service"
-                        }
-                      },
-                      {
-                        "key": "status",
-                        "value": {
-                          "stringValue": "false"
-                        }
-                      }
-                    ],
-                    "timeUnixNano": "0"
-                  },
-                  {
-                    "asDouble": 0,
-                    "attributes": [
-                      {
-                        "key": "condition",
-                        "value": {
-                          "stringValue": "MemoryPressure"
-                        }
-                      },
-                      {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "tcp-model"
-                        }
-                      },
-                      {
-                        "key": "node",
-                        "value": {
-                          "stringValue": "test-node"
-                        }
-                      },
-                      {
-                        "key": "prometheus",
-                        "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
-                        }
-                      },
-                      {
-                        "key": "prometheus_replica",
-                        "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
                         }
                       },
                       {
@@ -17797,27 +14005,39 @@
                         }
                       },
                       {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "tcp-model"
-                        }
-                      },
-                      {
                         "key": "node",
                         "value": {
                           "stringValue": "test-node"
                         }
                       },
                       {
-                        "key": "prometheus",
+                        "key": "service",
                         "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
+                          "stringValue": "test-service"
                         }
                       },
                       {
-                        "key": "prometheus_replica",
+                        "key": "status",
                         "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
+                          "stringValue": "unknown"
+                        }
+                      }
+                    ],
+                    "timeUnixNano": "0"
+                  },
+                  {
+                    "asDouble": 0,
+                    "attributes": [
+                      {
+                        "key": "condition",
+                        "value": {
+                          "stringValue": "MemoryPressure"
+                        }
+                      },
+                      {
+                        "key": "node",
+                        "value": {
+                          "stringValue": "test-node"
                         }
                       },
                       {
@@ -17845,27 +14065,39 @@
                         }
                       },
                       {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "http"
-                        }
-                      },
-                      {
                         "key": "node",
                         "value": {
                           "stringValue": "test-node"
                         }
                       },
                       {
-                        "key": "prometheus",
+                        "key": "service",
                         "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
+                          "stringValue": "test-service"
                         }
                       },
                       {
-                        "key": "prometheus_replica",
+                        "key": "status",
                         "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
+                          "stringValue": "false"
+                        }
+                      }
+                    ],
+                    "timeUnixNano": "0"
+                  },
+                  {
+                    "asDouble": 1,
+                    "attributes": [
+                      {
+                        "key": "condition",
+                        "value": {
+                          "stringValue": "NetworkUnavailable"
+                        }
+                      },
+                      {
+                        "key": "node",
+                        "value": {
+                          "stringValue": "test-node"
                         }
                       },
                       {
@@ -17893,27 +14125,9 @@
                         }
                       },
                       {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "http"
-                        }
-                      },
-                      {
                         "key": "node",
                         "value": {
                           "stringValue": "test-node"
-                        }
-                      },
-                      {
-                        "key": "prometheus",
-                        "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
-                        }
-                      },
-                      {
-                        "key": "prometheus_replica",
-                        "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
                         }
                       },
                       {
@@ -17941,123 +14155,9 @@
                         }
                       },
                       {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "http"
-                        }
-                      },
-                      {
                         "key": "node",
                         "value": {
                           "stringValue": "test-node"
-                        }
-                      },
-                      {
-                        "key": "prometheus",
-                        "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
-                        }
-                      },
-                      {
-                        "key": "prometheus_replica",
-                        "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
-                        }
-                      },
-                      {
-                        "key": "service",
-                        "value": {
-                          "stringValue": "test-service"
-                        }
-                      },
-                      {
-                        "key": "status",
-                        "value": {
-                          "stringValue": "unknown"
-                        }
-                      }
-                    ],
-                    "timeUnixNano": "0"
-                  },
-                  {
-                    "asDouble": 1,
-                    "attributes": [
-                      {
-                        "key": "condition",
-                        "value": {
-                          "stringValue": "NetworkUnavailable"
-                        }
-                      },
-                      {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "tcp-model"
-                        }
-                      },
-                      {
-                        "key": "node",
-                        "value": {
-                          "stringValue": "test-node"
-                        }
-                      },
-                      {
-                        "key": "prometheus",
-                        "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
-                        }
-                      },
-                      {
-                        "key": "prometheus_replica",
-                        "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
-                        }
-                      },
-                      {
-                        "key": "service",
-                        "value": {
-                          "stringValue": "test-service"
-                        }
-                      },
-                      {
-                        "key": "status",
-                        "value": {
-                          "stringValue": "false"
-                        }
-                      }
-                    ],
-                    "timeUnixNano": "0"
-                  },
-                  {
-                    "asDouble": 0,
-                    "attributes": [
-                      {
-                        "key": "condition",
-                        "value": {
-                          "stringValue": "NetworkUnavailable"
-                        }
-                      },
-                      {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "tcp-model"
-                        }
-                      },
-                      {
-                        "key": "node",
-                        "value": {
-                          "stringValue": "test-node"
-                        }
-                      },
-                      {
-                        "key": "prometheus",
-                        "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
-                        }
-                      },
-                      {
-                        "key": "prometheus_replica",
-                        "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
                         }
                       },
                       {
@@ -18085,27 +14185,39 @@
                         }
                       },
                       {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "tcp-model"
-                        }
-                      },
-                      {
                         "key": "node",
                         "value": {
                           "stringValue": "test-node"
                         }
                       },
                       {
-                        "key": "prometheus",
+                        "key": "service",
                         "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
+                          "stringValue": "test-service"
                         }
                       },
                       {
-                        "key": "prometheus_replica",
+                        "key": "status",
                         "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
+                          "stringValue": "unknown"
+                        }
+                      }
+                    ],
+                    "timeUnixNano": "0"
+                  },
+                  {
+                    "asDouble": 0,
+                    "attributes": [
+                      {
+                        "key": "condition",
+                        "value": {
+                          "stringValue": "NetworkUnavailable"
+                        }
+                      },
+                      {
+                        "key": "node",
+                        "value": {
+                          "stringValue": "test-node"
                         }
                       },
                       {
@@ -18133,27 +14245,39 @@
                         }
                       },
                       {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "http"
-                        }
-                      },
-                      {
                         "key": "node",
                         "value": {
                           "stringValue": "test-node"
                         }
                       },
                       {
-                        "key": "prometheus",
+                        "key": "service",
                         "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
+                          "stringValue": "test-service"
                         }
                       },
                       {
-                        "key": "prometheus_replica",
+                        "key": "status",
                         "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
+                          "stringValue": "false"
+                        }
+                      }
+                    ],
+                    "timeUnixNano": "0"
+                  },
+                  {
+                    "asDouble": 1,
+                    "attributes": [
+                      {
+                        "key": "condition",
+                        "value": {
+                          "stringValue": "PIDPressure"
+                        }
+                      },
+                      {
+                        "key": "node",
+                        "value": {
+                          "stringValue": "test-node"
                         }
                       },
                       {
@@ -18181,27 +14305,9 @@
                         }
                       },
                       {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "http"
-                        }
-                      },
-                      {
                         "key": "node",
                         "value": {
                           "stringValue": "test-node"
-                        }
-                      },
-                      {
-                        "key": "prometheus",
-                        "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
-                        }
-                      },
-                      {
-                        "key": "prometheus_replica",
-                        "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
                         }
                       },
                       {
@@ -18229,27 +14335,39 @@
                         }
                       },
                       {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "http"
-                        }
-                      },
-                      {
                         "key": "node",
                         "value": {
                           "stringValue": "test-node"
                         }
                       },
                       {
-                        "key": "prometheus",
+                        "key": "service",
                         "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
+                          "stringValue": "test-service"
                         }
                       },
                       {
-                        "key": "prometheus_replica",
+                        "key": "status",
                         "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
+                          "stringValue": "true"
+                        }
+                      }
+                    ],
+                    "timeUnixNano": "0"
+                  },
+                  {
+                    "asDouble": 0,
+                    "attributes": [
+                      {
+                        "key": "condition",
+                        "value": {
+                          "stringValue": "PIDPressure"
+                        }
+                      },
+                      {
+                        "key": "node",
+                        "value": {
+                          "stringValue": "test-node"
                         }
                       },
                       {
@@ -18268,54 +14386,6 @@
                     "timeUnixNano": "0"
                   },
                   {
-                    "asDouble": 1,
-                    "attributes": [
-                      {
-                        "key": "condition",
-                        "value": {
-                          "stringValue": "PIDPressure"
-                        }
-                      },
-                      {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "tcp-model"
-                        }
-                      },
-                      {
-                        "key": "node",
-                        "value": {
-                          "stringValue": "test-node"
-                        }
-                      },
-                      {
-                        "key": "prometheus",
-                        "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
-                        }
-                      },
-                      {
-                        "key": "prometheus_replica",
-                        "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
-                        }
-                      },
-                      {
-                        "key": "service",
-                        "value": {
-                          "stringValue": "test-service"
-                        }
-                      },
-                      {
-                        "key": "status",
-                        "value": {
-                          "stringValue": "false"
-                        }
-                      }
-                    ],
-                    "timeUnixNano": "0"
-                  },
-                  {
                     "asDouble": 0,
                     "attributes": [
                       {
@@ -18325,75 +14395,9 @@
                         }
                       },
                       {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "tcp-model"
-                        }
-                      },
-                      {
                         "key": "node",
                         "value": {
                           "stringValue": "test-node"
-                        }
-                      },
-                      {
-                        "key": "prometheus",
-                        "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
-                        }
-                      },
-                      {
-                        "key": "prometheus_replica",
-                        "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
-                        }
-                      },
-                      {
-                        "key": "service",
-                        "value": {
-                          "stringValue": "test-service"
-                        }
-                      },
-                      {
-                        "key": "status",
-                        "value": {
-                          "stringValue": "true"
-                        }
-                      }
-                    ],
-                    "timeUnixNano": "0"
-                  },
-                  {
-                    "asDouble": 0,
-                    "attributes": [
-                      {
-                        "key": "condition",
-                        "value": {
-                          "stringValue": "PIDPressure"
-                        }
-                      },
-                      {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "tcp-model"
-                        }
-                      },
-                      {
-                        "key": "node",
-                        "value": {
-                          "stringValue": "test-node"
-                        }
-                      },
-                      {
-                        "key": "prometheus",
-                        "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
-                        }
-                      },
-                      {
-                        "key": "prometheus_replica",
-                        "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
                         }
                       },
                       {
@@ -18421,27 +14425,39 @@
                         }
                       },
                       {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "http"
-                        }
-                      },
-                      {
                         "key": "node",
                         "value": {
                           "stringValue": "test-node"
                         }
                       },
                       {
-                        "key": "prometheus",
+                        "key": "service",
                         "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
+                          "stringValue": "test-service"
                         }
                       },
                       {
-                        "key": "prometheus_replica",
+                        "key": "status",
                         "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
+                          "stringValue": "false"
+                        }
+                      }
+                    ],
+                    "timeUnixNano": "0"
+                  },
+                  {
+                    "asDouble": 0,
+                    "attributes": [
+                      {
+                        "key": "condition",
+                        "value": {
+                          "stringValue": "Ready"
+                        }
+                      },
+                      {
+                        "key": "node",
+                        "value": {
+                          "stringValue": "test-node"
                         }
                       },
                       {
@@ -18469,27 +14485,39 @@
                         }
                       },
                       {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "http"
-                        }
-                      },
-                      {
                         "key": "node",
                         "value": {
                           "stringValue": "test-node"
                         }
                       },
                       {
-                        "key": "prometheus",
+                        "key": "service",
                         "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
+                          "stringValue": "test-service"
                         }
                       },
                       {
-                        "key": "prometheus_replica",
+                        "key": "status",
                         "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
+                          "stringValue": "true"
+                        }
+                      }
+                    ],
+                    "timeUnixNano": "0"
+                  },
+                  {
+                    "asDouble": 1,
+                    "attributes": [
+                      {
+                        "key": "condition",
+                        "value": {
+                          "stringValue": "Ready"
+                        }
+                      },
+                      {
+                        "key": "node",
+                        "value": {
+                          "stringValue": "test-node"
                         }
                       },
                       {
@@ -18517,27 +14545,9 @@
                         }
                       },
                       {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "http"
-                        }
-                      },
-                      {
                         "key": "node",
                         "value": {
                           "stringValue": "test-node"
-                        }
-                      },
-                      {
-                        "key": "prometheus",
-                        "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
-                        }
-                      },
-                      {
-                        "key": "prometheus_replica",
-                        "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
                         }
                       },
                       {
@@ -18565,123 +14575,9 @@
                         }
                       },
                       {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "tcp-model"
-                        }
-                      },
-                      {
                         "key": "node",
                         "value": {
                           "stringValue": "test-node"
-                        }
-                      },
-                      {
-                        "key": "prometheus",
-                        "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
-                        }
-                      },
-                      {
-                        "key": "prometheus_replica",
-                        "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
-                        }
-                      },
-                      {
-                        "key": "service",
-                        "value": {
-                          "stringValue": "test-service"
-                        }
-                      },
-                      {
-                        "key": "status",
-                        "value": {
-                          "stringValue": "false"
-                        }
-                      }
-                    ],
-                    "timeUnixNano": "0"
-                  },
-                  {
-                    "asDouble": 1,
-                    "attributes": [
-                      {
-                        "key": "condition",
-                        "value": {
-                          "stringValue": "Ready"
-                        }
-                      },
-                      {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "tcp-model"
-                        }
-                      },
-                      {
-                        "key": "node",
-                        "value": {
-                          "stringValue": "test-node"
-                        }
-                      },
-                      {
-                        "key": "prometheus",
-                        "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
-                        }
-                      },
-                      {
-                        "key": "prometheus_replica",
-                        "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
-                        }
-                      },
-                      {
-                        "key": "service",
-                        "value": {
-                          "stringValue": "test-service"
-                        }
-                      },
-                      {
-                        "key": "status",
-                        "value": {
-                          "stringValue": "true"
-                        }
-                      }
-                    ],
-                    "timeUnixNano": "0"
-                  },
-                  {
-                    "asDouble": 0,
-                    "attributes": [
-                      {
-                        "key": "condition",
-                        "value": {
-                          "stringValue": "Ready"
-                        }
-                      },
-                      {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "tcp-model"
-                        }
-                      },
-                      {
-                        "key": "node",
-                        "value": {
-                          "stringValue": "test-node"
-                        }
-                      },
-                      {
-                        "key": "prometheus",
-                        "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
-                        }
-                      },
-                      {
-                        "key": "prometheus_replica",
-                        "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
                         }
                       },
                       {
@@ -18710,27 +14606,9 @@
                     "asDouble": 15.89,
                     "attributes": [
                       {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "http"
-                        }
-                      },
-                      {
                         "key": "node",
                         "value": {
                           "stringValue": "test-node"
-                        }
-                      },
-                      {
-                        "key": "prometheus",
-                        "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
-                        }
-                      },
-                      {
-                        "key": "prometheus_replica",
-                        "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
                         }
                       },
                       {
@@ -18758,27 +14636,9 @@
                     "asDouble": 15.89,
                     "attributes": [
                       {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "tcp-model"
-                        }
-                      },
-                      {
                         "key": "node",
                         "value": {
                           "stringValue": "test-node"
-                        }
-                      },
-                      {
-                        "key": "prometheus",
-                        "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
-                        }
-                      },
-                      {
-                        "key": "prometheus_replica",
-                        "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
                         }
                       },
                       {
@@ -18813,27 +14673,9 @@
                     "asDouble": 16,
                     "attributes": [
                       {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "http"
-                        }
-                      },
-                      {
                         "key": "node",
                         "value": {
                           "stringValue": "test-node"
-                        }
-                      },
-                      {
-                        "key": "prometheus",
-                        "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
-                        }
-                      },
-                      {
-                        "key": "prometheus_replica",
-                        "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
                         }
                       },
                       {
@@ -18861,27 +14703,9 @@
                     "asDouble": 16,
                     "attributes": [
                       {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "tcp-model"
-                        }
-                      },
-                      {
                         "key": "node",
                         "value": {
                           "stringValue": "test-node"
-                        }
-                      },
-                      {
-                        "key": "prometheus",
-                        "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
-                        }
-                      },
-                      {
-                        "key": "prometheus_replica",
-                        "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
                         }
                       },
                       {
@@ -18916,27 +14740,9 @@
                     "asDouble": 63297781760,
                     "attributes": [
                       {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "http"
-                        }
-                      },
-                      {
                         "key": "node",
                         "value": {
                           "stringValue": "test-node"
-                        }
-                      },
-                      {
-                        "key": "prometheus",
-                        "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
-                        }
-                      },
-                      {
-                        "key": "prometheus_replica",
-                        "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
                         }
                       },
                       {
@@ -18964,27 +14770,9 @@
                     "asDouble": 63297781760,
                     "attributes": [
                       {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "tcp-model"
-                        }
-                      },
-                      {
                         "key": "node",
                         "value": {
                           "stringValue": "test-node"
-                        }
-                      },
-                      {
-                        "key": "prometheus",
-                        "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
-                        }
-                      },
-                      {
-                        "key": "prometheus_replica",
-                        "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
                         }
                       },
                       {
@@ -19019,27 +14807,9 @@
                     "asDouble": 66369060864,
                     "attributes": [
                       {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "http"
-                        }
-                      },
-                      {
                         "key": "node",
                         "value": {
                           "stringValue": "test-node"
-                        }
-                      },
-                      {
-                        "key": "prometheus",
-                        "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
-                        }
-                      },
-                      {
-                        "key": "prometheus_replica",
-                        "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
                         }
                       },
                       {
@@ -19067,27 +14837,9 @@
                     "asDouble": 66369060864,
                     "attributes": [
                       {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "tcp-model"
-                        }
-                      },
-                      {
                         "key": "node",
                         "value": {
                           "stringValue": "test-node"
-                        }
-                      },
-                      {
-                        "key": "prometheus",
-                        "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
-                        }
-                      },
-                      {
-                        "key": "prometheus_replica",
-                        "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
                         }
                       },
                       {
@@ -19128,27 +14880,9 @@
                         }
                       },
                       {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "http"
-                        }
-                      },
-                      {
                         "key": "node",
                         "value": {
                           "stringValue": "test-node"
-                        }
-                      },
-                      {
-                        "key": "prometheus",
-                        "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
-                        }
-                      },
-                      {
-                        "key": "prometheus_replica",
-                        "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
                         }
                       },
                       {
@@ -19176,27 +14910,9 @@
                         }
                       },
                       {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "tcp-model"
-                        }
-                      },
-                      {
                         "key": "node",
                         "value": {
                           "stringValue": "test-node"
-                        }
-                      },
-                      {
-                        "key": "prometheus",
-                        "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
-                        }
-                      },
-                      {
-                        "key": "prometheus_replica",
-                        "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
                         }
                       },
                       {
@@ -19231,27 +14947,9 @@
                         }
                       },
                       {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "http"
-                        }
-                      },
-                      {
                         "key": "node",
                         "value": {
                           "stringValue": "test-node"
-                        }
-                      },
-                      {
-                        "key": "prometheus",
-                        "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
-                        }
-                      },
-                      {
-                        "key": "prometheus_replica",
-                        "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
                         }
                       },
                       {
@@ -19279,27 +14977,9 @@
                         }
                       },
                       {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "tcp-model"
-                        }
-                      },
-                      {
                         "key": "node",
                         "value": {
                           "stringValue": "test-node"
-                        }
-                      },
-                      {
-                        "key": "prometheus",
-                        "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
-                        }
-                      },
-                      {
-                        "key": "prometheus_replica",
-                        "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
                         }
                       },
                       {
@@ -19334,27 +15014,9 @@
                         }
                       },
                       {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "http"
-                        }
-                      },
-                      {
                         "key": "node",
                         "value": {
                           "stringValue": "test-node"
-                        }
-                      },
-                      {
-                        "key": "prometheus",
-                        "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
-                        }
-                      },
-                      {
-                        "key": "prometheus_replica",
-                        "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
                         }
                       },
                       {
@@ -19382,27 +15044,9 @@
                         }
                       },
                       {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "tcp-model"
-                        }
-                      },
-                      {
                         "key": "node",
                         "value": {
                           "stringValue": "test-node"
-                        }
-                      },
-                      {
-                        "key": "prometheus",
-                        "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
-                        }
-                      },
-                      {
-                        "key": "prometheus_replica",
-                        "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
                         }
                       },
                       {
@@ -19437,27 +15081,9 @@
                         }
                       },
                       {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "http"
-                        }
-                      },
-                      {
                         "key": "node",
                         "value": {
                           "stringValue": "test-node"
-                        }
-                      },
-                      {
-                        "key": "prometheus",
-                        "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
-                        }
-                      },
-                      {
-                        "key": "prometheus_replica",
-                        "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
                         }
                       },
                       {
@@ -19485,27 +15111,9 @@
                         }
                       },
                       {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "tcp-model"
-                        }
-                      },
-                      {
                         "key": "node",
                         "value": {
                           "stringValue": "test-node"
-                        }
-                      },
-                      {
-                        "key": "prometheus",
-                        "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
-                        }
-                      },
-                      {
-                        "key": "prometheus_replica",
-                        "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
                         }
                       },
                       {
@@ -19540,27 +15148,9 @@
                         }
                       },
                       {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "http"
-                        }
-                      },
-                      {
                         "key": "node",
                         "value": {
                           "stringValue": "test-node"
-                        }
-                      },
-                      {
-                        "key": "prometheus",
-                        "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
-                        }
-                      },
-                      {
-                        "key": "prometheus_replica",
-                        "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
                         }
                       },
                       {
@@ -19588,27 +15178,9 @@
                         }
                       },
                       {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "tcp-model"
-                        }
-                      },
-                      {
                         "key": "node",
                         "value": {
                           "stringValue": "test-node"
-                        }
-                      },
-                      {
-                        "key": "prometheus",
-                        "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
-                        }
-                      },
-                      {
-                        "key": "prometheus_replica",
-                        "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
                         }
                       },
                       {
@@ -19758,27 +15330,9 @@
                         }
                       },
                       {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "http"
-                        }
-                      },
-                      {
                         "key": "node",
                         "value": {
                           "stringValue": "test-node"
-                        }
-                      },
-                      {
-                        "key": "prometheus",
-                        "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
-                        }
-                      },
-                      {
-                        "key": "prometheus_replica",
-                        "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
                         }
                       },
                       {
@@ -19800,27 +15354,9 @@
                         }
                       },
                       {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "tcp-model"
-                        }
-                      },
-                      {
                         "key": "node",
                         "value": {
                           "stringValue": "test-node"
-                        }
-                      },
-                      {
-                        "key": "prometheus",
-                        "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
-                        }
-                      },
-                      {
-                        "key": "prometheus_replica",
-                        "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
                         }
                       },
                       {
@@ -20071,12 +15607,6 @@
                         }
                       },
                       {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "https-metrics"
-                        }
-                      },
-                      {
                         "key": "id",
                         "value": {
                           "stringValue": "/kubepods/besteffort/pod0fbfc1ac-4d28-4655-bf39-b6e44fecd6a9"
@@ -20092,18 +15622,6 @@
                         "key": "node",
                         "value": {
                           "stringValue": "test-node"
-                        }
-                      },
-                      {
-                        "key": "prometheus",
-                        "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
-                        }
-                      },
-                      {
-                        "key": "prometheus_replica",
-                        "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
                         }
                       },
                       {
@@ -20126,12 +15644,6 @@
                         }
                       },
                       {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "https-metrics"
-                        }
-                      },
-                      {
                         "key": "id",
                         "value": {
                           "stringValue": "/kubepods/burstable/podbafeef2c-1292-4a5e-a92c-d709480b04b6"
@@ -20147,18 +15659,6 @@
                         "key": "node",
                         "value": {
                           "stringValue": "test-node"
-                        }
-                      },
-                      {
-                        "key": "prometheus",
-                        "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
-                        }
-                      },
-                      {
-                        "key": "prometheus_replica",
-                        "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
                         }
                       },
                       {
@@ -20184,12 +15684,6 @@
                     "asDouble": 459152,
                     "attributes": [
                       {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "https-metrics"
-                        }
-                      },
-                      {
                         "key": "id",
                         "value": {
                           "stringValue": "/kubepods/burstable/pod00d78412-39d4-4a5b-8e85-38a12611f369"
@@ -20205,18 +15699,6 @@
                         "key": "node",
                         "value": {
                           "stringValue": "test-node"
-                        }
-                      },
-                      {
-                        "key": "prometheus",
-                        "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
-                        }
-                      },
-                      {
-                        "key": "prometheus_replica",
-                        "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
                         }
                       },
                       {
@@ -20241,12 +15723,6 @@
                     "asDouble": 9795,
                     "attributes": [
                       {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "https-metrics"
-                        }
-                      },
-                      {
                         "key": "id",
                         "value": {
                           "stringValue": "/kubepods/podd228bba1-5ce2-486b-a44f-cdcfe4780cb0"
@@ -20262,18 +15738,6 @@
                         "key": "node",
                         "value": {
                           "stringValue": "test-node"
-                        }
-                      },
-                      {
-                        "key": "prometheus",
-                        "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
-                        }
-                      },
-                      {
-                        "key": "prometheus_replica",
-                        "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
                         }
                       },
                       {
@@ -20304,12 +15768,6 @@
                         }
                       },
                       {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "https-metrics"
-                        }
-                      },
-                      {
                         "key": "id",
                         "value": {
                           "stringValue": "/kubepods/besteffort/pod0fbfc1ac-4d28-4655-bf39-b6e44fecd6a9"
@@ -20325,18 +15783,6 @@
                         "key": "node",
                         "value": {
                           "stringValue": "test-node"
-                        }
-                      },
-                      {
-                        "key": "prometheus",
-                        "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
-                        }
-                      },
-                      {
-                        "key": "prometheus_replica",
-                        "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
                         }
                       },
                       {
@@ -20358,12 +15804,6 @@
                         }
                       },
                       {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "https-metrics"
-                        }
-                      },
-                      {
                         "key": "id",
                         "value": {
                           "stringValue": "/kubepods/burstable/podbafeef2c-1292-4a5e-a92c-d709480b04b6"
@@ -20379,18 +15819,6 @@
                         "key": "node",
                         "value": {
                           "stringValue": "test-node"
-                        }
-                      },
-                      {
-                        "key": "prometheus",
-                        "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
-                        }
-                      },
-                      {
-                        "key": "prometheus_replica",
-                        "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
                         }
                       },
                       {
@@ -20421,12 +15849,6 @@
                         }
                       },
                       {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "https-metrics"
-                        }
-                      },
-                      {
                         "key": "id",
                         "value": {
                           "stringValue": "/kubepods/burstable/podbafeef2c-1292-4a5e-a92c-d709480b04b6"
@@ -20442,18 +15864,6 @@
                         "key": "node",
                         "value": {
                           "stringValue": "test-node"
-                        }
-                      },
-                      {
-                        "key": "prometheus",
-                        "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
-                        }
-                      },
-                      {
-                        "key": "prometheus_replica",
-                        "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
                         }
                       },
                       {
@@ -20484,12 +15894,6 @@
                         }
                       },
                       {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "https-metrics"
-                        }
-                      },
-                      {
                         "key": "id",
                         "value": {
                           "stringValue": "/kubepods/burstable/podbafeef2c-1292-4a5e-a92c-d709480b04b6"
@@ -20505,18 +15909,6 @@
                         "key": "node",
                         "value": {
                           "stringValue": "test-node"
-                        }
-                      },
-                      {
-                        "key": "prometheus",
-                        "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
-                        }
-                      },
-                      {
-                        "key": "prometheus_replica",
-                        "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
                         }
                       },
                       {
@@ -20547,12 +15939,6 @@
                         }
                       },
                       {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "https-metrics"
-                        }
-                      },
-                      {
                         "key": "id",
                         "value": {
                           "stringValue": "/kubepods/burstable/podbafeef2c-1292-4a5e-a92c-d709480b04b6"
@@ -20568,18 +15954,6 @@
                         "key": "node",
                         "value": {
                           "stringValue": "test-node"
-                        }
-                      },
-                      {
-                        "key": "prometheus",
-                        "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
-                        }
-                      },
-                      {
-                        "key": "prometheus_replica",
-                        "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
                         }
                       },
                       {
@@ -20610,12 +15984,6 @@
                         }
                       },
                       {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "https-metrics"
-                        }
-                      },
-                      {
                         "key": "id",
                         "value": {
                           "stringValue": "/kubepods/burstable/podbafeef2c-1292-4a5e-a92c-d709480b04b6"
@@ -20631,18 +15999,6 @@
                         "key": "node",
                         "value": {
                           "stringValue": "test-node"
-                        }
-                      },
-                      {
-                        "key": "prometheus",
-                        "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
-                        }
-                      },
-                      {
-                        "key": "prometheus_replica",
-                        "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
                         }
                       },
                       {
@@ -20665,12 +16021,6 @@
                     "asDouble": 2037620736,
                     "attributes": [
                       {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "https-metrics"
-                        }
-                      },
-                      {
                         "key": "id",
                         "value": {
                           "stringValue": "/kubepods/burstable/podbafeef2c-1292-4a5e-a92c-d709480b04b6"
@@ -20686,18 +16036,6 @@
                         "key": "node",
                         "value": {
                           "stringValue": "test-node"
-                        }
-                      },
-                      {
-                        "key": "prometheus",
-                        "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
-                        }
-                      },
-                      {
-                        "key": "prometheus_replica",
-                        "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
                         }
                       },
                       {
@@ -20720,12 +16058,6 @@
                     "asDouble": 100000,
                     "attributes": [
                       {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "https-metrics"
-                        }
-                      },
-                      {
                         "key": "id",
                         "value": {
                           "stringValue": "/kubepods/burstable/podbafeef2c-1292-4a5e-a92c-d709480b04b6"
@@ -20741,18 +16073,6 @@
                         "key": "node",
                         "value": {
                           "stringValue": "test-node"
-                        }
-                      },
-                      {
-                        "key": "prometheus",
-                        "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
-                        }
-                      },
-                      {
-                        "key": "prometheus_replica",
-                        "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
                         }
                       },
                       {
@@ -20775,12 +16095,6 @@
                     "asDouble": 300000,
                     "attributes": [
                       {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "https-metrics"
-                        }
-                      },
-                      {
                         "key": "id",
                         "value": {
                           "stringValue": "/kubepods/burstable/pod00d78412-39d4-4a5b-8e85-38a12611f369"
@@ -20796,18 +16110,6 @@
                         "key": "node",
                         "value": {
                           "stringValue": "test-node"
-                        }
-                      },
-                      {
-                        "key": "prometheus",
-                        "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
-                        }
-                      },
-                      {
-                        "key": "prometheus_replica",
-                        "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
                         }
                       },
                       {
@@ -20830,12 +16132,6 @@
                     "asDouble": 0,
                     "attributes": [
                       {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "https-metrics"
-                        }
-                      },
-                      {
                         "key": "id",
                         "value": {
                           "stringValue": "/kubepods/burstable/podbafeef2c-1292-4a5e-a92c-d709480b04b6"
@@ -20851,18 +16147,6 @@
                         "key": "node",
                         "value": {
                           "stringValue": "test-node"
-                        }
-                      },
-                      {
-                        "key": "prometheus",
-                        "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
-                        }
-                      },
-                      {
-                        "key": "prometheus_replica",
-                        "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
                         }
                       },
                       {
@@ -21093,7 +16377,7 @@
               "gauge": {
                 "dataPoints": [
                   {
-                    "asDouble": 6442450944,
+                    "asDouble": 3221225472,
                     "timeUnixNano": "0"
                   }
                 ]
@@ -21251,7 +16535,7 @@
               "gauge": {
                 "dataPoints": [
                   {
-                    "asDouble": 6442450944,
+                    "asDouble": 3221225472,
                     "timeUnixNano": "0"
                   }
                 ]
@@ -21268,12 +16552,6 @@
                         "key": "cpu",
                         "value": {
                           "stringValue": "total"
-                        }
-                      },
-                      {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "https-metrics"
                         }
                       },
                       {
@@ -21295,18 +16573,6 @@
                         }
                       },
                       {
-                        "key": "prometheus",
-                        "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
-                        }
-                      },
-                      {
-                        "key": "prometheus_replica",
-                        "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
-                        }
-                      },
-                      {
                         "key": "service",
                         "value": {
                           "stringValue": "test-service"
@@ -21323,12 +16589,6 @@
                         "key": "cpu",
                         "value": {
                           "stringValue": "total"
-                        }
-                      },
-                      {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "https-metrics"
                         }
                       },
                       {
@@ -21350,18 +16610,6 @@
                         }
                       },
                       {
-                        "key": "prometheus",
-                        "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
-                        }
-                      },
-                      {
-                        "key": "prometheus_replica",
-                        "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
-                        }
-                      },
-                      {
                         "key": "service",
                         "value": {
                           "stringValue": "test-service"
@@ -21381,12 +16629,6 @@
                         }
                       },
                       {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "https-metrics"
-                        }
-                      },
-                      {
                         "key": "id",
                         "value": {
                           "stringValue": "/"
@@ -21402,18 +16644,6 @@
                         "key": "node",
                         "value": {
                           "stringValue": "test-node"
-                        }
-                      },
-                      {
-                        "key": "prometheus",
-                        "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
-                        }
-                      },
-                      {
-                        "key": "prometheus_replica",
-                        "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
                         }
                       },
                       {
@@ -21437,12 +16667,6 @@
                     "asDouble": 0,
                     "attributes": [
                       {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "https-metrics"
-                        }
-                      },
-                      {
                         "key": "id",
                         "value": {
                           "stringValue": "/"
@@ -21467,18 +16691,6 @@
                         }
                       },
                       {
-                        "key": "prometheus",
-                        "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
-                        }
-                      },
-                      {
-                        "key": "prometheus_replica",
-                        "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
-                        }
-                      },
-                      {
                         "key": "service",
                         "value": {
                           "stringValue": "test-service"
@@ -21491,12 +16703,6 @@
                   {
                     "asDouble": 0,
                     "attributes": [
-                      {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "https-metrics"
-                        }
-                      },
                       {
                         "key": "id",
                         "value": {
@@ -21522,18 +16728,6 @@
                         }
                       },
                       {
-                        "key": "prometheus",
-                        "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
-                        }
-                      },
-                      {
-                        "key": "prometheus_replica",
-                        "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
-                        }
-                      },
-                      {
                         "key": "service",
                         "value": {
                           "stringValue": "test-service"
@@ -21546,12 +16740,6 @@
                   {
                     "asDouble": 0,
                     "attributes": [
-                      {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "https-metrics"
-                        }
-                      },
                       {
                         "key": "id",
                         "value": {
@@ -21577,18 +16765,6 @@
                         }
                       },
                       {
-                        "key": "prometheus",
-                        "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
-                        }
-                      },
-                      {
-                        "key": "prometheus_replica",
-                        "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
-                        }
-                      },
-                      {
                         "key": "service",
                         "value": {
                           "stringValue": "test-service"
@@ -21601,12 +16777,6 @@
                   {
                     "asDouble": 0,
                     "attributes": [
-                      {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "https-metrics"
-                        }
-                      },
                       {
                         "key": "id",
                         "value": {
@@ -21632,18 +16802,6 @@
                         }
                       },
                       {
-                        "key": "prometheus",
-                        "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
-                        }
-                      },
-                      {
-                        "key": "prometheus_replica",
-                        "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
-                        }
-                      },
-                      {
                         "key": "service",
                         "value": {
                           "stringValue": "test-service"
@@ -21656,12 +16814,6 @@
                   {
                     "asDouble": 0,
                     "attributes": [
-                      {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "https-metrics"
-                        }
-                      },
                       {
                         "key": "id",
                         "value": {
@@ -21687,18 +16839,6 @@
                         }
                       },
                       {
-                        "key": "prometheus",
-                        "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
-                        }
-                      },
-                      {
-                        "key": "prometheus_replica",
-                        "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
-                        }
-                      },
-                      {
                         "key": "service",
                         "value": {
                           "stringValue": "test-service"
@@ -21711,12 +16851,6 @@
                   {
                     "asDouble": 0,
                     "attributes": [
-                      {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "https-metrics"
-                        }
-                      },
                       {
                         "key": "id",
                         "value": {
@@ -21742,18 +16876,6 @@
                         }
                       },
                       {
-                        "key": "prometheus",
-                        "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
-                        }
-                      },
-                      {
-                        "key": "prometheus_replica",
-                        "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
-                        }
-                      },
-                      {
                         "key": "service",
                         "value": {
                           "stringValue": "test-service"
@@ -21766,12 +16888,6 @@
                   {
                     "asDouble": 0,
                     "attributes": [
-                      {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "https-metrics"
-                        }
-                      },
                       {
                         "key": "id",
                         "value": {
@@ -21797,18 +16913,6 @@
                         }
                       },
                       {
-                        "key": "prometheus",
-                        "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
-                        }
-                      },
-                      {
-                        "key": "prometheus_replica",
-                        "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
-                        }
-                      },
-                      {
                         "key": "service",
                         "value": {
                           "stringValue": "test-service"
@@ -21821,12 +16925,6 @@
                   {
                     "asDouble": 0,
                     "attributes": [
-                      {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "https-metrics"
-                        }
-                      },
                       {
                         "key": "id",
                         "value": {
@@ -21852,18 +16950,6 @@
                         }
                       },
                       {
-                        "key": "prometheus",
-                        "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
-                        }
-                      },
-                      {
-                        "key": "prometheus_replica",
-                        "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
-                        }
-                      },
-                      {
                         "key": "service",
                         "value": {
                           "stringValue": "test-service"
@@ -21876,12 +16962,6 @@
                   {
                     "asDouble": 0,
                     "attributes": [
-                      {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "https-metrics"
-                        }
-                      },
                       {
                         "key": "id",
                         "value": {
@@ -21907,18 +16987,6 @@
                         }
                       },
                       {
-                        "key": "prometheus",
-                        "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
-                        }
-                      },
-                      {
-                        "key": "prometheus_replica",
-                        "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
-                        }
-                      },
-                      {
                         "key": "service",
                         "value": {
                           "stringValue": "test-service"
@@ -21931,12 +16999,6 @@
                   {
                     "asDouble": 0,
                     "attributes": [
-                      {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "https-metrics"
-                        }
-                      },
                       {
                         "key": "id",
                         "value": {
@@ -21962,18 +17024,6 @@
                         }
                       },
                       {
-                        "key": "prometheus",
-                        "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
-                        }
-                      },
-                      {
-                        "key": "prometheus_replica",
-                        "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
-                        }
-                      },
-                      {
                         "key": "service",
                         "value": {
                           "stringValue": "test-service"
@@ -21986,12 +17036,6 @@
                   {
                     "asDouble": 0,
                     "attributes": [
-                      {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "https-metrics"
-                        }
-                      },
                       {
                         "key": "id",
                         "value": {
@@ -22017,18 +17061,6 @@
                         }
                       },
                       {
-                        "key": "prometheus",
-                        "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
-                        }
-                      },
-                      {
-                        "key": "prometheus_replica",
-                        "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
-                        }
-                      },
-                      {
                         "key": "service",
                         "value": {
                           "stringValue": "test-service"
@@ -22041,12 +17073,6 @@
                   {
                     "asDouble": 0,
                     "attributes": [
-                      {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "https-metrics"
-                        }
-                      },
                       {
                         "key": "id",
                         "value": {
@@ -22072,18 +17098,6 @@
                         }
                       },
                       {
-                        "key": "prometheus",
-                        "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
-                        }
-                      },
-                      {
-                        "key": "prometheus_replica",
-                        "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
-                        }
-                      },
-                      {
                         "key": "service",
                         "value": {
                           "stringValue": "test-service"
@@ -22096,12 +17110,6 @@
                   {
                     "asDouble": 0,
                     "attributes": [
-                      {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "https-metrics"
-                        }
-                      },
                       {
                         "key": "id",
                         "value": {
@@ -22127,18 +17135,6 @@
                         }
                       },
                       {
-                        "key": "prometheus",
-                        "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
-                        }
-                      },
-                      {
-                        "key": "prometheus_replica",
-                        "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
-                        }
-                      },
-                      {
                         "key": "service",
                         "value": {
                           "stringValue": "test-service"
@@ -22151,12 +17147,6 @@
                   {
                     "asDouble": 0,
                     "attributes": [
-                      {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "https-metrics"
-                        }
-                      },
                       {
                         "key": "id",
                         "value": {
@@ -22182,18 +17172,6 @@
                         }
                       },
                       {
-                        "key": "prometheus",
-                        "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
-                        }
-                      },
-                      {
-                        "key": "prometheus_replica",
-                        "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
-                        }
-                      },
-                      {
                         "key": "service",
                         "value": {
                           "stringValue": "test-service"
@@ -22206,12 +17184,6 @@
                   {
                     "asDouble": 0,
                     "attributes": [
-                      {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "https-metrics"
-                        }
-                      },
                       {
                         "key": "id",
                         "value": {
@@ -22237,18 +17209,6 @@
                         }
                       },
                       {
-                        "key": "prometheus",
-                        "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
-                        }
-                      },
-                      {
-                        "key": "prometheus_replica",
-                        "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
-                        }
-                      },
-                      {
                         "key": "service",
                         "value": {
                           "stringValue": "test-service"
@@ -22261,12 +17221,6 @@
                   {
                     "asDouble": 0,
                     "attributes": [
-                      {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "https-metrics"
-                        }
-                      },
                       {
                         "key": "id",
                         "value": {
@@ -22292,18 +17246,6 @@
                         }
                       },
                       {
-                        "key": "prometheus",
-                        "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
-                        }
-                      },
-                      {
-                        "key": "prometheus_replica",
-                        "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
-                        }
-                      },
-                      {
                         "key": "service",
                         "value": {
                           "stringValue": "test-service"
@@ -22316,12 +17258,6 @@
                   {
                     "asDouble": 0,
                     "attributes": [
-                      {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "https-metrics"
-                        }
-                      },
                       {
                         "key": "id",
                         "value": {
@@ -22347,18 +17283,6 @@
                         }
                       },
                       {
-                        "key": "prometheus",
-                        "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
-                        }
-                      },
-                      {
-                        "key": "prometheus_replica",
-                        "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
-                        }
-                      },
-                      {
                         "key": "service",
                         "value": {
                           "stringValue": "test-service"
@@ -22371,12 +17295,6 @@
                   {
                     "asDouble": 0,
                     "attributes": [
-                      {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "https-metrics"
-                        }
-                      },
                       {
                         "key": "id",
                         "value": {
@@ -22402,18 +17320,6 @@
                         }
                       },
                       {
-                        "key": "prometheus",
-                        "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
-                        }
-                      },
-                      {
-                        "key": "prometheus_replica",
-                        "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
-                        }
-                      },
-                      {
                         "key": "service",
                         "value": {
                           "stringValue": "test-service"
@@ -22426,12 +17332,6 @@
                   {
                     "asDouble": 0,
                     "attributes": [
-                      {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "https-metrics"
-                        }
-                      },
                       {
                         "key": "id",
                         "value": {
@@ -22457,18 +17357,6 @@
                         }
                       },
                       {
-                        "key": "prometheus",
-                        "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
-                        }
-                      },
-                      {
-                        "key": "prometheus_replica",
-                        "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
-                        }
-                      },
-                      {
                         "key": "service",
                         "value": {
                           "stringValue": "test-service"
@@ -22481,12 +17369,6 @@
                   {
                     "asDouble": 0,
                     "attributes": [
-                      {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "https-metrics"
-                        }
-                      },
                       {
                         "key": "id",
                         "value": {
@@ -22512,18 +17394,6 @@
                         }
                       },
                       {
-                        "key": "prometheus",
-                        "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
-                        }
-                      },
-                      {
-                        "key": "prometheus_replica",
-                        "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
-                        }
-                      },
-                      {
                         "key": "service",
                         "value": {
                           "stringValue": "test-service"
@@ -22536,12 +17406,6 @@
                   {
                     "asDouble": 0,
                     "attributes": [
-                      {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "https-metrics"
-                        }
-                      },
                       {
                         "key": "id",
                         "value": {
@@ -22567,18 +17431,6 @@
                         }
                       },
                       {
-                        "key": "prometheus",
-                        "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
-                        }
-                      },
-                      {
-                        "key": "prometheus_replica",
-                        "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
-                        }
-                      },
-                      {
                         "key": "service",
                         "value": {
                           "stringValue": "test-service"
@@ -22591,12 +17443,6 @@
                   {
                     "asDouble": 0,
                     "attributes": [
-                      {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "https-metrics"
-                        }
-                      },
                       {
                         "key": "id",
                         "value": {
@@ -22622,18 +17468,6 @@
                         }
                       },
                       {
-                        "key": "prometheus",
-                        "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
-                        }
-                      },
-                      {
-                        "key": "prometheus_replica",
-                        "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
-                        }
-                      },
-                      {
                         "key": "service",
                         "value": {
                           "stringValue": "test-service"
@@ -22646,12 +17480,6 @@
                   {
                     "asDouble": 0,
                     "attributes": [
-                      {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "https-metrics"
-                        }
-                      },
                       {
                         "key": "id",
                         "value": {
@@ -22677,18 +17505,6 @@
                         }
                       },
                       {
-                        "key": "prometheus",
-                        "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
-                        }
-                      },
-                      {
-                        "key": "prometheus_replica",
-                        "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
-                        }
-                      },
-                      {
                         "key": "service",
                         "value": {
                           "stringValue": "test-service"
@@ -22701,12 +17517,6 @@
                   {
                     "asDouble": 0,
                     "attributes": [
-                      {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "https-metrics"
-                        }
-                      },
                       {
                         "key": "id",
                         "value": {
@@ -22729,18 +17539,6 @@
                         "key": "node",
                         "value": {
                           "stringValue": "test-node"
-                        }
-                      },
-                      {
-                        "key": "prometheus",
-                        "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
-                        }
-                      },
-                      {
-                        "key": "prometheus_replica",
-                        "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
                         }
                       },
                       {
@@ -22764,12 +17562,6 @@
                     "asDouble": 0,
                     "attributes": [
                       {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "https-metrics"
-                        }
-                      },
-                      {
                         "key": "id",
                         "value": {
                           "stringValue": "/"
@@ -22794,18 +17586,6 @@
                         }
                       },
                       {
-                        "key": "prometheus",
-                        "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
-                        }
-                      },
-                      {
-                        "key": "prometheus_replica",
-                        "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
-                        }
-                      },
-                      {
                         "key": "service",
                         "value": {
                           "stringValue": "test-service"
@@ -22818,12 +17598,6 @@
                   {
                     "asDouble": 0,
                     "attributes": [
-                      {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "https-metrics"
-                        }
-                      },
                       {
                         "key": "id",
                         "value": {
@@ -22849,18 +17623,6 @@
                         }
                       },
                       {
-                        "key": "prometheus",
-                        "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
-                        }
-                      },
-                      {
-                        "key": "prometheus_replica",
-                        "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
-                        }
-                      },
-                      {
                         "key": "service",
                         "value": {
                           "stringValue": "test-service"
@@ -22873,12 +17635,6 @@
                   {
                     "asDouble": 0,
                     "attributes": [
-                      {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "https-metrics"
-                        }
-                      },
                       {
                         "key": "id",
                         "value": {
@@ -22904,18 +17660,6 @@
                         }
                       },
                       {
-                        "key": "prometheus",
-                        "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
-                        }
-                      },
-                      {
-                        "key": "prometheus_replica",
-                        "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
-                        }
-                      },
-                      {
                         "key": "service",
                         "value": {
                           "stringValue": "test-service"
@@ -22928,12 +17672,6 @@
                   {
                     "asDouble": 0,
                     "attributes": [
-                      {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "https-metrics"
-                        }
-                      },
                       {
                         "key": "id",
                         "value": {
@@ -22959,18 +17697,6 @@
                         }
                       },
                       {
-                        "key": "prometheus",
-                        "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
-                        }
-                      },
-                      {
-                        "key": "prometheus_replica",
-                        "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
-                        }
-                      },
-                      {
                         "key": "service",
                         "value": {
                           "stringValue": "test-service"
@@ -22983,12 +17709,6 @@
                   {
                     "asDouble": 0,
                     "attributes": [
-                      {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "https-metrics"
-                        }
-                      },
                       {
                         "key": "id",
                         "value": {
@@ -23014,18 +17734,6 @@
                         }
                       },
                       {
-                        "key": "prometheus",
-                        "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
-                        }
-                      },
-                      {
-                        "key": "prometheus_replica",
-                        "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
-                        }
-                      },
-                      {
                         "key": "service",
                         "value": {
                           "stringValue": "test-service"
@@ -23038,12 +17746,6 @@
                   {
                     "asDouble": 0,
                     "attributes": [
-                      {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "https-metrics"
-                        }
-                      },
                       {
                         "key": "id",
                         "value": {
@@ -23069,18 +17771,6 @@
                         }
                       },
                       {
-                        "key": "prometheus",
-                        "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
-                        }
-                      },
-                      {
-                        "key": "prometheus_replica",
-                        "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
-                        }
-                      },
-                      {
                         "key": "service",
                         "value": {
                           "stringValue": "test-service"
@@ -23093,12 +17783,6 @@
                   {
                     "asDouble": 0,
                     "attributes": [
-                      {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "https-metrics"
-                        }
-                      },
                       {
                         "key": "id",
                         "value": {
@@ -23124,18 +17808,6 @@
                         }
                       },
                       {
-                        "key": "prometheus",
-                        "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
-                        }
-                      },
-                      {
-                        "key": "prometheus_replica",
-                        "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
-                        }
-                      },
-                      {
                         "key": "service",
                         "value": {
                           "stringValue": "test-service"
@@ -23148,12 +17820,6 @@
                   {
                     "asDouble": 0,
                     "attributes": [
-                      {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "https-metrics"
-                        }
-                      },
                       {
                         "key": "id",
                         "value": {
@@ -23179,18 +17845,6 @@
                         }
                       },
                       {
-                        "key": "prometheus",
-                        "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
-                        }
-                      },
-                      {
-                        "key": "prometheus_replica",
-                        "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
-                        }
-                      },
-                      {
                         "key": "service",
                         "value": {
                           "stringValue": "test-service"
@@ -23203,12 +17857,6 @@
                   {
                     "asDouble": 0,
                     "attributes": [
-                      {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "https-metrics"
-                        }
-                      },
                       {
                         "key": "id",
                         "value": {
@@ -23234,18 +17882,6 @@
                         }
                       },
                       {
-                        "key": "prometheus",
-                        "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
-                        }
-                      },
-                      {
-                        "key": "prometheus_replica",
-                        "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
-                        }
-                      },
-                      {
                         "key": "service",
                         "value": {
                           "stringValue": "test-service"
@@ -23258,12 +17894,6 @@
                   {
                     "asDouble": 0,
                     "attributes": [
-                      {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "https-metrics"
-                        }
-                      },
                       {
                         "key": "id",
                         "value": {
@@ -23289,18 +17919,6 @@
                         }
                       },
                       {
-                        "key": "prometheus",
-                        "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
-                        }
-                      },
-                      {
-                        "key": "prometheus_replica",
-                        "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
-                        }
-                      },
-                      {
                         "key": "service",
                         "value": {
                           "stringValue": "test-service"
@@ -23313,12 +17931,6 @@
                   {
                     "asDouble": 0,
                     "attributes": [
-                      {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "https-metrics"
-                        }
-                      },
                       {
                         "key": "id",
                         "value": {
@@ -23344,18 +17956,6 @@
                         }
                       },
                       {
-                        "key": "prometheus",
-                        "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
-                        }
-                      },
-                      {
-                        "key": "prometheus_replica",
-                        "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
-                        }
-                      },
-                      {
                         "key": "service",
                         "value": {
                           "stringValue": "test-service"
@@ -23368,12 +17968,6 @@
                   {
                     "asDouble": 0,
                     "attributes": [
-                      {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "https-metrics"
-                        }
-                      },
                       {
                         "key": "id",
                         "value": {
@@ -23399,18 +17993,6 @@
                         }
                       },
                       {
-                        "key": "prometheus",
-                        "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
-                        }
-                      },
-                      {
-                        "key": "prometheus_replica",
-                        "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
-                        }
-                      },
-                      {
                         "key": "service",
                         "value": {
                           "stringValue": "test-service"
@@ -23423,12 +18005,6 @@
                   {
                     "asDouble": 0,
                     "attributes": [
-                      {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "https-metrics"
-                        }
-                      },
                       {
                         "key": "id",
                         "value": {
@@ -23454,18 +18030,6 @@
                         }
                       },
                       {
-                        "key": "prometheus",
-                        "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
-                        }
-                      },
-                      {
-                        "key": "prometheus_replica",
-                        "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
-                        }
-                      },
-                      {
                         "key": "service",
                         "value": {
                           "stringValue": "test-service"
@@ -23478,12 +18042,6 @@
                   {
                     "asDouble": 0,
                     "attributes": [
-                      {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "https-metrics"
-                        }
-                      },
                       {
                         "key": "id",
                         "value": {
@@ -23509,18 +18067,6 @@
                         }
                       },
                       {
-                        "key": "prometheus",
-                        "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
-                        }
-                      },
-                      {
-                        "key": "prometheus_replica",
-                        "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
-                        }
-                      },
-                      {
                         "key": "service",
                         "value": {
                           "stringValue": "test-service"
@@ -23533,12 +18079,6 @@
                   {
                     "asDouble": 0,
                     "attributes": [
-                      {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "https-metrics"
-                        }
-                      },
                       {
                         "key": "id",
                         "value": {
@@ -23564,18 +18104,6 @@
                         }
                       },
                       {
-                        "key": "prometheus",
-                        "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
-                        }
-                      },
-                      {
-                        "key": "prometheus_replica",
-                        "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
-                        }
-                      },
-                      {
                         "key": "service",
                         "value": {
                           "stringValue": "test-service"
@@ -23588,12 +18116,6 @@
                   {
                     "asDouble": 0,
                     "attributes": [
-                      {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "https-metrics"
-                        }
-                      },
                       {
                         "key": "id",
                         "value": {
@@ -23619,18 +18141,6 @@
                         }
                       },
                       {
-                        "key": "prometheus",
-                        "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
-                        }
-                      },
-                      {
-                        "key": "prometheus_replica",
-                        "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
-                        }
-                      },
-                      {
                         "key": "service",
                         "value": {
                           "stringValue": "test-service"
@@ -23643,12 +18153,6 @@
                   {
                     "asDouble": 0,
                     "attributes": [
-                      {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "https-metrics"
-                        }
-                      },
                       {
                         "key": "id",
                         "value": {
@@ -23674,18 +18178,6 @@
                         }
                       },
                       {
-                        "key": "prometheus",
-                        "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
-                        }
-                      },
-                      {
-                        "key": "prometheus_replica",
-                        "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
-                        }
-                      },
-                      {
                         "key": "service",
                         "value": {
                           "stringValue": "test-service"
@@ -23698,12 +18190,6 @@
                   {
                     "asDouble": 0,
                     "attributes": [
-                      {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "https-metrics"
-                        }
-                      },
                       {
                         "key": "id",
                         "value": {
@@ -23729,18 +18215,6 @@
                         }
                       },
                       {
-                        "key": "prometheus",
-                        "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
-                        }
-                      },
-                      {
-                        "key": "prometheus_replica",
-                        "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
-                        }
-                      },
-                      {
                         "key": "service",
                         "value": {
                           "stringValue": "test-service"
@@ -23753,12 +18227,6 @@
                   {
                     "asDouble": 0,
                     "attributes": [
-                      {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "https-metrics"
-                        }
-                      },
                       {
                         "key": "id",
                         "value": {
@@ -23784,18 +18252,6 @@
                         }
                       },
                       {
-                        "key": "prometheus",
-                        "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
-                        }
-                      },
-                      {
-                        "key": "prometheus_replica",
-                        "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
-                        }
-                      },
-                      {
                         "key": "service",
                         "value": {
                           "stringValue": "test-service"
@@ -23808,12 +18264,6 @@
                   {
                     "asDouble": 0,
                     "attributes": [
-                      {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "https-metrics"
-                        }
-                      },
                       {
                         "key": "id",
                         "value": {
@@ -23839,18 +18289,6 @@
                         }
                       },
                       {
-                        "key": "prometheus",
-                        "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
-                        }
-                      },
-                      {
-                        "key": "prometheus_replica",
-                        "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
-                        }
-                      },
-                      {
                         "key": "service",
                         "value": {
                           "stringValue": "test-service"
@@ -23863,12 +18301,6 @@
                   {
                     "asDouble": 0,
                     "attributes": [
-                      {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "https-metrics"
-                        }
-                      },
                       {
                         "key": "id",
                         "value": {
@@ -23894,18 +18326,6 @@
                         }
                       },
                       {
-                        "key": "prometheus",
-                        "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
-                        }
-                      },
-                      {
-                        "key": "prometheus_replica",
-                        "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
-                        }
-                      },
-                      {
                         "key": "service",
                         "value": {
                           "stringValue": "test-service"
@@ -23918,12 +18338,6 @@
                   {
                     "asDouble": 0,
                     "attributes": [
-                      {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "https-metrics"
-                        }
-                      },
                       {
                         "key": "id",
                         "value": {
@@ -23949,18 +18363,6 @@
                         }
                       },
                       {
-                        "key": "prometheus",
-                        "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
-                        }
-                      },
-                      {
-                        "key": "prometheus_replica",
-                        "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
-                        }
-                      },
-                      {
                         "key": "service",
                         "value": {
                           "stringValue": "test-service"
@@ -23973,12 +18375,6 @@
                   {
                     "asDouble": 0,
                     "attributes": [
-                      {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "https-metrics"
-                        }
-                      },
                       {
                         "key": "id",
                         "value": {
@@ -24004,18 +18400,6 @@
                         }
                       },
                       {
-                        "key": "prometheus",
-                        "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
-                        }
-                      },
-                      {
-                        "key": "prometheus_replica",
-                        "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
-                        }
-                      },
-                      {
                         "key": "service",
                         "value": {
                           "stringValue": "test-service"
@@ -24028,12 +18412,6 @@
                   {
                     "asDouble": 0,
                     "attributes": [
-                      {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "https-metrics"
-                        }
-                      },
                       {
                         "key": "id",
                         "value": {
@@ -24056,18 +18434,6 @@
                         "key": "node",
                         "value": {
                           "stringValue": "test-node"
-                        }
-                      },
-                      {
-                        "key": "prometheus",
-                        "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
-                        }
-                      },
-                      {
-                        "key": "prometheus_replica",
-                        "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
                         }
                       },
                       {
@@ -24099,12 +18465,6 @@
                         }
                       },
                       {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "https-metrics"
-                        }
-                      },
-                      {
                         "key": "id",
                         "value": {
                           "stringValue": "/kubepods/burstable"
@@ -24120,18 +18480,6 @@
                         "key": "node",
                         "value": {
                           "stringValue": "test-node"
-                        }
-                      },
-                      {
-                        "key": "prometheus",
-                        "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
-                        }
-                      },
-                      {
-                        "key": "prometheus_replica",
-                        "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
                         }
                       },
                       {
@@ -24153,12 +18501,6 @@
                         }
                       },
                       {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "https-metrics"
-                        }
-                      },
-                      {
                         "key": "id",
                         "value": {
                           "stringValue": "/kubepods"
@@ -24174,18 +18516,6 @@
                         "key": "node",
                         "value": {
                           "stringValue": "test-node"
-                        }
-                      },
-                      {
-                        "key": "prometheus",
-                        "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
-                        }
-                      },
-                      {
-                        "key": "prometheus_replica",
-                        "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
                         }
                       },
                       {
@@ -24207,12 +18537,6 @@
                         }
                       },
                       {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "https-metrics"
-                        }
-                      },
-                      {
                         "key": "id",
                         "value": {
                           "stringValue": "/"
@@ -24228,18 +18552,6 @@
                         "key": "node",
                         "value": {
                           "stringValue": "test-node"
-                        }
-                      },
-                      {
-                        "key": "prometheus",
-                        "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
-                        }
-                      },
-                      {
-                        "key": "prometheus_replica",
-                        "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
                         }
                       },
                       {
@@ -24270,12 +18582,6 @@
                         }
                       },
                       {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "https-metrics"
-                        }
-                      },
-                      {
                         "key": "id",
                         "value": {
                           "stringValue": "/kubepods/burstable"
@@ -24294,18 +18600,6 @@
                         }
                       },
                       {
-                        "key": "prometheus",
-                        "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
-                        }
-                      },
-                      {
-                        "key": "prometheus_replica",
-                        "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
-                        }
-                      },
-                      {
                         "key": "service",
                         "value": {
                           "stringValue": "test-service"
@@ -24321,12 +18615,6 @@
                         "key": "device",
                         "value": {
                           "stringValue": "/dev/nvme0n1"
-                        }
-                      },
-                      {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "https-metrics"
                         }
                       },
                       {
@@ -24348,18 +18636,6 @@
                         }
                       },
                       {
-                        "key": "prometheus",
-                        "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
-                        }
-                      },
-                      {
-                        "key": "prometheus_replica",
-                        "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
-                        }
-                      },
-                      {
                         "key": "service",
                         "value": {
                           "stringValue": "test-service"
@@ -24378,12 +18654,6 @@
                         }
                       },
                       {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "https-metrics"
-                        }
-                      },
-                      {
                         "key": "id",
                         "value": {
                           "stringValue": "/"
@@ -24399,18 +18669,6 @@
                         "key": "node",
                         "value": {
                           "stringValue": "test-node"
-                        }
-                      },
-                      {
-                        "key": "prometheus",
-                        "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
-                        }
-                      },
-                      {
-                        "key": "prometheus_replica",
-                        "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
                         }
                       },
                       {
@@ -24432,12 +18690,6 @@
                         }
                       },
                       {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "https-metrics"
-                        }
-                      },
-                      {
                         "key": "id",
                         "value": {
                           "stringValue": "/kubepods/burstable"
@@ -24456,18 +18708,6 @@
                         }
                       },
                       {
-                        "key": "prometheus",
-                        "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
-                        }
-                      },
-                      {
-                        "key": "prometheus_replica",
-                        "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
-                        }
-                      },
-                      {
                         "key": "service",
                         "value": {
                           "stringValue": "test-service"
@@ -24483,12 +18723,6 @@
                         "key": "device",
                         "value": {
                           "stringValue": "/dev/nvme1n1"
-                        }
-                      },
-                      {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "https-metrics"
                         }
                       },
                       {
@@ -24510,18 +18744,6 @@
                         }
                       },
                       {
-                        "key": "prometheus",
-                        "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
-                        }
-                      },
-                      {
-                        "key": "prometheus_replica",
-                        "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
-                        }
-                      },
-                      {
                         "key": "service",
                         "value": {
                           "stringValue": "test-service"
@@ -24540,12 +18762,6 @@
                         }
                       },
                       {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "https-metrics"
-                        }
-                      },
-                      {
                         "key": "id",
                         "value": {
                           "stringValue": "/"
@@ -24561,18 +18777,6 @@
                         "key": "node",
                         "value": {
                           "stringValue": "test-node"
-                        }
-                      },
-                      {
-                        "key": "prometheus",
-                        "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
-                        }
-                      },
-                      {
-                        "key": "prometheus_replica",
-                        "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
                         }
                       },
                       {
@@ -24603,12 +18807,6 @@
                         }
                       },
                       {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "https-metrics"
-                        }
-                      },
-                      {
                         "key": "id",
                         "value": {
                           "stringValue": "/kubepods/burstable"
@@ -24627,18 +18825,6 @@
                         }
                       },
                       {
-                        "key": "prometheus",
-                        "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
-                        }
-                      },
-                      {
-                        "key": "prometheus_replica",
-                        "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
-                        }
-                      },
-                      {
                         "key": "service",
                         "value": {
                           "stringValue": "test-service"
@@ -24654,12 +18840,6 @@
                         "key": "device",
                         "value": {
                           "stringValue": "/dev/nvme0n1"
-                        }
-                      },
-                      {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "https-metrics"
                         }
                       },
                       {
@@ -24681,18 +18861,6 @@
                         }
                       },
                       {
-                        "key": "prometheus",
-                        "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
-                        }
-                      },
-                      {
-                        "key": "prometheus_replica",
-                        "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
-                        }
-                      },
-                      {
                         "key": "service",
                         "value": {
                           "stringValue": "test-service"
@@ -24711,12 +18879,6 @@
                         }
                       },
                       {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "https-metrics"
-                        }
-                      },
-                      {
                         "key": "id",
                         "value": {
                           "stringValue": "/"
@@ -24732,18 +18894,6 @@
                         "key": "node",
                         "value": {
                           "stringValue": "test-node"
-                        }
-                      },
-                      {
-                        "key": "prometheus",
-                        "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
-                        }
-                      },
-                      {
-                        "key": "prometheus_replica",
-                        "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
                         }
                       },
                       {
@@ -24765,12 +18915,6 @@
                         }
                       },
                       {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "https-metrics"
-                        }
-                      },
-                      {
                         "key": "id",
                         "value": {
                           "stringValue": "/"
@@ -24786,18 +18930,6 @@
                         "key": "node",
                         "value": {
                           "stringValue": "test-node"
-                        }
-                      },
-                      {
-                        "key": "prometheus",
-                        "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
-                        }
-                      },
-                      {
-                        "key": "prometheus_replica",
-                        "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
                         }
                       },
                       {
@@ -24819,12 +18951,6 @@
                         }
                       },
                       {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "https-metrics"
-                        }
-                      },
-                      {
                         "key": "id",
                         "value": {
                           "stringValue": "/kubepods/burstable"
@@ -24843,18 +18969,6 @@
                         }
                       },
                       {
-                        "key": "prometheus",
-                        "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
-                        }
-                      },
-                      {
-                        "key": "prometheus_replica",
-                        "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
-                        }
-                      },
-                      {
                         "key": "service",
                         "value": {
                           "stringValue": "test-service"
@@ -24870,12 +18984,6 @@
                         "key": "device",
                         "value": {
                           "stringValue": "/dev/nvme1n1"
-                        }
-                      },
-                      {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "https-metrics"
                         }
                       },
                       {
@@ -24897,18 +19005,6 @@
                         }
                       },
                       {
-                        "key": "prometheus",
-                        "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
-                        }
-                      },
-                      {
-                        "key": "prometheus_replica",
-                        "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
-                        }
-                      },
-                      {
                         "key": "service",
                         "value": {
                           "stringValue": "test-service"
@@ -24927,12 +19023,6 @@
                         }
                       },
                       {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "https-metrics"
-                        }
-                      },
-                      {
                         "key": "id",
                         "value": {
                           "stringValue": "/"
@@ -24948,18 +19038,6 @@
                         "key": "node",
                         "value": {
                           "stringValue": "test-node"
-                        }
-                      },
-                      {
-                        "key": "prometheus",
-                        "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
-                        }
-                      },
-                      {
-                        "key": "prometheus_replica",
-                        "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
                         }
                       },
                       {
@@ -24981,12 +19059,6 @@
                         }
                       },
                       {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "https-metrics"
-                        }
-                      },
-                      {
                         "key": "id",
                         "value": {
                           "stringValue": "/"
@@ -25002,18 +19074,6 @@
                         "key": "node",
                         "value": {
                           "stringValue": "test-node"
-                        }
-                      },
-                      {
-                        "key": "prometheus",
-                        "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
-                        }
-                      },
-                      {
-                        "key": "prometheus_replica",
-                        "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
                         }
                       },
                       {
@@ -25035,12 +19095,6 @@
                         }
                       },
                       {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "https-metrics"
-                        }
-                      },
-                      {
                         "key": "id",
                         "value": {
                           "stringValue": "/"
@@ -25056,18 +19110,6 @@
                         "key": "node",
                         "value": {
                           "stringValue": "test-node"
-                        }
-                      },
-                      {
-                        "key": "prometheus",
-                        "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
-                        }
-                      },
-                      {
-                        "key": "prometheus_replica",
-                        "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
                         }
                       },
                       {
@@ -25089,12 +19131,6 @@
                         }
                       },
                       {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "https-metrics"
-                        }
-                      },
-                      {
                         "key": "id",
                         "value": {
                           "stringValue": "/"
@@ -25110,18 +19146,6 @@
                         "key": "node",
                         "value": {
                           "stringValue": "test-node"
-                        }
-                      },
-                      {
-                        "key": "prometheus",
-                        "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
-                        }
-                      },
-                      {
-                        "key": "prometheus_replica",
-                        "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
                         }
                       },
                       {
@@ -25150,12 +19174,6 @@
                         }
                       },
                       {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "https-metrics"
-                        }
-                      },
-                      {
                         "key": "id",
                         "value": {
                           "stringValue": "/"
@@ -25171,18 +19189,6 @@
                         "key": "node",
                         "value": {
                           "stringValue": "test-node"
-                        }
-                      },
-                      {
-                        "key": "prometheus",
-                        "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
-                        }
-                      },
-                      {
-                        "key": "prometheus_replica",
-                        "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
                         }
                       },
                       {
@@ -25204,12 +19210,6 @@
                         }
                       },
                       {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "https-metrics"
-                        }
-                      },
-                      {
                         "key": "id",
                         "value": {
                           "stringValue": "/"
@@ -25225,18 +19225,6 @@
                         "key": "node",
                         "value": {
                           "stringValue": "test-node"
-                        }
-                      },
-                      {
-                        "key": "prometheus",
-                        "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
-                        }
-                      },
-                      {
-                        "key": "prometheus_replica",
-                        "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
                         }
                       },
                       {
@@ -25258,12 +19246,6 @@
                         }
                       },
                       {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "https-metrics"
-                        }
-                      },
-                      {
                         "key": "id",
                         "value": {
                           "stringValue": "/"
@@ -25279,18 +19261,6 @@
                         "key": "node",
                         "value": {
                           "stringValue": "test-node"
-                        }
-                      },
-                      {
-                        "key": "prometheus",
-                        "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
-                        }
-                      },
-                      {
-                        "key": "prometheus_replica",
-                        "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
                         }
                       },
                       {
@@ -25312,12 +19282,6 @@
                         }
                       },
                       {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "https-metrics"
-                        }
-                      },
-                      {
                         "key": "id",
                         "value": {
                           "stringValue": "/"
@@ -25333,18 +19297,6 @@
                         "key": "node",
                         "value": {
                           "stringValue": "test-node"
-                        }
-                      },
-                      {
-                        "key": "prometheus",
-                        "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
-                        }
-                      },
-                      {
-                        "key": "prometheus_replica",
-                        "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
                         }
                       },
                       {
@@ -25375,12 +19327,6 @@
                         }
                       },
                       {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "https-metrics"
-                        }
-                      },
-                      {
                         "key": "id",
                         "value": {
                           "stringValue": "/kubepods/burstable"
@@ -25399,18 +19345,6 @@
                         }
                       },
                       {
-                        "key": "prometheus",
-                        "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
-                        }
-                      },
-                      {
-                        "key": "prometheus_replica",
-                        "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
-                        }
-                      },
-                      {
                         "key": "service",
                         "value": {
                           "stringValue": "test-service"
@@ -25426,12 +19360,6 @@
                         "key": "device",
                         "value": {
                           "stringValue": "/dev/nvme0n1"
-                        }
-                      },
-                      {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "https-metrics"
                         }
                       },
                       {
@@ -25453,18 +19381,6 @@
                         }
                       },
                       {
-                        "key": "prometheus",
-                        "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
-                        }
-                      },
-                      {
-                        "key": "prometheus_replica",
-                        "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
-                        }
-                      },
-                      {
                         "key": "service",
                         "value": {
                           "stringValue": "test-service"
@@ -25483,12 +19399,6 @@
                         }
                       },
                       {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "https-metrics"
-                        }
-                      },
-                      {
                         "key": "id",
                         "value": {
                           "stringValue": "/"
@@ -25504,18 +19414,6 @@
                         "key": "node",
                         "value": {
                           "stringValue": "test-node"
-                        }
-                      },
-                      {
-                        "key": "prometheus",
-                        "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
-                        }
-                      },
-                      {
-                        "key": "prometheus_replica",
-                        "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
                         }
                       },
                       {
@@ -25537,12 +19435,6 @@
                         }
                       },
                       {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "https-metrics"
-                        }
-                      },
-                      {
                         "key": "id",
                         "value": {
                           "stringValue": "/kubepods/burstable"
@@ -25561,18 +19453,6 @@
                         }
                       },
                       {
-                        "key": "prometheus",
-                        "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
-                        }
-                      },
-                      {
-                        "key": "prometheus_replica",
-                        "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
-                        }
-                      },
-                      {
                         "key": "service",
                         "value": {
                           "stringValue": "test-service"
@@ -25588,12 +19468,6 @@
                         "key": "device",
                         "value": {
                           "stringValue": "/dev/nvme1n1"
-                        }
-                      },
-                      {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "https-metrics"
                         }
                       },
                       {
@@ -25615,18 +19489,6 @@
                         }
                       },
                       {
-                        "key": "prometheus",
-                        "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
-                        }
-                      },
-                      {
-                        "key": "prometheus_replica",
-                        "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
-                        }
-                      },
-                      {
                         "key": "service",
                         "value": {
                           "stringValue": "test-service"
@@ -25645,12 +19507,6 @@
                         }
                       },
                       {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "https-metrics"
-                        }
-                      },
-                      {
                         "key": "id",
                         "value": {
                           "stringValue": "/"
@@ -25666,18 +19522,6 @@
                         "key": "node",
                         "value": {
                           "stringValue": "test-node"
-                        }
-                      },
-                      {
-                        "key": "prometheus",
-                        "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
-                        }
-                      },
-                      {
-                        "key": "prometheus_replica",
-                        "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
                         }
                       },
                       {
@@ -25708,12 +19552,6 @@
                         }
                       },
                       {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "https-metrics"
-                        }
-                      },
-                      {
                         "key": "id",
                         "value": {
                           "stringValue": "/kubepods/burstable"
@@ -25732,18 +19570,6 @@
                         }
                       },
                       {
-                        "key": "prometheus",
-                        "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
-                        }
-                      },
-                      {
-                        "key": "prometheus_replica",
-                        "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
-                        }
-                      },
-                      {
                         "key": "service",
                         "value": {
                           "stringValue": "test-service"
@@ -25759,12 +19585,6 @@
                         "key": "device",
                         "value": {
                           "stringValue": "/dev/nvme0n1"
-                        }
-                      },
-                      {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "https-metrics"
                         }
                       },
                       {
@@ -25786,18 +19606,6 @@
                         }
                       },
                       {
-                        "key": "prometheus",
-                        "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
-                        }
-                      },
-                      {
-                        "key": "prometheus_replica",
-                        "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
-                        }
-                      },
-                      {
                         "key": "service",
                         "value": {
                           "stringValue": "test-service"
@@ -25816,12 +19624,6 @@
                         }
                       },
                       {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "https-metrics"
-                        }
-                      },
-                      {
                         "key": "id",
                         "value": {
                           "stringValue": "/"
@@ -25837,18 +19639,6 @@
                         "key": "node",
                         "value": {
                           "stringValue": "test-node"
-                        }
-                      },
-                      {
-                        "key": "prometheus",
-                        "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
-                        }
-                      },
-                      {
-                        "key": "prometheus_replica",
-                        "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
                         }
                       },
                       {
@@ -25870,12 +19660,6 @@
                         }
                       },
                       {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "https-metrics"
-                        }
-                      },
-                      {
                         "key": "id",
                         "value": {
                           "stringValue": "/"
@@ -25891,18 +19675,6 @@
                         "key": "node",
                         "value": {
                           "stringValue": "test-node"
-                        }
-                      },
-                      {
-                        "key": "prometheus",
-                        "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
-                        }
-                      },
-                      {
-                        "key": "prometheus_replica",
-                        "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
                         }
                       },
                       {
@@ -25924,12 +19696,6 @@
                         }
                       },
                       {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "https-metrics"
-                        }
-                      },
-                      {
                         "key": "id",
                         "value": {
                           "stringValue": "/kubepods/burstable"
@@ -25948,18 +19714,6 @@
                         }
                       },
                       {
-                        "key": "prometheus",
-                        "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
-                        }
-                      },
-                      {
-                        "key": "prometheus_replica",
-                        "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
-                        }
-                      },
-                      {
                         "key": "service",
                         "value": {
                           "stringValue": "test-service"
@@ -25975,12 +19729,6 @@
                         "key": "device",
                         "value": {
                           "stringValue": "/dev/nvme1n1"
-                        }
-                      },
-                      {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "https-metrics"
                         }
                       },
                       {
@@ -26002,18 +19750,6 @@
                         }
                       },
                       {
-                        "key": "prometheus",
-                        "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
-                        }
-                      },
-                      {
-                        "key": "prometheus_replica",
-                        "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
-                        }
-                      },
-                      {
                         "key": "service",
                         "value": {
                           "stringValue": "test-service"
@@ -26032,12 +19768,6 @@
                         }
                       },
                       {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "https-metrics"
-                        }
-                      },
-                      {
                         "key": "id",
                         "value": {
                           "stringValue": "/"
@@ -26053,18 +19783,6 @@
                         "key": "node",
                         "value": {
                           "stringValue": "test-node"
-                        }
-                      },
-                      {
-                        "key": "prometheus",
-                        "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
-                        }
-                      },
-                      {
-                        "key": "prometheus_replica",
-                        "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
                         }
                       },
                       {
@@ -26086,12 +19804,6 @@
                         }
                       },
                       {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "https-metrics"
-                        }
-                      },
-                      {
                         "key": "id",
                         "value": {
                           "stringValue": "/"
@@ -26107,18 +19819,6 @@
                         "key": "node",
                         "value": {
                           "stringValue": "test-node"
-                        }
-                      },
-                      {
-                        "key": "prometheus",
-                        "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
-                        }
-                      },
-                      {
-                        "key": "prometheus_replica",
-                        "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
                         }
                       },
                       {
@@ -26140,12 +19840,6 @@
                         }
                       },
                       {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "https-metrics"
-                        }
-                      },
-                      {
                         "key": "id",
                         "value": {
                           "stringValue": "/"
@@ -26161,18 +19855,6 @@
                         "key": "node",
                         "value": {
                           "stringValue": "test-node"
-                        }
-                      },
-                      {
-                        "key": "prometheus",
-                        "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
-                        }
-                      },
-                      {
-                        "key": "prometheus_replica",
-                        "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
                         }
                       },
                       {
@@ -26194,12 +19876,6 @@
                         }
                       },
                       {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "https-metrics"
-                        }
-                      },
-                      {
                         "key": "id",
                         "value": {
                           "stringValue": "/"
@@ -26215,18 +19891,6 @@
                         "key": "node",
                         "value": {
                           "stringValue": "test-node"
-                        }
-                      },
-                      {
-                        "key": "prometheus",
-                        "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
-                        }
-                      },
-                      {
-                        "key": "prometheus_replica",
-                        "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
                         }
                       },
                       {
@@ -26249,12 +19913,6 @@
                     "asDouble": 16153878528,
                     "attributes": [
                       {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "https-metrics"
-                        }
-                      },
-                      {
                         "key": "id",
                         "value": {
                           "stringValue": "/kubepods/burstable"
@@ -26273,18 +19931,6 @@
                         }
                       },
                       {
-                        "key": "prometheus",
-                        "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
-                        }
-                      },
-                      {
-                        "key": "prometheus_replica",
-                        "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
-                        }
-                      },
-                      {
                         "key": "service",
                         "value": {
                           "stringValue": "test-service"
@@ -26296,12 +19942,6 @@
                   {
                     "asDouble": 16759918592,
                     "attributes": [
-                      {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "https-metrics"
-                        }
-                      },
                       {
                         "key": "id",
                         "value": {
@@ -26321,18 +19961,6 @@
                         }
                       },
                       {
-                        "key": "prometheus",
-                        "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
-                        }
-                      },
-                      {
-                        "key": "prometheus_replica",
-                        "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
-                        }
-                      },
-                      {
                         "key": "service",
                         "value": {
                           "stringValue": "test-service"
@@ -26344,12 +19972,6 @@
                   {
                     "asDouble": 23541440512,
                     "attributes": [
-                      {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "https-metrics"
-                        }
-                      },
                       {
                         "key": "id",
                         "value": {
@@ -26366,18 +19988,6 @@
                         "key": "node",
                         "value": {
                           "stringValue": "test-node"
-                        }
-                      },
-                      {
-                        "key": "prometheus",
-                        "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
-                        }
-                      },
-                      {
-                        "key": "prometheus_replica",
-                        "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
                         }
                       },
                       {
@@ -26402,12 +20012,6 @@
                     "asDouble": 2678093498,
                     "attributes": [
                       {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "https-metrics"
-                        }
-                      },
-                      {
                         "key": "id",
                         "value": {
                           "stringValue": "/"
@@ -26432,18 +20036,6 @@
                         }
                       },
                       {
-                        "key": "prometheus",
-                        "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
-                        }
-                      },
-                      {
-                        "key": "prometheus_replica",
-                        "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
-                        }
-                      },
-                      {
                         "key": "service",
                         "value": {
                           "stringValue": "test-service"
@@ -26455,12 +20047,6 @@
                   {
                     "asDouble": 218864324,
                     "attributes": [
-                      {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "https-metrics"
-                        }
-                      },
                       {
                         "key": "id",
                         "value": {
@@ -26486,18 +20072,6 @@
                         }
                       },
                       {
-                        "key": "prometheus",
-                        "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
-                        }
-                      },
-                      {
-                        "key": "prometheus_replica",
-                        "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
-                        }
-                      },
-                      {
                         "key": "service",
                         "value": {
                           "stringValue": "test-service"
@@ -26509,12 +20083,6 @@
                   {
                     "asDouble": 2101170261,
                     "attributes": [
-                      {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "https-metrics"
-                        }
-                      },
                       {
                         "key": "id",
                         "value": {
@@ -26540,18 +20108,6 @@
                         }
                       },
                       {
-                        "key": "prometheus",
-                        "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
-                        }
-                      },
-                      {
-                        "key": "prometheus_replica",
-                        "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
-                        }
-                      },
-                      {
                         "key": "service",
                         "value": {
                           "stringValue": "test-service"
@@ -26563,12 +20119,6 @@
                   {
                     "asDouble": 376207215,
                     "attributes": [
-                      {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "https-metrics"
-                        }
-                      },
                       {
                         "key": "id",
                         "value": {
@@ -26594,18 +20144,6 @@
                         }
                       },
                       {
-                        "key": "prometheus",
-                        "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
-                        }
-                      },
-                      {
-                        "key": "prometheus_replica",
-                        "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
-                        }
-                      },
-                      {
                         "key": "service",
                         "value": {
                           "stringValue": "test-service"
@@ -26617,12 +20155,6 @@
                   {
                     "asDouble": 51255391223,
                     "attributes": [
-                      {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "https-metrics"
-                        }
-                      },
                       {
                         "key": "id",
                         "value": {
@@ -26648,18 +20180,6 @@
                         }
                       },
                       {
-                        "key": "prometheus",
-                        "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
-                        }
-                      },
-                      {
-                        "key": "prometheus_replica",
-                        "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
-                        }
-                      },
-                      {
                         "key": "service",
                         "value": {
                           "stringValue": "test-service"
@@ -26671,12 +20191,6 @@
                   {
                     "asDouble": 1180845233,
                     "attributes": [
-                      {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "https-metrics"
-                        }
-                      },
                       {
                         "key": "id",
                         "value": {
@@ -26702,18 +20216,6 @@
                         }
                       },
                       {
-                        "key": "prometheus",
-                        "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
-                        }
-                      },
-                      {
-                        "key": "prometheus_replica",
-                        "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
-                        }
-                      },
-                      {
                         "key": "service",
                         "value": {
                           "stringValue": "test-service"
@@ -26725,12 +20227,6 @@
                   {
                     "asDouble": 1224978156,
                     "attributes": [
-                      {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "https-metrics"
-                        }
-                      },
                       {
                         "key": "id",
                         "value": {
@@ -26756,18 +20252,6 @@
                         }
                       },
                       {
-                        "key": "prometheus",
-                        "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
-                        }
-                      },
-                      {
-                        "key": "prometheus_replica",
-                        "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
-                        }
-                      },
-                      {
                         "key": "service",
                         "value": {
                           "stringValue": "test-service"
@@ -26779,12 +20263,6 @@
                   {
                     "asDouble": 81530276,
                     "attributes": [
-                      {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "https-metrics"
-                        }
-                      },
                       {
                         "key": "id",
                         "value": {
@@ -26810,18 +20288,6 @@
                         }
                       },
                       {
-                        "key": "prometheus",
-                        "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
-                        }
-                      },
-                      {
-                        "key": "prometheus_replica",
-                        "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
-                        }
-                      },
-                      {
                         "key": "service",
                         "value": {
                           "stringValue": "test-service"
@@ -26833,12 +20299,6 @@
                   {
                     "asDouble": 6672,
                     "attributes": [
-                      {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "https-metrics"
-                        }
-                      },
                       {
                         "key": "id",
                         "value": {
@@ -26864,18 +20324,6 @@
                         }
                       },
                       {
-                        "key": "prometheus",
-                        "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
-                        }
-                      },
-                      {
-                        "key": "prometheus_replica",
-                        "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
-                        }
-                      },
-                      {
                         "key": "service",
                         "value": {
                           "stringValue": "test-service"
@@ -26887,12 +20335,6 @@
                   {
                     "asDouble": 946718321,
                     "attributes": [
-                      {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "https-metrics"
-                        }
-                      },
                       {
                         "key": "id",
                         "value": {
@@ -26918,18 +20360,6 @@
                         }
                       },
                       {
-                        "key": "prometheus",
-                        "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
-                        }
-                      },
-                      {
-                        "key": "prometheus_replica",
-                        "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
-                        }
-                      },
-                      {
                         "key": "service",
                         "value": {
                           "stringValue": "test-service"
@@ -26941,12 +20371,6 @@
                   {
                     "asDouble": 53617378,
                     "attributes": [
-                      {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "https-metrics"
-                        }
-                      },
                       {
                         "key": "id",
                         "value": {
@@ -26972,18 +20396,6 @@
                         }
                       },
                       {
-                        "key": "prometheus",
-                        "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
-                        }
-                      },
-                      {
-                        "key": "prometheus_replica",
-                        "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
-                        }
-                      },
-                      {
                         "key": "service",
                         "value": {
                           "stringValue": "test-service"
@@ -26995,12 +20407,6 @@
                   {
                     "asDouble": 23829127252,
                     "attributes": [
-                      {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "https-metrics"
-                        }
-                      },
                       {
                         "key": "id",
                         "value": {
@@ -27026,18 +20432,6 @@
                         }
                       },
                       {
-                        "key": "prometheus",
-                        "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
-                        }
-                      },
-                      {
-                        "key": "prometheus_replica",
-                        "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
-                        }
-                      },
-                      {
                         "key": "service",
                         "value": {
                           "stringValue": "test-service"
@@ -27049,12 +20443,6 @@
                   {
                     "asDouble": 33392685,
                     "attributes": [
-                      {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "https-metrics"
-                        }
-                      },
                       {
                         "key": "id",
                         "value": {
@@ -27080,18 +20468,6 @@
                         }
                       },
                       {
-                        "key": "prometheus",
-                        "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
-                        }
-                      },
-                      {
-                        "key": "prometheus_replica",
-                        "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
-                        }
-                      },
-                      {
                         "key": "service",
                         "value": {
                           "stringValue": "test-service"
@@ -27103,12 +20479,6 @@
                   {
                     "asDouble": 1361402689,
                     "attributes": [
-                      {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "https-metrics"
-                        }
-                      },
                       {
                         "key": "id",
                         "value": {
@@ -27134,18 +20504,6 @@
                         }
                       },
                       {
-                        "key": "prometheus",
-                        "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
-                        }
-                      },
-                      {
-                        "key": "prometheus_replica",
-                        "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
-                        }
-                      },
-                      {
                         "key": "service",
                         "value": {
                           "stringValue": "test-service"
@@ -27157,12 +20515,6 @@
                   {
                     "asDouble": 72777434,
                     "attributes": [
-                      {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "https-metrics"
-                        }
-                      },
                       {
                         "key": "id",
                         "value": {
@@ -27188,18 +20540,6 @@
                         }
                       },
                       {
-                        "key": "prometheus",
-                        "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
-                        }
-                      },
-                      {
-                        "key": "prometheus_replica",
-                        "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
-                        }
-                      },
-                      {
                         "key": "service",
                         "value": {
                           "stringValue": "test-service"
@@ -27211,12 +20551,6 @@
                   {
                     "asDouble": 1590628081,
                     "attributes": [
-                      {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "https-metrics"
-                        }
-                      },
                       {
                         "key": "id",
                         "value": {
@@ -27242,18 +20576,6 @@
                         }
                       },
                       {
-                        "key": "prometheus",
-                        "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
-                        }
-                      },
-                      {
-                        "key": "prometheus_replica",
-                        "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
-                        }
-                      },
-                      {
                         "key": "service",
                         "value": {
                           "stringValue": "test-service"
@@ -27265,12 +20587,6 @@
                   {
                     "asDouble": 190732556856,
                     "attributes": [
-                      {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "https-metrics"
-                        }
-                      },
                       {
                         "key": "id",
                         "value": {
@@ -27296,18 +20612,6 @@
                         }
                       },
                       {
-                        "key": "prometheus",
-                        "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
-                        }
-                      },
-                      {
-                        "key": "prometheus_replica",
-                        "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
-                        }
-                      },
-                      {
                         "key": "service",
                         "value": {
                           "stringValue": "test-service"
@@ -27319,12 +20623,6 @@
                   {
                     "asDouble": 73271658,
                     "attributes": [
-                      {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "https-metrics"
-                        }
-                      },
                       {
                         "key": "id",
                         "value": {
@@ -27350,18 +20648,6 @@
                         }
                       },
                       {
-                        "key": "prometheus",
-                        "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
-                        }
-                      },
-                      {
-                        "key": "prometheus_replica",
-                        "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
-                        }
-                      },
-                      {
                         "key": "service",
                         "value": {
                           "stringValue": "test-service"
@@ -27373,12 +20659,6 @@
                   {
                     "asDouble": 2860427714,
                     "attributes": [
-                      {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "https-metrics"
-                        }
-                      },
                       {
                         "key": "id",
                         "value": {
@@ -27404,18 +20684,6 @@
                         }
                       },
                       {
-                        "key": "prometheus",
-                        "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
-                        }
-                      },
-                      {
-                        "key": "prometheus_replica",
-                        "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
-                        }
-                      },
-                      {
                         "key": "service",
                         "value": {
                           "stringValue": "test-service"
@@ -27427,12 +20695,6 @@
                   {
                     "asDouble": 4599925887,
                     "attributes": [
-                      {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "https-metrics"
-                        }
-                      },
                       {
                         "key": "id",
                         "value": {
@@ -27458,18 +20720,6 @@
                         }
                       },
                       {
-                        "key": "prometheus",
-                        "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
-                        }
-                      },
-                      {
-                        "key": "prometheus_replica",
-                        "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
-                        }
-                      },
-                      {
                         "key": "service",
                         "value": {
                           "stringValue": "test-service"
@@ -27481,12 +20731,6 @@
                   {
                     "asDouble": 547109782,
                     "attributes": [
-                      {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "https-metrics"
-                        }
-                      },
                       {
                         "key": "id",
                         "value": {
@@ -27512,18 +20756,6 @@
                         }
                       },
                       {
-                        "key": "prometheus",
-                        "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
-                        }
-                      },
-                      {
-                        "key": "prometheus_replica",
-                        "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
-                        }
-                      },
-                      {
                         "key": "service",
                         "value": {
                           "stringValue": "test-service"
@@ -27535,12 +20767,6 @@
                   {
                     "asDouble": 1580364248,
                     "attributes": [
-                      {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "https-metrics"
-                        }
-                      },
                       {
                         "key": "id",
                         "value": {
@@ -27566,18 +20792,6 @@
                         }
                       },
                       {
-                        "key": "prometheus",
-                        "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
-                        }
-                      },
-                      {
-                        "key": "prometheus_replica",
-                        "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
-                        }
-                      },
-                      {
                         "key": "service",
                         "value": {
                           "stringValue": "test-service"
@@ -27589,12 +20803,6 @@
                   {
                     "asDouble": 9959410860474,
                     "attributes": [
-                      {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "https-metrics"
-                        }
-                      },
                       {
                         "key": "id",
                         "value": {
@@ -27620,18 +20828,6 @@
                         }
                       },
                       {
-                        "key": "prometheus",
-                        "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
-                        }
-                      },
-                      {
-                        "key": "prometheus_replica",
-                        "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
-                        }
-                      },
-                      {
                         "key": "service",
                         "value": {
                           "stringValue": "test-service"
@@ -27643,12 +20839,6 @@
                   {
                     "asDouble": 3052389234796,
                     "attributes": [
-                      {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "https-metrics"
-                        }
-                      },
                       {
                         "key": "id",
                         "value": {
@@ -27671,18 +20861,6 @@
                         "key": "node",
                         "value": {
                           "stringValue": "test-node"
-                        }
-                      },
-                      {
-                        "key": "prometheus",
-                        "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
-                        }
-                      },
-                      {
-                        "key": "prometheus_replica",
-                        "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
                         }
                       },
                       {
@@ -27707,12 +20885,6 @@
                     "asDouble": 0,
                     "attributes": [
                       {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "https-metrics"
-                        }
-                      },
-                      {
                         "key": "id",
                         "value": {
                           "stringValue": "/"
@@ -27737,18 +20909,6 @@
                         }
                       },
                       {
-                        "key": "prometheus",
-                        "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
-                        }
-                      },
-                      {
-                        "key": "prometheus_replica",
-                        "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
-                        }
-                      },
-                      {
                         "key": "service",
                         "value": {
                           "stringValue": "test-service"
@@ -27760,12 +20920,6 @@
                   {
                     "asDouble": 0,
                     "attributes": [
-                      {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "https-metrics"
-                        }
-                      },
                       {
                         "key": "id",
                         "value": {
@@ -27791,18 +20945,6 @@
                         }
                       },
                       {
-                        "key": "prometheus",
-                        "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
-                        }
-                      },
-                      {
-                        "key": "prometheus_replica",
-                        "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
-                        }
-                      },
-                      {
                         "key": "service",
                         "value": {
                           "stringValue": "test-service"
@@ -27814,12 +20956,6 @@
                   {
                     "asDouble": 0,
                     "attributes": [
-                      {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "https-metrics"
-                        }
-                      },
                       {
                         "key": "id",
                         "value": {
@@ -27845,18 +20981,6 @@
                         }
                       },
                       {
-                        "key": "prometheus",
-                        "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
-                        }
-                      },
-                      {
-                        "key": "prometheus_replica",
-                        "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
-                        }
-                      },
-                      {
                         "key": "service",
                         "value": {
                           "stringValue": "test-service"
@@ -27868,12 +20992,6 @@
                   {
                     "asDouble": 0,
                     "attributes": [
-                      {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "https-metrics"
-                        }
-                      },
                       {
                         "key": "id",
                         "value": {
@@ -27899,18 +21017,6 @@
                         }
                       },
                       {
-                        "key": "prometheus",
-                        "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
-                        }
-                      },
-                      {
-                        "key": "prometheus_replica",
-                        "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
-                        }
-                      },
-                      {
                         "key": "service",
                         "value": {
                           "stringValue": "test-service"
@@ -27922,12 +21028,6 @@
                   {
                     "asDouble": 0,
                     "attributes": [
-                      {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "https-metrics"
-                        }
-                      },
                       {
                         "key": "id",
                         "value": {
@@ -27953,18 +21053,6 @@
                         }
                       },
                       {
-                        "key": "prometheus",
-                        "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
-                        }
-                      },
-                      {
-                        "key": "prometheus_replica",
-                        "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
-                        }
-                      },
-                      {
                         "key": "service",
                         "value": {
                           "stringValue": "test-service"
@@ -27976,12 +21064,6 @@
                   {
                     "asDouble": 0,
                     "attributes": [
-                      {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "https-metrics"
-                        }
-                      },
                       {
                         "key": "id",
                         "value": {
@@ -28007,18 +21089,6 @@
                         }
                       },
                       {
-                        "key": "prometheus",
-                        "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
-                        }
-                      },
-                      {
-                        "key": "prometheus_replica",
-                        "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
-                        }
-                      },
-                      {
                         "key": "service",
                         "value": {
                           "stringValue": "test-service"
@@ -28030,12 +21100,6 @@
                   {
                     "asDouble": 0,
                     "attributes": [
-                      {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "https-metrics"
-                        }
-                      },
                       {
                         "key": "id",
                         "value": {
@@ -28061,18 +21125,6 @@
                         }
                       },
                       {
-                        "key": "prometheus",
-                        "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
-                        }
-                      },
-                      {
-                        "key": "prometheus_replica",
-                        "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
-                        }
-                      },
-                      {
                         "key": "service",
                         "value": {
                           "stringValue": "test-service"
@@ -28084,12 +21136,6 @@
                   {
                     "asDouble": 0,
                     "attributes": [
-                      {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "https-metrics"
-                        }
-                      },
                       {
                         "key": "id",
                         "value": {
@@ -28115,18 +21161,6 @@
                         }
                       },
                       {
-                        "key": "prometheus",
-                        "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
-                        }
-                      },
-                      {
-                        "key": "prometheus_replica",
-                        "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
-                        }
-                      },
-                      {
                         "key": "service",
                         "value": {
                           "stringValue": "test-service"
@@ -28138,12 +21172,6 @@
                   {
                     "asDouble": 0,
                     "attributes": [
-                      {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "https-metrics"
-                        }
-                      },
                       {
                         "key": "id",
                         "value": {
@@ -28169,18 +21197,6 @@
                         }
                       },
                       {
-                        "key": "prometheus",
-                        "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
-                        }
-                      },
-                      {
-                        "key": "prometheus_replica",
-                        "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
-                        }
-                      },
-                      {
                         "key": "service",
                         "value": {
                           "stringValue": "test-service"
@@ -28192,12 +21208,6 @@
                   {
                     "asDouble": 0,
                     "attributes": [
-                      {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "https-metrics"
-                        }
-                      },
                       {
                         "key": "id",
                         "value": {
@@ -28223,18 +21233,6 @@
                         }
                       },
                       {
-                        "key": "prometheus",
-                        "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
-                        }
-                      },
-                      {
-                        "key": "prometheus_replica",
-                        "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
-                        }
-                      },
-                      {
                         "key": "service",
                         "value": {
                           "stringValue": "test-service"
@@ -28246,12 +21244,6 @@
                   {
                     "asDouble": 0,
                     "attributes": [
-                      {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "https-metrics"
-                        }
-                      },
                       {
                         "key": "id",
                         "value": {
@@ -28277,18 +21269,6 @@
                         }
                       },
                       {
-                        "key": "prometheus",
-                        "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
-                        }
-                      },
-                      {
-                        "key": "prometheus_replica",
-                        "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
-                        }
-                      },
-                      {
                         "key": "service",
                         "value": {
                           "stringValue": "test-service"
@@ -28300,12 +21280,6 @@
                   {
                     "asDouble": 0,
                     "attributes": [
-                      {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "https-metrics"
-                        }
-                      },
                       {
                         "key": "id",
                         "value": {
@@ -28331,18 +21305,6 @@
                         }
                       },
                       {
-                        "key": "prometheus",
-                        "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
-                        }
-                      },
-                      {
-                        "key": "prometheus_replica",
-                        "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
-                        }
-                      },
-                      {
                         "key": "service",
                         "value": {
                           "stringValue": "test-service"
@@ -28354,12 +21316,6 @@
                   {
                     "asDouble": 0,
                     "attributes": [
-                      {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "https-metrics"
-                        }
-                      },
                       {
                         "key": "id",
                         "value": {
@@ -28385,18 +21341,6 @@
                         }
                       },
                       {
-                        "key": "prometheus",
-                        "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
-                        }
-                      },
-                      {
-                        "key": "prometheus_replica",
-                        "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
-                        }
-                      },
-                      {
                         "key": "service",
                         "value": {
                           "stringValue": "test-service"
@@ -28408,12 +21352,6 @@
                   {
                     "asDouble": 0,
                     "attributes": [
-                      {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "https-metrics"
-                        }
-                      },
                       {
                         "key": "id",
                         "value": {
@@ -28439,18 +21377,6 @@
                         }
                       },
                       {
-                        "key": "prometheus",
-                        "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
-                        }
-                      },
-                      {
-                        "key": "prometheus_replica",
-                        "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
-                        }
-                      },
-                      {
                         "key": "service",
                         "value": {
                           "stringValue": "test-service"
@@ -28462,12 +21388,6 @@
                   {
                     "asDouble": 0,
                     "attributes": [
-                      {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "https-metrics"
-                        }
-                      },
                       {
                         "key": "id",
                         "value": {
@@ -28493,18 +21413,6 @@
                         }
                       },
                       {
-                        "key": "prometheus",
-                        "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
-                        }
-                      },
-                      {
-                        "key": "prometheus_replica",
-                        "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
-                        }
-                      },
-                      {
                         "key": "service",
                         "value": {
                           "stringValue": "test-service"
@@ -28516,12 +21424,6 @@
                   {
                     "asDouble": 0,
                     "attributes": [
-                      {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "https-metrics"
-                        }
-                      },
                       {
                         "key": "id",
                         "value": {
@@ -28547,18 +21449,6 @@
                         }
                       },
                       {
-                        "key": "prometheus",
-                        "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
-                        }
-                      },
-                      {
-                        "key": "prometheus_replica",
-                        "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
-                        }
-                      },
-                      {
                         "key": "service",
                         "value": {
                           "stringValue": "test-service"
@@ -28570,12 +21460,6 @@
                   {
                     "asDouble": 0,
                     "attributes": [
-                      {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "https-metrics"
-                        }
-                      },
                       {
                         "key": "id",
                         "value": {
@@ -28601,18 +21485,6 @@
                         }
                       },
                       {
-                        "key": "prometheus",
-                        "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
-                        }
-                      },
-                      {
-                        "key": "prometheus_replica",
-                        "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
-                        }
-                      },
-                      {
                         "key": "service",
                         "value": {
                           "stringValue": "test-service"
@@ -28624,12 +21496,6 @@
                   {
                     "asDouble": 0,
                     "attributes": [
-                      {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "https-metrics"
-                        }
-                      },
                       {
                         "key": "id",
                         "value": {
@@ -28655,18 +21521,6 @@
                         }
                       },
                       {
-                        "key": "prometheus",
-                        "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
-                        }
-                      },
-                      {
-                        "key": "prometheus_replica",
-                        "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
-                        }
-                      },
-                      {
                         "key": "service",
                         "value": {
                           "stringValue": "test-service"
@@ -28678,12 +21532,6 @@
                   {
                     "asDouble": 0,
                     "attributes": [
-                      {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "https-metrics"
-                        }
-                      },
                       {
                         "key": "id",
                         "value": {
@@ -28709,18 +21557,6 @@
                         }
                       },
                       {
-                        "key": "prometheus",
-                        "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
-                        }
-                      },
-                      {
-                        "key": "prometheus_replica",
-                        "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
-                        }
-                      },
-                      {
                         "key": "service",
                         "value": {
                           "stringValue": "test-service"
@@ -28732,12 +21568,6 @@
                   {
                     "asDouble": 0,
                     "attributes": [
-                      {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "https-metrics"
-                        }
-                      },
                       {
                         "key": "id",
                         "value": {
@@ -28763,18 +21593,6 @@
                         }
                       },
                       {
-                        "key": "prometheus",
-                        "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
-                        }
-                      },
-                      {
-                        "key": "prometheus_replica",
-                        "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
-                        }
-                      },
-                      {
                         "key": "service",
                         "value": {
                           "stringValue": "test-service"
@@ -28786,12 +21604,6 @@
                   {
                     "asDouble": 0,
                     "attributes": [
-                      {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "https-metrics"
-                        }
-                      },
                       {
                         "key": "id",
                         "value": {
@@ -28817,18 +21629,6 @@
                         }
                       },
                       {
-                        "key": "prometheus",
-                        "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
-                        }
-                      },
-                      {
-                        "key": "prometheus_replica",
-                        "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
-                        }
-                      },
-                      {
                         "key": "service",
                         "value": {
                           "stringValue": "test-service"
@@ -28840,12 +21640,6 @@
                   {
                     "asDouble": 0,
                     "attributes": [
-                      {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "https-metrics"
-                        }
-                      },
                       {
                         "key": "id",
                         "value": {
@@ -28871,18 +21665,6 @@
                         }
                       },
                       {
-                        "key": "prometheus",
-                        "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
-                        }
-                      },
-                      {
-                        "key": "prometheus_replica",
-                        "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
-                        }
-                      },
-                      {
                         "key": "service",
                         "value": {
                           "stringValue": "test-service"
@@ -28894,12 +21676,6 @@
                   {
                     "asDouble": 0,
                     "attributes": [
-                      {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "https-metrics"
-                        }
-                      },
                       {
                         "key": "id",
                         "value": {
@@ -28925,18 +21701,6 @@
                         }
                       },
                       {
-                        "key": "prometheus",
-                        "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
-                        }
-                      },
-                      {
-                        "key": "prometheus_replica",
-                        "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
-                        }
-                      },
-                      {
                         "key": "service",
                         "value": {
                           "stringValue": "test-service"
@@ -28948,12 +21712,6 @@
                   {
                     "asDouble": 0,
                     "attributes": [
-                      {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "https-metrics"
-                        }
-                      },
                       {
                         "key": "id",
                         "value": {
@@ -28976,18 +21734,6 @@
                         "key": "node",
                         "value": {
                           "stringValue": "test-node"
-                        }
-                      },
-                      {
-                        "key": "prometheus",
-                        "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
-                        }
-                      },
-                      {
-                        "key": "prometheus_replica",
-                        "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
                         }
                       },
                       {
@@ -29012,12 +21758,6 @@
                     "asDouble": 5342695,
                     "attributes": [
                       {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "https-metrics"
-                        }
-                      },
-                      {
                         "key": "id",
                         "value": {
                           "stringValue": "/"
@@ -29042,18 +21782,6 @@
                         }
                       },
                       {
-                        "key": "prometheus",
-                        "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
-                        }
-                      },
-                      {
-                        "key": "prometheus_replica",
-                        "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
-                        }
-                      },
-                      {
                         "key": "service",
                         "value": {
                           "stringValue": "test-service"
@@ -29065,12 +21793,6 @@
                   {
                     "asDouble": 2850387,
                     "attributes": [
-                      {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "https-metrics"
-                        }
-                      },
                       {
                         "key": "id",
                         "value": {
@@ -29096,18 +21818,6 @@
                         }
                       },
                       {
-                        "key": "prometheus",
-                        "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
-                        }
-                      },
-                      {
-                        "key": "prometheus_replica",
-                        "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
-                        }
-                      },
-                      {
                         "key": "service",
                         "value": {
                           "stringValue": "test-service"
@@ -29119,12 +21829,6 @@
                   {
                     "asDouble": 4079599,
                     "attributes": [
-                      {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "https-metrics"
-                        }
-                      },
                       {
                         "key": "id",
                         "value": {
@@ -29150,18 +21854,6 @@
                         }
                       },
                       {
-                        "key": "prometheus",
-                        "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
-                        }
-                      },
-                      {
-                        "key": "prometheus_replica",
-                        "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
-                        }
-                      },
-                      {
                         "key": "service",
                         "value": {
                           "stringValue": "test-service"
@@ -29173,12 +21865,6 @@
                   {
                     "asDouble": 452104,
                     "attributes": [
-                      {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "https-metrics"
-                        }
-                      },
                       {
                         "key": "id",
                         "value": {
@@ -29204,18 +21890,6 @@
                         }
                       },
                       {
-                        "key": "prometheus",
-                        "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
-                        }
-                      },
-                      {
-                        "key": "prometheus_replica",
-                        "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
-                        }
-                      },
-                      {
                         "key": "service",
                         "value": {
                           "stringValue": "test-service"
@@ -29227,12 +21901,6 @@
                   {
                     "asDouble": 15021902,
                     "attributes": [
-                      {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "https-metrics"
-                        }
-                      },
                       {
                         "key": "id",
                         "value": {
@@ -29258,18 +21926,6 @@
                         }
                       },
                       {
-                        "key": "prometheus",
-                        "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
-                        }
-                      },
-                      {
-                        "key": "prometheus_replica",
-                        "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
-                        }
-                      },
-                      {
                         "key": "service",
                         "value": {
                           "stringValue": "test-service"
@@ -29281,12 +21937,6 @@
                   {
                     "asDouble": 1513657,
                     "attributes": [
-                      {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "https-metrics"
-                        }
-                      },
                       {
                         "key": "id",
                         "value": {
@@ -29312,18 +21962,6 @@
                         }
                       },
                       {
-                        "key": "prometheus",
-                        "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
-                        }
-                      },
-                      {
-                        "key": "prometheus_replica",
-                        "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
-                        }
-                      },
-                      {
                         "key": "service",
                         "value": {
                           "stringValue": "test-service"
@@ -29335,12 +21973,6 @@
                   {
                     "asDouble": 1363760,
                     "attributes": [
-                      {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "https-metrics"
-                        }
-                      },
                       {
                         "key": "id",
                         "value": {
@@ -29366,18 +21998,6 @@
                         }
                       },
                       {
-                        "key": "prometheus",
-                        "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
-                        }
-                      },
-                      {
-                        "key": "prometheus_replica",
-                        "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
-                        }
-                      },
-                      {
                         "key": "service",
                         "value": {
                           "stringValue": "test-service"
@@ -29389,12 +22009,6 @@
                   {
                     "asDouble": 460620,
                     "attributes": [
-                      {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "https-metrics"
-                        }
-                      },
                       {
                         "key": "id",
                         "value": {
@@ -29420,18 +22034,6 @@
                         }
                       },
                       {
-                        "key": "prometheus",
-                        "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
-                        }
-                      },
-                      {
-                        "key": "prometheus_replica",
-                        "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
-                        }
-                      },
-                      {
                         "key": "service",
                         "value": {
                           "stringValue": "test-service"
@@ -29443,12 +22045,6 @@
                   {
                     "asDouble": 39,
                     "attributes": [
-                      {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "https-metrics"
-                        }
-                      },
                       {
                         "key": "id",
                         "value": {
@@ -29474,18 +22070,6 @@
                         }
                       },
                       {
-                        "key": "prometheus",
-                        "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
-                        }
-                      },
-                      {
-                        "key": "prometheus_replica",
-                        "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
-                        }
-                      },
-                      {
                         "key": "service",
                         "value": {
                           "stringValue": "test-service"
@@ -29497,12 +22081,6 @@
                   {
                     "asDouble": 1828448,
                     "attributes": [
-                      {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "https-metrics"
-                        }
-                      },
                       {
                         "key": "id",
                         "value": {
@@ -29528,18 +22106,6 @@
                         }
                       },
                       {
-                        "key": "prometheus",
-                        "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
-                        }
-                      },
-                      {
-                        "key": "prometheus_replica",
-                        "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
-                        }
-                      },
-                      {
                         "key": "service",
                         "value": {
                           "stringValue": "test-service"
@@ -29551,12 +22117,6 @@
                   {
                     "asDouble": 332036,
                     "attributes": [
-                      {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "https-metrics"
-                        }
-                      },
                       {
                         "key": "id",
                         "value": {
@@ -29582,18 +22142,6 @@
                         }
                       },
                       {
-                        "key": "prometheus",
-                        "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
-                        }
-                      },
-                      {
-                        "key": "prometheus_replica",
-                        "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
-                        }
-                      },
-                      {
                         "key": "service",
                         "value": {
                           "stringValue": "test-service"
@@ -29605,12 +22153,6 @@
                   {
                     "asDouble": 6271779,
                     "attributes": [
-                      {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "https-metrics"
-                        }
-                      },
                       {
                         "key": "id",
                         "value": {
@@ -29636,18 +22178,6 @@
                         }
                       },
                       {
-                        "key": "prometheus",
-                        "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
-                        }
-                      },
-                      {
-                        "key": "prometheus_replica",
-                        "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
-                        }
-                      },
-                      {
                         "key": "service",
                         "value": {
                           "stringValue": "test-service"
@@ -29659,12 +22189,6 @@
                   {
                     "asDouble": 53501,
                     "attributes": [
-                      {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "https-metrics"
-                        }
-                      },
                       {
                         "key": "id",
                         "value": {
@@ -29690,18 +22214,6 @@
                         }
                       },
                       {
-                        "key": "prometheus",
-                        "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
-                        }
-                      },
-                      {
-                        "key": "prometheus_replica",
-                        "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
-                        }
-                      },
-                      {
                         "key": "service",
                         "value": {
                           "stringValue": "test-service"
@@ -29713,12 +22225,6 @@
                   {
                     "asDouble": 1674499,
                     "attributes": [
-                      {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "https-metrics"
-                        }
-                      },
                       {
                         "key": "id",
                         "value": {
@@ -29744,18 +22250,6 @@
                         }
                       },
                       {
-                        "key": "prometheus",
-                        "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
-                        }
-                      },
-                      {
-                        "key": "prometheus_replica",
-                        "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
-                        }
-                      },
-                      {
                         "key": "service",
                         "value": {
                           "stringValue": "test-service"
@@ -29767,12 +22261,6 @@
                   {
                     "asDouble": 762897,
                     "attributes": [
-                      {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "https-metrics"
-                        }
-                      },
                       {
                         "key": "id",
                         "value": {
@@ -29798,18 +22286,6 @@
                         }
                       },
                       {
-                        "key": "prometheus",
-                        "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
-                        }
-                      },
-                      {
-                        "key": "prometheus_replica",
-                        "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
-                        }
-                      },
-                      {
                         "key": "service",
                         "value": {
                           "stringValue": "test-service"
@@ -29821,12 +22297,6 @@
                   {
                     "asDouble": 3653549,
                     "attributes": [
-                      {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "https-metrics"
-                        }
-                      },
                       {
                         "key": "id",
                         "value": {
@@ -29852,18 +22322,6 @@
                         }
                       },
                       {
-                        "key": "prometheus",
-                        "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
-                        }
-                      },
-                      {
-                        "key": "prometheus_replica",
-                        "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
-                        }
-                      },
-                      {
                         "key": "service",
                         "value": {
                           "stringValue": "test-service"
@@ -29875,12 +22333,6 @@
                   {
                     "asDouble": 606980788,
                     "attributes": [
-                      {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "https-metrics"
-                        }
-                      },
                       {
                         "key": "id",
                         "value": {
@@ -29906,18 +22358,6 @@
                         }
                       },
                       {
-                        "key": "prometheus",
-                        "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
-                        }
-                      },
-                      {
-                        "key": "prometheus_replica",
-                        "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
-                        }
-                      },
-                      {
                         "key": "service",
                         "value": {
                           "stringValue": "test-service"
@@ -29929,12 +22369,6 @@
                   {
                     "asDouble": 770373,
                     "attributes": [
-                      {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "https-metrics"
-                        }
-                      },
                       {
                         "key": "id",
                         "value": {
@@ -29960,18 +22394,6 @@
                         }
                       },
                       {
-                        "key": "prometheus",
-                        "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
-                        }
-                      },
-                      {
-                        "key": "prometheus_replica",
-                        "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
-                        }
-                      },
-                      {
                         "key": "service",
                         "value": {
                           "stringValue": "test-service"
@@ -29983,12 +22405,6 @@
                   {
                     "asDouble": 5387620,
                     "attributes": [
-                      {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "https-metrics"
-                        }
-                      },
                       {
                         "key": "id",
                         "value": {
@@ -30014,18 +22430,6 @@
                         }
                       },
                       {
-                        "key": "prometheus",
-                        "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
-                        }
-                      },
-                      {
-                        "key": "prometheus_replica",
-                        "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
-                        }
-                      },
-                      {
                         "key": "service",
                         "value": {
                           "stringValue": "test-service"
@@ -30037,12 +22441,6 @@
                   {
                     "asDouble": 1351829,
                     "attributes": [
-                      {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "https-metrics"
-                        }
-                      },
                       {
                         "key": "id",
                         "value": {
@@ -30068,18 +22466,6 @@
                         }
                       },
                       {
-                        "key": "prometheus",
-                        "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
-                        }
-                      },
-                      {
-                        "key": "prometheus_replica",
-                        "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
-                        }
-                      },
-                      {
                         "key": "service",
                         "value": {
                           "stringValue": "test-service"
@@ -30091,12 +22477,6 @@
                   {
                     "asDouble": 1584899,
                     "attributes": [
-                      {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "https-metrics"
-                        }
-                      },
                       {
                         "key": "id",
                         "value": {
@@ -30122,18 +22502,6 @@
                         }
                       },
                       {
-                        "key": "prometheus",
-                        "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
-                        }
-                      },
-                      {
-                        "key": "prometheus_replica",
-                        "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
-                        }
-                      },
-                      {
                         "key": "service",
                         "value": {
                           "stringValue": "test-service"
@@ -30145,12 +22513,6 @@
                   {
                     "asDouble": 11019605,
                     "attributes": [
-                      {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "https-metrics"
-                        }
-                      },
                       {
                         "key": "id",
                         "value": {
@@ -30176,18 +22538,6 @@
                         }
                       },
                       {
-                        "key": "prometheus",
-                        "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
-                        }
-                      },
-                      {
-                        "key": "prometheus_replica",
-                        "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
-                        }
-                      },
-                      {
                         "key": "service",
                         "value": {
                           "stringValue": "test-service"
@@ -30199,12 +22549,6 @@
                   {
                     "asDouble": 3313118234,
                     "attributes": [
-                      {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "https-metrics"
-                        }
-                      },
                       {
                         "key": "id",
                         "value": {
@@ -30230,18 +22574,6 @@
                         }
                       },
                       {
-                        "key": "prometheus",
-                        "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
-                        }
-                      },
-                      {
-                        "key": "prometheus_replica",
-                        "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
-                        }
-                      },
-                      {
                         "key": "service",
                         "value": {
                           "stringValue": "test-service"
@@ -30253,12 +22585,6 @@
                   {
                     "asDouble": 1793036884,
                     "attributes": [
-                      {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "https-metrics"
-                        }
-                      },
                       {
                         "key": "id",
                         "value": {
@@ -30281,18 +22607,6 @@
                         "key": "node",
                         "value": {
                           "stringValue": "test-node"
-                        }
-                      },
-                      {
-                        "key": "prometheus",
-                        "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
-                        }
-                      },
-                      {
-                        "key": "prometheus_replica",
-                        "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
                         }
                       },
                       {
@@ -30317,12 +22631,6 @@
                     "asDouble": 30246615989,
                     "attributes": [
                       {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "https-metrics"
-                        }
-                      },
-                      {
                         "key": "id",
                         "value": {
                           "stringValue": "/"
@@ -30347,18 +22655,6 @@
                         }
                       },
                       {
-                        "key": "prometheus",
-                        "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
-                        }
-                      },
-                      {
-                        "key": "prometheus_replica",
-                        "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
-                        }
-                      },
-                      {
                         "key": "service",
                         "value": {
                           "stringValue": "test-service"
@@ -30370,12 +22666,6 @@
                   {
                     "asDouble": 12954348118,
                     "attributes": [
-                      {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "https-metrics"
-                        }
-                      },
                       {
                         "key": "id",
                         "value": {
@@ -30401,18 +22691,6 @@
                         }
                       },
                       {
-                        "key": "prometheus",
-                        "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
-                        }
-                      },
-                      {
-                        "key": "prometheus_replica",
-                        "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
-                        }
-                      },
-                      {
                         "key": "service",
                         "value": {
                           "stringValue": "test-service"
@@ -30424,12 +22702,6 @@
                   {
                     "asDouble": 53454705868,
                     "attributes": [
-                      {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "https-metrics"
-                        }
-                      },
                       {
                         "key": "id",
                         "value": {
@@ -30455,18 +22727,6 @@
                         }
                       },
                       {
-                        "key": "prometheus",
-                        "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
-                        }
-                      },
-                      {
-                        "key": "prometheus_replica",
-                        "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
-                        }
-                      },
-                      {
                         "key": "service",
                         "value": {
                           "stringValue": "test-service"
@@ -30478,12 +22738,6 @@
                   {
                     "asDouble": 36454829,
                     "attributes": [
-                      {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "https-metrics"
-                        }
-                      },
                       {
                         "key": "id",
                         "value": {
@@ -30509,18 +22763,6 @@
                         }
                       },
                       {
-                        "key": "prometheus",
-                        "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
-                        }
-                      },
-                      {
-                        "key": "prometheus_replica",
-                        "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
-                        }
-                      },
-                      {
                         "key": "service",
                         "value": {
                           "stringValue": "test-service"
@@ -30532,12 +22774,6 @@
                   {
                     "asDouble": 1745528714,
                     "attributes": [
-                      {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "https-metrics"
-                        }
-                      },
                       {
                         "key": "id",
                         "value": {
@@ -30563,18 +22799,6 @@
                         }
                       },
                       {
-                        "key": "prometheus",
-                        "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
-                        }
-                      },
-                      {
-                        "key": "prometheus_replica",
-                        "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
-                        }
-                      },
-                      {
                         "key": "service",
                         "value": {
                           "stringValue": "test-service"
@@ -30586,12 +22810,6 @@
                   {
                     "asDouble": 22351974104,
                     "attributes": [
-                      {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "https-metrics"
-                        }
-                      },
                       {
                         "key": "id",
                         "value": {
@@ -30617,18 +22835,6 @@
                         }
                       },
                       {
-                        "key": "prometheus",
-                        "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
-                        }
-                      },
-                      {
-                        "key": "prometheus_replica",
-                        "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
-                        }
-                      },
-                      {
                         "key": "service",
                         "value": {
                           "stringValue": "test-service"
@@ -30640,12 +22846,6 @@
                   {
                     "asDouble": 19674982563,
                     "attributes": [
-                      {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "https-metrics"
-                        }
-                      },
                       {
                         "key": "id",
                         "value": {
@@ -30671,18 +22871,6 @@
                         }
                       },
                       {
-                        "key": "prometheus",
-                        "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
-                        }
-                      },
-                      {
-                        "key": "prometheus_replica",
-                        "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
-                        }
-                      },
-                      {
                         "key": "service",
                         "value": {
                           "stringValue": "test-service"
@@ -30694,12 +22882,6 @@
                   {
                     "asDouble": 632886083,
                     "attributes": [
-                      {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "https-metrics"
-                        }
-                      },
                       {
                         "key": "id",
                         "value": {
@@ -30725,18 +22907,6 @@
                         }
                       },
                       {
-                        "key": "prometheus",
-                        "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
-                        }
-                      },
-                      {
-                        "key": "prometheus_replica",
-                        "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
-                        }
-                      },
-                      {
                         "key": "service",
                         "value": {
                           "stringValue": "test-service"
@@ -30748,12 +22918,6 @@
                   {
                     "asDouble": 8573,
                     "attributes": [
-                      {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "https-metrics"
-                        }
-                      },
                       {
                         "key": "id",
                         "value": {
@@ -30779,18 +22943,6 @@
                         }
                       },
                       {
-                        "key": "prometheus",
-                        "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
-                        }
-                      },
-                      {
-                        "key": "prometheus_replica",
-                        "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
-                        }
-                      },
-                      {
                         "key": "service",
                         "value": {
                           "stringValue": "test-service"
@@ -30802,12 +22954,6 @@
                   {
                     "asDouble": 24219926270,
                     "attributes": [
-                      {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "https-metrics"
-                        }
-                      },
                       {
                         "key": "id",
                         "value": {
@@ -30833,18 +22979,6 @@
                         }
                       },
                       {
-                        "key": "prometheus",
-                        "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
-                        }
-                      },
-                      {
-                        "key": "prometheus_replica",
-                        "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
-                        }
-                      },
-                      {
                         "key": "service",
                         "value": {
                           "stringValue": "test-service"
@@ -30856,12 +22990,6 @@
                   {
                     "asDouble": 876955213,
                     "attributes": [
-                      {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "https-metrics"
-                        }
-                      },
                       {
                         "key": "id",
                         "value": {
@@ -30887,18 +23015,6 @@
                         }
                       },
                       {
-                        "key": "prometheus",
-                        "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
-                        }
-                      },
-                      {
-                        "key": "prometheus_replica",
-                        "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
-                        }
-                      },
-                      {
                         "key": "service",
                         "value": {
                           "stringValue": "test-service"
@@ -30910,12 +23026,6 @@
                   {
                     "asDouble": 66369945759,
                     "attributes": [
-                      {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "https-metrics"
-                        }
-                      },
                       {
                         "key": "id",
                         "value": {
@@ -30941,18 +23051,6 @@
                         }
                       },
                       {
-                        "key": "prometheus",
-                        "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
-                        }
-                      },
-                      {
-                        "key": "prometheus_replica",
-                        "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
-                        }
-                      },
-                      {
                         "key": "service",
                         "value": {
                           "stringValue": "test-service"
@@ -30964,12 +23062,6 @@
                   {
                     "asDouble": 674998757,
                     "attributes": [
-                      {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "https-metrics"
-                        }
-                      },
                       {
                         "key": "id",
                         "value": {
@@ -30995,18 +23087,6 @@
                         }
                       },
                       {
-                        "key": "prometheus",
-                        "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
-                        }
-                      },
-                      {
-                        "key": "prometheus_replica",
-                        "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
-                        }
-                      },
-                      {
                         "key": "service",
                         "value": {
                           "stringValue": "test-service"
@@ -31018,12 +23098,6 @@
                   {
                     "asDouble": 13997043546,
                     "attributes": [
-                      {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "https-metrics"
-                        }
-                      },
                       {
                         "key": "id",
                         "value": {
@@ -31049,18 +23123,6 @@
                         }
                       },
                       {
-                        "key": "prometheus",
-                        "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
-                        }
-                      },
-                      {
-                        "key": "prometheus_replica",
-                        "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
-                        }
-                      },
-                      {
                         "key": "service",
                         "value": {
                           "stringValue": "test-service"
@@ -31072,12 +23134,6 @@
                   {
                     "asDouble": 70626956,
                     "attributes": [
-                      {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "https-metrics"
-                        }
-                      },
                       {
                         "key": "id",
                         "value": {
@@ -31103,18 +23159,6 @@
                         }
                       },
                       {
-                        "key": "prometheus",
-                        "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
-                        }
-                      },
-                      {
-                        "key": "prometheus_replica",
-                        "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
-                        }
-                      },
-                      {
                         "key": "service",
                         "value": {
                           "stringValue": "test-service"
@@ -31126,12 +23170,6 @@
                   {
                     "asDouble": 52620729388,
                     "attributes": [
-                      {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "https-metrics"
-                        }
-                      },
                       {
                         "key": "id",
                         "value": {
@@ -31157,18 +23195,6 @@
                         }
                       },
                       {
-                        "key": "prometheus",
-                        "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
-                        }
-                      },
-                      {
-                        "key": "prometheus_replica",
-                        "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
-                        }
-                      },
-                      {
                         "key": "service",
                         "value": {
                           "stringValue": "test-service"
@@ -31180,12 +23206,6 @@
                   {
                     "asDouble": 651537442530,
                     "attributes": [
-                      {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "https-metrics"
-                        }
-                      },
                       {
                         "key": "id",
                         "value": {
@@ -31211,18 +23231,6 @@
                         }
                       },
                       {
-                        "key": "prometheus",
-                        "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
-                        }
-                      },
-                      {
-                        "key": "prometheus_replica",
-                        "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
-                        }
-                      },
-                      {
                         "key": "service",
                         "value": {
                           "stringValue": "test-service"
@@ -31234,12 +23242,6 @@
                   {
                     "asDouble": 69967815,
                     "attributes": [
-                      {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "https-metrics"
-                        }
-                      },
                       {
                         "key": "id",
                         "value": {
@@ -31265,18 +23267,6 @@
                         }
                       },
                       {
-                        "key": "prometheus",
-                        "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
-                        }
-                      },
-                      {
-                        "key": "prometheus_replica",
-                        "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
-                        }
-                      },
-                      {
                         "key": "service",
                         "value": {
                           "stringValue": "test-service"
@@ -31288,12 +23278,6 @@
                   {
                     "asDouble": 50522824685,
                     "attributes": [
-                      {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "https-metrics"
-                        }
-                      },
                       {
                         "key": "id",
                         "value": {
@@ -31319,18 +23303,6 @@
                         }
                       },
                       {
-                        "key": "prometheus",
-                        "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
-                        }
-                      },
-                      {
-                        "key": "prometheus_replica",
-                        "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
-                        }
-                      },
-                      {
                         "key": "service",
                         "value": {
                           "stringValue": "test-service"
@@ -31342,12 +23314,6 @@
                   {
                     "asDouble": 6898163331,
                     "attributes": [
-                      {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "https-metrics"
-                        }
-                      },
                       {
                         "key": "id",
                         "value": {
@@ -31373,18 +23339,6 @@
                         }
                       },
                       {
-                        "key": "prometheus",
-                        "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
-                        }
-                      },
-                      {
-                        "key": "prometheus_replica",
-                        "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
-                        }
-                      },
-                      {
                         "key": "service",
                         "value": {
                           "stringValue": "test-service"
@@ -31396,12 +23350,6 @@
                   {
                     "asDouble": 23204692063,
                     "attributes": [
-                      {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "https-metrics"
-                        }
-                      },
                       {
                         "key": "id",
                         "value": {
@@ -31427,18 +23375,6 @@
                         }
                       },
                       {
-                        "key": "prometheus",
-                        "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
-                        }
-                      },
-                      {
-                        "key": "prometheus_replica",
-                        "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
-                        }
-                      },
-                      {
                         "key": "service",
                         "value": {
                           "stringValue": "test-service"
@@ -31450,12 +23386,6 @@
                   {
                     "asDouble": 167385009274,
                     "attributes": [
-                      {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "https-metrics"
-                        }
-                      },
                       {
                         "key": "id",
                         "value": {
@@ -31481,18 +23411,6 @@
                         }
                       },
                       {
-                        "key": "prometheus",
-                        "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
-                        }
-                      },
-                      {
-                        "key": "prometheus_replica",
-                        "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
-                        }
-                      },
-                      {
                         "key": "service",
                         "value": {
                           "stringValue": "test-service"
@@ -31504,12 +23422,6 @@
                   {
                     "asDouble": 4678095381492,
                     "attributes": [
-                      {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "https-metrics"
-                        }
-                      },
                       {
                         "key": "id",
                         "value": {
@@ -31535,18 +23447,6 @@
                         }
                       },
                       {
-                        "key": "prometheus",
-                        "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
-                        }
-                      },
-                      {
-                        "key": "prometheus_replica",
-                        "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
-                        }
-                      },
-                      {
                         "key": "service",
                         "value": {
                           "stringValue": "test-service"
@@ -31558,12 +23458,6 @@
                   {
                     "asDouble": 1090082041606,
                     "attributes": [
-                      {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "https-metrics"
-                        }
-                      },
                       {
                         "key": "id",
                         "value": {
@@ -31586,18 +23480,6 @@
                         "key": "node",
                         "value": {
                           "stringValue": "test-node"
-                        }
-                      },
-                      {
-                        "key": "prometheus",
-                        "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
-                        }
-                      },
-                      {
-                        "key": "prometheus_replica",
-                        "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
                         }
                       },
                       {
@@ -31622,12 +23504,6 @@
                     "asDouble": 0,
                     "attributes": [
                       {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "https-metrics"
-                        }
-                      },
-                      {
                         "key": "id",
                         "value": {
                           "stringValue": "/"
@@ -31652,18 +23528,6 @@
                         }
                       },
                       {
-                        "key": "prometheus",
-                        "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
-                        }
-                      },
-                      {
-                        "key": "prometheus_replica",
-                        "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
-                        }
-                      },
-                      {
                         "key": "service",
                         "value": {
                           "stringValue": "test-service"
@@ -31675,12 +23539,6 @@
                   {
                     "asDouble": 0,
                     "attributes": [
-                      {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "https-metrics"
-                        }
-                      },
                       {
                         "key": "id",
                         "value": {
@@ -31706,18 +23564,6 @@
                         }
                       },
                       {
-                        "key": "prometheus",
-                        "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
-                        }
-                      },
-                      {
-                        "key": "prometheus_replica",
-                        "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
-                        }
-                      },
-                      {
                         "key": "service",
                         "value": {
                           "stringValue": "test-service"
@@ -31729,12 +23575,6 @@
                   {
                     "asDouble": 0,
                     "attributes": [
-                      {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "https-metrics"
-                        }
-                      },
                       {
                         "key": "id",
                         "value": {
@@ -31760,18 +23600,6 @@
                         }
                       },
                       {
-                        "key": "prometheus",
-                        "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
-                        }
-                      },
-                      {
-                        "key": "prometheus_replica",
-                        "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
-                        }
-                      },
-                      {
                         "key": "service",
                         "value": {
                           "stringValue": "test-service"
@@ -31783,12 +23611,6 @@
                   {
                     "asDouble": 0,
                     "attributes": [
-                      {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "https-metrics"
-                        }
-                      },
                       {
                         "key": "id",
                         "value": {
@@ -31814,18 +23636,6 @@
                         }
                       },
                       {
-                        "key": "prometheus",
-                        "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
-                        }
-                      },
-                      {
-                        "key": "prometheus_replica",
-                        "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
-                        }
-                      },
-                      {
                         "key": "service",
                         "value": {
                           "stringValue": "test-service"
@@ -31837,12 +23647,6 @@
                   {
                     "asDouble": 0,
                     "attributes": [
-                      {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "https-metrics"
-                        }
-                      },
                       {
                         "key": "id",
                         "value": {
@@ -31868,18 +23672,6 @@
                         }
                       },
                       {
-                        "key": "prometheus",
-                        "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
-                        }
-                      },
-                      {
-                        "key": "prometheus_replica",
-                        "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
-                        }
-                      },
-                      {
                         "key": "service",
                         "value": {
                           "stringValue": "test-service"
@@ -31891,12 +23683,6 @@
                   {
                     "asDouble": 0,
                     "attributes": [
-                      {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "https-metrics"
-                        }
-                      },
                       {
                         "key": "id",
                         "value": {
@@ -31922,18 +23708,6 @@
                         }
                       },
                       {
-                        "key": "prometheus",
-                        "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
-                        }
-                      },
-                      {
-                        "key": "prometheus_replica",
-                        "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
-                        }
-                      },
-                      {
                         "key": "service",
                         "value": {
                           "stringValue": "test-service"
@@ -31945,12 +23719,6 @@
                   {
                     "asDouble": 0,
                     "attributes": [
-                      {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "https-metrics"
-                        }
-                      },
                       {
                         "key": "id",
                         "value": {
@@ -31976,18 +23744,6 @@
                         }
                       },
                       {
-                        "key": "prometheus",
-                        "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
-                        }
-                      },
-                      {
-                        "key": "prometheus_replica",
-                        "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
-                        }
-                      },
-                      {
                         "key": "service",
                         "value": {
                           "stringValue": "test-service"
@@ -31999,12 +23755,6 @@
                   {
                     "asDouble": 0,
                     "attributes": [
-                      {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "https-metrics"
-                        }
-                      },
                       {
                         "key": "id",
                         "value": {
@@ -32030,18 +23780,6 @@
                         }
                       },
                       {
-                        "key": "prometheus",
-                        "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
-                        }
-                      },
-                      {
-                        "key": "prometheus_replica",
-                        "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
-                        }
-                      },
-                      {
                         "key": "service",
                         "value": {
                           "stringValue": "test-service"
@@ -32053,12 +23791,6 @@
                   {
                     "asDouble": 0,
                     "attributes": [
-                      {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "https-metrics"
-                        }
-                      },
                       {
                         "key": "id",
                         "value": {
@@ -32084,18 +23816,6 @@
                         }
                       },
                       {
-                        "key": "prometheus",
-                        "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
-                        }
-                      },
-                      {
-                        "key": "prometheus_replica",
-                        "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
-                        }
-                      },
-                      {
                         "key": "service",
                         "value": {
                           "stringValue": "test-service"
@@ -32107,12 +23827,6 @@
                   {
                     "asDouble": 0,
                     "attributes": [
-                      {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "https-metrics"
-                        }
-                      },
                       {
                         "key": "id",
                         "value": {
@@ -32138,18 +23852,6 @@
                         }
                       },
                       {
-                        "key": "prometheus",
-                        "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
-                        }
-                      },
-                      {
-                        "key": "prometheus_replica",
-                        "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
-                        }
-                      },
-                      {
                         "key": "service",
                         "value": {
                           "stringValue": "test-service"
@@ -32161,12 +23863,6 @@
                   {
                     "asDouble": 0,
                     "attributes": [
-                      {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "https-metrics"
-                        }
-                      },
                       {
                         "key": "id",
                         "value": {
@@ -32192,18 +23888,6 @@
                         }
                       },
                       {
-                        "key": "prometheus",
-                        "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
-                        }
-                      },
-                      {
-                        "key": "prometheus_replica",
-                        "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
-                        }
-                      },
-                      {
                         "key": "service",
                         "value": {
                           "stringValue": "test-service"
@@ -32215,12 +23899,6 @@
                   {
                     "asDouble": 0,
                     "attributes": [
-                      {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "https-metrics"
-                        }
-                      },
                       {
                         "key": "id",
                         "value": {
@@ -32246,18 +23924,6 @@
                         }
                       },
                       {
-                        "key": "prometheus",
-                        "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
-                        }
-                      },
-                      {
-                        "key": "prometheus_replica",
-                        "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
-                        }
-                      },
-                      {
                         "key": "service",
                         "value": {
                           "stringValue": "test-service"
@@ -32269,12 +23935,6 @@
                   {
                     "asDouble": 0,
                     "attributes": [
-                      {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "https-metrics"
-                        }
-                      },
                       {
                         "key": "id",
                         "value": {
@@ -32300,18 +23960,6 @@
                         }
                       },
                       {
-                        "key": "prometheus",
-                        "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
-                        }
-                      },
-                      {
-                        "key": "prometheus_replica",
-                        "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
-                        }
-                      },
-                      {
                         "key": "service",
                         "value": {
                           "stringValue": "test-service"
@@ -32323,12 +23971,6 @@
                   {
                     "asDouble": 0,
                     "attributes": [
-                      {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "https-metrics"
-                        }
-                      },
                       {
                         "key": "id",
                         "value": {
@@ -32354,18 +23996,6 @@
                         }
                       },
                       {
-                        "key": "prometheus",
-                        "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
-                        }
-                      },
-                      {
-                        "key": "prometheus_replica",
-                        "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
-                        }
-                      },
-                      {
                         "key": "service",
                         "value": {
                           "stringValue": "test-service"
@@ -32377,12 +24007,6 @@
                   {
                     "asDouble": 0,
                     "attributes": [
-                      {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "https-metrics"
-                        }
-                      },
                       {
                         "key": "id",
                         "value": {
@@ -32408,18 +24032,6 @@
                         }
                       },
                       {
-                        "key": "prometheus",
-                        "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
-                        }
-                      },
-                      {
-                        "key": "prometheus_replica",
-                        "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
-                        }
-                      },
-                      {
                         "key": "service",
                         "value": {
                           "stringValue": "test-service"
@@ -32431,12 +24043,6 @@
                   {
                     "asDouble": 0,
                     "attributes": [
-                      {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "https-metrics"
-                        }
-                      },
                       {
                         "key": "id",
                         "value": {
@@ -32462,18 +24068,6 @@
                         }
                       },
                       {
-                        "key": "prometheus",
-                        "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
-                        }
-                      },
-                      {
-                        "key": "prometheus_replica",
-                        "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
-                        }
-                      },
-                      {
                         "key": "service",
                         "value": {
                           "stringValue": "test-service"
@@ -32485,12 +24079,6 @@
                   {
                     "asDouble": 0,
                     "attributes": [
-                      {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "https-metrics"
-                        }
-                      },
                       {
                         "key": "id",
                         "value": {
@@ -32516,18 +24104,6 @@
                         }
                       },
                       {
-                        "key": "prometheus",
-                        "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
-                        }
-                      },
-                      {
-                        "key": "prometheus_replica",
-                        "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
-                        }
-                      },
-                      {
                         "key": "service",
                         "value": {
                           "stringValue": "test-service"
@@ -32539,12 +24115,6 @@
                   {
                     "asDouble": 0,
                     "attributes": [
-                      {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "https-metrics"
-                        }
-                      },
                       {
                         "key": "id",
                         "value": {
@@ -32570,18 +24140,6 @@
                         }
                       },
                       {
-                        "key": "prometheus",
-                        "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
-                        }
-                      },
-                      {
-                        "key": "prometheus_replica",
-                        "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
-                        }
-                      },
-                      {
                         "key": "service",
                         "value": {
                           "stringValue": "test-service"
@@ -32593,12 +24151,6 @@
                   {
                     "asDouble": 0,
                     "attributes": [
-                      {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "https-metrics"
-                        }
-                      },
                       {
                         "key": "id",
                         "value": {
@@ -32624,18 +24176,6 @@
                         }
                       },
                       {
-                        "key": "prometheus",
-                        "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
-                        }
-                      },
-                      {
-                        "key": "prometheus_replica",
-                        "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
-                        }
-                      },
-                      {
                         "key": "service",
                         "value": {
                           "stringValue": "test-service"
@@ -32647,12 +24187,6 @@
                   {
                     "asDouble": 0,
                     "attributes": [
-                      {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "https-metrics"
-                        }
-                      },
                       {
                         "key": "id",
                         "value": {
@@ -32678,18 +24212,6 @@
                         }
                       },
                       {
-                        "key": "prometheus",
-                        "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
-                        }
-                      },
-                      {
-                        "key": "prometheus_replica",
-                        "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
-                        }
-                      },
-                      {
                         "key": "service",
                         "value": {
                           "stringValue": "test-service"
@@ -32701,12 +24223,6 @@
                   {
                     "asDouble": 0,
                     "attributes": [
-                      {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "https-metrics"
-                        }
-                      },
                       {
                         "key": "id",
                         "value": {
@@ -32732,18 +24248,6 @@
                         }
                       },
                       {
-                        "key": "prometheus",
-                        "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
-                        }
-                      },
-                      {
-                        "key": "prometheus_replica",
-                        "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
-                        }
-                      },
-                      {
                         "key": "service",
                         "value": {
                           "stringValue": "test-service"
@@ -32755,12 +24259,6 @@
                   {
                     "asDouble": 0,
                     "attributes": [
-                      {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "https-metrics"
-                        }
-                      },
                       {
                         "key": "id",
                         "value": {
@@ -32786,18 +24284,6 @@
                         }
                       },
                       {
-                        "key": "prometheus",
-                        "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
-                        }
-                      },
-                      {
-                        "key": "prometheus_replica",
-                        "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
-                        }
-                      },
-                      {
                         "key": "service",
                         "value": {
                           "stringValue": "test-service"
@@ -32809,12 +24295,6 @@
                   {
                     "asDouble": 0,
                     "attributes": [
-                      {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "https-metrics"
-                        }
-                      },
                       {
                         "key": "id",
                         "value": {
@@ -32840,18 +24320,6 @@
                         }
                       },
                       {
-                        "key": "prometheus",
-                        "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
-                        }
-                      },
-                      {
-                        "key": "prometheus_replica",
-                        "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
-                        }
-                      },
-                      {
                         "key": "service",
                         "value": {
                           "stringValue": "test-service"
@@ -32863,12 +24331,6 @@
                   {
                     "asDouble": 435,
                     "attributes": [
-                      {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "https-metrics"
-                        }
-                      },
                       {
                         "key": "id",
                         "value": {
@@ -32891,18 +24353,6 @@
                         "key": "node",
                         "value": {
                           "stringValue": "test-node"
-                        }
-                      },
-                      {
-                        "key": "prometheus",
-                        "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
-                        }
-                      },
-                      {
-                        "key": "prometheus_replica",
-                        "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
                         }
                       },
                       {
@@ -32927,12 +24377,6 @@
                     "asDouble": 8059373,
                     "attributes": [
                       {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "https-metrics"
-                        }
-                      },
-                      {
                         "key": "id",
                         "value": {
                           "stringValue": "/"
@@ -32957,18 +24401,6 @@
                         }
                       },
                       {
-                        "key": "prometheus",
-                        "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
-                        }
-                      },
-                      {
-                        "key": "prometheus_replica",
-                        "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
-                        }
-                      },
-                      {
                         "key": "service",
                         "value": {
                           "stringValue": "test-service"
@@ -32980,12 +24412,6 @@
                   {
                     "asDouble": 3707103,
                     "attributes": [
-                      {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "https-metrics"
-                        }
-                      },
                       {
                         "key": "id",
                         "value": {
@@ -33011,18 +24437,6 @@
                         }
                       },
                       {
-                        "key": "prometheus",
-                        "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
-                        }
-                      },
-                      {
-                        "key": "prometheus_replica",
-                        "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
-                        }
-                      },
-                      {
                         "key": "service",
                         "value": {
                           "stringValue": "test-service"
@@ -33034,12 +24448,6 @@
                   {
                     "asDouble": 5696906,
                     "attributes": [
-                      {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "https-metrics"
-                        }
-                      },
                       {
                         "key": "id",
                         "value": {
@@ -33065,18 +24473,6 @@
                         }
                       },
                       {
-                        "key": "prometheus",
-                        "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
-                        }
-                      },
-                      {
-                        "key": "prometheus_replica",
-                        "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
-                        }
-                      },
-                      {
                         "key": "service",
                         "value": {
                           "stringValue": "test-service"
@@ -33088,12 +24484,6 @@
                   {
                     "asDouble": 318526,
                     "attributes": [
-                      {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "https-metrics"
-                        }
-                      },
                       {
                         "key": "id",
                         "value": {
@@ -33119,18 +24509,6 @@
                         }
                       },
                       {
-                        "key": "prometheus",
-                        "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
-                        }
-                      },
-                      {
-                        "key": "prometheus_replica",
-                        "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
-                        }
-                      },
-                      {
                         "key": "service",
                         "value": {
                           "stringValue": "test-service"
@@ -33142,12 +24520,6 @@
                   {
                     "asDouble": 15227954,
                     "attributes": [
-                      {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "https-metrics"
-                        }
-                      },
                       {
                         "key": "id",
                         "value": {
@@ -33173,18 +24545,6 @@
                         }
                       },
                       {
-                        "key": "prometheus",
-                        "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
-                        }
-                      },
-                      {
-                        "key": "prometheus_replica",
-                        "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
-                        }
-                      },
-                      {
                         "key": "service",
                         "value": {
                           "stringValue": "test-service"
@@ -33196,12 +24556,6 @@
                   {
                     "asDouble": 2331028,
                     "attributes": [
-                      {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "https-metrics"
-                        }
-                      },
                       {
                         "key": "id",
                         "value": {
@@ -33227,18 +24581,6 @@
                         }
                       },
                       {
-                        "key": "prometheus",
-                        "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
-                        }
-                      },
-                      {
-                        "key": "prometheus_replica",
-                        "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
-                        }
-                      },
-                      {
                         "key": "service",
                         "value": {
                           "stringValue": "test-service"
@@ -33250,12 +24592,6 @@
                   {
                     "asDouble": 2058828,
                     "attributes": [
-                      {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "https-metrics"
-                        }
-                      },
                       {
                         "key": "id",
                         "value": {
@@ -33281,18 +24617,6 @@
                         }
                       },
                       {
-                        "key": "prometheus",
-                        "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
-                        }
-                      },
-                      {
-                        "key": "prometheus_replica",
-                        "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
-                        }
-                      },
-                      {
                         "key": "service",
                         "value": {
                           "stringValue": "test-service"
@@ -33304,12 +24628,6 @@
                   {
                     "asDouble": 436090,
                     "attributes": [
-                      {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "https-metrics"
-                        }
-                      },
                       {
                         "key": "id",
                         "value": {
@@ -33335,18 +24653,6 @@
                         }
                       },
                       {
-                        "key": "prometheus",
-                        "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
-                        }
-                      },
-                      {
-                        "key": "prometheus_replica",
-                        "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
-                        }
-                      },
-                      {
                         "key": "service",
                         "value": {
                           "stringValue": "test-service"
@@ -33358,12 +24664,6 @@
                   {
                     "asDouble": 52,
                     "attributes": [
-                      {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "https-metrics"
-                        }
-                      },
                       {
                         "key": "id",
                         "value": {
@@ -33389,18 +24689,6 @@
                         }
                       },
                       {
-                        "key": "prometheus",
-                        "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
-                        }
-                      },
-                      {
-                        "key": "prometheus_replica",
-                        "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
-                        }
-                      },
-                      {
                         "key": "service",
                         "value": {
                           "stringValue": "test-service"
@@ -33412,12 +24700,6 @@
                   {
                     "asDouble": 2631130,
                     "attributes": [
-                      {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "https-metrics"
-                        }
-                      },
                       {
                         "key": "id",
                         "value": {
@@ -33443,18 +24725,6 @@
                         }
                       },
                       {
-                        "key": "prometheus",
-                        "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
-                        }
-                      },
-                      {
-                        "key": "prometheus_replica",
-                        "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
-                        }
-                      },
-                      {
                         "key": "service",
                         "value": {
                           "stringValue": "test-service"
@@ -33466,12 +24736,6 @@
                   {
                     "asDouble": 368954,
                     "attributes": [
-                      {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "https-metrics"
-                        }
-                      },
                       {
                         "key": "id",
                         "value": {
@@ -33497,18 +24761,6 @@
                         }
                       },
                       {
-                        "key": "prometheus",
-                        "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
-                        }
-                      },
-                      {
-                        "key": "prometheus_replica",
-                        "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
-                        }
-                      },
-                      {
                         "key": "service",
                         "value": {
                           "stringValue": "test-service"
@@ -33520,12 +24772,6 @@
                   {
                     "asDouble": 6641162,
                     "attributes": [
-                      {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "https-metrics"
-                        }
-                      },
                       {
                         "key": "id",
                         "value": {
@@ -33551,18 +24797,6 @@
                         }
                       },
                       {
-                        "key": "prometheus",
-                        "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
-                        }
-                      },
-                      {
-                        "key": "prometheus_replica",
-                        "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
-                        }
-                      },
-                      {
                         "key": "service",
                         "value": {
                           "stringValue": "test-service"
@@ -33574,12 +24808,6 @@
                   {
                     "asDouble": 70612,
                     "attributes": [
-                      {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "https-metrics"
-                        }
-                      },
                       {
                         "key": "id",
                         "value": {
@@ -33605,18 +24833,6 @@
                         }
                       },
                       {
-                        "key": "prometheus",
-                        "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
-                        }
-                      },
-                      {
-                        "key": "prometheus_replica",
-                        "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
-                        }
-                      },
-                      {
                         "key": "service",
                         "value": {
                           "stringValue": "test-service"
@@ -33628,12 +24844,6 @@
                   {
                     "asDouble": 2548465,
                     "attributes": [
-                      {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "https-metrics"
-                        }
-                      },
                       {
                         "key": "id",
                         "value": {
@@ -33659,18 +24869,6 @@
                         }
                       },
                       {
-                        "key": "prometheus",
-                        "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
-                        }
-                      },
-                      {
-                        "key": "prometheus_replica",
-                        "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
-                        }
-                      },
-                      {
                         "key": "service",
                         "value": {
                           "stringValue": "test-service"
@@ -33682,12 +24880,6 @@
                   {
                     "asDouble": 786554,
                     "attributes": [
-                      {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "https-metrics"
-                        }
-                      },
                       {
                         "key": "id",
                         "value": {
@@ -33713,18 +24905,6 @@
                         }
                       },
                       {
-                        "key": "prometheus",
-                        "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
-                        }
-                      },
-                      {
-                        "key": "prometheus_replica",
-                        "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
-                        }
-                      },
-                      {
                         "key": "service",
                         "value": {
                           "stringValue": "test-service"
@@ -33736,12 +24916,6 @@
                   {
                     "asDouble": 5427051,
                     "attributes": [
-                      {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "https-metrics"
-                        }
-                      },
                       {
                         "key": "id",
                         "value": {
@@ -33767,18 +24941,6 @@
                         }
                       },
                       {
-                        "key": "prometheus",
-                        "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
-                        }
-                      },
-                      {
-                        "key": "prometheus_replica",
-                        "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
-                        }
-                      },
-                      {
                         "key": "service",
                         "value": {
                           "stringValue": "test-service"
@@ -33790,12 +24952,6 @@
                   {
                     "asDouble": 589078132,
                     "attributes": [
-                      {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "https-metrics"
-                        }
-                      },
                       {
                         "key": "id",
                         "value": {
@@ -33821,18 +24977,6 @@
                         }
                       },
                       {
-                        "key": "prometheus",
-                        "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
-                        }
-                      },
-                      {
-                        "key": "prometheus_replica",
-                        "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
-                        }
-                      },
-                      {
                         "key": "service",
                         "value": {
                           "stringValue": "test-service"
@@ -33844,12 +24988,6 @@
                   {
                     "asDouble": 776541,
                     "attributes": [
-                      {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "https-metrics"
-                        }
-                      },
                       {
                         "key": "id",
                         "value": {
@@ -33875,18 +25013,6 @@
                         }
                       },
                       {
-                        "key": "prometheus",
-                        "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
-                        }
-                      },
-                      {
-                        "key": "prometheus_replica",
-                        "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
-                        }
-                      },
-                      {
                         "key": "service",
                         "value": {
                           "stringValue": "test-service"
@@ -33898,12 +25024,6 @@
                   {
                     "asDouble": 7790344,
                     "attributes": [
-                      {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "https-metrics"
-                        }
-                      },
                       {
                         "key": "id",
                         "value": {
@@ -33929,18 +25049,6 @@
                         }
                       },
                       {
-                        "key": "prometheus",
-                        "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
-                        }
-                      },
-                      {
-                        "key": "prometheus_replica",
-                        "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
-                        }
-                      },
-                      {
                         "key": "service",
                         "value": {
                           "stringValue": "test-service"
@@ -33952,12 +25060,6 @@
                   {
                     "asDouble": 2219926,
                     "attributes": [
-                      {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "https-metrics"
-                        }
-                      },
                       {
                         "key": "id",
                         "value": {
@@ -33983,18 +25085,6 @@
                         }
                       },
                       {
-                        "key": "prometheus",
-                        "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
-                        }
-                      },
-                      {
-                        "key": "prometheus_replica",
-                        "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
-                        }
-                      },
-                      {
                         "key": "service",
                         "value": {
                           "stringValue": "test-service"
@@ -34006,12 +25096,6 @@
                   {
                     "asDouble": 2311833,
                     "attributes": [
-                      {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "https-metrics"
-                        }
-                      },
                       {
                         "key": "id",
                         "value": {
@@ -34037,18 +25121,6 @@
                         }
                       },
                       {
-                        "key": "prometheus",
-                        "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
-                        }
-                      },
-                      {
-                        "key": "prometheus_replica",
-                        "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
-                        }
-                      },
-                      {
                         "key": "service",
                         "value": {
                           "stringValue": "test-service"
@@ -34060,12 +25132,6 @@
                   {
                     "asDouble": 12509489,
                     "attributes": [
-                      {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "https-metrics"
-                        }
-                      },
                       {
                         "key": "id",
                         "value": {
@@ -34091,18 +25157,6 @@
                         }
                       },
                       {
-                        "key": "prometheus",
-                        "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
-                        }
-                      },
-                      {
-                        "key": "prometheus_replica",
-                        "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
-                        }
-                      },
-                      {
                         "key": "service",
                         "value": {
                           "stringValue": "test-service"
@@ -34114,12 +25168,6 @@
                   {
                     "asDouble": 2626851104,
                     "attributes": [
-                      {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "https-metrics"
-                        }
-                      },
                       {
                         "key": "id",
                         "value": {
@@ -34145,18 +25193,6 @@
                         }
                       },
                       {
-                        "key": "prometheus",
-                        "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
-                        }
-                      },
-                      {
-                        "key": "prometheus_replica",
-                        "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
-                        }
-                      },
-                      {
                         "key": "service",
                         "value": {
                           "stringValue": "test-service"
@@ -34168,12 +25204,6 @@
                   {
                     "asDouble": 1618455279,
                     "attributes": [
-                      {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "https-metrics"
-                        }
-                      },
                       {
                         "key": "id",
                         "value": {
@@ -34199,18 +25229,6 @@
                         }
                       },
                       {
-                        "key": "prometheus",
-                        "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
-                        }
-                      },
-                      {
-                        "key": "prometheus_replica",
-                        "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
-                        }
-                      },
-                      {
                         "key": "service",
                         "value": {
                           "stringValue": "test-service"
@@ -34230,12 +25248,6 @@
                     "asDouble": 100000,
                     "attributes": [
                       {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "https-metrics"
-                        }
-                      },
-                      {
                         "key": "id",
                         "value": {
                           "stringValue": "/kubepods/burstable"
@@ -34254,18 +25266,6 @@
                         }
                       },
                       {
-                        "key": "prometheus",
-                        "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
-                        }
-                      },
-                      {
-                        "key": "prometheus_replica",
-                        "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
-                        }
-                      },
-                      {
                         "key": "service",
                         "value": {
                           "stringValue": "test-service"
@@ -34277,12 +25277,6 @@
                   {
                     "asDouble": 100000,
                     "attributes": [
-                      {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "https-metrics"
-                        }
-                      },
                       {
                         "key": "id",
                         "value": {
@@ -34302,18 +25296,6 @@
                         }
                       },
                       {
-                        "key": "prometheus",
-                        "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
-                        }
-                      },
-                      {
-                        "key": "prometheus_replica",
-                        "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
-                        }
-                      },
-                      {
                         "key": "service",
                         "value": {
                           "stringValue": "test-service"
@@ -34325,12 +25307,6 @@
                   {
                     "asDouble": 100000,
                     "attributes": [
-                      {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "https-metrics"
-                        }
-                      },
                       {
                         "key": "id",
                         "value": {
@@ -34350,18 +25326,6 @@
                         }
                       },
                       {
-                        "key": "prometheus",
-                        "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
-                        }
-                      },
-                      {
-                        "key": "prometheus_replica",
-                        "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
-                        }
-                      },
-                      {
                         "key": "service",
                         "value": {
                           "stringValue": "test-service"
@@ -34373,12 +25337,6 @@
                   {
                     "asDouble": 100000,
                     "attributes": [
-                      {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "https-metrics"
-                        }
-                      },
                       {
                         "key": "id",
                         "value": {
@@ -34395,18 +25353,6 @@
                         "key": "node",
                         "value": {
                           "stringValue": "test-node"
-                        }
-                      },
-                      {
-                        "key": "prometheus",
-                        "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
-                        }
-                      },
-                      {
-                        "key": "prometheus_replica",
-                        "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
                         }
                       },
                       {
@@ -34429,12 +25375,6 @@
                     "asDouble": 0,
                     "attributes": [
                       {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "https-metrics"
-                        }
-                      },
-                      {
                         "key": "id",
                         "value": {
                           "stringValue": "/kubepods/burstable"
@@ -34453,18 +25393,6 @@
                         }
                       },
                       {
-                        "key": "prometheus",
-                        "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
-                        }
-                      },
-                      {
-                        "key": "prometheus_replica",
-                        "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
-                        }
-                      },
-                      {
                         "key": "service",
                         "value": {
                           "stringValue": "test-service"
@@ -34476,12 +25404,6 @@
                   {
                     "asDouble": 63402639360,
                     "attributes": [
-                      {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "https-metrics"
-                        }
-                      },
                       {
                         "key": "id",
                         "value": {
@@ -34501,18 +25423,6 @@
                         }
                       },
                       {
-                        "key": "prometheus",
-                        "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
-                        }
-                      },
-                      {
-                        "key": "prometheus_replica",
-                        "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
-                        }
-                      },
-                      {
                         "key": "service",
                         "value": {
                           "stringValue": "test-service"
@@ -34524,12 +25434,6 @@
                   {
                     "asDouble": 66369060864,
                     "attributes": [
-                      {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "https-metrics"
-                        }
-                      },
                       {
                         "key": "id",
                         "value": {
@@ -34549,18 +25453,6 @@
                         }
                       },
                       {
-                        "key": "prometheus",
-                        "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
-                        }
-                      },
-                      {
-                        "key": "prometheus_replica",
-                        "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
-                        }
-                      },
-                      {
                         "key": "service",
                         "value": {
                           "stringValue": "test-service"
@@ -34572,12 +25464,6 @@
                   {
                     "asDouble": 0,
                     "attributes": [
-                      {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "https-metrics"
-                        }
-                      },
                       {
                         "key": "id",
                         "value": {
@@ -34594,18 +25480,6 @@
                         "key": "node",
                         "value": {
                           "stringValue": "test-node"
-                        }
-                      },
-                      {
-                        "key": "prometheus",
-                        "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
-                        }
-                      },
-                      {
-                        "key": "prometheus_replica",
-                        "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
                         }
                       },
                       {
@@ -34634,12 +25508,6 @@
                         }
                       },
                       {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "https-metrics"
-                        }
-                      },
-                      {
                         "key": "id",
                         "value": {
                           "stringValue": "/"
@@ -34655,18 +25523,6 @@
                         "key": "node",
                         "value": {
                           "stringValue": "test-node"
-                        }
-                      },
-                      {
-                        "key": "prometheus",
-                        "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
-                        }
-                      },
-                      {
-                        "key": "prometheus_replica",
-                        "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
                         }
                       },
                       {
@@ -34725,12 +25581,6 @@
                     "asDouble": 23541440512,
                     "attributes": [
                       {
-                        "key": "endpoint",
-                        "value": {
-                          "stringValue": "https-metrics"
-                        }
-                      },
-                      {
                         "key": "id",
                         "value": {
                           "stringValue": "/"
@@ -34746,18 +25596,6 @@
                         "key": "node",
                         "value": {
                           "stringValue": "test-node"
-                        }
-                      },
-                      {
-                        "key": "prometheus",
-                        "value": {
-                          "stringValue": "prometheus-system/kube-prometheus-kube-prome-prometheus"
-                        }
-                      },
-                      {
-                        "key": "prometheus_replica",
-                        "value": {
-                          "stringValue": "prometheus-kube-prometheus-kube-prome-prometheus-0"
                         }
                       },
                       {

--- a/tests/integration/test_metric_collection.py
+++ b/tests/integration/test_metric_collection.py
@@ -89,7 +89,12 @@ def assert_prometheus_metrics(metricsContent, metrics):
                         if( missing_items.get('container') == 'POD'):
                             found = True
                             break
-                        
+
+                        # we are removing these prometheus attributes from all datapoints
+                        missing_items.pop('prometheus_replica')
+                        missing_items.pop('prometheus')
+                        missing_items.pop('endpoint')
+
                         #ignore instance,job as they are dropped by mock receiver
                         missing_items.pop('instance')
                         missing_items.pop('job')


### PR DESCRIPTION
Removed attributes `net.host.name`, `net.host.port`, `http.scheme`, `prometheus`, `prometheus_replica` and `endpoint` from exported metrics.
Some of them were filtered out even before, but they were renamed later, so the filters stopped working.