### PR TITLE
NH-63239: Fix of prometheus check

### DIFF
--- a/deploy/helm/CHANGELOG.md
+++ b/deploy/helm/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## [3.0.0-alpha.3] - 2023-11-03
+
+### Fixed
+
+- If `otel.metrics.prometheus.url` is empty, it ignores `otel.metrics.prometheus_check` to not fail on missing Prometheus
+
 ## [3.0.0-alpha.2] - 2023-11-03
 
 ### Fixed

--- a/deploy/helm/Chart.yaml
+++ b/deploy/helm/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: swo-k8s-collector
-version: 3.0.0-alpha.2
+version: 3.0.0-alpha.3
 appVersion: "0.8.8"
 description: SolarWinds Kubernetes Integration
 keywords:

--- a/deploy/helm/templates/metrics-deployment.yaml
+++ b/deploy/helm/templates/metrics-deployment.yaml
@@ -47,9 +47,9 @@ spec:
       affinity:
         {{- toYaml .Values.otel.metrics.affinity | nindent 8 }}
       {{- end }}
-      {{- if or .Values.otel.metrics.prometheus_check .Values.otel.metrics.swi_endpoint_check }}
+      {{- if or (and .Values.otel.metrics.prometheus_check .Values.otel.metrics.prometheus.url) .Values.otel.metrics.swi_endpoint_check }}
       initContainers:
-        {{- if .Values.otel.metrics.prometheus_check }}
+        {{- if and .Values.otel.metrics.prometheus_check .Values.otel.metrics.prometheus.url }}
         - name: prometheus-check
           image: busybox:1.36.1@sha256:5cd3db04b8be5773388576a83177aff4f40a03457a63855f4b9cbe30542b9a43
           command: ['sh', '-c', 'until $(wget --spider -nv $PROMETHEUS_URL/federate?); do echo waiting on prometheus; sleep 1; done && echo "Prometheus is available"']

--- a/deploy/helm/tests/__snapshot__/logs-fargate-config-map_test.yaml.snap
+++ b/deploy/helm/tests/__snapshot__/logs-fargate-config-map_test.yaml.snap
@@ -24,7 +24,7 @@ Fargate logging ConfigMap spec should include additional filters when they are c
           Match *
           Add sw.k8s.cluster.uid <CLUSTER_UID>
           Add sw.k8s.log.type container
-          Add sw.k8s.agent.manifest.version "3.0.0-alpha.2"
+          Add sw.k8s.agent.manifest.version "3.0.0-alpha.3"
     flb_log_cw: "false"
     output.conf: |
       [OUTPUT]
@@ -64,7 +64,7 @@ Fargate logging ConfigMap spec should match snapshot when Fargate logging is ena
           Match *
           Add sw.k8s.cluster.uid <CLUSTER_UID>
           Add sw.k8s.log.type container
-          Add sw.k8s.agent.manifest.version "3.0.0-alpha.2"
+          Add sw.k8s.agent.manifest.version "3.0.0-alpha.3"
     flb_log_cw: "false"
     output.conf: |
       [OUTPUT]

--- a/tests/integration/expected_output.json
+++ b/tests/integration/expected_output.json
@@ -126,7 +126,7 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "3.0.0-alpha.2"
+              "stringValue": "3.0.0-alpha.3"
             }
           },
           {
@@ -314,7 +314,7 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "3.0.0-alpha.2"
+              "stringValue": "3.0.0-alpha.3"
             }
           },
           {
@@ -514,7 +514,7 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "3.0.0-alpha.2"
+              "stringValue": "3.0.0-alpha.3"
             }
           },
           {
@@ -714,7 +714,7 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "3.0.0-alpha.2"
+              "stringValue": "3.0.0-alpha.3"
             }
           },
           {
@@ -914,7 +914,7 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "3.0.0-alpha.2"
+              "stringValue": "3.0.0-alpha.3"
             }
           },
           {
@@ -1114,7 +1114,7 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "3.0.0-alpha.2"
+              "stringValue": "3.0.0-alpha.3"
             }
           },
           {
@@ -1278,7 +1278,7 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "3.0.0-alpha.2"
+              "stringValue": "3.0.0-alpha.3"
             }
           },
           {
@@ -1478,7 +1478,7 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "3.0.0-alpha.2"
+              "stringValue": "3.0.0-alpha.3"
             }
           },
           {
@@ -1690,7 +1690,7 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "3.0.0-alpha.2"
+              "stringValue": "3.0.0-alpha.3"
             }
           },
           {
@@ -1890,7 +1890,7 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "3.0.0-alpha.2"
+              "stringValue": "3.0.0-alpha.3"
             }
           },
           {
@@ -2078,7 +2078,7 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "3.0.0-alpha.2"
+              "stringValue": "3.0.0-alpha.3"
             }
           },
           {
@@ -2236,7 +2236,7 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "3.0.0-alpha.2"
+              "stringValue": "3.0.0-alpha.3"
             }
           },
           {
@@ -2546,7 +2546,7 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "3.0.0-alpha.2"
+              "stringValue": "3.0.0-alpha.3"
             }
           },
           {
@@ -2716,7 +2716,7 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "3.0.0-alpha.2"
+              "stringValue": "3.0.0-alpha.3"
             }
           },
           {
@@ -2874,7 +2874,7 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "3.0.0-alpha.2"
+              "stringValue": "3.0.0-alpha.3"
             }
           },
           {
@@ -3391,7 +3391,7 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "3.0.0-alpha.2"
+              "stringValue": "3.0.0-alpha.3"
             }
           },
           {
@@ -3586,7 +3586,7 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "3.0.0-alpha.2"
+              "stringValue": "3.0.0-alpha.3"
             }
           },
           {
@@ -3796,7 +3796,7 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "3.0.0-alpha.2"
+              "stringValue": "3.0.0-alpha.3"
             }
           },
           {
@@ -3956,7 +3956,7 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "3.0.0-alpha.2"
+              "stringValue": "3.0.0-alpha.3"
             }
           },
           {
@@ -4110,7 +4110,7 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "3.0.0-alpha.2"
+              "stringValue": "3.0.0-alpha.3"
             }
           },
           {
@@ -4653,7 +4653,7 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "3.0.0-alpha.2"
+              "stringValue": "3.0.0-alpha.3"
             }
           },
           {
@@ -4915,7 +4915,7 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "3.0.0-alpha.2"
+              "stringValue": "3.0.0-alpha.3"
             }
           },
           {
@@ -5112,7 +5112,7 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "3.0.0-alpha.2"
+              "stringValue": "3.0.0-alpha.3"
             }
           },
           {
@@ -5270,7 +5270,7 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "3.0.0-alpha.2"
+              "stringValue": "3.0.0-alpha.3"
             }
           },
           {
@@ -5654,7 +5654,7 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "3.0.0-alpha.2"
+              "stringValue": "3.0.0-alpha.3"
             }
           },
           {
@@ -5842,7 +5842,7 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "3.0.0-alpha.2"
+              "stringValue": "3.0.0-alpha.3"
             }
           },
           {
@@ -6006,7 +6006,7 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "3.0.0-alpha.2"
+              "stringValue": "3.0.0-alpha.3"
             }
           },
           {
@@ -6213,7 +6213,7 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "3.0.0-alpha.2"
+              "stringValue": "3.0.0-alpha.3"
             }
           },
           {
@@ -6395,7 +6395,7 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "3.0.0-alpha.2"
+              "stringValue": "3.0.0-alpha.3"
             }
           },
           {
@@ -6571,7 +6571,7 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "3.0.0-alpha.2"
+              "stringValue": "3.0.0-alpha.3"
             }
           },
           {
@@ -6760,7 +6760,7 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "3.0.0-alpha.2"
+              "stringValue": "3.0.0-alpha.3"
             }
           },
           {
@@ -6900,7 +6900,7 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "3.0.0-alpha.2"
+              "stringValue": "3.0.0-alpha.3"
             }
           },
           {
@@ -7034,7 +7034,7 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "3.0.0-alpha.2"
+              "stringValue": "3.0.0-alpha.3"
             }
           },
           {
@@ -7168,7 +7168,7 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "3.0.0-alpha.2"
+              "stringValue": "3.0.0-alpha.3"
             }
           },
           {
@@ -7308,7 +7308,7 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "3.0.0-alpha.2"
+              "stringValue": "3.0.0-alpha.3"
             }
           },
           {
@@ -7466,7 +7466,7 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "3.0.0-alpha.2"
+              "stringValue": "3.0.0-alpha.3"
             }
           },
           {
@@ -7612,7 +7612,7 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "3.0.0-alpha.2"
+              "stringValue": "3.0.0-alpha.3"
             }
           },
           {
@@ -7758,7 +7758,7 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "3.0.0-alpha.2"
+              "stringValue": "3.0.0-alpha.3"
             }
           },
           {
@@ -7917,7 +7917,7 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "3.0.0-alpha.2"
+              "stringValue": "3.0.0-alpha.3"
             }
           },
           {
@@ -8069,7 +8069,7 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "3.0.0-alpha.2"
+              "stringValue": "3.0.0-alpha.3"
             }
           },
           {
@@ -8215,7 +8215,7 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "3.0.0-alpha.2"
+              "stringValue": "3.0.0-alpha.3"
             }
           },
           {
@@ -8395,7 +8395,7 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "3.0.0-alpha.2"
+              "stringValue": "3.0.0-alpha.3"
             }
           },
           {
@@ -8541,7 +8541,7 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "3.0.0-alpha.2"
+              "stringValue": "3.0.0-alpha.3"
             }
           },
           {
@@ -8693,7 +8693,7 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "3.0.0-alpha.2"
+              "stringValue": "3.0.0-alpha.3"
             }
           },
           {
@@ -8839,7 +8839,7 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "3.0.0-alpha.2"
+              "stringValue": "3.0.0-alpha.3"
             }
           },
           {
@@ -8985,7 +8985,7 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "3.0.0-alpha.2"
+              "stringValue": "3.0.0-alpha.3"
             }
           },
           {
@@ -9271,7 +9271,7 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "3.0.0-alpha.2"
+              "stringValue": "3.0.0-alpha.3"
             }
           },
           {
@@ -9417,7 +9417,7 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "3.0.0-alpha.2"
+              "stringValue": "3.0.0-alpha.3"
             }
           },
           {
@@ -9660,7 +9660,7 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "3.0.0-alpha.2"
+              "stringValue": "3.0.0-alpha.3"
             }
           },
           {
@@ -9824,7 +9824,7 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "3.0.0-alpha.2"
+              "stringValue": "3.0.0-alpha.3"
             }
           },
           {
@@ -10075,7 +10075,7 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "3.0.0-alpha.2"
+              "stringValue": "3.0.0-alpha.3"
             }
           },
           {
@@ -10221,7 +10221,7 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "3.0.0-alpha.2"
+              "stringValue": "3.0.0-alpha.3"
             }
           },
           {
@@ -10361,7 +10361,7 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "3.0.0-alpha.2"
+              "stringValue": "3.0.0-alpha.3"
             }
           },
           {
@@ -10541,7 +10541,7 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "3.0.0-alpha.2"
+              "stringValue": "3.0.0-alpha.3"
             }
           },
           {
@@ -10675,7 +10675,7 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "3.0.0-alpha.2"
+              "stringValue": "3.0.0-alpha.3"
             }
           },
           {
@@ -10833,7 +10833,7 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "3.0.0-alpha.2"
+              "stringValue": "3.0.0-alpha.3"
             }
           },
           {
@@ -11091,7 +11091,7 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "3.0.0-alpha.2"
+              "stringValue": "3.0.0-alpha.3"
             }
           },
           {
@@ -11243,7 +11243,7 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "3.0.0-alpha.2"
+              "stringValue": "3.0.0-alpha.3"
             }
           },
           {
@@ -11401,7 +11401,7 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "3.0.0-alpha.2"
+              "stringValue": "3.0.0-alpha.3"
             }
           },
           {
@@ -11572,7 +11572,7 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "3.0.0-alpha.2"
+              "stringValue": "3.0.0-alpha.3"
             }
           },
           {
@@ -11718,7 +11718,7 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "3.0.0-alpha.2"
+              "stringValue": "3.0.0-alpha.3"
             }
           },
           {
@@ -11908,7 +11908,7 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "3.0.0-alpha.2"
+              "stringValue": "3.0.0-alpha.3"
             }
           },
           {
@@ -12066,7 +12066,7 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "3.0.0-alpha.2"
+              "stringValue": "3.0.0-alpha.3"
             }
           },
           {
@@ -12224,7 +12224,7 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "3.0.0-alpha.2"
+              "stringValue": "3.0.0-alpha.3"
             }
           },
           {
@@ -12441,7 +12441,7 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "3.0.0-alpha.2"
+              "stringValue": "3.0.0-alpha.3"
             }
           },
           {
@@ -12661,7 +12661,7 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "3.0.0-alpha.2"
+              "stringValue": "3.0.0-alpha.3"
             }
           },
           {
@@ -12795,7 +12795,7 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "3.0.0-alpha.2"
+              "stringValue": "3.0.0-alpha.3"
             }
           },
           {
@@ -12935,7 +12935,7 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "3.0.0-alpha.2"
+              "stringValue": "3.0.0-alpha.3"
             }
           },
           {
@@ -13075,7 +13075,7 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "3.0.0-alpha.2"
+              "stringValue": "3.0.0-alpha.3"
             }
           },
           {
@@ -13423,7 +13423,7 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "3.0.0-alpha.2"
+              "stringValue": "3.0.0-alpha.3"
             }
           },
           {
@@ -13612,7 +13612,7 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "3.0.0-alpha.2"
+              "stringValue": "3.0.0-alpha.3"
             }
           },
           {
@@ -13801,7 +13801,7 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "3.0.0-alpha.2"
+              "stringValue": "3.0.0-alpha.3"
             }
           },
           {
@@ -13990,7 +13990,7 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "3.0.0-alpha.2"
+              "stringValue": "3.0.0-alpha.3"
             }
           },
           {
@@ -14173,7 +14173,7 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "3.0.0-alpha.2"
+              "stringValue": "3.0.0-alpha.3"
             }
           },
           {
@@ -16684,7 +16684,7 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "3.0.0-alpha.2"
+              "stringValue": "3.0.0-alpha.3"
             }
           },
           {
@@ -16842,7 +16842,7 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "3.0.0-alpha.2"
+              "stringValue": "3.0.0-alpha.3"
             }
           },
           {
@@ -17738,7 +17738,7 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "3.0.0-alpha.2"
+              "stringValue": "3.0.0-alpha.3"
             }
           },
           {
@@ -17845,7 +17845,7 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "3.0.0-alpha.2"
+              "stringValue": "3.0.0-alpha.3"
             }
           },
           {
@@ -18607,7 +18607,7 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "3.0.0-alpha.2"
+              "stringValue": "3.0.0-alpha.3"
             }
           },
           {
@@ -28279,7 +28279,7 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "3.0.0-alpha.2"
+              "stringValue": "3.0.0-alpha.3"
             }
           },
           {


### PR DESCRIPTION
If `otel.metrics.prometheus.url` is empty, it ignores `otel.metrics.prometheus_check` to not fail on missing Prometheus
