### PR TITLE
NH-63239: Making it possible to dev against remote test-cluster

### DIFF
--- a/.github/actions/deploy-kubernetes/action.yml
+++ b/.github/actions/deploy-kubernetes/action.yml
@@ -17,6 +17,7 @@ runs:
 
     - name: Print cluster info
       run: |
+        kubectl version
         kubectl get sc
         kubectl cluster-info dump --output=yaml
       shell: bash

--- a/.github/actions/deploy-skaffold/action.yml
+++ b/.github/actions/deploy-skaffold/action.yml
@@ -5,7 +5,7 @@ runs:
   steps:
     - name: Setup skaffold
       run: |
-        curl -Lo skaffold https://storage.googleapis.com/skaffold/releases/v2.0.3/skaffold-linux-amd64 && sudo install skaffold /usr/local/bin/
+        curl -Lo skaffold https://storage.googleapis.com/skaffold/releases/v2.7.1/skaffold-linux-amd64 && sudo install skaffold /usr/local/bin/
       shell: bash
     - name: Install Container Structure Test
       run: |

--- a/.github/actions/run-integration-tests/action.yaml
+++ b/.github/actions/run-integration-tests/action.yaml
@@ -5,19 +5,19 @@ runs:
   steps:
     - name: Run Integration tests
       run: |
-        kubectl create job --from=cronjob/integration-test integration-test-manual
+        kubectl create job -n test-namespace --from=cronjob/integration-test integration-test-manual
 
-        kubectl wait --for=condition=ready --timeout=60s pod -l job-name=integration-test-manual
-        kubetail -l job-name=integration-test-manual &  
+        kubectl wait -n test-namespace --for=condition=ready --timeout=60s pod -l job-name=integration-test-manual
+        kubetail -n test-namespace -l job-name=integration-test-manual &  
 
         # Wait for either complete or failed -
         while true; do
-            if kubectl wait --for=condition=complete --timeout=0 jobs/integration-test-manual 2>/dev/null; then
+            if kubectl wait -n test-namespace --for=condition=complete --timeout=0 jobs/integration-test-manual 2>/dev/null; then
                 job_result=0
                 break
             fi
 
-            if kubectl wait --for=condition=failed --timeout=0 jobs/integration-test-manual 2>/dev/null; then
+            if kubectl wait -n test-namespace --for=condition=failed --timeout=0 jobs/integration-test-manual 2>/dev/null; then
                 job_result=1
                 break
             fi
@@ -30,12 +30,12 @@ runs:
             echo "Tests failed"
             mkdir pod-logs
             echo "Folder Created"
-            pods=$(kubectl get pods -n monitoring -o=jsonpath='{.items[*].metadata.name}')
+            pods=$(kubectl get pods -n test-namespace -o=jsonpath='{.items[*].metadata.name}')
             for pod in $pods; do
-              containers=$(kubectl get pod $pod -n monitoring -o=jsonpath='{.spec.containers[*].name}')
+              containers=$(kubectl get pod $pod -n test-namespace -o=jsonpath='{.spec.containers[*].name}')
               for container in $containers; do
                 echo "Logs for pod $pod, container $container:"               
-                kubectl logs -n monitoring $pod -c $container > pod-logs/$container.txt
+                kubectl logs -n test-namespace $pod -c $container > pod-logs/$container.txt
               done
             done
 

--- a/.github/actions/run-integration-tests/action.yaml
+++ b/.github/actions/run-integration-tests/action.yaml
@@ -5,19 +5,19 @@ runs:
   steps:
     - name: Run Integration tests
       run: |
-        kubectl create job -n test-namespace --from=cronjob/integration-test integration-test-manual
+        kubectl create job --from=cronjob/integration-test integration-test-manual -n test-namespace
 
-        kubectl wait -n test-namespace --for=condition=ready --timeout=60s pod -l job-name=integration-test-manual
-        kubetail -n test-namespace -l job-name=integration-test-manual &  
+        kubectl wait --for=condition=ready --timeout=60s pod -l job-name=integration-test-manual -n test-namespace
+        kubetail -l job-name=integration-test-manual -n test-namespace &  
 
-        # Wait for either complete or failed -
+        # Wait for either complete or failed
         while true; do
-            if kubectl wait -n test-namespace --for=condition=complete --timeout=0 jobs/integration-test-manual 2>/dev/null; then
+            if kubectl wait --for=condition=complete --timeout=0 jobs/integration-test-manual -n test-namespace 2>/dev/null; then
                 job_result=0
                 break
             fi
 
-            if kubectl wait -n test-namespace --for=condition=failed --timeout=0 jobs/integration-test-manual 2>/dev/null; then
+            if kubectl wait --for=condition=failed --timeout=0 jobs/integration-test-manual -n test-namespace 2>/dev/null; then
                 job_result=1
                 break
             fi
@@ -51,7 +51,3 @@ runs:
         name: pod-logs
         path: pod-logs/
         retention-days: 1
-
-
-
-

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .env
+skaffold.env
 deploy/helm/charts/*.tgz

--- a/doc/development.md
+++ b/doc/development.md
@@ -101,6 +101,30 @@ You can look at `http://localhost:8088/logs.json` (each line is JSON as bulk sen
 #### Events
 You can look at `http://localhost:8088/events.json` (each line is JSON as bulk sent by OTEL collector)
 
+## Develop against remote cluster
+* Make sure that you have working kubeContext, set this to `test-cluster` profile section in `skaffold.yaml`:
+```
+    - op: replace
+      path: /deploy/kubeContext
+      value: "<your kube context here>"
+```
+* Create `skaffold.env` file with two environment variables which indicates your private space in the cluster, e.q.:
+```
+TEST_CLUSTER_NAMESPACE=my-dev-namespace
+TEST_CLUSTER_RELEASE_NAME=swi-my-dev-release
+```
+* Make sure that you have ECR repository where image `swi-opentelemetry-collector` will be pushed
+* Login to ECR repository. E.q.: `aws ecr get-login-password --region us-east-1 --profile <your AWS profile> | docker login --username AWS --password-stdin <Your ECR repository>`
+* (optionally) setup skaffold values to better target what you intent to develop. E.q.:
+```
+ebpfNetworkMonitoring.enabled: true
+otel.logs.enabled: false
+otel.events.enabled: false
+otel.metrics.batch.send_batch_size: 1024
+otel.metrics.batch.send_batch_max_size: 1024
+```
+* Run `skaffold dev -p=test-cluster --default-repo=<Your ECR repository>`
+
 ## Develop against remote prometheus
 
 You can port forward Prometheus server to localhost:9090 and run

--- a/skaffold.yaml
+++ b/skaffold.yaml
@@ -19,16 +19,18 @@ manifests:
   kustomize:
     paths:
       - tests/deploy/base
+      - tests/deploy/wiremock
       - tests/deploy/tests
     buildArgs:
       - --load-restrictor LoadRestrictionsNone
 deploy:
-  kubectl: {}
+  kubectl: 
+    defaultNamespace: test-namespace
   helm:
     releases:
       - name: swi-k8s-opentelemetry-collector
         chartPath: deploy/helm
-        namespace: monitoring
+        namespace: test-namespace
         createNamespace: true
         setValues:
           prometheus.enabled: true
@@ -45,7 +47,7 @@ deploy:
           otel.logs.filter.include.record_attributes[0].value: "^.*$"
           otel.logs.filter.exclude.match_type: "strict"
           otel.logs.filter.exclude.record_attributes[0].key: "k8s.namespace.name"
-          otel.logs.filter.exclude.record_attributes[0].value: "monitoring"
+          otel.logs.filter.exclude.record_attributes[0].value: "test-namespace"
           cluster.name: cluster name
           cluster.uid: cluster-uid-123456789
           # excluded annotations:
@@ -60,14 +62,48 @@ deploy:
 portForward:
 - resourceType: service
   resourceName: timeseries-mock-service
-  namespace: monitoring
+  namespace: test-namespace
   port: 8088
 - resourceType: service
   resourceName: swi-k8s-opentelemetry-collector-prometheus-server
-  namespace: monitoring
+  namespace: test-namespace
   port: 80
   localPort: 8080
 profiles:
+  - name: test-cluster
+    build:
+      artifacts:
+        - image: swi-k8s-opentelemetry-collector
+          docker:
+            dockerfile: build/docker/Dockerfile
+      local:
+        push: true
+    patches:
+    - op: replace
+      path: /deploy/helm/releases/0/namespace
+      value: "{{.TEST_CLUSTER_NAMESPACE}}"
+    - op: replace
+      path: /deploy/helm/releases/0/name
+      value: "{{.TEST_CLUSTER_RELEASE_NAME}}"
+    - op: replace
+      path: /portForward/0/namespace
+      value: "{{.TEST_CLUSTER_NAMESPACE}}"
+    - op: replace
+      path: /portForward/1/namespace
+      value: "{{.TEST_CLUSTER_NAMESPACE}}"
+    - op: replace
+      path: /portForward/1/resourceName
+      value: "{{.TEST_CLUSTER_RELEASE_NAME}}-prometheus-server"
+    - op: replace
+      path: /deploy/kubectl/defaultNamespace
+      value: "{{.TEST_CLUSTER_NAMESPACE}}"
+    - op: remove
+      path: /manifests/kustomize/paths/2
+    - op: remove
+      path: /manifests/kustomize/paths/1
+    - op: replace
+      path: /deploy/kubeContext
+      value: "<your kube context here>"
   - name: builder-only
     build:
       artifacts:
@@ -84,13 +120,13 @@ profiles:
     patches:
     - op: add
       path: /deploy/helm/releases/0/setValues/otel.metrics.prometheus.url
-      value: wiremock.monitoring.svc.cluster.local:8080
+      value: wiremock.test-namespace.svc.cluster.local:8080
     - op: replace
       path: /deploy/helm/releases/0/setValues/prometheus.enabled
       value: false
     - op: add
       path: "/deploy/helm/releases/0/setValues/otel.metrics.kube-state-metrics.url"
-      value: wiremock.monitoring.svc.cluster.local:8080
+      value: wiremock.test-namespace.svc.cluster.local:8080
     - op: replace
       path: "/deploy/helm/releases/0/setValues/kube-state-metrics.enabled"
       value: false
@@ -132,13 +168,13 @@ profiles:
     patches:
     - op: add
       path: /deploy/helm/releases/0/setValues/otel.metrics.prometheus.url
-      value: wiremock.monitoring.svc.cluster.local:8080
+      value: wiremock.test-namespace.svc.cluster.local:8080
     - op: replace
       path: /deploy/helm/releases/0/setValues/prometheus.enabled
       value: false
     - op: add
       path: "/deploy/helm/releases/0/setValues/otel.metrics.kube-state-metrics.url"
-      value: wiremock.monitoring.svc.cluster.local:8080
+      value: wiremock.test-namespace.svc.cluster.local:8080
     - op: replace
       path: /deploy/helm/releases/0/setValues/kube-state-metrics.enabled
       value: false
@@ -156,13 +192,13 @@ profiles:
         path: /deploy/helm/releases/0/setValues/otel.image.tag
       - op: add
         path: /deploy/helm/releases/0/setValues/otel.metrics.prometheus.url
-        value: wiremock.monitoring.svc.cluster.local:8080
+        value: wiremock.test-namespace.svc.cluster.local:8080
       - op: replace
         path: /deploy/helm/releases/0/setValues/prometheus.enabled
         value: false
       - op: add
         path: "/deploy/helm/releases/0/setValues/otel.metrics.kube-state-metrics.url"
-        value: wiremock.monitoring.svc.cluster.local:8080
+        value: wiremock.test-namespace.svc.cluster.local:8080
       - op: replace
         path: /deploy/helm/releases/0/setValues/kube-state-metrics.enabled
         value: false

--- a/tests/deploy/base/mocks.yaml
+++ b/tests/deploy/base/mocks.yaml
@@ -9,8 +9,6 @@ metadata:
 data:
   relay: |
     exporters:
-      logging:
-        loglevel: debug
       file/logs:
         path: /data/logs.json
         # empty rotation - workaround for https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/18251
@@ -62,7 +60,6 @@ data:
       pipelines:
         metrics:
           exporters:
-          - logging
           - file/metrics
           - prometheus
           processors:
@@ -70,7 +67,6 @@ data:
           - otlp
         logs/logs:
           exporters:
-          - logging
           - file/logs
           processors:
           - filter/events_out
@@ -78,7 +74,6 @@ data:
           - otlp
         logs/events:
           exporters:
-          - logging
           - file/events
           processors:
           - filter/events_in
@@ -123,6 +118,9 @@ spec:
     spec:
       securityContext:
         runAsUser: 0
+      nodeSelector:
+        kubernetes.io/os: linux
+        kubernetes.io/arch: amd64
       containers:
         - name: opentelemetry-collector
           command:
@@ -130,7 +128,7 @@ spec:
             - --config=/conf/relay.yaml
           securityContext:
             runAsUser: 0
-          image: "otel/opentelemetry-collector-contrib:0.73.0"
+          image: "otel/opentelemetry-collector-contrib:0.81.0"
           imagePullPolicy: IfNotPresent
           ports:
             - name: otlp
@@ -168,42 +166,6 @@ spec:
                 path: relay.yaml
         - name: output
           emptyDir: {}
----
-apiVersion: apps/v1
-kind: Deployment
-metadata:
-  name: wiremock
-spec:
-  replicas: 1
-  selector:
-    matchLabels:
-      app: wiremock
-  template:
-    metadata:
-      labels:
-        app: wiremock
-    spec:
-      containers:
-        - name: wiremock
-          image: wiremock
-          args:
-            - --verbose
-          ports:
-            - containerPort: 8080
-          env:
-            - name: JAVA_OPTS
-              value: "-Dwiremock.containerization=kubernetes -Dwiremock.extensions.containerization.replicas=1"
----
-apiVersion: v1
-kind: Service
-metadata:
-  name: wiremock
-spec:
-  selector:
-    app: wiremock
-  ports:
-    - name: wiremock
-      port: 8080
-      targetPort: 8080
+
 
 

--- a/tests/deploy/tests/integrationTestCronJob.yaml
+++ b/tests/deploy/tests/integrationTestCronJob.yaml
@@ -2,7 +2,7 @@ apiVersion: batch/v1
 kind: CronJob
 metadata:
   name: integration-test
-  namespace: default
+  namespace: test-namespace
 spec:
   suspend: true
   schedule: "0 0 1 1 *" # schedule does not matter (set to yearly), it will be suspended anyway
@@ -20,16 +20,16 @@ spec:
               image: integration-test
               env:
                 - name: TIMESERIES_MOCK_ENDPOINT
-                  value: timeseries-mock-service.monitoring.svc.cluster.local:8088
+                  value: timeseries-mock-service.test-namespace.svc.cluster.local:8088
                 - name: PROMETHEUS_MOCK_ENDPOINT
-                  value: wiremock.monitoring.svc.cluster.local:8080
+                  value: wiremock.test-namespace.svc.cluster.local:8080
           restartPolicy: Never
 ---
 apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: kube-api-for-tests
-  namespace: default
+  namespace: test-namespace
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
@@ -38,7 +38,7 @@ metadata:
 subjects:
   - kind: ServiceAccount
     name: kube-api-for-tests
-    namespace: default
+    namespace: test-namespace
 roleRef:
   kind: ClusterRole
   name: kube-api-for-tests-role

--- a/tests/deploy/tests/test_metric_manifest.yaml
+++ b/tests/deploy/tests/test_metric_manifest.yaml
@@ -1,18 +1,7 @@
 apiVersion: v1
-kind: Namespace
-metadata:
-  name: test-namespace
-  labels:
-    app: test-app
-    purpose: testing
-  annotations:
-    description: This is a test namespace.
----
-apiVersion: v1
 kind: Pod
 metadata:
   name: test-pod
-  namespace: test-namespace
   labels:
     app: test-pod
   annotations:
@@ -27,7 +16,6 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: test-deployment
-  namespace: test-namespace
   labels:
     app: test-deployment
   annotations:
@@ -53,7 +41,6 @@ apiVersion: apps/v1
 kind: StatefulSet
 metadata:
   name: test-statefulset
-  namespace: test-namespace
   labels:
     app: test-statefulset
   annotations:
@@ -80,7 +67,6 @@ apiVersion: apps/v1
 kind: ReplicaSet
 metadata:
   name: test-replicaset
-  namespace: test-namespace
   labels:
     app: test-replicaset
   annotations:
@@ -106,7 +92,6 @@ apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   name: test-daemonset
-  namespace: test-namespace
   labels:
     app: test-daemonset
   annotations:
@@ -131,7 +116,6 @@ apiVersion: batch/v1
 kind: CronJob
 metadata:
   name: test-cronjob
-  namespace: test-namespace
   labels:
     app: test-cronjob
   annotations:
@@ -176,7 +160,6 @@ apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
   name: test-pvc
-  namespace: test-namespace
   labels:
     example.com/label: "example-label"
   annotations:
@@ -201,7 +184,6 @@ apiVersion: v1
 kind: Service
 metadata:
   name: test-service
-  namespace: test-namespace
   labels:
     example.com/label: "example-label"
   annotations:

--- a/tests/deploy/wiremock/kustomization.yaml
+++ b/tests/deploy/wiremock/kustomization.yaml
@@ -2,4 +2,4 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
 resources:
-  - mocks.yaml
+  - wiremock.yaml

--- a/tests/deploy/wiremock/wiremock.yaml
+++ b/tests/deploy/wiremock/wiremock.yaml
@@ -1,0 +1,37 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: wiremock
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: wiremock
+  template:
+    metadata:
+      labels:
+        app: wiremock
+    spec:
+      containers:
+        - name: wiremock
+          image: wiremock
+          args:
+            - --verbose
+          ports:
+            - containerPort: 8080
+          env:
+            - name: JAVA_OPTS
+              value: "-Dwiremock.containerization=kubernetes -Dwiremock.extensions.containerization.replicas=1"
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: wiremock
+spec:
+  selector:
+    app: wiremock
+  ports:
+    - name: wiremock
+      port: 8080
+      targetPort: 8080

--- a/tests/integration/expected_output.json
+++ b/tests/integration/expected_output.json
@@ -28,27 +28,15 @@
             }
           },
           {
-            "key": "k8s.namespace.annotations.description",
-            "value": {
-              "stringValue": "This is a test namespace."
-            }
-          },
-          {
-            "key": "k8s.namespace.labels.app",
-            "value": {
-              "stringValue": "test-app"
-            }
-          },
-          {
             "key": "k8s.namespace.labels.kubernetes.io/metadata.name",
             "value": {
               "stringValue": "test-namespace"
             }
           },
           {
-            "key": "k8s.namespace.labels.purpose",
+            "key": "k8s.namespace.labels.name",
             "value": {
-              "stringValue": "testing"
+              "stringValue": "test-namespace"
             }
           },
           {
@@ -258,27 +246,15 @@
             }
           },
           {
-            "key": "k8s.namespace.annotations.description",
-            "value": {
-              "stringValue": "This is a test namespace."
-            }
-          },
-          {
-            "key": "k8s.namespace.labels.app",
-            "value": {
-              "stringValue": "test-app"
-            }
-          },
-          {
             "key": "k8s.namespace.labels.kubernetes.io/metadata.name",
             "value": {
               "stringValue": "test-namespace"
             }
           },
           {
-            "key": "k8s.namespace.labels.purpose",
+            "key": "k8s.namespace.labels.name",
             "value": {
-              "stringValue": "testing"
+              "stringValue": "test-namespace"
             }
           },
           {
@@ -470,27 +446,15 @@
             }
           },
           {
-            "key": "k8s.namespace.annotations.description",
-            "value": {
-              "stringValue": "This is a test namespace."
-            }
-          },
-          {
-            "key": "k8s.namespace.labels.app",
-            "value": {
-              "stringValue": "test-app"
-            }
-          },
-          {
             "key": "k8s.namespace.labels.kubernetes.io/metadata.name",
             "value": {
               "stringValue": "test-namespace"
             }
           },
           {
-            "key": "k8s.namespace.labels.purpose",
+            "key": "k8s.namespace.labels.name",
             "value": {
-              "stringValue": "testing"
+              "stringValue": "test-namespace"
             }
           },
           {
@@ -682,27 +646,15 @@
             }
           },
           {
-            "key": "k8s.namespace.annotations.description",
-            "value": {
-              "stringValue": "This is a test namespace."
-            }
-          },
-          {
-            "key": "k8s.namespace.labels.app",
-            "value": {
-              "stringValue": "test-app"
-            }
-          },
-          {
             "key": "k8s.namespace.labels.kubernetes.io/metadata.name",
             "value": {
               "stringValue": "test-namespace"
             }
           },
           {
-            "key": "k8s.namespace.labels.purpose",
+            "key": "k8s.namespace.labels.name",
             "value": {
-              "stringValue": "testing"
+              "stringValue": "test-namespace"
             }
           },
           {
@@ -894,27 +846,15 @@
             }
           },
           {
-            "key": "k8s.namespace.annotations.description",
-            "value": {
-              "stringValue": "This is a test namespace."
-            }
-          },
-          {
-            "key": "k8s.namespace.labels.app",
-            "value": {
-              "stringValue": "test-app"
-            }
-          },
-          {
             "key": "k8s.namespace.labels.kubernetes.io/metadata.name",
             "value": {
               "stringValue": "test-namespace"
             }
           },
           {
-            "key": "k8s.namespace.labels.purpose",
+            "key": "k8s.namespace.labels.name",
             "value": {
-              "stringValue": "testing"
+              "stringValue": "test-namespace"
             }
           },
           {
@@ -1106,27 +1046,15 @@
             }
           },
           {
-            "key": "k8s.namespace.annotations.description",
-            "value": {
-              "stringValue": "This is a test namespace."
-            }
-          },
-          {
-            "key": "k8s.namespace.labels.app",
-            "value": {
-              "stringValue": "test-app"
-            }
-          },
-          {
             "key": "k8s.namespace.labels.kubernetes.io/metadata.name",
             "value": {
               "stringValue": "test-namespace"
             }
           },
           {
-            "key": "k8s.namespace.labels.purpose",
+            "key": "k8s.namespace.labels.name",
             "value": {
-              "stringValue": "testing"
+              "stringValue": "test-namespace"
             }
           },
           {
@@ -1276,27 +1204,15 @@
             }
           },
           {
-            "key": "k8s.namespace.annotations.description",
-            "value": {
-              "stringValue": "This is a test namespace."
-            }
-          },
-          {
-            "key": "k8s.namespace.labels.app",
-            "value": {
-              "stringValue": "test-app"
-            }
-          },
-          {
             "key": "k8s.namespace.labels.kubernetes.io/metadata.name",
             "value": {
               "stringValue": "test-namespace"
             }
           },
           {
-            "key": "k8s.namespace.labels.purpose",
+            "key": "k8s.namespace.labels.name",
             "value": {
-              "stringValue": "testing"
+              "stringValue": "test-namespace"
             }
           },
           {
@@ -1488,27 +1404,15 @@
             }
           },
           {
-            "key": "k8s.namespace.annotations.description",
-            "value": {
-              "stringValue": "This is a test namespace."
-            }
-          },
-          {
-            "key": "k8s.namespace.labels.app",
-            "value": {
-              "stringValue": "test-app"
-            }
-          },
-          {
             "key": "k8s.namespace.labels.kubernetes.io/metadata.name",
             "value": {
               "stringValue": "test-namespace"
             }
           },
           {
-            "key": "k8s.namespace.labels.purpose",
+            "key": "k8s.namespace.labels.name",
             "value": {
-              "stringValue": "testing"
+              "stringValue": "test-namespace"
             }
           },
           {
@@ -1712,27 +1616,15 @@
             }
           },
           {
-            "key": "k8s.namespace.annotations.description",
-            "value": {
-              "stringValue": "This is a test namespace."
-            }
-          },
-          {
-            "key": "k8s.namespace.labels.app",
-            "value": {
-              "stringValue": "test-app"
-            }
-          },
-          {
             "key": "k8s.namespace.labels.kubernetes.io/metadata.name",
             "value": {
               "stringValue": "test-namespace"
             }
           },
           {
-            "key": "k8s.namespace.labels.purpose",
+            "key": "k8s.namespace.labels.name",
             "value": {
-              "stringValue": "testing"
+              "stringValue": "test-namespace"
             }
           },
           {
@@ -1930,27 +1822,15 @@
             }
           },
           {
-            "key": "k8s.namespace.annotations.description",
-            "value": {
-              "stringValue": "This is a test namespace."
-            }
-          },
-          {
-            "key": "k8s.namespace.labels.app",
-            "value": {
-              "stringValue": "test-app"
-            }
-          },
-          {
             "key": "k8s.namespace.labels.kubernetes.io/metadata.name",
             "value": {
               "stringValue": "test-namespace"
             }
           },
           {
-            "key": "k8s.namespace.labels.purpose",
+            "key": "k8s.namespace.labels.name",
             "value": {
-              "stringValue": "testing"
+              "stringValue": "test-namespace"
             }
           },
           {
@@ -2136,27 +2016,15 @@
             }
           },
           {
-            "key": "k8s.namespace.annotations.description",
-            "value": {
-              "stringValue": "This is a test namespace."
-            }
-          },
-          {
-            "key": "k8s.namespace.labels.app",
-            "value": {
-              "stringValue": "test-app"
-            }
-          },
-          {
             "key": "k8s.namespace.labels.kubernetes.io/metadata.name",
             "value": {
               "stringValue": "test-namespace"
             }
           },
           {
-            "key": "k8s.namespace.labels.purpose",
+            "key": "k8s.namespace.labels.name",
             "value": {
-              "stringValue": "testing"
+              "stringValue": "test-namespace"
             }
           },
           {
@@ -2306,27 +2174,15 @@
             }
           },
           {
-            "key": "k8s.namespace.annotations.description",
-            "value": {
-              "stringValue": "This is a test namespace."
-            }
-          },
-          {
-            "key": "k8s.namespace.labels.app",
-            "value": {
-              "stringValue": "test-app"
-            }
-          },
-          {
             "key": "k8s.namespace.labels.kubernetes.io/metadata.name",
             "value": {
               "stringValue": "test-namespace"
             }
           },
           {
-            "key": "k8s.namespace.labels.purpose",
+            "key": "k8s.namespace.labels.name",
             "value": {
-              "stringValue": "testing"
+              "stringValue": "test-namespace"
             }
           },
           {
@@ -2604,27 +2460,15 @@
             }
           },
           {
-            "key": "k8s.namespace.annotations.description",
-            "value": {
-              "stringValue": "This is a test namespace."
-            }
-          },
-          {
-            "key": "k8s.namespace.labels.app",
-            "value": {
-              "stringValue": "test-app"
-            }
-          },
-          {
             "key": "k8s.namespace.labels.kubernetes.io/metadata.name",
             "value": {
               "stringValue": "test-namespace"
             }
           },
           {
-            "key": "k8s.namespace.labels.purpose",
+            "key": "k8s.namespace.labels.name",
             "value": {
-              "stringValue": "testing"
+              "stringValue": "test-namespace"
             }
           },
           {
@@ -2786,27 +2630,15 @@
             }
           },
           {
-            "key": "k8s.namespace.annotations.description",
-            "value": {
-              "stringValue": "This is a test namespace."
-            }
-          },
-          {
-            "key": "k8s.namespace.labels.app",
-            "value": {
-              "stringValue": "test-app"
-            }
-          },
-          {
             "key": "k8s.namespace.labels.kubernetes.io/metadata.name",
             "value": {
               "stringValue": "test-namespace"
             }
           },
           {
-            "key": "k8s.namespace.labels.purpose",
+            "key": "k8s.namespace.labels.name",
             "value": {
-              "stringValue": "testing"
+              "stringValue": "test-namespace"
             }
           },
           {
@@ -2980,27 +2812,15 @@
             }
           },
           {
-            "key": "k8s.namespace.annotations.description",
-            "value": {
-              "stringValue": "This is a test namespace."
-            }
-          },
-          {
-            "key": "k8s.namespace.labels.app",
-            "value": {
-              "stringValue": "test-app"
-            }
-          },
-          {
             "key": "k8s.namespace.labels.kubernetes.io/metadata.name",
             "value": {
               "stringValue": "test-namespace"
             }
           },
           {
-            "key": "k8s.namespace.labels.purpose",
+            "key": "k8s.namespace.labels.name",
             "value": {
-              "stringValue": "testing"
+              "stringValue": "test-namespace"
             }
           },
           {
@@ -3515,27 +3335,15 @@
             }
           },
           {
-            "key": "k8s.namespace.annotations.description",
-            "value": {
-              "stringValue": "This is a test namespace."
-            }
-          },
-          {
-            "key": "k8s.namespace.labels.app",
-            "value": {
-              "stringValue": "test-app"
-            }
-          },
-          {
             "key": "k8s.namespace.labels.kubernetes.io/metadata.name",
             "value": {
               "stringValue": "test-namespace"
             }
           },
           {
-            "key": "k8s.namespace.labels.purpose",
+            "key": "k8s.namespace.labels.name",
             "value": {
-              "stringValue": "testing"
+              "stringValue": "test-namespace"
             }
           },
           {
@@ -3722,27 +3530,15 @@
             }
           },
           {
-            "key": "k8s.namespace.annotations.description",
-            "value": {
-              "stringValue": "This is a test namespace."
-            }
-          },
-          {
-            "key": "k8s.namespace.labels.app",
-            "value": {
-              "stringValue": "test-app"
-            }
-          },
-          {
             "key": "k8s.namespace.labels.kubernetes.io/metadata.name",
             "value": {
               "stringValue": "test-namespace"
             }
           },
           {
-            "key": "k8s.namespace.labels.purpose",
+            "key": "k8s.namespace.labels.name",
             "value": {
-              "stringValue": "testing"
+              "stringValue": "test-namespace"
             }
           },
           {
@@ -3944,27 +3740,15 @@
             }
           },
           {
-            "key": "k8s.namespace.annotations.description",
-            "value": {
-              "stringValue": "This is a test namespace."
-            }
-          },
-          {
-            "key": "k8s.namespace.labels.app",
-            "value": {
-              "stringValue": "test-app"
-            }
-          },
-          {
             "key": "k8s.namespace.labels.kubernetes.io/metadata.name",
             "value": {
               "stringValue": "test-namespace"
             }
           },
           {
-            "key": "k8s.namespace.labels.purpose",
+            "key": "k8s.namespace.labels.name",
             "value": {
-              "stringValue": "testing"
+              "stringValue": "test-namespace"
             }
           },
           {
@@ -4116,27 +3900,15 @@
             }
           },
           {
-            "key": "k8s.namespace.annotations.description",
-            "value": {
-              "stringValue": "This is a test namespace."
-            }
-          },
-          {
-            "key": "k8s.namespace.labels.app",
-            "value": {
-              "stringValue": "test-app"
-            }
-          },
-          {
             "key": "k8s.namespace.labels.kubernetes.io/metadata.name",
             "value": {
               "stringValue": "test-namespace"
             }
           },
           {
-            "key": "k8s.namespace.labels.purpose",
+            "key": "k8s.namespace.labels.name",
             "value": {
-              "stringValue": "testing"
+              "stringValue": "test-namespace"
             }
           },
           {
@@ -4282,27 +4054,15 @@
             }
           },
           {
-            "key": "k8s.namespace.annotations.description",
-            "value": {
-              "stringValue": "This is a test namespace."
-            }
-          },
-          {
-            "key": "k8s.namespace.labels.app",
-            "value": {
-              "stringValue": "test-app"
-            }
-          },
-          {
             "key": "k8s.namespace.labels.kubernetes.io/metadata.name",
             "value": {
               "stringValue": "test-namespace"
             }
           },
           {
-            "key": "k8s.namespace.labels.purpose",
+            "key": "k8s.namespace.labels.name",
             "value": {
-              "stringValue": "testing"
+              "stringValue": "test-namespace"
             }
           },
           {
@@ -4837,27 +4597,15 @@
             }
           },
           {
-            "key": "k8s.namespace.annotations.description",
-            "value": {
-              "stringValue": "This is a test namespace."
-            }
-          },
-          {
-            "key": "k8s.namespace.labels.app",
-            "value": {
-              "stringValue": "test-app"
-            }
-          },
-          {
             "key": "k8s.namespace.labels.kubernetes.io/metadata.name",
             "value": {
               "stringValue": "test-namespace"
             }
           },
           {
-            "key": "k8s.namespace.labels.purpose",
+            "key": "k8s.namespace.labels.name",
             "value": {
-              "stringValue": "testing"
+              "stringValue": "test-namespace"
             }
           },
           {
@@ -5111,27 +4859,15 @@
             }
           },
           {
-            "key": "k8s.namespace.annotations.description",
-            "value": {
-              "stringValue": "This is a test namespace."
-            }
-          },
-          {
-            "key": "k8s.namespace.labels.app",
-            "value": {
-              "stringValue": "test-app"
-            }
-          },
-          {
             "key": "k8s.namespace.labels.kubernetes.io/metadata.name",
             "value": {
               "stringValue": "test-namespace"
             }
           },
           {
-            "key": "k8s.namespace.labels.purpose",
+            "key": "k8s.namespace.labels.name",
             "value": {
-              "stringValue": "testing"
+              "stringValue": "test-namespace"
             }
           },
           {
@@ -5320,27 +5056,15 @@
             }
           },
           {
-            "key": "k8s.namespace.annotations.description",
-            "value": {
-              "stringValue": "This is a test namespace."
-            }
-          },
-          {
-            "key": "k8s.namespace.labels.app",
-            "value": {
-              "stringValue": "test-app"
-            }
-          },
-          {
             "key": "k8s.namespace.labels.kubernetes.io/metadata.name",
             "value": {
               "stringValue": "test-namespace"
             }
           },
           {
-            "key": "k8s.namespace.labels.purpose",
+            "key": "k8s.namespace.labels.name",
             "value": {
-              "stringValue": "testing"
+              "stringValue": "test-namespace"
             }
           },
           {
@@ -5484,27 +5208,15 @@
             }
           },
           {
-            "key": "k8s.namespace.annotations.description",
-            "value": {
-              "stringValue": "This is a test namespace."
-            }
-          },
-          {
-            "key": "k8s.namespace.labels.app",
-            "value": {
-              "stringValue": "test-app"
-            }
-          },
-          {
             "key": "k8s.namespace.labels.kubernetes.io/metadata.name",
             "value": {
               "stringValue": "test-namespace"
             }
           },
           {
-            "key": "k8s.namespace.labels.purpose",
+            "key": "k8s.namespace.labels.name",
             "value": {
-              "stringValue": "testing"
+              "stringValue": "test-namespace"
             }
           },
           {
@@ -5832,27 +5544,15 @@
             }
           },
           {
-            "key": "k8s.namespace.annotations.description",
-            "value": {
-              "stringValue": "This is a test namespace."
-            }
-          },
-          {
-            "key": "k8s.namespace.labels.app",
-            "value": {
-              "stringValue": "test-app"
-            }
-          },
-          {
             "key": "k8s.namespace.labels.kubernetes.io/metadata.name",
             "value": {
               "stringValue": "test-namespace"
             }
           },
           {
-            "key": "k8s.namespace.labels.purpose",
+            "key": "k8s.namespace.labels.name",
             "value": {
-              "stringValue": "testing"
+              "stringValue": "test-namespace"
             }
           },
           {
@@ -6038,27 +5738,15 @@
             }
           },
           {
-            "key": "k8s.namespace.annotations.description",
-            "value": {
-              "stringValue": "This is a test namespace."
-            }
-          },
-          {
-            "key": "k8s.namespace.labels.app",
-            "value": {
-              "stringValue": "test-app"
-            }
-          },
-          {
             "key": "k8s.namespace.labels.kubernetes.io/metadata.name",
             "value": {
               "stringValue": "test-namespace"
             }
           },
           {
-            "key": "k8s.namespace.labels.purpose",
+            "key": "k8s.namespace.labels.name",
             "value": {
-              "stringValue": "testing"
+              "stringValue": "test-namespace"
             }
           },
           {
@@ -6220,27 +5908,15 @@
             }
           },
           {
-            "key": "k8s.namespace.annotations.description",
-            "value": {
-              "stringValue": "This is a test namespace."
-            }
-          },
-          {
-            "key": "k8s.namespace.labels.app",
-            "value": {
-              "stringValue": "test-app"
-            }
-          },
-          {
             "key": "k8s.namespace.labels.kubernetes.io/metadata.name",
             "value": {
               "stringValue": "test-namespace"
             }
           },
           {
-            "key": "k8s.namespace.labels.purpose",
+            "key": "k8s.namespace.labels.name",
             "value": {
-              "stringValue": "testing"
+              "stringValue": "test-namespace"
             }
           },
           {
@@ -6421,27 +6097,15 @@
             }
           },
           {
-            "key": "k8s.namespace.annotations.description",
-            "value": {
-              "stringValue": "This is a test namespace."
-            }
-          },
-          {
-            "key": "k8s.namespace.labels.app",
-            "value": {
-              "stringValue": "test-app"
-            }
-          },
-          {
             "key": "k8s.namespace.labels.kubernetes.io/metadata.name",
             "value": {
               "stringValue": "test-namespace"
             }
           },
           {
-            "key": "k8s.namespace.labels.purpose",
+            "key": "k8s.namespace.labels.name",
             "value": {
-              "stringValue": "testing"
+              "stringValue": "test-namespace"
             }
           },
           {
@@ -6627,27 +6291,15 @@
             }
           },
           {
-            "key": "k8s.namespace.annotations.description",
-            "value": {
-              "stringValue": "This is a test namespace."
-            }
-          },
-          {
-            "key": "k8s.namespace.labels.app",
-            "value": {
-              "stringValue": "test-app"
-            }
-          },
-          {
             "key": "k8s.namespace.labels.kubernetes.io/metadata.name",
             "value": {
               "stringValue": "test-namespace"
             }
           },
           {
-            "key": "k8s.namespace.labels.purpose",
+            "key": "k8s.namespace.labels.name",
             "value": {
-              "stringValue": "testing"
+              "stringValue": "test-namespace"
             }
           },
           {
@@ -6821,27 +6473,15 @@
             }
           },
           {
-            "key": "k8s.namespace.annotations.description",
-            "value": {
-              "stringValue": "This is a test namespace."
-            }
-          },
-          {
-            "key": "k8s.namespace.labels.app",
-            "value": {
-              "stringValue": "test-app"
-            }
-          },
-          {
             "key": "k8s.namespace.labels.kubernetes.io/metadata.name",
             "value": {
               "stringValue": "test-namespace"
             }
           },
           {
-            "key": "k8s.namespace.labels.purpose",
+            "key": "k8s.namespace.labels.name",
             "value": {
-              "stringValue": "testing"
+              "stringValue": "test-namespace"
             }
           },
           {
@@ -7022,27 +6662,15 @@
             }
           },
           {
-            "key": "k8s.namespace.annotations.description",
-            "value": {
-              "stringValue": "This is a test namespace."
-            }
-          },
-          {
-            "key": "k8s.namespace.labels.app",
-            "value": {
-              "stringValue": "test-app"
-            }
-          },
-          {
             "key": "k8s.namespace.labels.kubernetes.io/metadata.name",
             "value": {
               "stringValue": "test-namespace"
             }
           },
           {
-            "key": "k8s.namespace.labels.purpose",
+            "key": "k8s.namespace.labels.name",
             "value": {
-              "stringValue": "testing"
+              "stringValue": "test-namespace"
             }
           },
           {
@@ -7204,27 +6832,15 @@
             }
           },
           {
-            "key": "k8s.namespace.annotations.description",
-            "value": {
-              "stringValue": "This is a test namespace."
-            }
-          },
-          {
-            "key": "k8s.namespace.labels.app",
-            "value": {
-              "stringValue": "test-app"
-            }
-          },
-          {
             "key": "k8s.namespace.labels.kubernetes.io/metadata.name",
             "value": {
               "stringValue": "test-namespace"
             }
           },
           {
-            "key": "k8s.namespace.labels.purpose",
+            "key": "k8s.namespace.labels.name",
             "value": {
-              "stringValue": "testing"
+              "stringValue": "test-namespace"
             }
           },
           {
@@ -7350,27 +6966,15 @@
             }
           },
           {
-            "key": "k8s.namespace.annotations.description",
-            "value": {
-              "stringValue": "This is a test namespace."
-            }
-          },
-          {
-            "key": "k8s.namespace.labels.app",
-            "value": {
-              "stringValue": "test-app"
-            }
-          },
-          {
             "key": "k8s.namespace.labels.kubernetes.io/metadata.name",
             "value": {
               "stringValue": "test-namespace"
             }
           },
           {
-            "key": "k8s.namespace.labels.purpose",
+            "key": "k8s.namespace.labels.name",
             "value": {
-              "stringValue": "testing"
+              "stringValue": "test-namespace"
             }
           },
           {
@@ -7496,27 +7100,15 @@
             }
           },
           {
-            "key": "k8s.namespace.annotations.description",
-            "value": {
-              "stringValue": "This is a test namespace."
-            }
-          },
-          {
-            "key": "k8s.namespace.labels.app",
-            "value": {
-              "stringValue": "test-app"
-            }
-          },
-          {
             "key": "k8s.namespace.labels.kubernetes.io/metadata.name",
             "value": {
               "stringValue": "test-namespace"
             }
           },
           {
-            "key": "k8s.namespace.labels.purpose",
+            "key": "k8s.namespace.labels.name",
             "value": {
-              "stringValue": "testing"
+              "stringValue": "test-namespace"
             }
           },
           {
@@ -7648,27 +7240,15 @@
             }
           },
           {
-            "key": "k8s.namespace.annotations.description",
-            "value": {
-              "stringValue": "This is a test namespace."
-            }
-          },
-          {
-            "key": "k8s.namespace.labels.app",
-            "value": {
-              "stringValue": "test-app"
-            }
-          },
-          {
             "key": "k8s.namespace.labels.kubernetes.io/metadata.name",
             "value": {
               "stringValue": "test-namespace"
             }
           },
           {
-            "key": "k8s.namespace.labels.purpose",
+            "key": "k8s.namespace.labels.name",
             "value": {
-              "stringValue": "testing"
+              "stringValue": "test-namespace"
             }
           },
           {
@@ -7806,27 +7386,15 @@
             }
           },
           {
-            "key": "k8s.namespace.annotations.description",
-            "value": {
-              "stringValue": "This is a test namespace."
-            }
-          },
-          {
-            "key": "k8s.namespace.labels.app",
-            "value": {
-              "stringValue": "test-app"
-            }
-          },
-          {
             "key": "k8s.namespace.labels.kubernetes.io/metadata.name",
             "value": {
               "stringValue": "test-namespace"
             }
           },
           {
-            "key": "k8s.namespace.labels.purpose",
+            "key": "k8s.namespace.labels.name",
             "value": {
-              "stringValue": "testing"
+              "stringValue": "test-namespace"
             }
           },
           {
@@ -7976,27 +7544,15 @@
             }
           },
           {
-            "key": "k8s.namespace.annotations.description",
-            "value": {
-              "stringValue": "This is a test namespace."
-            }
-          },
-          {
-            "key": "k8s.namespace.labels.app",
-            "value": {
-              "stringValue": "test-app"
-            }
-          },
-          {
             "key": "k8s.namespace.labels.kubernetes.io/metadata.name",
             "value": {
               "stringValue": "test-namespace"
             }
           },
           {
-            "key": "k8s.namespace.labels.purpose",
+            "key": "k8s.namespace.labels.name",
             "value": {
-              "stringValue": "testing"
+              "stringValue": "test-namespace"
             }
           },
           {
@@ -8134,27 +7690,15 @@
             }
           },
           {
-            "key": "k8s.namespace.annotations.description",
-            "value": {
-              "stringValue": "This is a test namespace."
-            }
-          },
-          {
-            "key": "k8s.namespace.labels.app",
-            "value": {
-              "stringValue": "test-app"
-            }
-          },
-          {
             "key": "k8s.namespace.labels.kubernetes.io/metadata.name",
             "value": {
               "stringValue": "test-namespace"
             }
           },
           {
-            "key": "k8s.namespace.labels.purpose",
+            "key": "k8s.namespace.labels.name",
             "value": {
-              "stringValue": "testing"
+              "stringValue": "test-namespace"
             }
           },
           {
@@ -8305,27 +7849,15 @@
             }
           },
           {
-            "key": "k8s.namespace.annotations.description",
-            "value": {
-              "stringValue": "This is a test namespace."
-            }
-          },
-          {
-            "key": "k8s.namespace.labels.app",
-            "value": {
-              "stringValue": "test-app"
-            }
-          },
-          {
             "key": "k8s.namespace.labels.kubernetes.io/metadata.name",
             "value": {
               "stringValue": "test-namespace"
             }
           },
           {
-            "key": "k8s.namespace.labels.purpose",
+            "key": "k8s.namespace.labels.name",
             "value": {
-              "stringValue": "testing"
+              "stringValue": "test-namespace"
             }
           },
           {
@@ -8469,27 +8001,15 @@
             }
           },
           {
-            "key": "k8s.namespace.annotations.description",
-            "value": {
-              "stringValue": "This is a test namespace."
-            }
-          },
-          {
-            "key": "k8s.namespace.labels.app",
-            "value": {
-              "stringValue": "test-app"
-            }
-          },
-          {
             "key": "k8s.namespace.labels.kubernetes.io/metadata.name",
             "value": {
               "stringValue": "test-namespace"
             }
           },
           {
-            "key": "k8s.namespace.labels.purpose",
+            "key": "k8s.namespace.labels.name",
             "value": {
-              "stringValue": "testing"
+              "stringValue": "test-namespace"
             }
           },
           {
@@ -8627,27 +8147,15 @@
             }
           },
           {
-            "key": "k8s.namespace.annotations.description",
-            "value": {
-              "stringValue": "This is a test namespace."
-            }
-          },
-          {
-            "key": "k8s.namespace.labels.app",
-            "value": {
-              "stringValue": "test-app"
-            }
-          },
-          {
             "key": "k8s.namespace.labels.kubernetes.io/metadata.name",
             "value": {
               "stringValue": "test-namespace"
             }
           },
           {
-            "key": "k8s.namespace.labels.purpose",
+            "key": "k8s.namespace.labels.name",
             "value": {
-              "stringValue": "testing"
+              "stringValue": "test-namespace"
             }
           },
           {
@@ -8819,27 +8327,15 @@
             }
           },
           {
-            "key": "k8s.namespace.annotations.description",
-            "value": {
-              "stringValue": "This is a test namespace."
-            }
-          },
-          {
-            "key": "k8s.namespace.labels.app",
-            "value": {
-              "stringValue": "test-app"
-            }
-          },
-          {
             "key": "k8s.namespace.labels.kubernetes.io/metadata.name",
             "value": {
               "stringValue": "test-namespace"
             }
           },
           {
-            "key": "k8s.namespace.labels.purpose",
+            "key": "k8s.namespace.labels.name",
             "value": {
-              "stringValue": "testing"
+              "stringValue": "test-namespace"
             }
           },
           {
@@ -8977,27 +8473,15 @@
             }
           },
           {
-            "key": "k8s.namespace.annotations.description",
-            "value": {
-              "stringValue": "This is a test namespace."
-            }
-          },
-          {
-            "key": "k8s.namespace.labels.app",
-            "value": {
-              "stringValue": "test-app"
-            }
-          },
-          {
             "key": "k8s.namespace.labels.kubernetes.io/metadata.name",
             "value": {
               "stringValue": "test-namespace"
             }
           },
           {
-            "key": "k8s.namespace.labels.purpose",
+            "key": "k8s.namespace.labels.name",
             "value": {
-              "stringValue": "testing"
+              "stringValue": "test-namespace"
             }
           },
           {
@@ -9129,27 +8613,15 @@
             }
           },
           {
-            "key": "k8s.namespace.annotations.description",
-            "value": {
-              "stringValue": "This is a test namespace."
-            }
-          },
-          {
-            "key": "k8s.namespace.labels.app",
-            "value": {
-              "stringValue": "test-app"
-            }
-          },
-          {
             "key": "k8s.namespace.labels.kubernetes.io/metadata.name",
             "value": {
               "stringValue": "test-namespace"
             }
           },
           {
-            "key": "k8s.namespace.labels.purpose",
+            "key": "k8s.namespace.labels.name",
             "value": {
-              "stringValue": "testing"
+              "stringValue": "test-namespace"
             }
           },
           {
@@ -9299,27 +8771,15 @@
             }
           },
           {
-            "key": "k8s.namespace.annotations.description",
-            "value": {
-              "stringValue": "This is a test namespace."
-            }
-          },
-          {
-            "key": "k8s.namespace.labels.app",
-            "value": {
-              "stringValue": "test-app"
-            }
-          },
-          {
             "key": "k8s.namespace.labels.kubernetes.io/metadata.name",
             "value": {
               "stringValue": "test-namespace"
             }
           },
           {
-            "key": "k8s.namespace.labels.purpose",
+            "key": "k8s.namespace.labels.name",
             "value": {
-              "stringValue": "testing"
+              "stringValue": "test-namespace"
             }
           },
           {
@@ -9457,27 +8917,15 @@
             }
           },
           {
-            "key": "k8s.namespace.annotations.description",
-            "value": {
-              "stringValue": "This is a test namespace."
-            }
-          },
-          {
-            "key": "k8s.namespace.labels.app",
-            "value": {
-              "stringValue": "test-app"
-            }
-          },
-          {
             "key": "k8s.namespace.labels.kubernetes.io/metadata.name",
             "value": {
               "stringValue": "test-namespace"
             }
           },
           {
-            "key": "k8s.namespace.labels.purpose",
+            "key": "k8s.namespace.labels.name",
             "value": {
-              "stringValue": "testing"
+              "stringValue": "test-namespace"
             }
           },
           {
@@ -9755,27 +9203,15 @@
             }
           },
           {
-            "key": "k8s.namespace.annotations.description",
-            "value": {
-              "stringValue": "This is a test namespace."
-            }
-          },
-          {
-            "key": "k8s.namespace.labels.app",
-            "value": {
-              "stringValue": "test-app"
-            }
-          },
-          {
             "key": "k8s.namespace.labels.kubernetes.io/metadata.name",
             "value": {
               "stringValue": "test-namespace"
             }
           },
           {
-            "key": "k8s.namespace.labels.purpose",
+            "key": "k8s.namespace.labels.name",
             "value": {
-              "stringValue": "testing"
+              "stringValue": "test-namespace"
             }
           },
           {
@@ -9913,27 +9349,15 @@
             }
           },
           {
-            "key": "k8s.namespace.annotations.description",
-            "value": {
-              "stringValue": "This is a test namespace."
-            }
-          },
-          {
-            "key": "k8s.namespace.labels.app",
-            "value": {
-              "stringValue": "test-app"
-            }
-          },
-          {
             "key": "k8s.namespace.labels.kubernetes.io/metadata.name",
             "value": {
               "stringValue": "test-namespace"
             }
           },
           {
-            "key": "k8s.namespace.labels.purpose",
+            "key": "k8s.namespace.labels.name",
             "value": {
-              "stringValue": "testing"
+              "stringValue": "test-namespace"
             }
           },
           {
@@ -10168,27 +9592,15 @@
             }
           },
           {
-            "key": "k8s.namespace.annotations.description",
-            "value": {
-              "stringValue": "This is a test namespace."
-            }
-          },
-          {
-            "key": "k8s.namespace.labels.app",
-            "value": {
-              "stringValue": "test-app"
-            }
-          },
-          {
             "key": "k8s.namespace.labels.kubernetes.io/metadata.name",
             "value": {
               "stringValue": "test-namespace"
             }
           },
           {
-            "key": "k8s.namespace.labels.purpose",
+            "key": "k8s.namespace.labels.name",
             "value": {
-              "stringValue": "testing"
+              "stringValue": "test-namespace"
             }
           },
           {
@@ -10344,27 +9756,15 @@
             }
           },
           {
-            "key": "k8s.namespace.annotations.description",
-            "value": {
-              "stringValue": "This is a test namespace."
-            }
-          },
-          {
-            "key": "k8s.namespace.labels.app",
-            "value": {
-              "stringValue": "test-app"
-            }
-          },
-          {
             "key": "k8s.namespace.labels.kubernetes.io/metadata.name",
             "value": {
               "stringValue": "test-namespace"
             }
           },
           {
-            "key": "k8s.namespace.labels.purpose",
+            "key": "k8s.namespace.labels.name",
             "value": {
-              "stringValue": "testing"
+              "stringValue": "test-namespace"
             }
           },
           {
@@ -10607,27 +10007,15 @@
             }
           },
           {
-            "key": "k8s.namespace.annotations.description",
-            "value": {
-              "stringValue": "This is a test namespace."
-            }
-          },
-          {
-            "key": "k8s.namespace.labels.app",
-            "value": {
-              "stringValue": "test-app"
-            }
-          },
-          {
             "key": "k8s.namespace.labels.kubernetes.io/metadata.name",
             "value": {
               "stringValue": "test-namespace"
             }
           },
           {
-            "key": "k8s.namespace.labels.purpose",
+            "key": "k8s.namespace.labels.name",
             "value": {
-              "stringValue": "testing"
+              "stringValue": "test-namespace"
             }
           },
           {
@@ -10765,27 +10153,15 @@
             }
           },
           {
-            "key": "k8s.namespace.annotations.description",
-            "value": {
-              "stringValue": "This is a test namespace."
-            }
-          },
-          {
-            "key": "k8s.namespace.labels.app",
-            "value": {
-              "stringValue": "test-app"
-            }
-          },
-          {
             "key": "k8s.namespace.labels.kubernetes.io/metadata.name",
             "value": {
               "stringValue": "test-namespace"
             }
           },
           {
-            "key": "k8s.namespace.labels.purpose",
+            "key": "k8s.namespace.labels.name",
             "value": {
-              "stringValue": "testing"
+              "stringValue": "test-namespace"
             }
           },
           {
@@ -10917,27 +10293,15 @@
             }
           },
           {
-            "key": "k8s.namespace.annotations.description",
-            "value": {
-              "stringValue": "This is a test namespace."
-            }
-          },
-          {
-            "key": "k8s.namespace.labels.app",
-            "value": {
-              "stringValue": "test-app"
-            }
-          },
-          {
             "key": "k8s.namespace.labels.kubernetes.io/metadata.name",
             "value": {
               "stringValue": "test-namespace"
             }
           },
           {
-            "key": "k8s.namespace.labels.purpose",
+            "key": "k8s.namespace.labels.name",
             "value": {
-              "stringValue": "testing"
+              "stringValue": "test-namespace"
             }
           },
           {
@@ -11109,27 +10473,15 @@
             }
           },
           {
-            "key": "k8s.namespace.annotations.description",
-            "value": {
-              "stringValue": "This is a test namespace."
-            }
-          },
-          {
-            "key": "k8s.namespace.labels.app",
-            "value": {
-              "stringValue": "test-app"
-            }
-          },
-          {
             "key": "k8s.namespace.labels.kubernetes.io/metadata.name",
             "value": {
               "stringValue": "test-namespace"
             }
           },
           {
-            "key": "k8s.namespace.labels.purpose",
+            "key": "k8s.namespace.labels.name",
             "value": {
-              "stringValue": "testing"
+              "stringValue": "test-namespace"
             }
           },
           {
@@ -11255,27 +10607,15 @@
             }
           },
           {
-            "key": "k8s.namespace.annotations.description",
-            "value": {
-              "stringValue": "This is a test namespace."
-            }
-          },
-          {
-            "key": "k8s.namespace.labels.app",
-            "value": {
-              "stringValue": "test-app"
-            }
-          },
-          {
             "key": "k8s.namespace.labels.kubernetes.io/metadata.name",
             "value": {
               "stringValue": "test-namespace"
             }
           },
           {
-            "key": "k8s.namespace.labels.purpose",
+            "key": "k8s.namespace.labels.name",
             "value": {
-              "stringValue": "testing"
+              "stringValue": "test-namespace"
             }
           },
           {
@@ -11407,27 +10747,15 @@
             }
           },
           {
-            "key": "k8s.namespace.annotations.description",
-            "value": {
-              "stringValue": "This is a test namespace."
-            }
-          },
-          {
-            "key": "k8s.namespace.labels.app",
-            "value": {
-              "stringValue": "test-app"
-            }
-          },
-          {
             "key": "k8s.namespace.labels.kubernetes.io/metadata.name",
             "value": {
               "stringValue": "test-namespace"
             }
           },
           {
-            "key": "k8s.namespace.labels.purpose",
+            "key": "k8s.namespace.labels.name",
             "value": {
-              "stringValue": "testing"
+              "stringValue": "test-namespace"
             }
           },
           {
@@ -11689,27 +11017,15 @@
             }
           },
           {
-            "key": "k8s.namespace.annotations.description",
-            "value": {
-              "stringValue": "This is a test namespace."
-            }
-          },
-          {
-            "key": "k8s.namespace.labels.app",
-            "value": {
-              "stringValue": "test-app"
-            }
-          },
-          {
             "key": "k8s.namespace.labels.kubernetes.io/metadata.name",
             "value": {
               "stringValue": "test-namespace"
             }
           },
           {
-            "key": "k8s.namespace.labels.purpose",
+            "key": "k8s.namespace.labels.name",
             "value": {
-              "stringValue": "testing"
+              "stringValue": "test-namespace"
             }
           },
           {
@@ -11847,27 +11163,15 @@
             }
           },
           {
-            "key": "k8s.namespace.annotations.description",
-            "value": {
-              "stringValue": "This is a test namespace."
-            }
-          },
-          {
-            "key": "k8s.namespace.labels.app",
-            "value": {
-              "stringValue": "test-app"
-            }
-          },
-          {
             "key": "k8s.namespace.labels.kubernetes.io/metadata.name",
             "value": {
               "stringValue": "test-namespace"
             }
           },
           {
-            "key": "k8s.namespace.labels.purpose",
+            "key": "k8s.namespace.labels.name",
             "value": {
-              "stringValue": "testing"
+              "stringValue": "test-namespace"
             }
           },
           {
@@ -12017,27 +11321,15 @@
             }
           },
           {
-            "key": "k8s.namespace.annotations.description",
-            "value": {
-              "stringValue": "This is a test namespace."
-            }
-          },
-          {
-            "key": "k8s.namespace.labels.app",
-            "value": {
-              "stringValue": "test-app"
-            }
-          },
-          {
             "key": "k8s.namespace.labels.kubernetes.io/metadata.name",
             "value": {
               "stringValue": "test-namespace"
             }
           },
           {
-            "key": "k8s.namespace.labels.purpose",
+            "key": "k8s.namespace.labels.name",
             "value": {
-              "stringValue": "testing"
+              "stringValue": "test-namespace"
             }
           },
           {
@@ -12200,27 +11492,15 @@
             }
           },
           {
-            "key": "k8s.namespace.annotations.description",
-            "value": {
-              "stringValue": "This is a test namespace."
-            }
-          },
-          {
-            "key": "k8s.namespace.labels.app",
-            "value": {
-              "stringValue": "test-app"
-            }
-          },
-          {
             "key": "k8s.namespace.labels.kubernetes.io/metadata.name",
             "value": {
               "stringValue": "test-namespace"
             }
           },
           {
-            "key": "k8s.namespace.labels.purpose",
+            "key": "k8s.namespace.labels.name",
             "value": {
-              "stringValue": "testing"
+              "stringValue": "test-namespace"
             }
           },
           {
@@ -12370,27 +11650,15 @@
             }
           },
           {
-            "key": "k8s.namespace.annotations.description",
-            "value": {
-              "stringValue": "This is a test namespace."
-            }
-          },
-          {
-            "key": "k8s.namespace.labels.app",
-            "value": {
-              "stringValue": "test-app"
-            }
-          },
-          {
             "key": "k8s.namespace.labels.kubernetes.io/metadata.name",
             "value": {
               "stringValue": "test-namespace"
             }
           },
           {
-            "key": "k8s.namespace.labels.purpose",
+            "key": "k8s.namespace.labels.name",
             "value": {
-              "stringValue": "testing"
+              "stringValue": "test-namespace"
             }
           },
           {
@@ -12572,27 +11840,15 @@
             }
           },
           {
-            "key": "k8s.namespace.annotations.description",
-            "value": {
-              "stringValue": "This is a test namespace."
-            }
-          },
-          {
-            "key": "k8s.namespace.labels.app",
-            "value": {
-              "stringValue": "test-app"
-            }
-          },
-          {
             "key": "k8s.namespace.labels.kubernetes.io/metadata.name",
             "value": {
               "stringValue": "test-namespace"
             }
           },
           {
-            "key": "k8s.namespace.labels.purpose",
+            "key": "k8s.namespace.labels.name",
             "value": {
-              "stringValue": "testing"
+              "stringValue": "test-namespace"
             }
           },
           {
@@ -12742,27 +11998,15 @@
             }
           },
           {
-            "key": "k8s.namespace.annotations.description",
-            "value": {
-              "stringValue": "This is a test namespace."
-            }
-          },
-          {
-            "key": "k8s.namespace.labels.app",
-            "value": {
-              "stringValue": "test-app"
-            }
-          },
-          {
             "key": "k8s.namespace.labels.kubernetes.io/metadata.name",
             "value": {
               "stringValue": "test-namespace"
             }
           },
           {
-            "key": "k8s.namespace.labels.purpose",
+            "key": "k8s.namespace.labels.name",
             "value": {
-              "stringValue": "testing"
+              "stringValue": "test-namespace"
             }
           },
           {
@@ -12894,27 +12138,15 @@
             }
           },
           {
-            "key": "k8s.namespace.annotations.description",
-            "value": {
-              "stringValue": "This is a test namespace."
-            }
-          },
-          {
-            "key": "k8s.namespace.labels.app",
-            "value": {
-              "stringValue": "test-app"
-            }
-          },
-          {
             "key": "k8s.namespace.labels.kubernetes.io/metadata.name",
             "value": {
               "stringValue": "test-namespace"
             }
           },
           {
-            "key": "k8s.namespace.labels.purpose",
+            "key": "k8s.namespace.labels.name",
             "value": {
-              "stringValue": "testing"
+              "stringValue": "test-namespace"
             }
           },
           {
@@ -13147,27 +12379,15 @@
             }
           },
           {
-            "key": "k8s.namespace.annotations.description",
-            "value": {
-              "stringValue": "This is a test namespace."
-            }
-          },
-          {
-            "key": "k8s.namespace.labels.app",
-            "value": {
-              "stringValue": "test-app"
-            }
-          },
-          {
             "key": "k8s.namespace.labels.kubernetes.io/metadata.name",
             "value": {
               "stringValue": "test-namespace"
             }
           },
           {
-            "key": "k8s.namespace.labels.purpose",
+            "key": "k8s.namespace.labels.name",
             "value": {
-              "stringValue": "testing"
+              "stringValue": "test-namespace"
             }
           },
           {
@@ -13379,27 +12599,15 @@
             }
           },
           {
-            "key": "k8s.namespace.annotations.description",
-            "value": {
-              "stringValue": "This is a test namespace."
-            }
-          },
-          {
-            "key": "k8s.namespace.labels.app",
-            "value": {
-              "stringValue": "test-app"
-            }
-          },
-          {
             "key": "k8s.namespace.labels.kubernetes.io/metadata.name",
             "value": {
               "stringValue": "test-namespace"
             }
           },
           {
-            "key": "k8s.namespace.labels.purpose",
+            "key": "k8s.namespace.labels.name",
             "value": {
-              "stringValue": "testing"
+              "stringValue": "test-namespace"
             }
           },
           {
@@ -13525,27 +12733,15 @@
             }
           },
           {
-            "key": "k8s.namespace.annotations.description",
-            "value": {
-              "stringValue": "This is a test namespace."
-            }
-          },
-          {
-            "key": "k8s.namespace.labels.app",
-            "value": {
-              "stringValue": "test-app"
-            }
-          },
-          {
             "key": "k8s.namespace.labels.kubernetes.io/metadata.name",
             "value": {
               "stringValue": "test-namespace"
             }
           },
           {
-            "key": "k8s.namespace.labels.purpose",
+            "key": "k8s.namespace.labels.name",
             "value": {
-              "stringValue": "testing"
+              "stringValue": "test-namespace"
             }
           },
           {
@@ -13677,27 +12873,15 @@
             }
           },
           {
-            "key": "k8s.namespace.annotations.description",
-            "value": {
-              "stringValue": "This is a test namespace."
-            }
-          },
-          {
-            "key": "k8s.namespace.labels.app",
-            "value": {
-              "stringValue": "test-app"
-            }
-          },
-          {
             "key": "k8s.namespace.labels.kubernetes.io/metadata.name",
             "value": {
               "stringValue": "test-namespace"
             }
           },
           {
-            "key": "k8s.namespace.labels.purpose",
+            "key": "k8s.namespace.labels.name",
             "value": {
-              "stringValue": "testing"
+              "stringValue": "test-namespace"
             }
           },
           {
@@ -13829,27 +13013,15 @@
             }
           },
           {
-            "key": "k8s.namespace.annotations.description",
-            "value": {
-              "stringValue": "This is a test namespace."
-            }
-          },
-          {
-            "key": "k8s.namespace.labels.app",
-            "value": {
-              "stringValue": "test-app"
-            }
-          },
-          {
             "key": "k8s.namespace.labels.kubernetes.io/metadata.name",
             "value": {
               "stringValue": "test-namespace"
             }
           },
           {
-            "key": "k8s.namespace.labels.purpose",
+            "key": "k8s.namespace.labels.name",
             "value": {
-              "stringValue": "testing"
+              "stringValue": "test-namespace"
             }
           },
           {
@@ -14189,27 +13361,15 @@
             }
           },
           {
-            "key": "k8s.namespace.annotations.description",
-            "value": {
-              "stringValue": "This is a test namespace."
-            }
-          },
-          {
-            "key": "k8s.namespace.labels.app",
-            "value": {
-              "stringValue": "test-app"
-            }
-          },
-          {
             "key": "k8s.namespace.labels.kubernetes.io/metadata.name",
             "value": {
               "stringValue": "test-namespace"
             }
           },
           {
-            "key": "k8s.namespace.labels.purpose",
+            "key": "k8s.namespace.labels.name",
             "value": {
-              "stringValue": "testing"
+              "stringValue": "test-namespace"
             }
           },
           {
@@ -14390,27 +13550,15 @@
             }
           },
           {
-            "key": "k8s.namespace.annotations.description",
-            "value": {
-              "stringValue": "This is a test namespace."
-            }
-          },
-          {
-            "key": "k8s.namespace.labels.app",
-            "value": {
-              "stringValue": "test-app"
-            }
-          },
-          {
             "key": "k8s.namespace.labels.kubernetes.io/metadata.name",
             "value": {
               "stringValue": "test-namespace"
             }
           },
           {
-            "key": "k8s.namespace.labels.purpose",
+            "key": "k8s.namespace.labels.name",
             "value": {
-              "stringValue": "testing"
+              "stringValue": "test-namespace"
             }
           },
           {
@@ -14591,27 +13739,15 @@
             }
           },
           {
-            "key": "k8s.namespace.annotations.description",
-            "value": {
-              "stringValue": "This is a test namespace."
-            }
-          },
-          {
-            "key": "k8s.namespace.labels.app",
-            "value": {
-              "stringValue": "test-app"
-            }
-          },
-          {
             "key": "k8s.namespace.labels.kubernetes.io/metadata.name",
             "value": {
               "stringValue": "test-namespace"
             }
           },
           {
-            "key": "k8s.namespace.labels.purpose",
+            "key": "k8s.namespace.labels.name",
             "value": {
-              "stringValue": "testing"
+              "stringValue": "test-namespace"
             }
           },
           {
@@ -14792,27 +13928,15 @@
             }
           },
           {
-            "key": "k8s.namespace.annotations.description",
-            "value": {
-              "stringValue": "This is a test namespace."
-            }
-          },
-          {
-            "key": "k8s.namespace.labels.app",
-            "value": {
-              "stringValue": "test-app"
-            }
-          },
-          {
             "key": "k8s.namespace.labels.kubernetes.io/metadata.name",
             "value": {
               "stringValue": "test-namespace"
             }
           },
           {
-            "key": "k8s.namespace.labels.purpose",
+            "key": "k8s.namespace.labels.name",
             "value": {
-              "stringValue": "testing"
+              "stringValue": "test-namespace"
             }
           },
           {
@@ -14993,27 +14117,15 @@
             }
           },
           {
-            "key": "k8s.namespace.annotations.description",
-            "value": {
-              "stringValue": "This is a test namespace."
-            }
-          },
-          {
-            "key": "k8s.namespace.labels.app",
-            "value": {
-              "stringValue": "test-app"
-            }
-          },
-          {
             "key": "k8s.namespace.labels.kubernetes.io/metadata.name",
             "value": {
               "stringValue": "test-namespace"
             }
           },
           {
-            "key": "k8s.namespace.labels.purpose",
+            "key": "k8s.namespace.labels.name",
             "value": {
-              "stringValue": "testing"
+              "stringValue": "test-namespace"
             }
           },
           {
@@ -17516,27 +16628,15 @@
             }
           },
           {
-            "key": "k8s.namespace.annotations.description",
-            "value": {
-              "stringValue": "This is a test namespace."
-            }
-          },
-          {
-            "key": "k8s.namespace.labels.app",
-            "value": {
-              "stringValue": "test-app"
-            }
-          },
-          {
             "key": "k8s.namespace.labels.kubernetes.io/metadata.name",
             "value": {
               "stringValue": "test-namespace"
             }
           },
           {
-            "key": "k8s.namespace.labels.purpose",
+            "key": "k8s.namespace.labels.name",
             "value": {
-              "stringValue": "testing"
+              "stringValue": "test-namespace"
             }
           },
           {
@@ -17686,27 +16786,15 @@
             }
           },
           {
-            "key": "k8s.namespace.annotations.description",
-            "value": {
-              "stringValue": "This is a test namespace."
-            }
-          },
-          {
-            "key": "k8s.namespace.labels.app",
-            "value": {
-              "stringValue": "test-app"
-            }
-          },
-          {
             "key": "k8s.namespace.labels.kubernetes.io/metadata.name",
             "value": {
               "stringValue": "test-namespace"
             }
           },
           {
-            "key": "k8s.namespace.labels.purpose",
+            "key": "k8s.namespace.labels.name",
             "value": {
-              "stringValue": "testing"
+              "stringValue": "test-namespace"
             }
           },
           {
@@ -18588,27 +17676,15 @@
             }
           },
           {
-            "key": "k8s.namespace.annotations.description",
-            "value": {
-              "stringValue": "This is a test namespace."
-            }
-          },
-          {
-            "key": "k8s.namespace.labels.app",
-            "value": {
-              "stringValue": "test-app"
-            }
-          },
-          {
             "key": "k8s.namespace.labels.kubernetes.io/metadata.name",
             "value": {
               "stringValue": "test-namespace"
             }
           },
           {
-            "key": "k8s.namespace.labels.purpose",
+            "key": "k8s.namespace.labels.name",
             "value": {
-              "stringValue": "testing"
+              "stringValue": "test-namespace"
             }
           },
           {
@@ -18713,27 +17789,15 @@
             }
           },
           {
-            "key": "k8s.namespace.annotations.description",
-            "value": {
-              "stringValue": "This is a test namespace."
-            }
-          },
-          {
-            "key": "k8s.namespace.labels.app",
-            "value": {
-              "stringValue": "test-app"
-            }
-          },
-          {
             "key": "k8s.namespace.labels.kubernetes.io/metadata.name",
             "value": {
               "stringValue": "test-namespace"
             }
           },
           {
-            "key": "k8s.namespace.labels.purpose",
+            "key": "k8s.namespace.labels.name",
             "value": {
-              "stringValue": "testing"
+              "stringValue": "test-namespace"
             }
           },
           {
@@ -29181,54 +28245,6 @@
               },
               "name": "k8s.node.network.transmit_packets_dropped"
             },
-            {
-              "gauge": {
-                "dataPoints": [
-                  {
-                    "asDouble": 2,
-                    "timeUnixNano": "0"
-                  }
-                ]
-              },
-              "name": "k8s.node.pods"
-            }
-          ],
-          "scope": {}
-        }
-      ]
-    },
-    {
-      "resource": {
-        "attributes": [
-          {
-            "key": "k8s.cluster.name",
-            "value": {
-              "stringValue": "cluster name"
-            }
-          },
-          {
-            "key": "sw.k8s.agent.app.version",
-            "value": {
-              "stringValue": "0.8.6"
-            }
-          },
-          {
-            "key": "sw.k8s.agent.manifest.version",
-            "value": {
-              "stringValue": "2.8.0-alpha.8"
-            }
-          },
-          {
-            "key": "sw.k8s.cluster.uid",
-            "value": {
-              "stringValue": "cluster-uid-123456789"
-            }
-          }
-        ]
-      },
-      "scopeMetrics": [
-        {
-          "metrics": [
             {
               "gauge": {
                 "dataPoints": [

--- a/tests/integration/test_events_collection.py
+++ b/tests/integration/test_events_collection.py
@@ -8,10 +8,10 @@ pod_name = 'dummy-pod'
 expected_event = f'Started container {pod_name}'
 
 def setup_function():
-    run_shell_command(f"kubectl run {pod_name} --labels \"test-label=test-value\" --overrides=\"{{ \\\"apiVersion\\\": \\\"v1\\\", \\\"metadata\\\": {{\\\"annotations\\\": {{ \\\"test-annotation\\\":\\\"test-value\\\" }} }} }}\" --image bash:alpine3.16 -- -ec \"while :; do sleep 5 ; done\"")
+    run_shell_command(f"kubectl run {pod_name} --labels \"test-label=test-value\" --overrides=\"{{ \\\"apiVersion\\\": \\\"v1\\\", \\\"metadata\\\": {{\\\"annotations\\\": {{ \\\"test-annotation\\\":\\\"test-value\\\" }} }} }}\" --image bash:alpine3.16 -n default -- -ec \"while :; do sleep 5 ; done\"")
 
 def teardown_function():
-    run_shell_command(f'kubectl delete pod {pod_name}')
+    run_shell_command(f'kubectl delete pod {pod_name} -n default')
 
 def test_events_generated():
     retry_until_ok(url, assert_test_event_found, print_failure)

--- a/tests/integration/test_log_collection.py
+++ b/tests/integration/test_log_collection.py
@@ -8,10 +8,10 @@ pod_name = 'dummy-logging-pod'
 tested_log = '!!testlog!!'
 
 def setup_function():
-    run_shell_command(f'kubectl run {pod_name} --image bash:alpine3.16 -- -ec "while :; do echo \'{tested_log}\'; sleep 5 ; done"')
+    run_shell_command(f'kubectl run {pod_name} --image bash:alpine3.16 -n default -- -ec "while :; do echo \'{tested_log}\'; sleep 5 ; done"')
 
 def teardown_function():
-    run_shell_command(f'kubectl delete pod {pod_name}')
+    run_shell_command(f'kubectl delete pod {pod_name} -n default')
 
 def test_logs_generated():
     retry_until_ok(url, assert_test_log_found, print_failure)


### PR DESCRIPTION
I developed this as part of eBPF efforts, since eBPF cannot be tested on local docker-desktop

Generally:
* adjusting manifests so that namespace can be overridden, in order to make that happen I had to updated resources to be deployed to single namespace and leverage `defaultNamespace` option for mocks
* creating new skaffold profile
* moving wiremock to separate manifest so that it can be excluded from deployment
* updating timeseries-mock-service and removing console log as it slows it down and is unnecessary
* documentation