### PR TITLE
NH-57813: Fixing windows docker image

### DIFF
--- a/build/docker/Dockerfile.Windows
+++ b/build/docker/Dockerfile.Windows
@@ -18,12 +18,12 @@ WORKDIR /src/src/wrapper
 ARG CGO_ENABLED=0
 ARG GOEXPERIMENT=boringcrypto
 
-RUN go build -a -o /wrapper.exe
+RUN go build -a -o ./wrapper.exe
 
 FROM mcr.microsoft.com/windows/nanoserver:ltsc2022
 
 COPY --from=builder /src/swi-k8s-opentelemetry-collector /swi-otelcol.exe
-COPY --from=wrapper /wrapper.exe /wrapper.exe
+COPY --from=wrapper /src/src/wrapper/wrapper.exe /wrapper.exe
 
 ENTRYPOINT ["wrapper.exe"]
 CMD ["swi-otelcol.exe", "--config=/opt/default-config.yaml"]


### PR DESCRIPTION
On GitHub actions I got: 
```
wrapper: go build wrapper: copying C:\Windows\TEMP\go-build792349289\b001\exe\a.out.exe: open /wrapper.exe: Access is denied.
The command 'cmd /S /C go build -a -o /wrapper.exe' returned a non-zero code: 1
```
see: https://github.com/solarwinds/swi-k8s-opentelemetry-collector/actions/runs/6458171456/job/17531295588

This was not reproducible locally on Windows 10. This fixes it.