### PR TITLE
NH-42143: Reverting base image to `scratch`

### DIFF
--- a/build/docker/Dockerfile
+++ b/build/docker/Dockerfile
@@ -30,7 +30,7 @@ FROM base as wrapper
 WORKDIR /src/src/wrapper
 RUN CGO_ENABLED=0 GOEXPERIMENT=boringcrypto go build -a -tags netgo -ldflags '-w -extldflags "-static"' -o /bin/wrapper && chmod +x /bin/wrapper
 
-FROM bash
+FROM scratch
 
 ARG USER_UID=10001
 USER ${USER_UID}

--- a/build/docker/structure-test.yaml
+++ b/build/docker/structure-test.yaml
@@ -17,4 +17,4 @@ commandTests:
   - name: "swi-otelcol is working in the image"
     command: "/swi-otelcol"
     args: ["-v"]
-    expectedOutput: ["swi-k8s-opentelemetry-collector version 0.8.11"]
+    expectedOutput: ["swi-k8s-opentelemetry-collector version 0.8.12"]

--- a/build/swi-k8s-opentelemetry-collector.yaml
+++ b/build/swi-k8s-opentelemetry-collector.yaml
@@ -2,7 +2,7 @@ dist:
   name: swi-k8s-opentelemetry-collector
   description: "SolarWinds distribution for OpenTelemetry"
   otelcol_version: "0.81.0"
-  version: "0.8.11"
+  version: "0.8.12"
 exporters:
   - gomod: go.opentelemetry.io/collector/exporter/otlpexporter v0.81.0
 


### PR DESCRIPTION
In previous PR I set base image to `bash` (which I needed for debugging) and forgot to turn it back. So it is accidental.