### PR TITLE
NH-67033: Added option to configure liveness and readiness probes initial startup delay on metrics collector

### DIFF
--- a/deploy/helm/CHANGELOG.md
+++ b/deploy/helm/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## [3.1.0-rc.6] - 2023-11-24
+
+### Added
+- Added option to configure liveness and readiness probes initial startup delay on metrics collector, defaulting to 10s
+
 ## [3.1.0-rc.5] - 2023-11-24
 
 ### Fixed

--- a/deploy/helm/Chart.yaml
+++ b/deploy/helm/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: swo-k8s-collector
-version: 3.1.0-rc.5
+version: 3.1.0-rc.6
 appVersion: "0.8.10"
 description: SolarWinds Kubernetes Integration
 keywords:

--- a/deploy/helm/templates/metrics-deployment.yaml
+++ b/deploy/helm/templates/metrics-deployment.yaml
@@ -133,10 +133,16 @@ spec:
             - configMapRef:
                 name: {{ include "common.fullname" (tuple . "-metrics-env-config") }}
           livenessProbe:
+            {{- if .Values.otel.metrics.livenessProbe.initialDelaySeconds }}
+            initialDelaySeconds: {{ .Values.otel.metrics.livenessProbe.initialDelaySeconds }}
+            {{- end }}
             httpGet:
               path: /
               port: 13133
           readinessProbe:
+            {{- if .Values.otel.metrics.readinessProbe.initialDelaySeconds }}
+            initialDelaySeconds: {{ .Values.otel.metrics.readinessProbe.initialDelaySeconds }}
+            {{- end }}
             httpGet:
               path: /
               port: 13133

--- a/deploy/helm/tests/__snapshot__/logs-fargate-config-map_test.yaml.snap
+++ b/deploy/helm/tests/__snapshot__/logs-fargate-config-map_test.yaml.snap
@@ -24,7 +24,7 @@ Fargate logging ConfigMap spec should include additional filters when they are c
           Match *
           Add sw.k8s.cluster.uid <CLUSTER_UID>
           Add sw.k8s.log.type container
-          Add sw.k8s.agent.manifest.version "3.1.0-rc.5"
+          Add sw.k8s.agent.manifest.version "3.1.0-rc.6"
     flb_log_cw: "false"
     output.conf: |
       [OUTPUT]
@@ -64,7 +64,7 @@ Fargate logging ConfigMap spec should match snapshot when Fargate logging is ena
           Match *
           Add sw.k8s.cluster.uid <CLUSTER_UID>
           Add sw.k8s.log.type container
-          Add sw.k8s.agent.manifest.version "3.1.0-rc.5"
+          Add sw.k8s.agent.manifest.version "3.1.0-rc.6"
     flb_log_cw: "false"
     output.conf: |
       [OUTPUT]

--- a/deploy/helm/tests/__snapshot__/metrics-deployment_test.yaml.snap
+++ b/deploy/helm/tests/__snapshot__/metrics-deployment_test.yaml.snap
@@ -27,6 +27,7 @@ Metrics collector spec should match snapshot when using default values:
           httpGet:
             path: /
             port: 13133
+          initialDelaySeconds: 10
         name: swi-opentelemetry-collector
         ports:
           - containerPort: 4317
@@ -39,6 +40,7 @@ Metrics collector spec should match snapshot when using default values:
           httpGet:
             path: /
             port: 13133
+          initialDelaySeconds: 10
         resources:
           limits:
             memory: 3Gi

--- a/deploy/helm/values.yaml
+++ b/deploy/helm/values.yaml
@@ -255,6 +255,11 @@ otel:
     affinity: {}
     terminationGracePeriodSeconds: 600
 
+    readinessProbe:
+      initialDelaySeconds: 10
+    livenessProbe:
+      initialDelaySeconds: 10
+
   # Configuration for Events collection
   events:
     # Define whether events will be collected and sent


### PR DESCRIPTION
The reason is that metrics collector newly has OTLP endpoint and healthcheck does not test its availability, so adding initial delay just to make sure that pod gets ready after the endpoint is available
