### PR TITLE
NH-66305: Adding `force_extra_scrape_metrics` option

### DIFF
--- a/deploy/helm/CHANGELOG.md
+++ b/deploy/helm/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Automatic discovery and scraping of prometheus endpoints on pods. Driven by `otel.metrics.autodiscovery.prometheusEndpoints.enabled` option in `values.yaml`, by default enabled (Fargate not yet supported). 
+  - In case `otel.metrics.autodiscovery.prometheusEndpoints.enabled` is set to `true` (which is by default) `extra_scrape_metrics` is ignored as there is high chance that those metrics will be collected two times. You can override this behavior by by setting `force_extra_scrape_metrics` to true.
 - Upgraded OTEL collector image to `0.8.9` (see [Release notes](https://github.com/solarwinds/swi-k8s-opentelemetry-collector/releases/tag/0.8.9))
 
 ## [3.0.0-alpha.6] - 2023-11-07

--- a/deploy/helm/metrics-collector-config.yaml
+++ b/deploy/helm/metrics-collector-config.yaml
@@ -1541,7 +1541,7 @@ receivers:
       grpc:
         endpoint: 0.0.0.0:{{ .Values.otel.metrics.otlp_endpoint.port }}
   k8s_events:
-{{- if and .Values.otel.metrics.extra_scrape_metrics .Values.otel.metrics.prometheus.url }}
+{{- if and (and .Values.otel.metrics.extra_scrape_metrics (or (not .Values.otel.metrics.autodiscovery.prometheusEndpoints.enabled) .Values.otel.metrics.force_extra_scrape_metrics)) .Values.otel.metrics.prometheus.url }}
   prometheus/prometheus-server:
     config:
       scrape_configs:
@@ -1698,7 +1698,7 @@ service:
         - batch
       receivers:
         - otlp
-{{- if and .Values.otel.metrics.extra_scrape_metrics .Values.otel.metrics.prometheus.url }}
+{{- if and (and .Values.otel.metrics.extra_scrape_metrics (or (not .Values.otel.metrics.autodiscovery.prometheusEndpoints.enabled) .Values.otel.metrics.force_extra_scrape_metrics)) .Values.otel.metrics.prometheus.url }}
     metrics/prometheus:
       exporters:
         - forward/prometheus

--- a/deploy/helm/templates/NOTES.txt
+++ b/deploy/helm/templates/NOTES.txt
@@ -1,6 +1,11 @@
 {{- if and .Values.otel.metrics.extra_scrape_metrics .Values.prometheus -}}
 {{- if .Values.prometheus.enabled -}}
 WARNING: you rely on bundled Prometheus, but it was removed in this version. To scrape custom metrics you can deploy your own instance of Prometheus and set `.otel.metrics.prometheus.url`.
+
 {{- end -}}
+{{- end -}}
+{{- if and .Values.otel.metrics.extra_scrape_metrics (and .Values.otel.metrics.autodiscovery.prometheusEndpoints.enabled (not .Values.otel.metrics.force_extra_scrape_metrics)) -}}
+WARNING: You have enabled autodiscovery of prometheus endpoints, so `extra_scrape_metrics` is ignored. If you are sure that those metrics won't be covered by autodiscovery set `otel.metrics.force_extra_scrape_metrics` to `true`.
+
 {{- end -}}
 

--- a/deploy/helm/tests/metrics-collector-config-map_test.yaml
+++ b/deploy/helm/tests/metrics-collector-config-map_test.yaml
@@ -11,6 +11,7 @@ tests:
   - it: Metrics config should match snapshot when using Prometheus url with extra_scrape_metrics
     template: metrics-collector-config-map.yaml
     set:
+      otel.metrics.force_extra_scrape_metrics: true
       otel.metrics.prometheus.url: "my-prometheus-url"
       otel.metrics.extra_scrape_metrics: ["test-metric"]
     asserts:

--- a/deploy/helm/tests/notes_test.yaml
+++ b/deploy/helm/tests/notes_test.yaml
@@ -9,9 +9,19 @@ tests:
 
   - it: should pass the notes file with extra_scrape_metrics and prometheus.enabled
     set:
+      otel.metrics.force_extra_scrape_metrics: true
       otel.metrics.extra_scrape_metrics: ["test-metric"]
       prometheus.enabled: true
     asserts:
       - equalRaw:
+          value: 'WARNING: you rely on bundled Prometheus, but it was removed in this version. To scrape custom metrics you can deploy your own instance of Prometheus and set `.otel.metrics.prometheus.url`.'
+
+  - it: should pass the notes file with extra_scrape_metrics and force_extra_scrape_metrics
+    set:
+      otel.metrics.autodiscovery.prometheusEndpoints.enabled: true
+      otel.metrics.force_extra_scrape_metrics: false
+      otel.metrics.extra_scrape_metrics: ["test-metric"]
+    asserts:
+      - equalRaw:
           value: | 
-            WARNING: you rely on bundled Prometheus, but it was removed in this version. To scrape custom metrics you can deploy your own instance of Prometheus and set `.otel.metrics.prometheus.url`.
+            WARNING: You have enabled autodiscovery of prometheus endpoints, so `extra_scrape_metrics` is ignored. If you are sure that those metrics won't be covered by autodiscovery set `otel.metrics.force_extra_scrape_metrics` to `true`.

--- a/deploy/helm/values.yaml
+++ b/deploy/helm/values.yaml
@@ -86,6 +86,11 @@ otel:
     # See format in https://prometheus.io/docs/prometheus/latest/querying/basics/#instant-vector-selectors
     extra_scrape_metrics: []
 
+    # In case `otel.metrics.autodiscovery.prometheusEndpoints.enabled` is set to `true` (which is by default) there is a possibility
+    # that those extra prometheus metrics are scraped by the collector, so in this case `extra_scrape_metrics` is ignored. By setting 
+    # `force_extra_scrape_metrics` to `true` you can force the collector to scrape those metrics.
+    force_extra_scrape_metrics: false
+
     # Batching configuration for metrics
     # see https://github.com/open-telemetry/opentelemetry-collector/tree/main/processor/batchprocessor for configuration reference
     batch:


### PR DESCRIPTION
Depends on https://github.com/solarwinds/swi-k8s-opentelemetry-collector/pull/448 

To avoid scraping metrics from both Prometheus and using autodiscovery of application metrics I ignore `extra_scrape_metrics` if `otel.metrics.autodiscovery.prometheusEndpoints.enabled` is enabled (true by default). Customer can override this behavior with `force_extra_scrape_metrics` if he is really sure extra scraped metrics are not autodiscovered