### PR TITLE
NH-66305: Adding support for scraping application metrics

### DIFF
--- a/deploy/helm/CHANGELOG.md
+++ b/deploy/helm/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Added
+
+- Automatic discovery and scraping of prometheus endpoints on pods. Driven by `otel.metrics.autodiscovery.prometheusEndpoints.enabled` option in `values.yaml`, by default enabled (Fargate not yet supported). 
+- Upgraded OTEL collector image to `0.8.9` (see [Release notes](https://github.com/solarwinds/swi-k8s-opentelemetry-collector/releases/tag/0.8.9))
+
 ## [3.0.0-alpha.6] - 2023-11-07
 
 - correctly filtering out `ebpf_net` metrics by default (which is internal eBPF telemetry)

--- a/deploy/helm/Chart.yaml
+++ b/deploy/helm/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: swo-k8s-collector
 version: 3.0.0-alpha.6
-appVersion: "0.8.8"
+appVersion: "0.8.9"
 description: SolarWinds Kubernetes Integration
 keywords:
   - monitoring

--- a/deploy/helm/node-collector-config.yaml
+++ b/deploy/helm/node-collector-config.yaml
@@ -13,6 +13,13 @@ extensions:
   memory_ballast:
 {{ toYaml .Values.otel.logs.memory_ballast | indent 4 }}
 {{- end }}
+{{- if and .Values.otel.metrics.enabled .Values.otel.metrics.autodiscovery.prometheusEndpoints.enabled }}
+  k8s_observer:
+    auth_type: serviceAccount
+    node: ${NODE_NAME}
+    observe_pods: true
+    observe_nodes: false
+{{- end }}
 
 processors:
   memory_limiter:
@@ -34,6 +41,31 @@ processors:
       - host.name
       - service.name
 
+  resource/all:
+    attributes:
+
+      # Collector and Manifest version
+      - key: sw.k8s.agent.manifest.version
+        value: ${MANIFEST_VERSION}
+        action: insert
+
+      - key: sw.k8s.agent.app.version
+        value: ${APP_VERSION}
+        action: insert
+
+      # Cluster
+      - key: sw.k8s.cluster.uid
+        value: ${CLUSTER_UID}
+        action: insert
+
+      - key: k8s.cluster.name
+        value: ${CLUSTER_NAME}
+        action: insert
+
+      # Node
+      - key: k8s.node.name
+        value: ${NODE_NAME}
+        action: insert
 
   resource/container:
     attributes:
@@ -105,6 +137,48 @@ processors:
 
   batch:
 {{ toYaml .Values.otel.logs.batch | indent 4 }}
+
+  k8sattributes:
+    auth_type: "serviceAccount"
+    passthrough: false
+    filter:
+      node_from_env_var: NODE_NAME
+    extract:
+      metadata:
+        - k8s.deployment.name
+        - k8s.replicaset.name
+        - k8s.daemonset.name
+        - k8s.job.name
+        - k8s.cronjob.name
+        - k8s.statefulset.name
+      labels:
+        - key_regex: (.*)
+          tag_name: k8s.pod.labels.$$1
+          from: pod
+        - key_regex: (.*)
+          tag_name: k8s.namespace.labels.$$1
+          from: namespace
+      annotations:
+        - key_regex: (.*)
+          tag_name: k8s.pod.annotations.$$1
+          from: pod
+        - key_regex: (.*)
+          tag_name: k8s.namespace.annotations.$$1
+          from: namespace
+    pod_association:
+      - sources:
+          - from: resource_attribute
+            name: k8s.pod.name
+          - from: resource_attribute
+            name: k8s.namespace.name
+
+  metricstransform/rename:
+    transforms:
+      # add `k8s.` prefix to all metrics
+      - include: ^(.*)$$
+        match_type: regexp
+        action: update
+        new_name: k8s.$${1}
 
 receivers:
 {{- if and (not .isWindows) .Values.otel.logs.journal }}
@@ -243,12 +317,40 @@ receivers:
         from: body.log
         to: body
 
+{{- if and .Values.otel.metrics.enabled .Values.otel.metrics.autodiscovery.prometheusEndpoints.enabled }}
+  receiver_creator:
+    watch_observers: 
+      - k8s_observer
+    receivers:
+      prometheus:
+        {{- if .Values.otel.metrics.autodiscovery.prometheusEndpoints.additionalRules }}
+        rule: type == "pod" && annotations["prometheus.io/scrape"] == "true" && {{ .Values.otel.metrics.autodiscovery.prometheusEndpoints.additionalRules }}
+        {{- else }}
+        rule: type == "pod" && annotations["prometheus.io/scrape"] == "true"
+        {{- end }} 
+        config:
+          config:
+            scrape_configs:
+              - job_name: pod
+                scheme: "http"
+                scrape_interval: {{ quote .Values.otel.metrics.prometheus.scrape_interval }}
+                metrics_path: '`"prometheus.io/path" in annotations ? annotations["prometheus.io/path"] : "/metrics"`'
+                honor_timestamps: false
+                honor_labels: true
+                static_configs:
+                  - targets:
+                      - '`endpoint`:`"prometheus.io/port" in annotations ? annotations["prometheus.io/port"] : 9090`'
+{{- end }}
+
 service:
   extensions:
     - file_storage
     - health_check
 {{- if .Values.otel.logs.memory_ballast }}
     - memory_ballast
+{{- end}}
+{{- if and .Values.otel.metrics.enabled .Values.otel.metrics.autodiscovery.prometheusEndpoints.enabled }}
+    - k8s_observer
 {{- end}}
   pipelines:
 {{- if .Values.otel.logs.container }}
@@ -279,6 +381,20 @@ service:
       receivers:
         - journald/runlogs
         - journald/varlogs
+{{- end }}
+{{- if and .Values.otel.metrics.enabled .Values.otel.metrics.autodiscovery.prometheusEndpoints.enabled }}
+    metrics:
+      exporters:
+        - otlp
+      processors:
+        - memory_limiter
+        - metricstransform/rename
+        - groupbyattrs/all
+        - resource/all
+        - k8sattributes
+        - batch
+      receivers:
+        - receiver_creator
 {{- end }}
   telemetry:
 {{- if .Values.otel.logs.telemetry.logs.enabled }}

--- a/deploy/helm/templates/node-collector-daemon-set-windows.yaml
+++ b/deploy/helm/templates/node-collector-daemon-set-windows.yaml
@@ -29,6 +29,7 @@ spec:
 {{- end}}
     spec:
       terminationGracePeriodSeconds: 30
+      serviceAccountName: {{ include "common.fullname" . }}
       tolerations:
       {{- if .Values.otel.logs.tolerations }}
       {{ toYaml .Values.otel.logs.tolerations | nindent 8 }}

--- a/deploy/helm/templates/node-collector-daemon-set.yaml
+++ b/deploy/helm/templates/node-collector-daemon-set.yaml
@@ -29,6 +29,7 @@ spec:
 {{- end}}
     spec:
       terminationGracePeriodSeconds: 30
+      serviceAccountName: {{ include "common.fullname" . }}
       securityContext:
         fsGroup: 0
         runAsUser: 0

--- a/deploy/helm/tests/__snapshot__/events-collector-deployment_test.yaml.snap
+++ b/deploy/helm/tests/__snapshot__/events-collector-deployment_test.yaml.snap
@@ -19,7 +19,7 @@ Events collector spec should match snapshot when using default values:
         envFrom:
           - configMapRef:
               name: RELEASE-NAME-swo-k8s-collector-common-env
-        image: solarwinds/swi-opentelemetry-collector:0.8.8
+        image: solarwinds/swi-opentelemetry-collector:0.8.9
         imagePullPolicy: IfNotPresent
         livenessProbe:
           httpGet:

--- a/deploy/helm/tests/__snapshot__/metrics-deployment_test.yaml.snap
+++ b/deploy/helm/tests/__snapshot__/metrics-deployment_test.yaml.snap
@@ -21,7 +21,7 @@ Metrics collector spec should match snapshot when using default values:
               name: RELEASE-NAME-swo-k8s-collector-common-env
           - configMapRef:
               name: RELEASE-NAME-swo-k8s-collector-metrics-env-config
-        image: solarwinds/swi-opentelemetry-collector:0.8.8
+        image: solarwinds/swi-opentelemetry-collector:0.8.9
         imagePullPolicy: IfNotPresent
         livenessProbe:
           httpGet:

--- a/deploy/helm/tests/__snapshot__/node-collector-config-map-windows_test.yaml.snap
+++ b/deploy/helm/tests/__snapshot__/node-collector-config-map-windows_test.yaml.snap
@@ -14,6 +14,11 @@ Node collector config for windows nodes should match snapshot when using default
           directory: /var/lib/swo/checkpoints
           timeout: 5s
         health_check: {}
+        k8s_observer:
+          auth_type: serviceAccount
+          node: ${NODE_NAME}
+          observe_nodes: false
+          observe_pods: true
       processors:
         batch:
           send_batch_max_size: 512
@@ -34,10 +39,66 @@ Node collector config for windows nodes should match snapshot when using default
           - k8s.pod.uid
           - host.name
           - service.name
+        k8sattributes:
+          auth_type: serviceAccount
+          extract:
+            annotations:
+            - from: pod
+              key_regex: (.*)
+              tag_name: k8s.pod.annotations.$$1
+            - from: namespace
+              key_regex: (.*)
+              tag_name: k8s.namespace.annotations.$$1
+            labels:
+            - from: pod
+              key_regex: (.*)
+              tag_name: k8s.pod.labels.$$1
+            - from: namespace
+              key_regex: (.*)
+              tag_name: k8s.namespace.labels.$$1
+            metadata:
+            - k8s.deployment.name
+            - k8s.replicaset.name
+            - k8s.daemonset.name
+            - k8s.job.name
+            - k8s.cronjob.name
+            - k8s.statefulset.name
+          filter:
+            node_from_env_var: NODE_NAME
+          passthrough: false
+          pod_association:
+          - sources:
+            - from: resource_attribute
+              name: k8s.pod.name
+            - from: resource_attribute
+              name: k8s.namespace.name
         memory_limiter:
           check_interval: 1s
           limit_mib: 550
           spike_limit_mib: 300
+        metricstransform/rename:
+          transforms:
+          - action: update
+            include: ^(.*)$$
+            match_type: regexp
+            new_name: k8s.$${1}
+        resource/all:
+          attributes:
+          - action: insert
+            key: sw.k8s.agent.manifest.version
+            value: ${MANIFEST_VERSION}
+          - action: insert
+            key: sw.k8s.agent.app.version
+            value: ${APP_VERSION}
+          - action: insert
+            key: sw.k8s.cluster.uid
+            value: ${CLUSTER_UID}
+          - action: insert
+            key: k8s.cluster.name
+            value: ${CLUSTER_NAME}
+          - action: insert
+            key: k8s.node.name
+            value: ${NODE_NAME}
         resource/container:
           attributes:
           - action: insert
@@ -165,10 +226,31 @@ Node collector config for windows nodes should match snapshot when using default
           poll_interval: 200ms
           start_at: end
           storage: file_storage
+        receiver_creator:
+          receivers:
+            prometheus:
+              config:
+                config:
+                  scrape_configs:
+                  - honor_labels: true
+                    honor_timestamps: false
+                    job_name: pod
+                    metrics_path: '`"prometheus.io/path" in annotations ? annotations["prometheus.io/path"]
+                      : "/metrics"`'
+                    scheme: http
+                    scrape_interval: 60s
+                    static_configs:
+                    - targets:
+                      - '`endpoint`:`"prometheus.io/port" in annotations ? annotations["prometheus.io/port"]
+                        : 9090`'
+              rule: type == "pod" && annotations["prometheus.io/scrape"] == "true"
+          watch_observers:
+          - k8s_observer
       service:
         extensions:
         - file_storage
         - health_check
+        - k8s_observer
         pipelines:
           logs:
             exporters:
@@ -182,6 +264,18 @@ Node collector config for windows nodes should match snapshot when using default
             - batch
             receivers:
             - filelog
+          metrics:
+            exporters:
+            - otlp
+            processors:
+            - memory_limiter
+            - metricstransform/rename
+            - groupbyattrs/all
+            - resource/all
+            - k8sattributes
+            - batch
+            receivers:
+            - receiver_creator
         telemetry:
           logs:
             level: info

--- a/deploy/helm/tests/__snapshot__/node-collector-config-map_test.yaml.snap
+++ b/deploy/helm/tests/__snapshot__/node-collector-config-map_test.yaml.snap
@@ -14,6 +14,11 @@ Node collector config should match snapshot when using default values:
           directory: /var/lib/swo/checkpoints
           timeout: 5s
         health_check: {}
+        k8s_observer:
+          auth_type: serviceAccount
+          node: ${NODE_NAME}
+          observe_nodes: false
+          observe_pods: true
       processors:
         batch:
           send_batch_max_size: 512
@@ -34,10 +39,66 @@ Node collector config should match snapshot when using default values:
           - k8s.pod.uid
           - host.name
           - service.name
+        k8sattributes:
+          auth_type: serviceAccount
+          extract:
+            annotations:
+            - from: pod
+              key_regex: (.*)
+              tag_name: k8s.pod.annotations.$$1
+            - from: namespace
+              key_regex: (.*)
+              tag_name: k8s.namespace.annotations.$$1
+            labels:
+            - from: pod
+              key_regex: (.*)
+              tag_name: k8s.pod.labels.$$1
+            - from: namespace
+              key_regex: (.*)
+              tag_name: k8s.namespace.labels.$$1
+            metadata:
+            - k8s.deployment.name
+            - k8s.replicaset.name
+            - k8s.daemonset.name
+            - k8s.job.name
+            - k8s.cronjob.name
+            - k8s.statefulset.name
+          filter:
+            node_from_env_var: NODE_NAME
+          passthrough: false
+          pod_association:
+          - sources:
+            - from: resource_attribute
+              name: k8s.pod.name
+            - from: resource_attribute
+              name: k8s.namespace.name
         memory_limiter:
           check_interval: 1s
           limit_mib: 550
           spike_limit_mib: 300
+        metricstransform/rename:
+          transforms:
+          - action: update
+            include: ^(.*)$$
+            match_type: regexp
+            new_name: k8s.$${1}
+        resource/all:
+          attributes:
+          - action: insert
+            key: sw.k8s.agent.manifest.version
+            value: ${MANIFEST_VERSION}
+          - action: insert
+            key: sw.k8s.agent.app.version
+            value: ${APP_VERSION}
+          - action: insert
+            key: sw.k8s.cluster.uid
+            value: ${CLUSTER_UID}
+          - action: insert
+            key: k8s.cluster.name
+            value: ${CLUSTER_NAME}
+          - action: insert
+            key: k8s.node.name
+            value: ${NODE_NAME}
         resource/container:
           attributes:
           - action: insert
@@ -197,10 +258,31 @@ Node collector config should match snapshot when using default values:
           - kubelet
           - docker
           - containerd
+        receiver_creator:
+          receivers:
+            prometheus:
+              config:
+                config:
+                  scrape_configs:
+                  - honor_labels: true
+                    honor_timestamps: false
+                    job_name: pod
+                    metrics_path: '`"prometheus.io/path" in annotations ? annotations["prometheus.io/path"]
+                      : "/metrics"`'
+                    scheme: http
+                    scrape_interval: 60s
+                    static_configs:
+                    - targets:
+                      - '`endpoint`:`"prometheus.io/port" in annotations ? annotations["prometheus.io/port"]
+                        : 9090`'
+              rule: type == "pod" && annotations["prometheus.io/scrape"] == "true"
+          watch_observers:
+          - k8s_observer
       service:
         extensions:
         - file_storage
         - health_check
+        - k8s_observer
         pipelines:
           logs:
             exporters:
@@ -225,6 +307,18 @@ Node collector config should match snapshot when using default values:
             receivers:
             - journald/runlogs
             - journald/varlogs
+          metrics:
+            exporters:
+            - otlp
+            processors:
+            - memory_limiter
+            - metricstransform/rename
+            - groupbyattrs/all
+            - resource/all
+            - k8sattributes
+            - batch
+            receivers:
+            - receiver_creator
         telemetry:
           logs:
             level: info

--- a/deploy/helm/tests/__snapshot__/node-collector-daemon-set-windows_test.yaml.snap
+++ b/deploy/helm/tests/__snapshot__/node-collector-daemon-set-windows_test.yaml.snap
@@ -38,7 +38,7 @@ DaemonSet spec for windows nodes should match snapshot when using default values
         envFrom:
           - configMapRef:
               name: RELEASE-NAME-swo-k8s-collector-common-env
-        image: solarwinds/swi-opentelemetry-collector:0.8.8-nanoserver-ltsc2022
+        image: solarwinds/swi-opentelemetry-collector:0.8.9-nanoserver-ltsc2022
         imagePullPolicy: IfNotPresent
         livenessProbe:
           httpGet:
@@ -76,6 +76,7 @@ DaemonSet spec for windows nodes should match snapshot when using default values
     nodeSelector:
       kubernetes.io/arch: amd64
       kubernetes.io/os: windows
+    serviceAccountName: RELEASE-NAME-swo-k8s-collector
     terminationGracePeriodSeconds: 30
     tolerations:
       - effect: NoSchedule

--- a/deploy/helm/tests/__snapshot__/node-collector-daemon-set_test.yaml.snap
+++ b/deploy/helm/tests/__snapshot__/node-collector-daemon-set_test.yaml.snap
@@ -38,7 +38,7 @@ DaemonSet spec should match snapshot when ebpfNetworkMonitoring is enabled:
         envFrom:
           - configMapRef:
               name: RELEASE-NAME-swo-k8s-collector-common-env
-        image: solarwinds/swi-opentelemetry-collector:0.8.8
+        image: solarwinds/swi-opentelemetry-collector:0.8.9
         imagePullPolicy: IfNotPresent
         livenessProbe:
           httpGet:
@@ -86,6 +86,7 @@ DaemonSet spec should match snapshot when ebpfNetworkMonitoring is enabled:
       fsGroup: 0
       runAsGroup: 0
       runAsUser: 0
+    serviceAccountName: RELEASE-NAME-swo-k8s-collector
     terminationGracePeriodSeconds: 30
     tolerations:
       - effect: NoSchedule
@@ -156,7 +157,7 @@ DaemonSet spec should match snapshot when using default values:
         envFrom:
           - configMapRef:
               name: RELEASE-NAME-swo-k8s-collector-common-env
-        image: solarwinds/swi-opentelemetry-collector:0.8.8
+        image: solarwinds/swi-opentelemetry-collector:0.8.9
         imagePullPolicy: IfNotPresent
         livenessProbe:
           httpGet:
@@ -204,6 +205,7 @@ DaemonSet spec should match snapshot when using default values:
       fsGroup: 0
       runAsGroup: 0
       runAsUser: 0
+    serviceAccountName: RELEASE-NAME-swo-k8s-collector
     terminationGracePeriodSeconds: 30
     tolerations:
       - effect: NoSchedule

--- a/deploy/helm/values.yaml
+++ b/deploy/helm/values.yaml
@@ -26,6 +26,23 @@ otel:
     # Define whether metrics will be collected and sent
     enabled: true
 
+    # configuration for metric discovery
+    autodiscovery:
+      prometheusEndpoints: 
+        # Define whether metrics will be discovered and scraped by prometheus annotations
+        enabled: true
+
+        # Additional custom rule for discovery (following rule is always present: type == "pod" && annotations["prometheus.io/scrape"] == "true")
+        # Available fields
+        #   `id` - ID of source endpoint
+        #   `name` - name of the pod
+        #   `namespace` - namespace of the pod
+        #   `uid` - unique id of the pod
+        #   `labels` - map of labels set on the pod
+        #   `annotations` - map of annotations set on the pod
+        # Example: namespace == "test-namespace" && labels["app"] == "test-app"
+        additionalRules: 
+
     # Check if SWI OTEL endpoint is reachable
     swi_endpoint_check: true
 

--- a/tests/deploy/tests/test_metric_manifest.yaml
+++ b/tests/deploy/tests/test_metric_manifest.yaml
@@ -6,11 +6,16 @@ metadata:
     app: test-pod
   annotations:
     test-annotation: "test-value"
+    prometheus.io/scrape: "true"
+    prometheus.io/path: "/metrics"
+    prometheus.io/port: "8080"
 spec:
   containers:
   - name: test-container
     image: busybox
-    command: ["sh", "-c", "sleep infinity"]
+    command: ["sh", "-c", "echo 'test_metric_from_pod 1' > /metrics; httpd -f -p 8080 -h /; sleep infinity"]
+    ports:
+    - containerPort: 8080
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -31,11 +36,16 @@ spec:
         app: test-deployment
       annotations:
         test-annotation: "test-value"
+        prometheus.io/scrape: "true"
+        prometheus.io/path: "/custom_metrics"
+        prometheus.io/port: "8081"
     spec:
       containers:
       - name: test-container
         image: busybox
-        command: ["sh", "-c", "sleep infinity"]
+        command: ["sh", "-c", "echo 'test_metric_from_deployment 1' > /custom_metrics; httpd -f -p 8081 -h /; sleep infinity"]
+        ports:
+        - containerPort: 8081
 ---
 apiVersion: apps/v1
 kind: StatefulSet

--- a/tests/integration/expected_telemetry/deployment.json
+++ b/tests/integration/expected_telemetry/deployment.json
@@ -13,9 +13,7 @@
         { "name": "k8s.kube_deployment_status_replicas_available" },
         { "name": "k8s.kube_deployment_status_replicas_ready" },
         { "name": "k8s.kube_deployment_status_replicas_unavailable" },
-        { "name": "k8s.kube_deployment_status_replicas_updated" },
-        { "name": "k8s.test_metric_from_deployment" }
-
+        { "name": "k8s.kube_deployment_status_replicas_updated" }
     ],
     "resource_attributes": [
         "sw.k8s.cluster.uid",

--- a/tests/integration/expected_telemetry/deployment.json
+++ b/tests/integration/expected_telemetry/deployment.json
@@ -13,7 +13,9 @@
         { "name": "k8s.kube_deployment_status_replicas_available" },
         { "name": "k8s.kube_deployment_status_replicas_ready" },
         { "name": "k8s.kube_deployment_status_replicas_unavailable" },
-        { "name": "k8s.kube_deployment_status_replicas_updated" }
+        { "name": "k8s.kube_deployment_status_replicas_updated" },
+        { "name": "k8s.test_metric_from_deployment" }
+
     ],
     "resource_attributes": [
         "sw.k8s.cluster.uid",

--- a/tests/integration/expected_telemetry/deployment_with_metric.json
+++ b/tests/integration/expected_telemetry/deployment_with_metric.json
@@ -1,0 +1,11 @@
+{
+    "metrics": [
+        { "name": "k8s.test_metric_from_deployment" }
+],
+    "resource_attributes": [
+        "sw.k8s.cluster.uid",
+        { "key":"k8s.cluster.name", "value": "cluster name" },
+        { "key":"k8s.namespace.name", "value": "test-namespace" }, 
+        { "key":"k8s.deployment.name", "value": "test-deployment" }
+    ]
+}

--- a/tests/integration/expected_telemetry/pod.json
+++ b/tests/integration/expected_telemetry/pod.json
@@ -20,7 +20,8 @@
         { "name": "k8s.kube_pod_status_phase" },
         { "name": "k8s.kube_pod_status_ready" },
         { "name": "k8s.pod.containers" },
-        { "name": "k8s.pod.containers.running" }
+        { "name": "k8s.pod.containers.running" },
+        { "name": "k8s.test_metric_from_pod" }
     ],
     "resource_attributes": [
         "sw.k8s.cluster.uid",

--- a/tests/integration/test_metric_collection.py
+++ b/tests/integration/test_metric_collection.py
@@ -51,7 +51,7 @@ def test_expected_otel_message_content_is_generated(file_name):
     retry_until_ok(url, 
                    lambda content: assert_test_contain_expected_datapoints(content, metrics, resource_attributes),
                    print_failure_otel_content,
-                   timeout=60)
+                   timeout=120)
 
 def test_no_metric_datapoints_for_internal_containers():
     retry_until_ok(url, assert_test_no_metric_datapoints_for_internal_containers,


### PR DESCRIPTION
Depends on: https://github.com/solarwinds/swi-k8s-opentelemetry-collector/pull/447

Summary:
* Added metrics pipeline to node-collector
* Adding support for scraping application metrics with configurable custom rule
* `k8sattributes` configured to watch only entities from `NODE_NAME` (to reduce memory footprint)
* `k8s_observer` configured to watch only pods from `NODE_NAME`
* `receiver_creator` creates `promethesreceiver` for each discovered Pod on given node