### PR TITLE
NH-63239: correctly filtering out `ebpf_net` metrics by default

### DIFF
--- a/deploy/helm/CHANGELOG.md
+++ b/deploy/helm/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## [3.0.0-alpha.6] - 2023-11-07
+
+- correctly filtering out `ebpf_net` metrics by default (which is internal eBPF telemetry)
+
 ## [3.0.0-alpha.5] - 2023-11-06
 
 ### Fixed

--- a/deploy/helm/Chart.yaml
+++ b/deploy/helm/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: swo-k8s-collector
-version: 3.0.0-alpha.5
+version: 3.0.0-alpha.6
 appVersion: "0.8.8"
 description: SolarWinds Kubernetes Integration
 keywords:

--- a/deploy/helm/metrics-collector-config.yaml
+++ b/deploy/helm/metrics-collector-config.yaml
@@ -171,13 +171,13 @@ processors:
         action: update
         new_name: k8s.$${1}$${2}
   
-  metricstransform/rename-ebpf:
+  metricstransform/rename-otel:
     transforms:
-      # add `k8s.` suffix to all metrics that are clearly provided by eBPF networking
-      - include: ^(tcp.|udp.|http.|dns.)(.*)$$
+      # add `k8s.` prefix to all metrics
+      - include: ^(.*)$$
         match_type: regexp
         action: update
-        new_name: k8s.$${1}$${2}
+        new_name: k8s.$${1}
 
   # Transformations done on all metrics before any grouping
   swmetricstransform/preprocessing:
@@ -1690,10 +1690,10 @@ service:
         - otlp
       processors:
         - memory_limiter
-{{- if and .Values.ebpfNetworkMonitoring.enabled .Values.ebpfNetworkMonitoring.reducer.telemetry.metrics.enabled  }}
+{{- if and .Values.ebpfNetworkMonitoring.enabled (not .Values.ebpfNetworkMonitoring.reducer.telemetry.metrics.enabled)  }}
         - filter/ebpf
 {{- end }}
-        - metricstransform/rename-ebpf
+        - metricstransform/rename-otel
         - resource/otlp-metrics
         - batch
       receivers:

--- a/deploy/helm/tests/__snapshot__/logs-fargate-config-map_test.yaml.snap
+++ b/deploy/helm/tests/__snapshot__/logs-fargate-config-map_test.yaml.snap
@@ -24,7 +24,7 @@ Fargate logging ConfigMap spec should include additional filters when they are c
           Match *
           Add sw.k8s.cluster.uid <CLUSTER_UID>
           Add sw.k8s.log.type container
-          Add sw.k8s.agent.manifest.version "3.0.0-alpha.5"
+          Add sw.k8s.agent.manifest.version "3.0.0-alpha.6"
     flb_log_cw: "false"
     output.conf: |
       [OUTPUT]
@@ -64,7 +64,7 @@ Fargate logging ConfigMap spec should match snapshot when Fargate logging is ena
           Match *
           Add sw.k8s.cluster.uid <CLUSTER_UID>
           Add sw.k8s.log.type container
-          Add sw.k8s.agent.manifest.version "3.0.0-alpha.5"
+          Add sw.k8s.agent.manifest.version "3.0.0-alpha.6"
     flb_log_cw: "false"
     output.conf: |
       [OUTPUT]

--- a/deploy/helm/tests/__snapshot__/metrics-collector-config-map-fargate_test.yaml.snap
+++ b/deploy/helm/tests/__snapshot__/metrics-collector-config-map-fargate_test.yaml.snap
@@ -1706,12 +1706,12 @@ Metrics config should match snapshot when using default values:
             include: ^(kube_|container_|kubernetes_|kubelet_)(.*)$$
             match_type: regexp
             new_name: k8s.$${1}$${2}
-        metricstransform/rename-ebpf:
+        metricstransform/rename-otel:
           transforms:
           - action: update
-            include: ^(tcp.|udp.|http.|dns.)(.*)$$
+            include: ^(.*)$$
             match_type: regexp
-            new_name: k8s.$${1}$${2}
+            new_name: k8s.$${1}
         resource/events:
           attributes:
           - action: insert
@@ -2253,7 +2253,7 @@ Metrics config should match snapshot when using default values:
             - otlp
             processors:
             - memory_limiter
-            - metricstransform/rename-ebpf
+            - metricstransform/rename-otel
             - resource/otlp-metrics
             - batch
             receivers:

--- a/deploy/helm/tests/__snapshot__/metrics-collector-config-map_test.yaml.snap
+++ b/deploy/helm/tests/__snapshot__/metrics-collector-config-map_test.yaml.snap
@@ -1709,12 +1709,12 @@ Metrics config should match snapshot when using Prometheus url with extra_scrape
             include: ^(kube_|container_|kubernetes_|kubelet_)(.*)$$
             match_type: regexp
             new_name: k8s.$${1}$${2}
-        metricstransform/rename-ebpf:
+        metricstransform/rename-otel:
           transforms:
           - action: update
-            include: ^(tcp.|udp.|http.|dns.)(.*)$$
+            include: ^(.*)$$
             match_type: regexp
-            new_name: k8s.$${1}$${2}
+            new_name: k8s.$${1}
         resource/events:
           attributes:
           - action: insert
@@ -2271,7 +2271,7 @@ Metrics config should match snapshot when using Prometheus url with extra_scrape
             - otlp
             processors:
             - memory_limiter
-            - metricstransform/rename-ebpf
+            - metricstransform/rename-otel
             - resource/otlp-metrics
             - batch
             receivers:
@@ -4045,12 +4045,12 @@ Metrics config should match snapshot when using default values:
             include: ^(kube_|container_|kubernetes_|kubelet_)(.*)$$
             match_type: regexp
             new_name: k8s.$${1}$${2}
-        metricstransform/rename-ebpf:
+        metricstransform/rename-otel:
           transforms:
           - action: update
-            include: ^(tcp.|udp.|http.|dns.)(.*)$$
+            include: ^(.*)$$
             match_type: regexp
-            new_name: k8s.$${1}$${2}
+            new_name: k8s.$${1}
         resource/events:
           attributes:
           - action: insert
@@ -4592,7 +4592,7 @@ Metrics config should match snapshot when using default values:
             - otlp
             processors:
             - memory_limiter
-            - metricstransform/rename-ebpf
+            - metricstransform/rename-otel
             - resource/otlp-metrics
             - batch
             receivers:

--- a/skaffold.yaml
+++ b/skaffold.yaml
@@ -72,6 +72,10 @@ deploy:
           prometheus-node-exporter.enabled: false
           prometheus-pushgateway.enabled: false
           kube-state-metrics.enabled: false
+          server:
+            nodeSelector:
+              "kubernetes\\.io\\/os": linux
+              "kubernetes\\.io\\/arch": amd64
   kubeContext: docker-desktop
 portForward:
 - resourceType: service

--- a/tests/integration/expected_output.json
+++ b/tests/integration/expected_output.json
@@ -126,7 +126,7 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "3.0.0-alpha.5"
+              "stringValue": "3.0.0-alpha.6"
             }
           },
           {
@@ -314,7 +314,7 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "3.0.0-alpha.5"
+              "stringValue": "3.0.0-alpha.6"
             }
           },
           {
@@ -514,7 +514,7 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "3.0.0-alpha.5"
+              "stringValue": "3.0.0-alpha.6"
             }
           },
           {
@@ -714,7 +714,7 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "3.0.0-alpha.5"
+              "stringValue": "3.0.0-alpha.6"
             }
           },
           {
@@ -914,7 +914,7 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "3.0.0-alpha.5"
+              "stringValue": "3.0.0-alpha.6"
             }
           },
           {
@@ -1114,7 +1114,7 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "3.0.0-alpha.5"
+              "stringValue": "3.0.0-alpha.6"
             }
           },
           {
@@ -1278,7 +1278,7 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "3.0.0-alpha.5"
+              "stringValue": "3.0.0-alpha.6"
             }
           },
           {
@@ -1478,7 +1478,7 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "3.0.0-alpha.5"
+              "stringValue": "3.0.0-alpha.6"
             }
           },
           {
@@ -1690,7 +1690,7 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "3.0.0-alpha.5"
+              "stringValue": "3.0.0-alpha.6"
             }
           },
           {
@@ -1890,7 +1890,7 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "3.0.0-alpha.5"
+              "stringValue": "3.0.0-alpha.6"
             }
           },
           {
@@ -2078,7 +2078,7 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "3.0.0-alpha.5"
+              "stringValue": "3.0.0-alpha.6"
             }
           },
           {
@@ -2236,7 +2236,7 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "3.0.0-alpha.5"
+              "stringValue": "3.0.0-alpha.6"
             }
           },
           {
@@ -2546,7 +2546,7 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "3.0.0-alpha.5"
+              "stringValue": "3.0.0-alpha.6"
             }
           },
           {
@@ -2716,7 +2716,7 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "3.0.0-alpha.5"
+              "stringValue": "3.0.0-alpha.6"
             }
           },
           {
@@ -2874,7 +2874,7 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "3.0.0-alpha.5"
+              "stringValue": "3.0.0-alpha.6"
             }
           },
           {
@@ -3391,7 +3391,7 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "3.0.0-alpha.5"
+              "stringValue": "3.0.0-alpha.6"
             }
           },
           {
@@ -3586,7 +3586,7 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "3.0.0-alpha.5"
+              "stringValue": "3.0.0-alpha.6"
             }
           },
           {
@@ -3796,7 +3796,7 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "3.0.0-alpha.5"
+              "stringValue": "3.0.0-alpha.6"
             }
           },
           {
@@ -3956,7 +3956,7 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "3.0.0-alpha.5"
+              "stringValue": "3.0.0-alpha.6"
             }
           },
           {
@@ -4110,7 +4110,7 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "3.0.0-alpha.5"
+              "stringValue": "3.0.0-alpha.6"
             }
           },
           {
@@ -4653,7 +4653,7 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "3.0.0-alpha.5"
+              "stringValue": "3.0.0-alpha.6"
             }
           },
           {
@@ -4915,7 +4915,7 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "3.0.0-alpha.5"
+              "stringValue": "3.0.0-alpha.6"
             }
           },
           {
@@ -5112,7 +5112,7 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "3.0.0-alpha.5"
+              "stringValue": "3.0.0-alpha.6"
             }
           },
           {
@@ -5270,7 +5270,7 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "3.0.0-alpha.5"
+              "stringValue": "3.0.0-alpha.6"
             }
           },
           {
@@ -5654,7 +5654,7 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "3.0.0-alpha.5"
+              "stringValue": "3.0.0-alpha.6"
             }
           },
           {
@@ -5842,7 +5842,7 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "3.0.0-alpha.5"
+              "stringValue": "3.0.0-alpha.6"
             }
           },
           {
@@ -6006,7 +6006,7 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "3.0.0-alpha.5"
+              "stringValue": "3.0.0-alpha.6"
             }
           },
           {
@@ -6213,7 +6213,7 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "3.0.0-alpha.5"
+              "stringValue": "3.0.0-alpha.6"
             }
           },
           {
@@ -6395,7 +6395,7 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "3.0.0-alpha.5"
+              "stringValue": "3.0.0-alpha.6"
             }
           },
           {
@@ -6571,7 +6571,7 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "3.0.0-alpha.5"
+              "stringValue": "3.0.0-alpha.6"
             }
           },
           {
@@ -6760,7 +6760,7 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "3.0.0-alpha.5"
+              "stringValue": "3.0.0-alpha.6"
             }
           },
           {
@@ -6900,7 +6900,7 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "3.0.0-alpha.5"
+              "stringValue": "3.0.0-alpha.6"
             }
           },
           {
@@ -7034,7 +7034,7 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "3.0.0-alpha.5"
+              "stringValue": "3.0.0-alpha.6"
             }
           },
           {
@@ -7168,7 +7168,7 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "3.0.0-alpha.5"
+              "stringValue": "3.0.0-alpha.6"
             }
           },
           {
@@ -7308,7 +7308,7 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "3.0.0-alpha.5"
+              "stringValue": "3.0.0-alpha.6"
             }
           },
           {
@@ -7466,7 +7466,7 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "3.0.0-alpha.5"
+              "stringValue": "3.0.0-alpha.6"
             }
           },
           {
@@ -7612,7 +7612,7 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "3.0.0-alpha.5"
+              "stringValue": "3.0.0-alpha.6"
             }
           },
           {
@@ -7758,7 +7758,7 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "3.0.0-alpha.5"
+              "stringValue": "3.0.0-alpha.6"
             }
           },
           {
@@ -7917,7 +7917,7 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "3.0.0-alpha.5"
+              "stringValue": "3.0.0-alpha.6"
             }
           },
           {
@@ -8069,7 +8069,7 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "3.0.0-alpha.5"
+              "stringValue": "3.0.0-alpha.6"
             }
           },
           {
@@ -8215,7 +8215,7 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "3.0.0-alpha.5"
+              "stringValue": "3.0.0-alpha.6"
             }
           },
           {
@@ -8395,7 +8395,7 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "3.0.0-alpha.5"
+              "stringValue": "3.0.0-alpha.6"
             }
           },
           {
@@ -8541,7 +8541,7 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "3.0.0-alpha.5"
+              "stringValue": "3.0.0-alpha.6"
             }
           },
           {
@@ -8693,7 +8693,7 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "3.0.0-alpha.5"
+              "stringValue": "3.0.0-alpha.6"
             }
           },
           {
@@ -8839,7 +8839,7 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "3.0.0-alpha.5"
+              "stringValue": "3.0.0-alpha.6"
             }
           },
           {
@@ -8985,7 +8985,7 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "3.0.0-alpha.5"
+              "stringValue": "3.0.0-alpha.6"
             }
           },
           {
@@ -9271,7 +9271,7 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "3.0.0-alpha.5"
+              "stringValue": "3.0.0-alpha.6"
             }
           },
           {
@@ -9417,7 +9417,7 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "3.0.0-alpha.5"
+              "stringValue": "3.0.0-alpha.6"
             }
           },
           {
@@ -9660,7 +9660,7 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "3.0.0-alpha.5"
+              "stringValue": "3.0.0-alpha.6"
             }
           },
           {
@@ -9824,7 +9824,7 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "3.0.0-alpha.5"
+              "stringValue": "3.0.0-alpha.6"
             }
           },
           {
@@ -10075,7 +10075,7 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "3.0.0-alpha.5"
+              "stringValue": "3.0.0-alpha.6"
             }
           },
           {
@@ -10221,7 +10221,7 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "3.0.0-alpha.5"
+              "stringValue": "3.0.0-alpha.6"
             }
           },
           {
@@ -10361,7 +10361,7 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "3.0.0-alpha.5"
+              "stringValue": "3.0.0-alpha.6"
             }
           },
           {
@@ -10541,7 +10541,7 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "3.0.0-alpha.5"
+              "stringValue": "3.0.0-alpha.6"
             }
           },
           {
@@ -10675,7 +10675,7 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "3.0.0-alpha.5"
+              "stringValue": "3.0.0-alpha.6"
             }
           },
           {
@@ -10833,7 +10833,7 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "3.0.0-alpha.5"
+              "stringValue": "3.0.0-alpha.6"
             }
           },
           {
@@ -11091,7 +11091,7 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "3.0.0-alpha.5"
+              "stringValue": "3.0.0-alpha.6"
             }
           },
           {
@@ -11243,7 +11243,7 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "3.0.0-alpha.5"
+              "stringValue": "3.0.0-alpha.6"
             }
           },
           {
@@ -11401,7 +11401,7 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "3.0.0-alpha.5"
+              "stringValue": "3.0.0-alpha.6"
             }
           },
           {
@@ -11572,7 +11572,7 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "3.0.0-alpha.5"
+              "stringValue": "3.0.0-alpha.6"
             }
           },
           {
@@ -11718,7 +11718,7 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "3.0.0-alpha.5"
+              "stringValue": "3.0.0-alpha.6"
             }
           },
           {
@@ -11908,7 +11908,7 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "3.0.0-alpha.5"
+              "stringValue": "3.0.0-alpha.6"
             }
           },
           {
@@ -12066,7 +12066,7 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "3.0.0-alpha.5"
+              "stringValue": "3.0.0-alpha.6"
             }
           },
           {
@@ -12224,7 +12224,7 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "3.0.0-alpha.5"
+              "stringValue": "3.0.0-alpha.6"
             }
           },
           {
@@ -12441,7 +12441,7 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "3.0.0-alpha.5"
+              "stringValue": "3.0.0-alpha.6"
             }
           },
           {
@@ -12661,7 +12661,7 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "3.0.0-alpha.5"
+              "stringValue": "3.0.0-alpha.6"
             }
           },
           {
@@ -12795,7 +12795,7 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "3.0.0-alpha.5"
+              "stringValue": "3.0.0-alpha.6"
             }
           },
           {
@@ -12935,7 +12935,7 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "3.0.0-alpha.5"
+              "stringValue": "3.0.0-alpha.6"
             }
           },
           {
@@ -13075,7 +13075,7 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "3.0.0-alpha.5"
+              "stringValue": "3.0.0-alpha.6"
             }
           },
           {
@@ -13423,7 +13423,7 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "3.0.0-alpha.5"
+              "stringValue": "3.0.0-alpha.6"
             }
           },
           {
@@ -13612,7 +13612,7 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "3.0.0-alpha.5"
+              "stringValue": "3.0.0-alpha.6"
             }
           },
           {
@@ -13801,7 +13801,7 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "3.0.0-alpha.5"
+              "stringValue": "3.0.0-alpha.6"
             }
           },
           {
@@ -13990,7 +13990,7 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "3.0.0-alpha.5"
+              "stringValue": "3.0.0-alpha.6"
             }
           },
           {
@@ -14173,7 +14173,7 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "3.0.0-alpha.5"
+              "stringValue": "3.0.0-alpha.6"
             }
           },
           {
@@ -16684,7 +16684,7 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "3.0.0-alpha.5"
+              "stringValue": "3.0.0-alpha.6"
             }
           },
           {
@@ -16842,7 +16842,7 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "3.0.0-alpha.5"
+              "stringValue": "3.0.0-alpha.6"
             }
           },
           {
@@ -17738,7 +17738,7 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "3.0.0-alpha.5"
+              "stringValue": "3.0.0-alpha.6"
             }
           },
           {
@@ -17845,7 +17845,7 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "3.0.0-alpha.5"
+              "stringValue": "3.0.0-alpha.6"
             }
           },
           {
@@ -18607,7 +18607,7 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "3.0.0-alpha.5"
+              "stringValue": "3.0.0-alpha.6"
             }
           },
           {
@@ -28279,7 +28279,7 @@
           {
             "key": "sw.k8s.agent.manifest.version",
             "value": {
-              "stringValue": "3.0.0-alpha.5"
+              "stringValue": "3.0.0-alpha.6"
             }
           },
           {


### PR DESCRIPTION
* correctly filtering out ebpf_net metrics (those are internal metrics that customers does not need and can be opt-in via values.yaml)
* prefixing all metrics that arrives to OTEL endpoint with `k8s`, not just ebpf ones (for now it won't have impact, but in case customers would use that endpoint we would prefix it as well)
