### PR TITLE
NH-42143: Building multiarch image with AMD64 and ARM64 platforms

### DIFF
--- a/.github/workflows/buildAndDeploy.yml
+++ b/.github/workflows/buildAndDeploy.yml
@@ -52,18 +52,6 @@ jobs:
 
       - name: Run integration tests
         uses: ./.github/actions/run-integration-tests
-
-      - name: Save image
-        if: github.event_name == 'release' && github.event.action == 'published' && !contains(github.ref, 'swo-k8s-collector')
-        run: |
-          docker save --output swi-k8s-opentelemetry-collector.tar swi-k8s-opentelemetry-collector:${{ steps.generate-tag.outputs.value }}
-
-      - uses: actions/upload-artifact@v3
-        if: github.event_name == 'release' && github.event.action == 'published' && !contains(github.ref, 'swo-k8s-collector')
-        with:
-          name: image
-          path: swi-k8s-opentelemetry-collector.tar
-          retention-days: 2
   
   build_and_test_windows:
     runs-on: windows-2022
@@ -264,31 +252,29 @@ jobs:
       name: production
       url: https://hub.docker.com/repository/docker/solarwinds/swi-opentelemetry-collector
     steps:
-      - uses: actions/download-artifact@v3
-        with:
-          name: image
-
+      - name: Checkout
+        uses: actions/checkout@v4
       - name: Get image tag
         id: vars
         run: echo ::set-output name=tag::${GITHUB_REF#refs/*/}
 
-      - name: Load image
-        run: |
-          docker load --input swi-k8s-opentelemetry-collector.tar
-
-      - name: Tag images
-        run: |
-          docker tag swi-k8s-opentelemetry-collector:${{ needs.build_and_test.outputs.image_tag }} ${{ env.DOCKERHUB_IMAGE }}:${{ steps.vars.outputs.tag }}
-          docker tag swi-k8s-opentelemetry-collector:${{ needs.build_and_test.outputs.image_tag }} ${{ env.DOCKERHUB_IMAGE }}:latest
-
-      - name: Docker login
-        env:
-          DOCKER_HUB_CI_PASSWORD: ${{ secrets.DOCKER_HUB_CI_PASSWORD }}
-          DOCKER_HUB_CI_USER: ${{ secrets.DOCKER_HUB_CI_USER }}
-        run: echo "$DOCKER_HUB_CI_PASSWORD" | docker login -u "$DOCKER_HUB_CI_USER" --password-stdin
-
-      - name: Push as specific
-        run: docker push ${{ env.DOCKERHUB_IMAGE }}:${{ steps.vars.outputs.tag }}
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKER_HUB_CI_USER }}
+          password: ${{ secrets.DOCKER_HUB_CI_PASSWORD }}
+      - name: Build and push
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: build/docker/Dockerfile
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: ${{ env.DOCKERHUB_IMAGE }}:${{ steps.vars.outputs.tag }}
 
   deploy_dockerhub_windows:
     runs-on: windows-2022

--- a/build/docker/Dockerfile
+++ b/build/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM docker.io/library/golang:1.21.4-bookworm@sha256:85aacbed94a248f792beb89198649ddbc730649054b397f8d689e9c4c4cceab7 as base
+FROM docker.io/library/golang:1.21.4-bookworm as base
 WORKDIR /src
 COPY ["./src/", "./src/"]
 
@@ -16,47 +16,21 @@ RUN if [[ -z "$CREATE_VENDOR_DIR" ]] ; then echo vendor creation skipped ; else 
 FROM base as tests
 RUN cd src/processor/swmetricstransformprocessor && go test ./...
 
-FROM alpine:3.18@sha256:eece025e432126ce23f223450a0326fbebde39cdf496a85d8c016293fc851978 as prep
+FROM alpine:3.18 as prep
 RUN apk --update add ca-certificates
 
-FROM debian:12.2@sha256:fab22df37377621693c68650b06680c0d8f7c6bf816ec92637944778db3ca2c0 as journal
+FROM debian:12.2 as journal
 RUN apt update
 RUN apt install -y systemd
+COPY /build/docker/copy-journalbinary.sh /script.sh
+RUN chmod +x /script.sh
+RUN /script.sh
 
 FROM base as wrapper
 WORKDIR /src/src/wrapper
 RUN CGO_ENABLED=0 GOEXPERIMENT=boringcrypto go build -a -tags netgo -ldflags '-w -extldflags "-static"' -o /bin/wrapper && chmod +x /bin/wrapper
 
-FROM scratch as journalbinaries
-
-# dynamically linked libraries that are required for journalctl and the journalctl binary itself
-#   use `ldd /bin/journalctl` to get dynamically linked libraries from the binary
-COPY --from=journal /bin/journalctl /bin/journalctl
-COPY --from=journal /usr/lib/x86_64-linux-gnu/systemd/libsystemd-shared-252.so /usr/lib/x86_64-linux-gnu/systemd/libsystemd-shared-252.so
-COPY --from=journal /lib/x86_64-linux-gnu/libacl.so.1 /lib/x86_64-linux-gnu/libacl.so.1
-COPY --from=journal /lib/x86_64-linux-gnu/libaudit.so.1 /lib/x86_64-linux-gnu/libaudit.so.1
-COPY --from=journal /lib/x86_64-linux-gnu/libblkid.so.1 /lib/x86_64-linux-gnu/libblkid.so.1
-COPY --from=journal /lib/x86_64-linux-gnu/libc.so.6 /lib/x86_64-linux-gnu/libc.so.6
-COPY --from=journal /lib/x86_64-linux-gnu/libcap-ng.so.0 /lib/x86_64-linux-gnu/libcap-ng.so.0
-COPY --from=journal /lib/x86_64-linux-gnu/libcap.so.2 /lib/x86_64-linux-gnu/libcap.so.2
-COPY --from=journal /lib/x86_64-linux-gnu/libcrypt.so.1 /lib/x86_64-linux-gnu/libcrypt.so.1
-COPY --from=journal /lib/x86_64-linux-gnu/libcrypto.so.3 /lib/x86_64-linux-gnu/libcrypto.so.3
-COPY --from=journal /lib/x86_64-linux-gnu/libgcrypt.so.20 /lib/x86_64-linux-gnu/libgcrypt.so.20
-COPY --from=journal /lib/x86_64-linux-gnu/libgpg-error.so.0 /lib/x86_64-linux-gnu/libgpg-error.so.0
-COPY --from=journal /lib/x86_64-linux-gnu/libip4tc.so.2 /lib/x86_64-linux-gnu/libip4tc.so.2
-COPY --from=journal /lib/x86_64-linux-gnu/libkmod.so.2 /lib/x86_64-linux-gnu/libkmod.so.2
-COPY --from=journal /lib/x86_64-linux-gnu/liblz4.so.1 /lib/x86_64-linux-gnu/liblz4.so.1
-COPY --from=journal /lib/x86_64-linux-gnu/liblzma.so.5 /lib/x86_64-linux-gnu/liblzma.so.5
-COPY --from=journal /lib/x86_64-linux-gnu/libm.so.6 /lib/x86_64-linux-gnu/libm.so.6
-COPY --from=journal /lib/x86_64-linux-gnu/libmount.so.1 /lib/x86_64-linux-gnu/libmount.so.1
-COPY --from=journal /lib/x86_64-linux-gnu/libpam.so.0 /lib/x86_64-linux-gnu/libpam.so.0
-COPY --from=journal /lib/x86_64-linux-gnu/libpcre2-8.so.0 /lib/x86_64-linux-gnu/libpcre2-8.so.0
-COPY --from=journal /lib/x86_64-linux-gnu/libseccomp.so.2 /lib/x86_64-linux-gnu/libseccomp.so.2
-COPY --from=journal /lib/x86_64-linux-gnu/libselinux.so.1 /lib/x86_64-linux-gnu/libselinux.so.1
-COPY --from=journal /lib/x86_64-linux-gnu/libzstd.so.1 /lib/x86_64-linux-gnu/libzstd.so.1
-COPY --from=journal /lib64/ld-linux-x86-64.so.2 /lib64/ld-linux-x86-64.so.2
-
-FROM scratch
+FROM bash
 
 ARG USER_UID=10001
 USER ${USER_UID}
@@ -64,7 +38,7 @@ USER ${USER_UID}
 COPY --from=prep /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
 COPY --from=builder /src/swi-k8s-opentelemetry-collector /swi-otelcol
 COPY --from=wrapper /bin/wrapper /wrapper
-COPY --from=journalbinaries / /
+COPY --from=journal /journalctl-deps/ /
 
 ENTRYPOINT ["/wrapper"]
 CMD ["/swi-otelcol", "--config=/opt/default-config.yaml"]

--- a/build/docker/copy-journalbinary.sh
+++ b/build/docker/copy-journalbinary.sh
@@ -1,0 +1,45 @@
+#!/bin/bash
+
+# The binary whose dependencies we want to find
+BINARY="/bin/journalctl"
+
+# The directory where we'll copy the dependencies
+DEP_DIR="/journalctl-deps"
+
+# Function to copy the binary and its dependencies
+copy_dependencies() {
+    # Find the dependencies using ldd
+
+    local deps=$(ldd $BINARY | grep "=>" | awk '{print $3}')
+    
+    # Create the dependency directory if it doesn't exist
+    mkdir -p $DEP_DIR
+
+    # Copy the binary itself
+    mkdir -p $DEP_DIR/bin
+    cp $BINARY $DEP_DIR/bin
+
+    # Copy each dependency
+    for dep in $deps; do
+        # Create subdirectories if necessary
+        local dir=$(dirname $dep)
+        mkdir -p $DEP_DIR$dir
+
+        # Copy the library file
+        echo "Copying $dep to $DEP_DIR$dir"
+        cp $dep $DEP_DIR$dir
+    done
+
+    # Copy the dynamic linker
+    local linker=$(ldd $BINARY | grep 'ld-linux' | awk '{print $1}')
+    if [ -n "$linker" ]; then
+        mkdir -p $DEP_DIR$(dirname $linker)
+
+        echo "Copying $linker to $DEP_DIR$(dirname $linker)"
+        cp $linker $DEP_DIR$(dirname $linker)
+    fi
+}
+
+copy_dependencies
+
+echo "Dependencies copied to $DEP_DIR"

--- a/build/docker/structure-test.yaml
+++ b/build/docker/structure-test.yaml
@@ -17,4 +17,4 @@ commandTests:
   - name: "swi-otelcol is working in the image"
     command: "/swi-otelcol"
     args: ["-v"]
-    expectedOutput: ["swi-k8s-opentelemetry-collector version 0.8.9"]
+    expectedOutput: ["swi-k8s-opentelemetry-collector version 0.8.11"]

--- a/build/swi-k8s-opentelemetry-collector.yaml
+++ b/build/swi-k8s-opentelemetry-collector.yaml
@@ -2,7 +2,7 @@ dist:
   name: swi-k8s-opentelemetry-collector
   description: "SolarWinds distribution for OpenTelemetry"
   otelcol_version: "0.81.0"
-  version: "0.8.9"
+  version: "0.8.11"
 exporters:
   - gomod: go.opentelemetry.io/collector/exporter/otlpexporter v0.81.0
 


### PR DESCRIPTION
* making dockerfile platform agnostic
    * it is no longer possible to use sha256 with base images
* building amd64 and arm64 platforms (it is no longer possible to save/load tar, it must be built in step together with push)
    * ARM64 is built using QEMU emulation and due to that its building is very slow (takes like 25 minutes), but it is not the issue since we build our image quite rarely. 
