### PR TITLE
Added option to configure retry_on_failure and increasing GRPC request timeout

### DIFF
--- a/deploy/helm/CHANGELOG.md
+++ b/deploy/helm/CHANGELOG.md
@@ -13,6 +13,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Added option to offload sending_queue to storage, reducing memory requirement for the collector
 - Added option to configure sending_queue
+- Added option to configure retry_on_failure
+  - default for initial_interval is now `10s` (previously was `5s`) avoiding unnecessary retries when backend takes time to respond
 
 ## [3.1.0-alpha.2] - 2023-11-16
 

--- a/deploy/helm/events-collector-config.yaml
+++ b/deploy/helm/events-collector-config.yaml
@@ -5,6 +5,11 @@ exporters:
       insecure: ${OTEL_ENVOY_ADDRESS_TLS_INSECURE}
     headers:
       "Authorization": "Bearer ${SOLARWINDS_API_TOKEN}"
+    retry_on_failure:
+      enabled: {{ .Values.otel.events.retry_on_failure.enabled }}
+      initial_interval: {{ .Values.otel.events.retry_on_failure.initial_interval }}
+      max_interval: {{ .Values.otel.events.retry_on_failure.max_interval }}
+      max_elapsed_time: {{ .Values.otel.events.retry_on_failure.max_elapsed_time }}
     sending_queue:
       enabled: {{ .Values.otel.events.sending_queue.enabled }}
       num_consumers: {{ .Values.otel.events.sending_queue.num_consumers }}

--- a/deploy/helm/metrics-collector-config.yaml
+++ b/deploy/helm/metrics-collector-config.yaml
@@ -5,6 +5,11 @@ exporters:
       insecure: ${OTEL_ENVOY_ADDRESS_TLS_INSECURE}
     headers:
       "Authorization": "Bearer ${SOLARWINDS_API_TOKEN}"
+    retry_on_failure:
+      enabled: {{ .Values.otel.metrics.retry_on_failure.enabled }}
+      initial_interval: {{ .Values.otel.metrics.retry_on_failure.initial_interval }}
+      max_interval: {{ .Values.otel.metrics.retry_on_failure.max_interval }}
+      max_elapsed_time: {{ .Values.otel.metrics.retry_on_failure.max_elapsed_time }}
     sending_queue:
       enabled: {{ .Values.otel.metrics.sending_queue.enabled }}
       num_consumers: {{ .Values.otel.metrics.sending_queue.num_consumers }}

--- a/deploy/helm/node-collector-config.yaml
+++ b/deploy/helm/node-collector-config.yaml
@@ -5,6 +5,11 @@ exporters:
       insecure: ${OTEL_ENVOY_ADDRESS_TLS_INSECURE}
     headers:
       "Authorization": "Bearer ${SOLARWINDS_API_TOKEN}"
+    retry_on_failure:
+      enabled: {{ .Values.otel.node_collector.retry_on_failure.enabled }}
+      initial_interval: {{ .Values.otel.node_collector.retry_on_failure.initial_interval }}
+      max_interval: {{ .Values.otel.node_collector.retry_on_failure.max_interval }}
+      max_elapsed_time: {{ .Values.otel.node_collector.retry_on_failure.max_elapsed_time }}
     sending_queue:
       enabled: {{ .Values.otel.node_collector.sending_queue.enabled }}
       num_consumers: {{ .Values.otel.node_collector.sending_queue.num_consumers }}

--- a/deploy/helm/tests/__snapshot__/events-collector-config-map_test.yaml.snap
+++ b/deploy/helm/tests/__snapshot__/events-collector-config-map_test.yaml.snap
@@ -6,6 +6,11 @@ Events config should match snapshot when using default values:
           endpoint: ${OTEL_ENVOY_ADDRESS}
           headers:
             Authorization: Bearer ${SOLARWINDS_API_TOKEN}
+          retry_on_failure:
+            enabled: true
+            initial_interval: 10s
+            max_elapsed_time: 300s
+            max_interval: 30s
           sending_queue:
             enabled: true
             num_consumers: 10

--- a/deploy/helm/tests/__snapshot__/metrics-collector-config-map-fargate_test.yaml.snap
+++ b/deploy/helm/tests/__snapshot__/metrics-collector-config-map-fargate_test.yaml.snap
@@ -282,6 +282,11 @@ Metrics config should match snapshot when using default values:
           endpoint: ${OTEL_ENVOY_ADDRESS}
           headers:
             Authorization: Bearer ${SOLARWINDS_API_TOKEN}
+          retry_on_failure:
+            enabled: true
+            initial_interval: 10s
+            max_elapsed_time: 300s
+            max_interval: 30s
           sending_queue:
             enabled: true
             num_consumers: 10

--- a/deploy/helm/tests/__snapshot__/metrics-collector-config-map_test.yaml.snap
+++ b/deploy/helm/tests/__snapshot__/metrics-collector-config-map_test.yaml.snap
@@ -282,6 +282,11 @@ Metrics config should match snapshot when using Prometheus url with extra_scrape
           endpoint: ${OTEL_ENVOY_ADDRESS}
           headers:
             Authorization: Bearer ${SOLARWINDS_API_TOKEN}
+          retry_on_failure:
+            enabled: true
+            initial_interval: 10s
+            max_elapsed_time: 300s
+            max_interval: 30s
           sending_queue:
             enabled: true
             num_consumers: 10
@@ -2622,6 +2627,11 @@ Metrics config should match snapshot when using default values:
           endpoint: ${OTEL_ENVOY_ADDRESS}
           headers:
             Authorization: Bearer ${SOLARWINDS_API_TOKEN}
+          retry_on_failure:
+            enabled: true
+            initial_interval: 10s
+            max_elapsed_time: 300s
+            max_interval: 30s
           sending_queue:
             enabled: true
             num_consumers: 10

--- a/deploy/helm/tests/__snapshot__/node-collector-config-map-windows_test.yaml.snap
+++ b/deploy/helm/tests/__snapshot__/node-collector-config-map-windows_test.yaml.snap
@@ -7,6 +7,11 @@ Node collector config for windows nodes should match snapshot when using default
           endpoint: ${OTEL_ENVOY_ADDRESS}
           headers:
             Authorization: Bearer ${SOLARWINDS_API_TOKEN}
+          retry_on_failure:
+            enabled: true
+            initial_interval: 10s
+            max_elapsed_time: 300s
+            max_interval: 30s
           sending_queue:
             enabled: true
             num_consumers: 10

--- a/deploy/helm/tests/__snapshot__/node-collector-config-map_test.yaml.snap
+++ b/deploy/helm/tests/__snapshot__/node-collector-config-map_test.yaml.snap
@@ -7,6 +7,11 @@ Node collector config should match snapshot when using default values:
           endpoint: ${OTEL_ENVOY_ADDRESS}
           headers:
             Authorization: Bearer ${SOLARWINDS_API_TOKEN}
+          retry_on_failure:
+            enabled: true
+            initial_interval: 10s
+            max_elapsed_time: 300s
+            max_interval: 30s
           sending_queue:
             enabled: true
             num_consumers: 10

--- a/deploy/helm/values.yaml
+++ b/deploy/helm/values.yaml
@@ -49,6 +49,18 @@ otel:
         enabled: false
         directory: /var/lib/swo/sending_queue
 
+    retry_on_failure:
+      enabled: true
+
+      # Time to wait after the first failure before retrying; ignored if enabled is false
+      initial_interval: 10s
+
+      # Is the upper bound on backoff; ignored if enabled is false
+      max_interval: 30s
+
+      # Is the maximum amount of time spent trying to send a batch; ignored if enabled is false
+      max_elapsed_time: 300s
+
   # Configuration for metrics collection
   metrics:
     # Define whether metrics will be collected and sent
@@ -100,6 +112,18 @@ otel:
       # When enabled sending_queue of metrics collector will be offloaded to disk. It will use emptyDir volume
       # This will reduce amount of memory, but it will use slightly more CPU and will have slightly lower throughput
       offload_to_disk: false
+
+    retry_on_failure:
+      enabled: true
+
+      # Time to wait after the first failure before retrying; ignored if enabled is false
+      initial_interval: 10s
+
+      # Is the upper bound on backoff; ignored if enabled is false
+      max_interval: 30s
+
+      # Is the maximum amount of time spent trying to send a batch; ignored if enabled is false
+      max_elapsed_time: 300s
 
     prometheus:
       # URL of prometheus where to scrape
@@ -254,6 +278,18 @@ otel:
       # When enabled sending_queue of metrics collector will be offloaded to disk. It will use emptyDir volume
       # This will reduce amount of memory, but it will use slightly more CPU and will have slightly lower throughput
       offload_to_disk: false
+
+    retry_on_failure:
+      enabled: true
+
+      # Time to wait after the first failure before retrying; ignored if enabled is false
+      initial_interval: 10s
+
+      # Is the upper bound on backoff; ignored if enabled is false
+      max_interval: 30s
+
+      # Is the maximum amount of time spent trying to send a batch; ignored if enabled is false
+      max_elapsed_time: 300s
 
     # Memory limiter configuration. The memory limiter is used to prevent out of memory situations on the collector.
     # See https://github.com/open-telemetry/opentelemetry-collector/tree/main/processor/memorylimiterprocessor for configuration reference


### PR DESCRIPTION
Depends on https://github.com/solarwinds/swi-k8s-opentelemetry-collector/pull/464 (to avoid merge conflicts)

This follows on this thread: https://swicloud.slack.com/archives/C02HF9XCHB8/p1698707326607679

we are getting a lot of `DeadlineExceeded` errors here and there and even if we have backoff retry which will make sure that it will try again, it is increasing memory usage and also some data may be written twice, as writes on the backend are not transactional and they can be successfully written to kafka even if request fails.

Therefore setting default of `initial_interval` to `10s` (previously was `5s`)
