### PR TITLE
NH-66009: Adjust helm chart to meet AKS requirements

### DIFF
--- a/deploy/helm/CHANGELOG.md
+++ b/deploy/helm/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Added
+
+- Images can be overriden by setting `global.azure.images.<image_key>` in `values.yaml`
+
 ## [3.1.1] - 2023-11-30
 
 ### Fixed

--- a/deploy/helm/CHANGELOG.md
+++ b/deploy/helm/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## [3.2.0-alpha.5] - 2023-12-01
+
 ### Added
 
 - Images can be overriden by setting `global.azure.images.<image_key>` in `values.yaml`

--- a/deploy/helm/CHANGELOG.md
+++ b/deploy/helm/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Images can be overriden by setting `global.azure.images.<image_key>` in `values.yaml`
+- Added `otel.api_token` to allow setting API token for OTEL collector through `values.yaml`
 
 ## [3.2.0-alpha.4] - 2023-11-30
 

--- a/deploy/helm/Chart.yaml
+++ b/deploy/helm/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: swo-k8s-collector
-version: 3.2.0-alpha.4
+version: 3.2.0-alpha.5
 appVersion: "0.8.12"
 description: SolarWinds Kubernetes Integration
 keywords:

--- a/deploy/helm/templates/_helpers.tpl
+++ b/deploy/helm/templates/_helpers.tpl
@@ -199,3 +199,86 @@ pod_association:
 {{ include "common.k8s-instrumentation.resource" (tuple . "node" (index . 1) (index . 2)) }}
 {{ include "common.k8s-instrumentation.resource.namespaced" (tuple . "service" (index . 1) (index . 2)) }}
 {{- end -}}
+
+{{/*
+common.image - Helper template to determine the image path based on various conditions.
+
+Usage:
+{{ include "common.image" (tuple $root $path $nameObj $defaultFullImage $defaultTag) }}
+
+Where:
+- $root: The root context of the chart (usually passed as '.' from the calling template).
+- $path: The path within .Values where the image information is located.
+- $nameObj: The key name for the image configuration. This can be either a string or a slice.
+  - If a string, it is used as the key name for both otel and Azure image configurations.
+  - If a slice, it expects two elements:
+    - The first element is the key name for the otel image configuration.
+    - The second element is the key name for the Azure image configuration.
+- $defaultFullImage: (Optional) A default image (including tag) to use if the specified image is not found. 
+  - Expected format: "repository/image:tag".
+- $defaultTag: (Optional) A default tag to use if no tag is specified in the image configuration.
+
+Details:
+- The template first checks if $nameObj is a slice to handle different keys for otel and Azure configurations.
+- It then prepares the image path based on whether the chart is configured to use Azure (`$root.Values.aks`) or custom settings.
+- For Azure configurations, it constructs the image path using Azure registry, image, and digest details.
+- For non-Azure configurations, it uses the repository and tag from the specified path in .Values, falling back to default values if necessary.
+
+Example:
+{{ include "common.image" (tuple . .Values.otel "image" "myrepo/myimage:v1.0.0" "v1.0.0") }}
+- This example uses "image" as the key for both otel and Azure configurations, with default image "myrepo/myimage:v1.0.0" and default tag "v1.0.0".
+*/}}
+{{- define "common.image" -}}
+{{- $root := index . 0 -}}
+{{- $path := index . 1 -}}
+{{- $nameObj := index . 2 -}}
+{{- $name := "" -}}
+{{- $azureName := "" -}}
+{{- if eq (kindOf $nameObj) "slice" -}}
+  {{- $name = index $nameObj 0 -}}
+  {{- $azureName = index $nameObj 1 -}}
+{{- else -}}
+  {{- $name = $nameObj -}}
+  {{- $azureName = $nameObj -}}
+{{- end -}}
+
+{{- $defaultFullImage := "" -}}
+{{- $defaultImage := "" -}}
+{{- $defaultTag := "" -}}
+{{- if gt (len .) 3 -}}
+  {{- $defaultFullImage = index . 3 -}}
+{{- end -}}
+
+{{- if gt (len .) 4 -}}
+  {{- $defaultTag = index . 4 -}}
+{{- end -}}
+
+{{- if $defaultFullImage -}}
+  {{- $defaultImageParts := split ":" $defaultFullImage -}}
+  {{- $defaultImage = $defaultImageParts._0 -}}
+  {{- if gt (len $defaultImageParts) 1 -}}
+    {{- $defaultTag = $defaultImageParts._1 -}}
+  {{- end -}}
+{{- end -}}
+
+{{- if and $root.Values.aks $root.Values.global $root.Values.global.azure $root.Values.global.azure.images (index $root.Values.global.azure.images $azureName) -}}
+  {{- $azurePath := $root.Values.global.azure.images -}}
+  {{- $azureImageObj := index $azurePath $azureName -}}
+  {{- $azureDigest := index $azureImageObj "digest" -}}
+  {{- $azureImage := index $azureImageObj "image" -}}
+  {{- $azureRegistry := index $azureImageObj "registry" -}}
+  {{- printf "%s/%s@%s" $azureRegistry $azureImage $azureDigest -}}
+{{- else -}}
+  {{- $valuesPath := index $path $name -}}
+  {{- $valuesRepository := index $valuesPath "repository" -}}
+  {{- $valuesTag := index $valuesPath "tag" -}}
+  {{- $repo := $valuesRepository | default $defaultImage -}}
+  {{- $tag := $valuesTag | default $defaultTag -}}
+  {{- if $tag -}}
+    {{- printf "%s:%s" $repo $tag -}}
+  {{- else -}}
+    {{- printf "%s" $repo -}}
+  {{- end -}}
+{{- end -}}
+
+{{- end -}}

--- a/deploy/helm/templates/_helpers.tpl
+++ b/deploy/helm/templates/_helpers.tpl
@@ -43,19 +43,21 @@ Usages:
 {{- end -}}
 
 {{/*
-Common template labels
+Common pod labels - those labels are included on every pod in the chart
 */}}
-{{- define "common.template-labels" -}}
-app.kubernetes.io/part-of: swo-k8s-collector
-app.kubernetes.io/instance: {{ template "common.fullname" . }}
-app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- define "common.pod-labels" -}}
+{{- if .Values.aks }}
+azure-extensions-usage-release-identifier: {{ .Release.Name }}
+{{- end -}}
 {{- end -}}
 
 {{/*
 Common labels
 */}}
 {{- define "common.labels" -}}
-{{ include "common.template-labels" . }}
+app.kubernetes.io/part-of: swo-k8s-collector
+app.kubernetes.io/instance: {{ template "common.fullname" . }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
 {{- if .Chart.AppVersion }}
 helm.sh/chart: {{ include "common.chart" . }}
 app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}

--- a/deploy/helm/templates/_helpers.tpl
+++ b/deploy/helm/templates/_helpers.tpl
@@ -282,3 +282,14 @@ Example:
 {{- end -}}
 
 {{- end -}}
+
+{{/*
+Define name for the Secret
+*/}}
+{{- define "common.secret" -}}
+{{- if .Values.otel.api_token }}
+{{- include "common.fullname" (tuple . "-secret") }}
+{{- else }}
+{{- "solarwinds-api-token" }}
+{{- end }}
+{{- end -}}

--- a/deploy/helm/templates/autoupdate/autoupdate-cronjob.yaml
+++ b/deploy/helm/templates/autoupdate/autoupdate-cronjob.yaml
@@ -19,7 +19,7 @@ spec:
           {{- end }}
           containers:
           - name: helm-upgrade
-            image: "{{ .Values.autoupdate.image.repository | default "alpine/k8s" }}:{{ .Values.autoupdate.image.tag | default "1.27.2@sha256:bbdbcb2e799b50958beb278de4a309d60bd238c14bdaff50c4e5ae42e446f745" }}"
+            image: "{{ include "common.image" (tuple . .Values.autoupdate (tuple "image" "autoupdate") "alpine/k8s:1.27.2") }}"
             imagePullPolicy: {{ .Values.otel.image.pullPolicy }}
             command: 
               - /bin/bash

--- a/deploy/helm/templates/events-collector-deployment.yaml
+++ b/deploy/helm/templates/events-collector-deployment.yaml
@@ -26,8 +26,9 @@ spec:
 {{- end}}
       labels:
         app.kubernetes.io/name: swo-k8s-collector
-{{ include "common.template-labels" . | indent 8 }}
+{{ include "common.labels" . | indent 8 }}
         app: {{ include "common.fullname" (tuple . "-events") }}
+{{ include "common.pod-labels" . | indent 8 }}
     spec:
       terminationGracePeriodSeconds: {{ .Values.otel.events.terminationGracePeriodSeconds }}
       serviceAccountName: {{ include "common.fullname" . }}

--- a/deploy/helm/templates/events-collector-deployment.yaml
+++ b/deploy/helm/templates/events-collector-deployment.yaml
@@ -79,7 +79,7 @@ spec:
             - name: SOLARWINDS_API_TOKEN
               valueFrom:
                 secretKeyRef:
-                  name: solarwinds-api-token
+                  name: {{ template "common.secret" . }}
                   key: SOLARWINDS_API_TOKEN
                   optional: true
           envFrom:

--- a/deploy/helm/templates/events-collector-deployment.yaml
+++ b/deploy/helm/templates/events-collector-deployment.yaml
@@ -68,7 +68,7 @@ spec:
             - /swi-otelcol
             - --config=/conf/relay.yaml
           securityContext: {}
-          image: "{{ .Values.otel.image.repository }}:{{ .Values.otel.image.tag | default .Chart.AppVersion }}"
+          image: "{{ include "common.image" (tuple . .Values.otel "image" nil .Chart.AppVersion) }}"
           imagePullPolicy: {{ .Values.otel.image.pullPolicy }}
           env:
             - name: MY_POD_IP

--- a/deploy/helm/templates/metrics-deployment.yaml
+++ b/deploy/helm/templates/metrics-deployment.yaml
@@ -104,7 +104,7 @@ spec:
             - name: SOLARWINDS_API_TOKEN
               valueFrom:
                 secretKeyRef:
-                  name: solarwinds-api-token
+                  name: {{ template "common.secret" . }}
                   key: SOLARWINDS_API_TOKEN
                   optional: true
         {{- end }}
@@ -126,7 +126,7 @@ spec:
             - name: SOLARWINDS_API_TOKEN
               valueFrom:
                 secretKeyRef:
-                  name: solarwinds-api-token
+                  name: {{ template "common.secret" . }}
                   key: SOLARWINDS_API_TOKEN
                   optional: true
           ports:

--- a/deploy/helm/templates/metrics-deployment.yaml
+++ b/deploy/helm/templates/metrics-deployment.yaml
@@ -67,7 +67,7 @@ spec:
       initContainers:
         {{- if and .Values.otel.metrics.prometheus_check .Values.otel.metrics.prometheus.url }}
         - name: prometheus-check
-          image: "{{ .Values.otel.init_images.busy_box.repository | default "busybox" }}:{{ .Values.otel.init_images.busy_box.tag | default "1.36.1@sha256:5cd3db04b8be5773388576a83177aff4f40a03457a63855f4b9cbe30542b9a43" }}"
+          image: "{{ include "common.image" (tuple . .Values.otel.init_images "busy_box" "busybox:1.36.1") }}"
           imagePullPolicy: {{ .Values.otel.init_images.busy_box.pullPolicy }}
           command: ['sh', '-c', 'until $(wget --spider -nv $PROMETHEUS_URL/federate?); do echo waiting on prometheus; sleep 1; done && echo "Prometheus is available"']
           envFrom:
@@ -76,7 +76,7 @@ spec:
         {{- end }}
         {{- if .Values.otel.metrics.swi_endpoint_check }}
         - name: otel-endpoint-check
-          image: "{{ .Values.otel.init_images.swi_endpoint_check.repository | default "fullstorydev/grpcurl" }}:{{ .Values.otel.init_images.swi_endpoint_check.tag | default "v1.8.7@sha256:ee1a84e31a5f99af12e0767314c59f05a578c01d28404049a3964d67a15b3580" }}"
+          image: "{{ include "common.image" (tuple . .Values.otel.init_images "swi_endpoint_check" "fullstorydev/grpcurl:v1.8.7") }}"
           imagePullPolicy: {{ .Values.otel.init_images.swi_endpoint_check.pullPolicy }}
           command: ['/bin/grpcurl', '-expand-headers',
                     '-proto', 'opentelemetry/proto/collector/logs/v1/logs_service.proto',
@@ -115,7 +115,7 @@ spec:
             - /swi-otelcol
             - --config=/conf/relay.yaml
           securityContext: {}
-          image: "{{ .Values.otel.image.repository }}:{{ .Values.otel.image.tag | default .Chart.AppVersion }}"
+          image: "{{ include "common.image" (tuple . .Values.otel "image" nil .Chart.AppVersion) }}"
           imagePullPolicy: {{ .Values.otel.image.pullPolicy }}
           env:
             - name: MY_POD_IP

--- a/deploy/helm/templates/metrics-deployment.yaml
+++ b/deploy/helm/templates/metrics-deployment.yaml
@@ -27,8 +27,9 @@ spec:
 {{- end}}
       labels:
         app.kubernetes.io/name: swo-k8s-collector
-{{ include "common.template-labels" . | indent 8 }}
+{{ include "common.labels" . | indent 8 }}
         app: {{ include "common.fullname" (tuple . "-metrics") }}
+{{ include "common.pod-labels" . | indent 8 }}
     spec:
       terminationGracePeriodSeconds: {{ .Values.otel.metrics.terminationGracePeriodSeconds }}
       serviceAccountName: {{ include "common.fullname" . }}

--- a/deploy/helm/templates/network/k8s-collector-deployment.yaml
+++ b/deploy/helm/templates/network/k8s-collector-deployment.yaml
@@ -18,6 +18,8 @@ spec:
     metadata:
       labels:
         app: {{ include "common.fullname" (tuple . "-network-k8s-collector") }}
+{{ include "common.labels" . | indent 8 }}
+{{ include "common.pod-labels" . | indent 8 }}
       annotations:
         checksum/config: {{ include (print $.Template.BasePath "/network/configmap.yaml") . | sha256sum }}
         checksum/values: {{ toJson .Values | sha256sum }}

--- a/deploy/helm/templates/network/k8s-collector-deployment.yaml
+++ b/deploy/helm/templates/network/k8s-collector-deployment.yaml
@@ -31,7 +31,7 @@ spec:
       {{- end }}
       initContainers:
         - name: wait-for-reducer
-          image: "{{ .Values.otel.init_images.busy_box.repository | default "busybox" }}:{{ .Values.otel.init_images.busy_box.tag | default "1.36.1@sha256:5cd3db04b8be5773388576a83177aff4f40a03457a63855f4b9cbe30542b9a43" }}"
+          image: "{{ include "common.image" (tuple . .Values.otel.init_images "busy_box" "busybox:1.36.1") }}"
           imagePullPolicy: {{ .Values.otel.init_images.busy_box.pullPolicy }}
           command: ['sh', '-c', 'until nc -zv $EBPF_NET_INTAKE_HOST $EBPF_NET_INTAKE_PORT; do echo "Waiting for reducer endpoint..."; sleep 5; done;']
           env:
@@ -40,13 +40,13 @@ spec:
             - name: "EBPF_NET_INTAKE_PORT"
               value: "{{ .Values.ebpfNetworkMonitoring.reducer.telemetryPort }}"
       containers:
-      - image: "{{ .Values.ebpfNetworkMonitoring.k8sCollector.watcher.image.repository | default "otel/opentelemetry-ebpf-k8s-watcher" }}:{{ .Values.ebpfNetworkMonitoring.k8sCollector.watcher.image.tag | default "v0.10.0" }}"
+      - image: "{{ include "common.image" (tuple . .Values.ebpfNetworkMonitoring.k8sCollector.watcher (tuple "image" "ebpf_k8s_watcher") "otel/opentelemetry-ebpf-k8s-watcher:v0.10.0") }}"
         imagePullPolicy: {{ .Values.ebpfNetworkMonitoring.k8sCollector.watcher.image.pullPolicy }}
         name: k8s-watcher
         args:
           - --log-console
           - --log-level={{ .Values.ebpfNetworkMonitoring.k8sCollector.telemetry.logs.level }}
-      - image: "{{ .Values.ebpfNetworkMonitoring.k8sCollector.relay.image.repository | default "otel/opentelemetry-ebpf-k8s-relay" }}:{{ .Values.ebpfNetworkMonitoring.k8sCollector.relay.image.tag | default "v0.10.0" }}"
+      - image: "{{ include "common.image" (tuple . .Values.ebpfNetworkMonitoring.k8sCollector.relay (tuple "image" "ebpf_k8s_relay") "otel/opentelemetry-ebpf-k8s-relay:v0.10.0") }}"
         imagePullPolicy: {{ .Values.ebpfNetworkMonitoring.k8sCollector.watcher.image.pullPolicy }}
         name: k8s-relay
         args:

--- a/deploy/helm/templates/network/kernel-collector-daemonset.yaml
+++ b/deploy/helm/templates/network/kernel-collector-daemonset.yaml
@@ -54,7 +54,7 @@ spec:
       {{- end }}
       initContainers:
         - name: wait-for-reducer
-          image: "{{ .Values.otel.init_images.busy_box.repository | default "busybox" }}:{{ .Values.otel.init_images.busy_box.tag | default "1.36.1@sha256:5cd3db04b8be5773388576a83177aff4f40a03457a63855f4b9cbe30542b9a43" }}"
+          image: "{{ include "common.image" (tuple . .Values.otel.init_images "busy_box" "busybox:1.36.1") }}"
           imagePullPolicy: {{ .Values.otel.init_images.busy_box.pullPolicy }}
           command: ['sh', '-c', 'until nc -zv $EBPF_NET_INTAKE_HOST $EBPF_NET_INTAKE_PORT; do echo "Waiting for reducer endpoint..."; sleep 5; done;']
           env:
@@ -64,7 +64,7 @@ spec:
               value: "{{ .Values.ebpfNetworkMonitoring.reducer.telemetryPort }}"
       containers:
         - name: swi-kernel-collector
-          image: "{{ .Values.ebpfNetworkMonitoring.kernelCollector.image.repository | default "otel/opentelemetry-ebpf-kernel-collector" }}:{{ .Values.ebpfNetworkMonitoring.kernelCollector.image.tag | default "latest" }}"
+          image: "{{ include "common.image" (tuple . .Values.ebpfNetworkMonitoring.kernelCollector (tuple "image" "ebpf_kernel_collector") "otel/opentelemetry-ebpf-kernel-collector:v0.10.0") }}"
           imagePullPolicy: {{ .Values.ebpfNetworkMonitoring.kernelCollector.image.pullPolicy | default "IfNotPresent" }}
           args:
             - --config-file=/etc/network-explorer/config.yaml

--- a/deploy/helm/templates/network/kernel-collector-daemonset.yaml
+++ b/deploy/helm/templates/network/kernel-collector-daemonset.yaml
@@ -5,7 +5,7 @@ metadata:
   name: {{ include "common.fullname" (tuple . "-kernel-collector") }}
   namespace: {{ .Release.Namespace }}
   labels:
-    {{- include "common.labels" . | nindent 4 }}
+{{ include "common.labels" . | nindent 4 }}
 spec:
   selector:
     matchLabels:
@@ -14,7 +14,8 @@ spec:
     metadata:
       labels:
         app: {{ include "common.fullname" (tuple . "-kernel-collector") }}
-{{- include "common.labels" . | nindent 8 }}
+{{ include "common.labels" . | nindent 8 }}
+{{ include "common.pod-labels" . | indent 8 }}
       annotations:
         checksum/config: {{ include (print $.Template.BasePath "/network/configmap.yaml") . | sha256sum }}
     spec:

--- a/deploy/helm/templates/network/reducer-deployment.yaml
+++ b/deploy/helm/templates/network/reducer-deployment.yaml
@@ -28,7 +28,7 @@ spec:
       {{- end }}
       initContainers:
         - name: wait-for-metrics-collector
-          image: "{{ .Values.otel.init_images.busy_box.repository | default "busybox" }}:{{ .Values.otel.init_images.busy_box.tag | default "1.36.1@sha256:5cd3db04b8be5773388576a83177aff4f40a03457a63855f4b9cbe30542b9a43" }}"
+          image: "{{ include "common.image" (tuple . .Values.otel.init_images "busy_box" "busybox:1.36.1") }}"
           imagePullPolicy: {{ .Values.otel.init_images.busy_box.pullPolicy }}
           command: ['sh', '-c', 'until nc -zv $METRICS_COLLECTOR_HOST $METRICS_COLLECTOR_PORT; do echo "Waiting for metrics collector endpoint..."; sleep 5; done;']
           env:
@@ -38,7 +38,7 @@ spec:
               value: "{{ .Values.otel.metrics.otlp_endpoint.port }}"
       containers:
         - name: reducer
-          image: "{{ .Values.ebpfNetworkMonitoring.reducer.image.repository | default "otel/opentelemetry-ebpf-reducer" }}:{{ .Values.ebpfNetworkMonitoring.reducer.image.tag | default "v0.10.0" }}"
+          image: "{{ include "common.image" (tuple . .Values.ebpfNetworkMonitoring.reducer (tuple "image" "ebpf_reducer") "otel/opentelemetry-ebpf-reducer:v0.10.0") }}"
           imagePullPolicy: {{ .Values.ebpfNetworkMonitoring.reducer.image.pullPolicy }}
           args:
             - --port={{ .Values.ebpfNetworkMonitoring.reducer.telemetryPort }}

--- a/deploy/helm/templates/network/reducer-deployment.yaml
+++ b/deploy/helm/templates/network/reducer-deployment.yaml
@@ -16,6 +16,8 @@ spec:
     metadata:
       labels:
         app: {{ include "common.fullname" (tuple . "-network-k8s-reducer") }}
+{{ include "common.labels" . | indent 8 }}
+{{ include "common.pod-labels" . | indent 8 }}
       annotations:
         checksum/values: {{ toJson .Values | sha256sum }}
     spec:

--- a/deploy/helm/templates/node-collector-daemon-set-windows.yaml
+++ b/deploy/helm/templates/node-collector-daemon-set-windows.yaml
@@ -86,7 +86,7 @@ spec:
             - name: SOLARWINDS_API_TOKEN
               valueFrom:
                 secretKeyRef:
-                  name: solarwinds-api-token
+                  name: {{ template "common.secret" . }}
                   key: SOLARWINDS_API_TOKEN
                   optional: true
           envFrom:

--- a/deploy/helm/templates/node-collector-daemon-set-windows.yaml
+++ b/deploy/helm/templates/node-collector-daemon-set-windows.yaml
@@ -17,6 +17,7 @@ spec:
         app.kubernetes.io/name: swo-k8s-collector
         app: {{ include "common.fullname" (tuple . "-node-collector-windows") }}
 {{ include "common.labels" . | indent 8 }}
+{{ include "common.pod-labels" . | indent 8 }}
       annotations:
         checksum/config: {{ tpl (.Files.Get "node-collector-config-map-windows.yaml") . | sha256sum }}
         checksum/config_common_env: {{ include (print $.Template.BasePath "/common-env-config-map.yaml") . | sha256sum }}

--- a/deploy/helm/templates/node-collector-daemon-set-windows.yaml
+++ b/deploy/helm/templates/node-collector-daemon-set-windows.yaml
@@ -62,8 +62,8 @@ spec:
       {{- end }}
       containers:
         - name: swi-opentelemetry-collector
-          image: "{{ .Values.otel.image.repository }}:{{ .Values.otel.image.tag | default .Chart.AppVersion }}-nanoserver-ltsc2022"
-          imagePullPolicy: {{ .Values.otel.image.pullPolicy }}
+          image: "{{ include "common.image" (tuple . .Values.otel "image_windows" nil (printf "%s%s" .Chart.AppVersion "-nanoserver-ltsc2022")) }}"
+          imagePullPolicy: {{ .Values.otel.image_windows.pullPolicy }}
           command:
             - c:\wrapper.exe
             - c:\swi-otelcol.exe

--- a/deploy/helm/templates/node-collector-daemon-set.yaml
+++ b/deploy/helm/templates/node-collector-daemon-set.yaml
@@ -17,6 +17,7 @@ spec:
         app.kubernetes.io/name: swo-k8s-collector
         app: {{ include "common.fullname" (tuple . "-node-collector") }}
 {{ include "common.labels" . | indent 8 }}
+{{ include "common.pod-labels" . | indent 8 }}
       annotations:
         checksum/config: {{ include (print $.Template.BasePath "/node-collector-config-map.yaml") . | sha256sum }}
         checksum/config_common_env: {{ include (print $.Template.BasePath "/common-env-config-map.yaml") . | sha256sum }}

--- a/deploy/helm/templates/node-collector-daemon-set.yaml
+++ b/deploy/helm/templates/node-collector-daemon-set.yaml
@@ -97,7 +97,7 @@ spec:
             - name: SOLARWINDS_API_TOKEN
               valueFrom:
                 secretKeyRef:
-                  name: solarwinds-api-token
+                  name: {{ template "common.secret" . }}
                   key: SOLARWINDS_API_TOKEN
                   optional: true
           envFrom:

--- a/deploy/helm/templates/node-collector-daemon-set.yaml
+++ b/deploy/helm/templates/node-collector-daemon-set.yaml
@@ -73,7 +73,7 @@ spec:
       {{- end }}
       containers:
         - name: swi-opentelemetry-collector
-          image: "{{ .Values.otel.image.repository }}:{{ .Values.otel.image.tag | default .Chart.AppVersion }}"
+          image: "{{ include "common.image" (tuple . .Values.otel "image" nil .Chart.AppVersion) }}"
           imagePullPolicy: {{ .Values.otel.image.pullPolicy }}
           command:
             - /wrapper

--- a/deploy/helm/templates/secret.yaml
+++ b/deploy/helm/templates/secret.yaml
@@ -1,0 +1,12 @@
+{{- if .Values.otel.api_token }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ template "common.secret" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+{{ include "common.labels" . | indent 4 }}
+type: Opaque
+data:
+  SOLARWINDS_API_TOKEN: {{ .Values.otel.api_token | b64enc }}
+{{- end}}

--- a/deploy/helm/templates/swo-agent-statefulset.yaml
+++ b/deploy/helm/templates/swo-agent-statefulset.yaml
@@ -37,7 +37,7 @@ spec:
       {{- end }}
       containers:
         - name: swo-agent
-          image: "{{ .Values.swoagent.image.repository }}:{{ .Values.swoagent.image.tag | default "v2.6.28@sha256:acfbb0122d24b4b8e9c9c9e2cf33ff1ee19abd2957a04098635a2bb9a248b716" }}"
+          image: "{{ include "common.image" (tuple . .Values.swoagent (tuple "image" "swoagent") "solarwinds/swo-agent:v2.6.28") }}"
           imagePullPolicy: {{ .Values.swoagent.image.pullPolicy }}
           env:
             - name: UAMS_CLIENT_ID_OVERRIDE_SOURCE_NAME

--- a/deploy/helm/templates/swo-agent-statefulset.yaml
+++ b/deploy/helm/templates/swo-agent-statefulset.yaml
@@ -47,7 +47,7 @@ spec:
             - name: UAMS_ACCESS_TOKEN
               valueFrom:
                 secretKeyRef:
-                  name: solarwinds-api-token
+                  name: {{ template "common.secret" . }}
                   key: SOLARWINDS_API_TOKEN
           resources:
 {{ toYaml .Values.swoagent.resources | indent 12 }}

--- a/deploy/helm/templates/swo-agent-statefulset.yaml
+++ b/deploy/helm/templates/swo-agent-statefulset.yaml
@@ -23,9 +23,10 @@ spec:
       annotations:
         checksum/values: {{ toJson .Values | sha256sum }}
       labels:
-{{ include "common.template-labels" . | indent 8 }}
+{{ include "common.labels" . | indent 8 }}
         app: {{ include "common.fullname" (tuple . "-swo-agent") }}
         solarwinds/swo-agent: "true"
+{{ include "common.pod-labels" . | indent 8 }}
     spec:
       securityContext: {}
       nodeSelector:

--- a/deploy/helm/tests/__snapshot__/events-collector-deployment_test.yaml.snap
+++ b/deploy/helm/tests/__snapshot__/events-collector-deployment_test.yaml.snap
@@ -33,7 +33,7 @@ Events collector spec should match snapshot when using default values:
         envFrom:
           - configMapRef:
               name: RELEASE-NAME-swo-k8s-collector-common-env
-        image: solarwinds/swi-opentelemetry-collector:0.8.12
+        image: solarwinds/swi-opentelemetry-collector:1.0.0
         imagePullPolicy: IfNotPresent
         livenessProbe:
           httpGet:

--- a/deploy/helm/tests/__snapshot__/k8s-collector-deployment_test.yaml.snap
+++ b/deploy/helm/tests/__snapshot__/k8s-collector-deployment_test.yaml.snap
@@ -37,7 +37,7 @@ K8s Collector spec should match snapshot when using default values:
             value: RELEASE-NAME-swo-k8s-collector-network-k8s-reducer
           - name: EBPF_NET_INTAKE_PORT
             value: "7000"
-        image: busybox:1.36.1@sha256:5cd3db04b8be5773388576a83177aff4f40a03457a63855f4b9cbe30542b9a43
+        image: busybox:1.36.1
         imagePullPolicy: IfNotPresent
         name: wait-for-reducer
     nodeSelector:

--- a/deploy/helm/tests/__snapshot__/kernel-collector-daemonset_test.yaml.snap
+++ b/deploy/helm/tests/__snapshot__/kernel-collector-daemonset_test.yaml.snap
@@ -31,7 +31,7 @@ DaemonSet spec should match snapshot when ebpfNetworkMonitoring is enabled:
             value: "4317"
           - name: BCC_PROBE_SUFFIX
             value: <CLUSTER_NAME>
-        image: otel/opentelemetry-ebpf-kernel-collector:latest
+        image: otel/opentelemetry-ebpf-kernel-collector:v0.10.0
         imagePullPolicy: IfNotPresent
         name: swi-kernel-collector
         resources:
@@ -62,7 +62,7 @@ DaemonSet spec should match snapshot when ebpfNetworkMonitoring is enabled:
             value: RELEASE-NAME-swo-k8s-collector-network-k8s-reducer
           - name: EBPF_NET_INTAKE_PORT
             value: "7000"
-        image: busybox:1.36.1@sha256:5cd3db04b8be5773388576a83177aff4f40a03457a63855f4b9cbe30542b9a43
+        image: busybox:1.36.1
         imagePullPolicy: IfNotPresent
         name: wait-for-reducer
     nodeSelector:

--- a/deploy/helm/tests/__snapshot__/logs-fargate-config-map_test.yaml.snap
+++ b/deploy/helm/tests/__snapshot__/logs-fargate-config-map_test.yaml.snap
@@ -24,7 +24,7 @@ Fargate logging ConfigMap spec should include additional filters when they are c
           Match *
           Add sw.k8s.cluster.uid <CLUSTER_UID>
           Add sw.k8s.log.type container
-          Add sw.k8s.agent.manifest.version "3.2.0-alpha.4"
+          Add sw.k8s.agent.manifest.version "3.2.0-alpha.5"
     flb_log_cw: "false"
     output.conf: |
       [OUTPUT]
@@ -64,7 +64,7 @@ Fargate logging ConfigMap spec should match snapshot when Fargate logging is ena
           Match *
           Add sw.k8s.cluster.uid <CLUSTER_UID>
           Add sw.k8s.log.type container
-          Add sw.k8s.agent.manifest.version "3.2.0-alpha.4"
+          Add sw.k8s.agent.manifest.version "3.2.0-alpha.5"
     flb_log_cw: "false"
     output.conf: |
       [OUTPUT]

--- a/deploy/helm/tests/__snapshot__/metrics-deployment_test.yaml.snap
+++ b/deploy/helm/tests/__snapshot__/metrics-deployment_test.yaml.snap
@@ -35,7 +35,7 @@ Metrics collector spec should match snapshot when using default values:
               name: RELEASE-NAME-swo-k8s-collector-common-env
           - configMapRef:
               name: RELEASE-NAME-swo-k8s-collector-metrics-env-config
-        image: solarwinds/swi-opentelemetry-collector:0.8.12
+        image: solarwinds/swi-opentelemetry-collector:1.0.0
         imagePullPolicy: IfNotPresent
         livenessProbe:
           httpGet:
@@ -84,7 +84,7 @@ Metrics collector spec should match snapshot when using default values:
                 key: SOLARWINDS_API_TOKEN
                 name: solarwinds-api-token
                 optional: true
-        image: fullstorydev/grpcurl:v1.8.7@sha256:ee1a84e31a5f99af12e0767314c59f05a578c01d28404049a3964d67a15b3580
+        image: fullstorydev/grpcurl:v1.8.7
         imagePullPolicy: IfNotPresent
         name: otel-endpoint-check
         volumeMounts:

--- a/deploy/helm/tests/__snapshot__/node-collector-daemon-set-windows_test.yaml.snap
+++ b/deploy/helm/tests/__snapshot__/node-collector-daemon-set-windows_test.yaml.snap
@@ -38,7 +38,7 @@ DaemonSet spec for windows nodes should match snapshot when using default values
         envFrom:
           - configMapRef:
               name: RELEASE-NAME-swo-k8s-collector-common-env
-        image: solarwinds/swi-opentelemetry-collector:0.8.12-nanoserver-ltsc2022
+        image: solarwinds/swi-opentelemetry-collector:1.0.0-nanoserver-ltsc2022
         imagePullPolicy: IfNotPresent
         livenessProbe:
           httpGet:

--- a/deploy/helm/tests/__snapshot__/node-collector-daemon-set_test.yaml.snap
+++ b/deploy/helm/tests/__snapshot__/node-collector-daemon-set_test.yaml.snap
@@ -47,7 +47,7 @@ DaemonSet spec should match snapshot when ebpfNetworkMonitoring is enabled:
         envFrom:
           - configMapRef:
               name: RELEASE-NAME-swo-k8s-collector-common-env
-        image: solarwinds/swi-opentelemetry-collector:0.8.12
+        image: solarwinds/swi-opentelemetry-collector:1.0.0
         imagePullPolicy: IfNotPresent
         livenessProbe:
           httpGet:
@@ -172,7 +172,7 @@ DaemonSet spec should match snapshot when using default values:
         envFrom:
           - configMapRef:
               name: RELEASE-NAME-swo-k8s-collector-common-env
-        image: solarwinds/swi-opentelemetry-collector:0.8.12
+        image: solarwinds/swi-opentelemetry-collector:1.0.0
         imagePullPolicy: IfNotPresent
         livenessProbe:
           httpGet:

--- a/deploy/helm/tests/__snapshot__/reducer-deployment_test.yaml.snap
+++ b/deploy/helm/tests/__snapshot__/reducer-deployment_test.yaml.snap
@@ -48,7 +48,7 @@ Reducer spec should match snapshot when using default values:
             value: RELEASE-NAME-swo-k8s-collector-metrics-collector
           - name: METRICS_COLLECTOR_PORT
             value: "4317"
-        image: busybox:1.36.1@sha256:5cd3db04b8be5773388576a83177aff4f40a03457a63855f4b9cbe30542b9a43
+        image: busybox:1.36.1
         imagePullPolicy: IfNotPresent
         name: wait-for-metrics-collector
     nodeSelector:

--- a/deploy/helm/tests/events-collector-deployment_test.yaml
+++ b/deploy/helm/tests/events-collector-deployment_test.yaml
@@ -7,6 +7,8 @@ templates:
 tests:
   - it: Events collector spec should match snapshot when using default values
     template: events-collector-deployment.yaml
+    chart:
+      appVersion: 1.0.0
     asserts:
       - matchSnapshot:
           path: spec.template.spec

--- a/deploy/helm/tests/metrics-deployment_test.yaml
+++ b/deploy/helm/tests/metrics-deployment_test.yaml
@@ -8,6 +8,92 @@ templates:
 tests:
   - it: Metrics collector spec should match snapshot when using default values
     template: metrics-deployment.yaml
+    chart:
+      appVersion: 1.0.0
     asserts:
       - matchSnapshot:
           path: spec.template.spec
+  - it: Image should be correct in default state
+    template: metrics-deployment.yaml
+    chart:
+      appVersion: 1.0.0
+    asserts:
+    - equal:
+          path: spec.template.spec.containers[0].image
+          value: solarwinds/swi-opentelemetry-collector:1.0.0
+  - it: Image should be correct when overriden repository
+    template: metrics-deployment.yaml
+    chart:
+      appVersion: 1.0.0
+    set:
+      otel.image.repository: "swi-opentelemetry-collector"
+    asserts:
+    - equal:
+          path: spec.template.spec.containers[0].image
+          value: swi-opentelemetry-collector:1.0.0
+  - it: Image should be correct when overriden tag
+    template: metrics-deployment.yaml
+    set:
+      otel.image.tag: "beta1"
+    asserts:
+    - equal:
+          path: spec.template.spec.containers[0].image
+          value: solarwinds/swi-opentelemetry-collector:beta1
+  - it: Image should be correct when overriden by azure
+    template: metrics-deployment.yaml
+    set:
+      aks: true
+      global.azure.images.image.digest: "abcd"
+      global.azure.images.image.image: "swi-opentelemetry-collector:v1.2.3"
+      global.azure.images.image.registry: "azurek8s.azure.io/marketplaceimages"
+    asserts:
+    - equal:
+          path: spec.template.spec.containers[0].image
+          value: azurek8s.azure.io/marketplaceimages/swi-opentelemetry-collector:v1.2.3@abcd
+  - it: Image otel-endpoint-check should be correct in default state
+    template: metrics-deployment.yaml
+    set:
+      otel.metrics.swi_endpoint_check: true
+    asserts:
+    - equal:
+          path: spec.template.spec.initContainers[0].image
+          value: fullstorydev/grpcurl:v1.8.7
+  - it: Image otel-endpoint-check should be correct when overriden repository
+    template: metrics-deployment.yaml
+    set:
+      otel.metrics.swi_endpoint_check: true
+      otel.init_images.swi_endpoint_check.repository: "aws/test-grpcurl"
+    asserts:
+    - equal:
+          path: spec.template.spec.initContainers[0].image
+          value: aws/test-grpcurl:v1.8.7
+  - it: Image otel-endpoint-check should be correct when overriden tag
+    template: metrics-deployment.yaml
+    set:
+      otel.metrics.swi_endpoint_check: true
+      otel.init_images.swi_endpoint_check.tag: "beta1"
+    asserts:
+    - equal:
+          path: spec.template.spec.initContainers[0].image
+          value: fullstorydev/grpcurl:beta1
+  - it: Image otel-endpoint-check should be correct when overriden by azure
+    template: metrics-deployment.yaml
+    set:
+      otel.metrics.swi_endpoint_check: true
+      aks: true
+      global.azure.images.swi_endpoint_check.digest: "abcd"
+      global.azure.images.swi_endpoint_check.image: "owngrpcurl:v1.2.3"
+      global.azure.images.swi_endpoint_check.registry: "azurek8s.azure.io/marketplaceimages"
+    asserts:
+    - equal:
+          path: spec.template.spec.initContainers[0].image
+          value: azurek8s.azure.io/marketplaceimages/owngrpcurl:v1.2.3@abcd
+  - it: Image prometheus-check should be correct in default state
+    template: metrics-deployment.yaml
+    set:
+      otel.metrics.prometheus_check: true
+      otel.metrics.prometheus.url: "http://prometheus:9090"
+    asserts:
+    - equal:
+          path: spec.template.spec.initContainers[0].image
+          value: busybox:1.36.1

--- a/deploy/helm/tests/metrics-deployment_test.yaml
+++ b/deploy/helm/tests/metrics-deployment_test.yaml
@@ -50,6 +50,10 @@ tests:
     - equal:
           path: spec.template.spec.containers[0].image
           value: azurek8s.azure.io/marketplaceimages/swi-opentelemetry-collector:v1.2.3@abcd
+    - isSubset:
+        path: spec.template.metadata.labels
+        content:
+          azure-extensions-usage-release-identifier: RELEASE-NAME
   - it: Image otel-endpoint-check should be correct in default state
     template: metrics-deployment.yaml
     set:

--- a/deploy/helm/tests/node-collector-daemon-set-windows_test.yaml
+++ b/deploy/helm/tests/node-collector-daemon-set-windows_test.yaml
@@ -7,6 +7,35 @@ templates:
 tests:
   - it: DaemonSet spec for windows nodes should match snapshot when using default values
     template: node-collector-daemon-set-windows.yaml
+    chart:
+      appVersion: 1.0.0
     asserts:
       - matchSnapshot:
           path: spec.template.spec
+  - it: Image should be correct in default state
+    template: node-collector-daemon-set-windows.yaml
+    chart:
+      appVersion: 1.0.0
+    asserts:
+    - equal:
+          path: spec.template.spec.containers[0].image
+          value: solarwinds/swi-opentelemetry-collector:1.0.0-nanoserver-ltsc2022
+  - it: Image should be correct when overriden tag
+    template: node-collector-daemon-set-windows.yaml
+    set:
+      otel.image_windows.tag: "beta1-nanoserver-ltsc2022"
+    asserts:
+    - equal:
+          path: spec.template.spec.containers[0].image
+          value: solarwinds/swi-opentelemetry-collector:beta1-nanoserver-ltsc2022
+  - it: Image should be correct when overriden by azure
+    template: node-collector-daemon-set-windows.yaml
+    set:
+      aks: true
+      global.azure.images.image_windows.digest: "abcd"
+      global.azure.images.image_windows.image: "swi-opentelemetry-collector:v1.2.3"
+      global.azure.images.image_windows.registry: "azurek8s.azure.io/marketplaceimages"
+    asserts:
+    - equal:
+          path: spec.template.spec.containers[0].image
+          value: azurek8s.azure.io/marketplaceimages/swi-opentelemetry-collector:v1.2.3@abcd

--- a/deploy/helm/tests/node-collector-daemon-set_test.yaml
+++ b/deploy/helm/tests/node-collector-daemon-set_test.yaml
@@ -8,11 +8,15 @@ templates:
 tests:
   - it: DaemonSet spec should match snapshot when using default values
     template: node-collector-daemon-set.yaml
+    chart:
+      appVersion: 1.0.0
     asserts:
       - matchSnapshot:
           path: spec.template.spec
   - it: DaemonSet spec should match snapshot when ebpfNetworkMonitoring is enabled
     template: node-collector-daemon-set.yaml
+    chart:
+      appVersion: 1.0.0
     set:
       ebpfNetworkMonitoring.enabled: true
     asserts:

--- a/deploy/helm/tests/swo-agent-statefulset_test.yaml
+++ b/deploy/helm/tests/swo-agent-statefulset_test.yaml
@@ -1,0 +1,34 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/helm-unittest/helm-unittest/main/schema/helm-testsuite.json
+suite: Test for swo-agent-statefulset
+templates:
+  - swo-agent-statefulset.yaml
+tests:
+  - it: Image should be correct in default state
+    template: swo-agent-statefulset.yaml
+    set:
+      swoagent.enabled: true
+    asserts:
+    - equal:
+          path: spec.template.spec.containers[0].image
+          value: solarwinds/swo-agent:v2.6.28
+  - it: Image should be correct when overriden tag
+    template: swo-agent-statefulset.yaml
+    set:
+      swoagent.enabled: true
+      swoagent.image.tag: "beta1"
+    asserts:
+    - equal:
+          path: spec.template.spec.containers[0].image
+          value: solarwinds/swo-agent:beta1
+  - it: Image should be correct when overriden by azure
+    template: swo-agent-statefulset.yaml
+    set:
+      swoagent.enabled: true
+      aks: true
+      global.azure.images.swoagent.digest: "abcd"
+      global.azure.images.swoagent.image: "swo-agent:v1.2.3"
+      global.azure.images.swoagent.registry: "azurek8s.azure.io/marketplaceimages"
+    asserts:
+    - equal:
+          path: spec.template.spec.containers[0].image
+          value: azurek8s.azure.io/marketplaceimages/swo-agent:v1.2.3@abcd

--- a/deploy/helm/values.yaml
+++ b/deploy/helm/values.yaml
@@ -23,6 +23,12 @@ otel:
     # if not set appVersion field from Chart.yaml is used
     tag: ""
     pullPolicy: IfNotPresent
+  
+  image_windows:
+    repository: solarwinds/swi-opentelemetry-collector
+    # if not set appVersion field from Chart.yaml is used
+    tag: ""
+    pullPolicy: IfNotPresent
 
   init_images:
     swi_endpoint_check:

--- a/deploy/helm/values.yaml
+++ b/deploy/helm/values.yaml
@@ -14,6 +14,9 @@ otel:
   endpoint: <OTEL_ENVOY_ADDRESS>
   tls_insecure: false
 
+  # SWO API token used for authentication. If filled it will create secret that will be used by the collector
+  api_token: ""
+
   # The OTEL collector supports an HTTPS proxy. Specify the full URL of the HTTPS
   # proxy here. e.g. https_proxy: "https://myproxy.mydomain.com:8080"
   https_proxy_url: ""


### PR DESCRIPTION
* Adding `common.image` which can override image from existing locations as well as from azure
* Covering all use cases via helm unit tests
* setting chart appVersion in unit tests so that we don't need to regenerate them with every bump
* Added `otel.api_token` to allow setting API token for OTEL collector through `values.yaml`
* Instrumented all pods with `azure-extensions-usage-release-identifier` on AKS