### PR TITLE
NH-67743: Improving graceful termination

### DIFF
--- a/deploy/helm/CHANGELOG.md
+++ b/deploy/helm/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `sending_queue`.`queue_size` changed from `1000` to `200`, decreasing amount of memory it can take
 
 ### Added
+- Added option to configure terminationGracePeriodSeconds defaulting to 10 minutes, so that it is guaranteed that collector process whole pipeline
 - Added option to offload sending_queue to storage, reducing memory requirement for the collector
 - Added option to configure sending_queue
 

--- a/deploy/helm/templates/events-collector-deployment.yaml
+++ b/deploy/helm/templates/events-collector-deployment.yaml
@@ -29,6 +29,7 @@ spec:
 {{ include "common.template-labels" . | indent 8 }}
         app: {{ include "common.fullname" (tuple . "-events") }}
     spec:
+      terminationGracePeriodSeconds: {{ .Values.otel.events.terminationGracePeriodSeconds }}
       serviceAccountName: {{ include "common.fullname" . }}
       securityContext: {}
       nodeSelector:

--- a/deploy/helm/templates/metrics-deployment.yaml
+++ b/deploy/helm/templates/metrics-deployment.yaml
@@ -30,6 +30,7 @@ spec:
 {{ include "common.template-labels" . | indent 8 }}
         app: {{ include "common.fullname" (tuple . "-metrics") }}
     spec:
+      terminationGracePeriodSeconds: {{ .Values.otel.metrics.terminationGracePeriodSeconds }}
       serviceAccountName: {{ include "common.fullname" . }}
       securityContext: {}
       nodeSelector:

--- a/deploy/helm/templates/node-collector-daemon-set-windows.yaml
+++ b/deploy/helm/templates/node-collector-daemon-set-windows.yaml
@@ -28,7 +28,7 @@ spec:
         prometheus.io/scheme: "http"
 {{- end}}
     spec:
-      terminationGracePeriodSeconds: 30
+      terminationGracePeriodSeconds: {{ .Values.otel.node_collector.terminationGracePeriodSeconds }}
       serviceAccountName: {{ include "common.fullname" . }}
       tolerations:
       {{- if .Values.otel.logs.tolerations }}

--- a/deploy/helm/templates/node-collector-daemon-set.yaml
+++ b/deploy/helm/templates/node-collector-daemon-set.yaml
@@ -28,7 +28,7 @@ spec:
         prometheus.io/scheme: "http"
 {{- end}}
     spec:
-      terminationGracePeriodSeconds: 30
+      terminationGracePeriodSeconds: {{ .Values.otel.node_collector.terminationGracePeriodSeconds }}
       serviceAccountName: {{ include "common.fullname" . }}
       securityContext:
         fsGroup: 0

--- a/deploy/helm/tests/__snapshot__/events-collector-deployment_test.yaml.snap
+++ b/deploy/helm/tests/__snapshot__/events-collector-deployment_test.yaml.snap
@@ -49,6 +49,7 @@ Events collector spec should match snapshot when using default values:
       kubernetes.io/os: linux
     securityContext: {}
     serviceAccountName: RELEASE-NAME-swo-k8s-collector
+    terminationGracePeriodSeconds: 600
     volumes:
       - configMap:
           items:

--- a/deploy/helm/tests/__snapshot__/metrics-deployment_test.yaml.snap
+++ b/deploy/helm/tests/__snapshot__/metrics-deployment_test.yaml.snap
@@ -93,6 +93,7 @@ Metrics collector spec should match snapshot when using default values:
       kubernetes.io/os: linux
     securityContext: {}
     serviceAccountName: RELEASE-NAME-swo-k8s-collector
+    terminationGracePeriodSeconds: 600
     volumes:
       - configMap:
           items:

--- a/deploy/helm/tests/__snapshot__/node-collector-daemon-set-windows_test.yaml.snap
+++ b/deploy/helm/tests/__snapshot__/node-collector-daemon-set-windows_test.yaml.snap
@@ -77,7 +77,7 @@ DaemonSet spec for windows nodes should match snapshot when using default values
       kubernetes.io/arch: amd64
       kubernetes.io/os: windows
     serviceAccountName: RELEASE-NAME-swo-k8s-collector
-    terminationGracePeriodSeconds: 30
+    terminationGracePeriodSeconds: 600
     tolerations:
       - effect: NoSchedule
         operator: Exists

--- a/deploy/helm/tests/__snapshot__/node-collector-daemon-set_test.yaml.snap
+++ b/deploy/helm/tests/__snapshot__/node-collector-daemon-set_test.yaml.snap
@@ -87,7 +87,7 @@ DaemonSet spec should match snapshot when ebpfNetworkMonitoring is enabled:
       runAsGroup: 0
       runAsUser: 0
     serviceAccountName: RELEASE-NAME-swo-k8s-collector
-    terminationGracePeriodSeconds: 30
+    terminationGracePeriodSeconds: 600
     tolerations:
       - effect: NoSchedule
         operator: Exists
@@ -206,7 +206,7 @@ DaemonSet spec should match snapshot when using default values:
       runAsGroup: 0
       runAsUser: 0
     serviceAccountName: RELEASE-NAME-swo-k8s-collector
-    terminationGracePeriodSeconds: 30
+    terminationGracePeriodSeconds: 600
     tolerations:
       - effect: NoSchedule
         operator: Exists

--- a/deploy/helm/values.yaml
+++ b/deploy/helm/values.yaml
@@ -36,6 +36,8 @@ otel:
       pullPolicy: IfNotPresent
 
   node_collector:
+    terminationGracePeriodSeconds: 600
+
     sending_queue:
       enabled: true
 
@@ -227,6 +229,7 @@ otel:
     nodeSelector: {}
     tolerations: []
     affinity: {}
+    terminationGracePeriodSeconds: 600
 
   # Configuration for Events collection
   events:
@@ -331,6 +334,7 @@ otel:
     nodeSelector: {}
     tolerations: []
     affinity: {}
+    terminationGracePeriodSeconds: 600
 
   # Configuration for Logs collection
   logs:


### PR DESCRIPTION
Added option to configure terminationGracePeriodSeconds defaulting to 10 minutes, so that it is guaranteed that collector process whole pipeline