### PR TITLE
NH-63239: node-collector no longer mounts `nodePort`.

### DIFF
--- a/deploy/helm/CHANGELOG.md
+++ b/deploy/helm/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Fixes metrics collector, when `otel.metrics.extra_scrape_metrics` and `prometheus.enabled` are set
+- node-collector no longer mounts `hostPort`. This was solved by separating kernel-collector into separate daemonset
 
 ## [3.0.0-alpha.4] - 2023-11-03
 

--- a/deploy/helm/templates/network/kernel-collector-daemonset.yaml
+++ b/deploy/helm/templates/network/kernel-collector-daemonset.yaml
@@ -1,0 +1,111 @@
+{{- if and .Values.ebpfNetworkMonitoring.enabled .Values.ebpfNetworkMonitoring.kernelCollector.enabled }}
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: {{ include "common.fullname" (tuple . "-kernel-collector") }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "common.labels" . | nindent 4 }}
+spec:
+  selector:
+    matchLabels:
+      app: {{ include "common.fullname" (tuple . "-kernel-collector") }}
+  template:
+    metadata:
+      labels:
+        app: {{ include "common.fullname" (tuple . "-kernel-collector") }}
+{{- include "common.labels" . | nindent 8 }}
+      annotations:
+        checksum/config: {{ include (print $.Template.BasePath "/network/configmap.yaml") . | sha256sum }}
+    spec:
+      terminationGracePeriodSeconds: 30
+      securityContext:
+        fsGroup: 0
+        runAsUser: 0
+        runAsGroup: 0
+      tolerations:
+      {{- if .Values.ebpfNetworkMonitoring.kernelCollector.tolerations }}
+      {{ toYaml .Values.ebpfNetworkMonitoring.kernelCollector.tolerations | nindent 8 }}
+      {{- else }}
+        - operator: Exists
+          effect: NoSchedule
+      {{- end }}
+      affinity:
+      {{- if .Values.ebpfNetworkMonitoring.kernelCollector.affinity }}
+      {{ toYaml .Values.ebpfNetworkMonitoring.kernelCollector.affinity | nindent 8 }}
+      {{- end }}
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: eks.amazonaws.com/compute-type
+                operator: NotIn
+                values:
+                - fargate
+      nodeSelector:
+      {{- if .Values.ebpfNetworkMonitoring.kernelCollector.nodeSelector }}
+      {{ toYaml .Values.ebpfNetworkMonitoring.kernelCollector.nodeSelector | nindent 8 }}
+      {{- end }}
+        kubernetes.io/os: linux
+        kubernetes.io/arch: amd64
+      containers:
+        - name: swi-kernel-collector
+          image: "{{ .Values.ebpfNetworkMonitoring.kernelCollector.image.repository | default "otel/opentelemetry-ebpf-kernel-collector" }}:{{ .Values.ebpfNetworkMonitoring.kernelCollector.image.tag | default "latest" }}"
+          imagePullPolicy: {{ .Values.ebpfNetworkMonitoring.kernelCollector.image.pullPolicy | default "IfNotPresent" }}
+          args:
+            - --config-file=/etc/network-explorer/config.yaml
+            - --disable-nomad-metadata
+            - --{{ .Values.ebpfNetworkMonitoring.kernelCollector.telemetry.logs.level }}
+          env:
+            - name: "EBPF_NET_CLUSTER_NAME"
+              value: {{ quote .Values.cluster.name }}
+            - name: "EBPF_NET_DISABLE_HTTP_METRICS"
+              value: "false"
+            - name: "EBPF_NET_KERNEL_HEADERS_AUTO_FETCH"
+              value: "true"
+            - name: "EBPF_NET_INTAKE_HOST"
+              value: "{{ include "common.fullname" (tuple . "-network-k8s-reducer") }}"
+            - name: "EBPF_NET_INTAKE_PORT"
+              value: "{{ .Values.ebpfNetworkMonitoring.reducer.telemetryPort }}"
+            - name: "EBPF_NET_CRASH_METRIC_HOST"
+              value: "{{ include "common.fullname" (tuple . "-metrics-collector") }}"
+            - name: "EBPF_NET_CRASH_METRIC_PORT"
+              value: "{{ .Values.otel.metrics.otlp_endpoint.port }}"
+            - name: "BCC_PROBE_SUFFIX"
+              value: {{ quote .Values.cluster.name }}
+          resources:
+            {{ toYaml .Values.ebpfNetworkMonitoring.kernelCollector.resources | nindent 12 }}
+          securityContext:
+            privileged: true
+          volumeMounts:
+            - mountPath: /hostfs/
+              name: host-root
+              readOnly: true
+            - mountPath: /hostfs/var/cache
+              name: host-var-cache
+              readOnly: false
+            - mountPath: /etc/network-explorer
+              name: network-explorer-config
+              readOnly: true
+      volumes:
+        - name: network-explorer-config
+          projected:
+            sources:
+            - configMap:
+                name: {{ include "common.fullname" (tuple . "-network-otel-collector-config") }}
+                items:
+                - key: config.yaml
+                  path: config.yaml
+        - name: host-root
+          hostPath:
+            path: /
+            type: Directory
+        - name: host-var-cache
+          hostPath:
+            path: /var/cache
+            type: DirectoryOrCreate
+      dnsPolicy: ClusterFirstWithHostNet
+      hostNetwork: true
+      hostPID: true
+      serviceAccountName: {{ include "common.fullname" . }}
+{{- end }}

--- a/deploy/helm/templates/node-collector-daemon-set.yaml
+++ b/deploy/helm/templates/node-collector-daemon-set.yaml
@@ -1,4 +1,4 @@
-{{- if or .Values.otel.logs.enabled (and .Values.ebpfNetworkMonitoring.enabled .Values.ebpfNetworkMonitoring.kernelCollector.enabled) }}
+{{- if .Values.otel.logs.enabled }}
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:
@@ -21,9 +21,6 @@ spec:
         checksum/config: {{ include (print $.Template.BasePath "/node-collector-config-map.yaml") . | sha256sum }}
         checksum/config_common_env: {{ include (print $.Template.BasePath "/common-env-config-map.yaml") . | sha256sum }}
         checksum/values: {{ toJson .Values | sha256sum }}
-{{- if and .Values.ebpfNetworkMonitoring.enabled .Values.ebpfNetworkMonitoring.kernelCollector.enabled }}
-        checksum/network_config: {{ include (print $.Template.BasePath "/network/configmap.yaml") . | sha256sum }}
-{{- end}}
 {{- if .Values.otel.logs.telemetry.metrics.enabled }}
         prometheus.io/scrape: "true"
         prometheus.io/port: {{ (split ":" .Values.otel.logs.telemetry.metrics.address)._1 | quote }}
@@ -33,7 +30,6 @@ spec:
     spec:
       terminationGracePeriodSeconds: 30
       securityContext:
-        ## In order to reliably read logs from mounted node logging paths, we need to run as root
         fsGroup: 0
         runAsUser: 0
         runAsGroup: 0
@@ -64,7 +60,6 @@ spec:
         kubernetes.io/os: linux
         kubernetes.io/arch: amd64
       containers:
-{{- if .Values.otel.logs.enabled }}
         - name: swi-opentelemetry-collector
           image: "{{ .Values.otel.image.repository }}:{{ .Values.otel.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.otel.image.pullPolicy }}
@@ -133,55 +128,7 @@ spec:
               readOnly: true
             - name: logcheckpoints
               mountPath: {{ .Values.otel.logs.filestorage.directory }}
-{{- end }}
-{{- if and .Values.ebpfNetworkMonitoring.enabled .Values.ebpfNetworkMonitoring.kernelCollector.enabled }}
-        - name: swi-kernel-collector
-          image: "{{ .Values.ebpfNetworkMonitoring.kernelCollector.image.repository | default "otel/opentelemetry-ebpf-kernel-collector" }}:{{ .Values.ebpfNetworkMonitoring.kernelCollector.image.tag | default "v0.10.0" }}"
-          imagePullPolicy: {{ .Values.ebpfNetworkMonitoring.reducer.image.pullPolicy }}
-          args:
-            - --config-file=/etc/network-explorer/config.yaml
-            - --disable-nomad-metadata
-            - --{{ .Values.ebpfNetworkMonitoring.kernelCollector.telemetry.logs.level }}
-          env:
-            - name: "EBPF_NET_CLUSTER_NAME"
-              value: {{ quote .Values.cluster.name }}
-            - name: "EBPF_NET_DISABLE_HTTP_METRICS"
-              value: "false"
-            - name: "EBPF_NET_KERNEL_HEADERS_AUTO_FETCH"
-              value: "true"
-            - name: "EBPF_NET_INTAKE_HOST"
-              value: "{{ include "common.fullname" (tuple . "-network-k8s-reducer") }}"
-            - name: "EBPF_NET_INTAKE_PORT"
-              value: "7000"
-            - name: "EBPF_NET_HOST_DIR"
-              value: "/hostfs"
-            - name: "EBPF_NET_CRASH_METRIC_HOST"
-              value: "{{ include "common.fullname" (tuple . "-metrics-collector") }}"
-            - name: "EBPF_NET_CRASH_METRIC_PORT"
-              value: "{{ .Values.otel.metrics.otlp_endpoint.port }}"
-            - name: "BCC_PROBE_SUFFIX"
-              value: {{ quote .Values.cluster.name }}
-          resources:
-            {}
-          securityContext:
-            privileged: true
-          volumeMounts:
-          - mountPath: /hostfs/
-            name: host-root
-            readOnly: true
-          - mountPath: /hostfs/var/cache
-            name: host-var-cache
-            readOnly: false
-          - mountPath: /etc/network-explorer
-            name: {{ include "common.fullname" (tuple . "-network-otel-collector-config") }}
-            readOnly: true
-      dnsPolicy: ClusterFirstWithHostNet
-      hostNetwork: true
-      hostPID: true
-      serviceAccountName: {{ include "common.fullname" . }}
-{{- end }}
       volumes:
-{{- if .Values.otel.logs.telemetry.metrics.enabled }}
         - name: varlogpods
           hostPath:
             path: /var/log/pods
@@ -207,23 +154,4 @@ spec:
             items:
               - key: logs.config
                 path: relay.yaml
-{{- end }}
-{{- if and .Values.ebpfNetworkMonitoring.enabled .Values.ebpfNetworkMonitoring.kernelCollector.enabled }}
-        - name: {{ include "common.fullname" (tuple . "-network-otel-collector-config") }}
-          projected:
-            sources:
-            - configMap:
-                name: {{ include "common.fullname" (tuple . "-network-otel-collector-config") }}
-                items:
-                - key: config.yaml
-                  path: config.yaml
-        - name: host-root
-          hostPath:
-            path: /
-            type: Directory
-        - name: host-var-cache
-          hostPath:
-            path: /var/cache
-            type: DirectoryOrCreate
-{{- end }}
 {{- end }}

--- a/deploy/helm/tests/__snapshot__/kernel-collector-daemonset_test.yaml.snap
+++ b/deploy/helm/tests/__snapshot__/kernel-collector-daemonset_test.yaml.snap
@@ -1,0 +1,83 @@
+DaemonSet spec should match snapshot when ebpfNetworkMonitoring is enabled:
+  1: |
+    affinity:
+      nodeAffinity:
+        requiredDuringSchedulingIgnoredDuringExecution:
+          nodeSelectorTerms:
+            - matchExpressions:
+                - key: eks.amazonaws.com/compute-type
+                  operator: NotIn
+                  values:
+                    - fargate
+    containers:
+      - args:
+          - --config-file=/etc/network-explorer/config.yaml
+          - --disable-nomad-metadata
+          - --warning
+        env:
+          - name: EBPF_NET_CLUSTER_NAME
+            value: <CLUSTER_NAME>
+          - name: EBPF_NET_DISABLE_HTTP_METRICS
+            value: "false"
+          - name: EBPF_NET_KERNEL_HEADERS_AUTO_FETCH
+            value: "true"
+          - name: EBPF_NET_INTAKE_HOST
+            value: RELEASE-NAME-swo-k8s-collector-network-k8s-reducer
+          - name: EBPF_NET_INTAKE_PORT
+            value: "7000"
+          - name: EBPF_NET_CRASH_METRIC_HOST
+            value: RELEASE-NAME-swo-k8s-collector-metrics-collector
+          - name: EBPF_NET_CRASH_METRIC_PORT
+            value: "4317"
+          - name: BCC_PROBE_SUFFIX
+            value: <CLUSTER_NAME>
+        image: otel/opentelemetry-ebpf-kernel-collector:latest
+        imagePullPolicy: IfNotPresent
+        name: swi-kernel-collector
+        resources:
+          requests:
+            memory: 50Mi
+        securityContext:
+          privileged: true
+        volumeMounts:
+          - mountPath: /hostfs/
+            name: host-root
+            readOnly: true
+          - mountPath: /hostfs/var/cache
+            name: host-var-cache
+            readOnly: false
+          - mountPath: /etc/network-explorer
+            name: network-explorer-config
+            readOnly: true
+    dnsPolicy: ClusterFirstWithHostNet
+    hostNetwork: true
+    hostPID: true
+    nodeSelector:
+      kubernetes.io/arch: amd64
+      kubernetes.io/os: linux
+    securityContext:
+      fsGroup: 0
+      runAsGroup: 0
+      runAsUser: 0
+    serviceAccountName: RELEASE-NAME-swo-k8s-collector
+    terminationGracePeriodSeconds: 30
+    tolerations:
+      - effect: NoSchedule
+        operator: Exists
+    volumes:
+      - name: network-explorer-config
+        projected:
+          sources:
+            - configMap:
+                items:
+                  - key: config.yaml
+                    path: config.yaml
+                name: RELEASE-NAME-swo-k8s-collector-network-otel-collector-config
+      - hostPath:
+          path: /
+          type: Directory
+        name: host-root
+      - hostPath:
+          path: /var/cache
+          type: DirectoryOrCreate
+        name: host-var-cache

--- a/deploy/helm/tests/__snapshot__/node-collector-daemon-set_test.yaml.snap
+++ b/deploy/helm/tests/__snapshot__/node-collector-daemon-set_test.yaml.snap
@@ -79,48 +79,6 @@ DaemonSet spec should match snapshot when ebpfNetworkMonitoring is enabled:
             readOnly: true
           - mountPath: /var/lib/swo/checkpoints
             name: logcheckpoints
-      - args:
-          - --config-file=/etc/network-explorer/config.yaml
-          - --disable-nomad-metadata
-          - --warning
-        env:
-          - name: EBPF_NET_CLUSTER_NAME
-            value: <CLUSTER_NAME>
-          - name: EBPF_NET_DISABLE_HTTP_METRICS
-            value: "false"
-          - name: EBPF_NET_KERNEL_HEADERS_AUTO_FETCH
-            value: "true"
-          - name: EBPF_NET_INTAKE_HOST
-            value: RELEASE-NAME-swo-k8s-collector-network-k8s-reducer
-          - name: EBPF_NET_INTAKE_PORT
-            value: "7000"
-          - name: EBPF_NET_HOST_DIR
-            value: /hostfs
-          - name: EBPF_NET_CRASH_METRIC_HOST
-            value: RELEASE-NAME-swo-k8s-collector-metrics-collector
-          - name: EBPF_NET_CRASH_METRIC_PORT
-            value: "4317"
-          - name: BCC_PROBE_SUFFIX
-            value: <CLUSTER_NAME>
-        image: otel/opentelemetry-ebpf-kernel-collector:v0.10.0
-        imagePullPolicy: IfNotPresent
-        name: swi-kernel-collector
-        resources: {}
-        securityContext:
-          privileged: true
-        volumeMounts:
-          - mountPath: /hostfs/
-            name: host-root
-            readOnly: true
-          - mountPath: /hostfs/var/cache
-            name: host-var-cache
-            readOnly: false
-          - mountPath: /etc/network-explorer
-            name: RELEASE-NAME-swo-k8s-collector-network-otel-collector-config
-            readOnly: true
-    dnsPolicy: ClusterFirstWithHostNet
-    hostNetwork: true
-    hostPID: true
     nodeSelector:
       kubernetes.io/arch: amd64
       kubernetes.io/os: linux
@@ -128,7 +86,6 @@ DaemonSet spec should match snapshot when ebpfNetworkMonitoring is enabled:
       fsGroup: 0
       runAsGroup: 0
       runAsUser: 0
-    serviceAccountName: RELEASE-NAME-swo-k8s-collector
     terminationGracePeriodSeconds: 30
     tolerations:
       - effect: NoSchedule
@@ -159,22 +116,6 @@ DaemonSet spec should match snapshot when ebpfNetworkMonitoring is enabled:
               path: relay.yaml
           name: RELEASE-NAME-swo-k8s-collector-node-collector-config
         name: opentelemetry-collector-configmap
-      - name: RELEASE-NAME-swo-k8s-collector-network-otel-collector-config
-        projected:
-          sources:
-            - configMap:
-                items:
-                  - key: config.yaml
-                    path: config.yaml
-                name: RELEASE-NAME-swo-k8s-collector-network-otel-collector-config
-      - hostPath:
-          path: /
-          type: Directory
-        name: host-root
-      - hostPath:
-          path: /var/cache
-          type: DirectoryOrCreate
-        name: host-var-cache
 DaemonSet spec should match snapshot when using default values:
   1: |
     affinity:

--- a/deploy/helm/tests/kernel-collector-daemonset_test.yaml
+++ b/deploy/helm/tests/kernel-collector-daemonset_test.yaml
@@ -1,0 +1,13 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/helm-unittest/helm-unittest/main/schema/helm-testsuite.json
+suite: Test for kernel-collector-daemonset
+templates:
+  - network/kernel-collector-daemonset.yaml
+  - network/configmap.yaml
+tests:
+  - it: DaemonSet spec should match snapshot when ebpfNetworkMonitoring is enabled
+    template: network/kernel-collector-daemonset.yaml
+    set:
+      ebpfNetworkMonitoring.enabled: true
+    asserts:
+      - matchSnapshot:
+          path: spec.template.spec

--- a/deploy/helm/values.yaml
+++ b/deploy/helm/values.yaml
@@ -428,6 +428,17 @@ ebpfNetworkMonitoring:
       tag: ""
       pullPolicy: IfNotPresent
 
+    resources:
+      requests:
+        memory: 50Mi
+
+    # Scheduling configurations
+    nodeSelector: {}
+    # By default: tolerations allow the DaemonSet to be deployed on tainted nodes so that we can also collect logs from those nodes.
+    tolerations: []
+    # By default: affinity is set to run the DaemonSet on linux amd64.
+    affinity: {}
+
   k8sCollector:
     enabled: true
 

--- a/skaffold.yaml
+++ b/skaffold.yaml
@@ -56,6 +56,8 @@ deploy:
           # excluded labels:
           # * skaffold.dev/ - deployed by skaffold, contains unique ids so it must be excluded
           otel.metrics.k8s_instrumentation.labels.excludePattern: "skaffold\\.dev/.*"
+
+          ebpfNetworkMonitoring.enabled: true
         upgradeOnChange: true
       
       # Deploy prometheus for development purposes. Metrics prefixed with `output_` contains metrics produced by the agent
@@ -113,6 +115,12 @@ profiles:
       path: /manifests/kustomize/paths/2
     - op: remove
       path: /manifests/kustomize/paths/1
+    - op: replace
+      path: /deploy/helm/releases/1/namespace
+      value: "{{.TEST_CLUSTER_NAMESPACE}}"
+    - op: replace
+      path: /deploy/helm/releases/1/name
+      value: "{{.TEST_CLUSTER_RELEASE_NAME}}-prometheus"
     - op: replace
       path: /deploy/kubeContext
       value: "<your kube context here>"


### PR DESCRIPTION
When `hostNetwork: true` is set (which is case when ebpf is enabled) it automatically mounts all ports to host port, which is problem in case of node-collector. 
This was solved by separating kernel-collector into separate daemonset
