### PR TITLE
Adding minimal Helm version constraint

### DIFF
--- a/.github/actions/deploy-kubernetes/action.yml
+++ b/.github/actions/deploy-kubernetes/action.yml
@@ -14,7 +14,11 @@ runs:
         traefik-enabled: false
         docker-enabled: true
         metrics-enabled: true
-        helm-version: 3.10.3
+
+    - name: Install Helm
+      uses: azure/setup-helm@v3
+      with:
+        version: '3.10.3'
 
     - name: Print cluster info
       run: |

--- a/.github/actions/deploy-kubernetes/action.yml
+++ b/.github/actions/deploy-kubernetes/action.yml
@@ -22,6 +22,7 @@ runs:
 
     - name: Print cluster info
       run: |
+        helm version
         kubectl version
         kubectl get sc
         kubectl cluster-info dump --output=yaml

--- a/.github/actions/deploy-kubernetes/action.yml
+++ b/.github/actions/deploy-kubernetes/action.yml
@@ -14,6 +14,7 @@ runs:
         traefik-enabled: false
         docker-enabled: true
         metrics-enabled: true
+        helm-version: 3.10.3
 
     - name: Print cluster info
       run: |

--- a/.github/workflows/buildAndDeploy.yml
+++ b/.github/workflows/buildAndDeploy.yml
@@ -122,7 +122,7 @@ jobs:
       - name: Set up Helm
         uses: azure/setup-helm@v3
         with:
-          version: v3.10.0
+          version: v3.10.3
 
       - name: Add dependency chart repos
         run: |

--- a/deploy/helm/templates/_helpers.tpl
+++ b/deploy/helm/templates/_helpers.tpl
@@ -295,3 +295,9 @@ Define name for the Secret
 {{- "solarwinds-api-token" }}
 {{- end }}
 {{- end -}}
+
+{{- define "common.minHelmVersion" -}}
+{{- if semverCompare "<3.10.3" .Capabilities.HelmVersion.Version }}
+  {{- fail (printf "Minimum required Helm version is 3.10.3, current version is %s" .Capabilities.HelmVersion.Version) }}
+{{- end }}
+{{- end }}

--- a/deploy/helm/templates/cluster-role-binding.yaml
+++ b/deploy/helm/templates/cluster-role-binding.yaml
@@ -1,3 +1,4 @@
+{{ include "common.minHelmVersion" . }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:

--- a/deploy/helm/templates/cluster-role.yaml
+++ b/deploy/helm/templates/cluster-role.yaml
@@ -1,3 +1,4 @@
+{{ include "common.minHelmVersion" . }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:

--- a/deploy/helm/templates/collector-service.yaml
+++ b/deploy/helm/templates/collector-service.yaml
@@ -1,3 +1,4 @@
+{{ include "common.minHelmVersion" . }}
 apiVersion: v1
 kind: Service
 metadata:

--- a/deploy/helm/templates/common-env-config-map.yaml
+++ b/deploy/helm/templates/common-env-config-map.yaml
@@ -1,3 +1,4 @@
+{{ include "common.minHelmVersion" . }}
 apiVersion: v1
 kind: ConfigMap
 metadata:

--- a/deploy/helm/templates/events-collector-config-map.yaml
+++ b/deploy/helm/templates/events-collector-config-map.yaml
@@ -1,3 +1,4 @@
+{{ include "common.minHelmVersion" . }}
 {{- if .Values.otel.events.enabled }}
 apiVersion: v1
 kind: ConfigMap

--- a/deploy/helm/templates/events-collector-deployment.yaml
+++ b/deploy/helm/templates/events-collector-deployment.yaml
@@ -1,3 +1,4 @@
+{{ include "common.minHelmVersion" . }}
 {{- if .Values.otel.events.enabled }}
 apiVersion: apps/v1
 kind: Deployment

--- a/deploy/helm/templates/logs-fargate-config-map.yaml
+++ b/deploy/helm/templates/logs-fargate-config-map.yaml
@@ -1,3 +1,4 @@
+{{ include "common.minHelmVersion" . }}
 {{- if and .Values.aws_fargate.enabled .Values.aws_fargate.logs.enabled }}
 {{- $pattern := "[^a-zA-Z0-9\\.\\-_/#]" -}}
 {{- $replacement := "" -}}

--- a/deploy/helm/templates/logs-fargate-namespace.yaml
+++ b/deploy/helm/templates/logs-fargate-namespace.yaml
@@ -1,3 +1,4 @@
+{{ include "common.minHelmVersion" . }}
 {{- if and .Values.aws_fargate.enabled .Values.aws_fargate.logs.enabled }}
 kind: Namespace
 apiVersion: v1

--- a/deploy/helm/templates/metrics-collector-config-map.yaml
+++ b/deploy/helm/templates/metrics-collector-config-map.yaml
@@ -1,3 +1,4 @@
+{{ include "common.minHelmVersion" . }}
 {{- if .Values.otel.metrics.enabled }}
 apiVersion: v1
 kind: ConfigMap

--- a/deploy/helm/templates/metrics-collector-env-config-map.yaml
+++ b/deploy/helm/templates/metrics-collector-env-config-map.yaml
@@ -1,3 +1,4 @@
+{{ include "common.minHelmVersion" . }}
 {{- if .Values.otel.metrics.enabled }}
 apiVersion: v1
 kind: ConfigMap

--- a/deploy/helm/templates/metrics-deployment.yaml
+++ b/deploy/helm/templates/metrics-deployment.yaml
@@ -1,3 +1,4 @@
+{{ include "common.minHelmVersion" . }}
 {{- if .Values.otel.metrics.enabled }}
 apiVersion: apps/v1
 kind: Deployment

--- a/deploy/helm/templates/network/configmap.yaml
+++ b/deploy/helm/templates/network/configmap.yaml
@@ -1,3 +1,4 @@
+{{ include "common.minHelmVersion" . }}
 {{- if .Values.ebpfNetworkMonitoring.enabled }}
 apiVersion: v1
 kind: ConfigMap

--- a/deploy/helm/templates/network/k8s-collector-clusterrole.yaml
+++ b/deploy/helm/templates/network/k8s-collector-clusterrole.yaml
@@ -1,3 +1,4 @@
+{{ include "common.minHelmVersion" . }}
 {{- if and .Values.ebpfNetworkMonitoring.enabled .Values.ebpfNetworkMonitoring.k8sCollector.enabled  }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole

--- a/deploy/helm/templates/network/k8s-collector-clusterrolebinding.yaml
+++ b/deploy/helm/templates/network/k8s-collector-clusterrolebinding.yaml
@@ -1,3 +1,4 @@
+{{ include "common.minHelmVersion" . }}
 {{- if and .Values.ebpfNetworkMonitoring.enabled .Values.ebpfNetworkMonitoring.k8sCollector.enabled  }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding

--- a/deploy/helm/templates/network/k8s-collector-deployment.yaml
+++ b/deploy/helm/templates/network/k8s-collector-deployment.yaml
@@ -1,3 +1,4 @@
+{{ include "common.minHelmVersion" . }}
 {{- if and .Values.ebpfNetworkMonitoring.enabled .Values.ebpfNetworkMonitoring.k8sCollector.enabled  }}
 apiVersion: apps/v1
 kind: Deployment

--- a/deploy/helm/templates/network/kernel-collector-daemonset.yaml
+++ b/deploy/helm/templates/network/kernel-collector-daemonset.yaml
@@ -1,3 +1,4 @@
+{{ include "common.minHelmVersion" . }}
 {{- if and .Values.ebpfNetworkMonitoring.enabled .Values.ebpfNetworkMonitoring.kernelCollector.enabled }}
 apiVersion: apps/v1
 kind: DaemonSet

--- a/deploy/helm/templates/network/reducer-deployment.yaml
+++ b/deploy/helm/templates/network/reducer-deployment.yaml
@@ -1,3 +1,4 @@
+{{ include "common.minHelmVersion" . }}
 {{- if .Values.ebpfNetworkMonitoring.enabled }}
 apiVersion: apps/v1
 kind: Deployment

--- a/deploy/helm/templates/network/reducer-service.yaml
+++ b/deploy/helm/templates/network/reducer-service.yaml
@@ -1,3 +1,4 @@
+{{ include "common.minHelmVersion" . }}
 {{- if .Values.ebpfNetworkMonitoring.enabled }}
 apiVersion: v1
 kind: Service

--- a/deploy/helm/templates/node-collector-config-map-windows.yaml
+++ b/deploy/helm/templates/node-collector-config-map-windows.yaml
@@ -1,3 +1,4 @@
+{{ include "common.minHelmVersion" . }}
 {{- if or .Values.otel.logs.enabled .Values.otel.metrics.enabled }}
 apiVersion: v1
 kind: ConfigMap

--- a/deploy/helm/templates/node-collector-config-map.yaml
+++ b/deploy/helm/templates/node-collector-config-map.yaml
@@ -1,3 +1,4 @@
+{{ include "common.minHelmVersion" . }}
 {{- if or .Values.otel.logs.enabled .Values.otel.metrics.enabled }}
 apiVersion: v1
 kind: ConfigMap

--- a/deploy/helm/templates/node-collector-daemon-set-windows.yaml
+++ b/deploy/helm/templates/node-collector-daemon-set-windows.yaml
@@ -1,3 +1,4 @@
+{{ include "common.minHelmVersion" . }}
 {{- if .Values.otel.logs.enabled }}
 apiVersion: apps/v1
 kind: DaemonSet

--- a/deploy/helm/templates/node-collector-daemon-set.yaml
+++ b/deploy/helm/templates/node-collector-daemon-set.yaml
@@ -1,3 +1,4 @@
+{{ include "common.minHelmVersion" . }}
 {{- if or .Values.otel.logs.enabled .Values.otel.metrics.enabled }}
 apiVersion: apps/v1
 kind: DaemonSet

--- a/deploy/helm/templates/secret.yaml
+++ b/deploy/helm/templates/secret.yaml
@@ -1,3 +1,4 @@
+{{ include "common.minHelmVersion" . }}
 {{- if .Values.otel.api_token }}
 apiVersion: v1
 kind: Secret

--- a/deploy/helm/templates/service-account.yaml
+++ b/deploy/helm/templates/service-account.yaml
@@ -1,3 +1,4 @@
+{{ include "common.minHelmVersion" . }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:

--- a/deploy/helm/templates/swo-agent-statefulset.yaml
+++ b/deploy/helm/templates/swo-agent-statefulset.yaml
@@ -1,3 +1,4 @@
+{{ include "common.minHelmVersion" . }}
 {{- if .Values.swoagent.enabled }}
 apiVersion: apps/v1
 kind: StatefulSet


### PR DESCRIPTION
* Previously user got some random rendering error if he had unsupported Helm version. Now we are failing fast with human message
* Version 3.10.3 is known that has all features we use, it is already 1 year old so it shouldn't limit users
