### PR TITLE
NH-63828 Support for Windows Server 2019

### DIFF
--- a/deploy/helm/CHANGELOG.md
+++ b/deploy/helm/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## [3.2.0-alpha.6] - 2023-12-05
+
+### Added
+
+- Added Windows Server 2019 support
+
 ## [3.2.0-alpha.5] - 2023-12-01
 
 ### Added

--- a/deploy/helm/Chart.yaml
+++ b/deploy/helm/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: swo-k8s-collector
-version: 3.2.0-alpha.5
-appVersion: "0.8.12"
+version: 3.2.0-alpha.6
+appVersion: "0.8.13"
 description: SolarWinds Kubernetes Integration
 keywords:
   - monitoring

--- a/deploy/helm/templates/node-collector-daemon-set-windows.yaml
+++ b/deploy/helm/templates/node-collector-daemon-set-windows.yaml
@@ -64,7 +64,7 @@ spec:
       {{- end }}
       containers:
         - name: swi-opentelemetry-collector
-          image: "{{ include "common.image" (tuple . .Values.otel "image_windows" nil (printf "%s%s" .Chart.AppVersion "-nanoserver-ltsc2022")) }}"
+          image: "{{ include "common.image" (tuple . .Values.otel "image_windows" nil (printf "%s%s" .Chart.AppVersion "-nanoserver")) }}"
           imagePullPolicy: {{ .Values.otel.image_windows.pullPolicy }}
           command:
             - c:\wrapper.exe

--- a/deploy/helm/tests/__snapshot__/logs-fargate-config-map_test.yaml.snap
+++ b/deploy/helm/tests/__snapshot__/logs-fargate-config-map_test.yaml.snap
@@ -24,7 +24,7 @@ Fargate logging ConfigMap spec should include additional filters when they are c
           Match *
           Add sw.k8s.cluster.uid <CLUSTER_UID>
           Add sw.k8s.log.type container
-          Add sw.k8s.agent.manifest.version "3.2.0-alpha.5"
+          Add sw.k8s.agent.manifest.version "3.2.0-alpha.6"
     flb_log_cw: "false"
     output.conf: |
       [OUTPUT]
@@ -64,7 +64,7 @@ Fargate logging ConfigMap spec should match snapshot when Fargate logging is ena
           Match *
           Add sw.k8s.cluster.uid <CLUSTER_UID>
           Add sw.k8s.log.type container
-          Add sw.k8s.agent.manifest.version "3.2.0-alpha.5"
+          Add sw.k8s.agent.manifest.version "3.2.0-alpha.6"
     flb_log_cw: "false"
     output.conf: |
       [OUTPUT]

--- a/deploy/helm/tests/__snapshot__/node-collector-daemon-set-windows_test.yaml.snap
+++ b/deploy/helm/tests/__snapshot__/node-collector-daemon-set-windows_test.yaml.snap
@@ -38,7 +38,7 @@ DaemonSet spec for windows nodes should match snapshot when using default values
         envFrom:
           - configMapRef:
               name: RELEASE-NAME-swo-k8s-collector-common-env
-        image: solarwinds/swi-opentelemetry-collector:1.0.0-nanoserver-ltsc2022
+        image: solarwinds/swi-opentelemetry-collector:1.0.0-nanoserver
         imagePullPolicy: IfNotPresent
         livenessProbe:
           httpGet:

--- a/deploy/helm/tests/node-collector-daemon-set-windows_test.yaml
+++ b/deploy/helm/tests/node-collector-daemon-set-windows_test.yaml
@@ -19,15 +19,15 @@ tests:
     asserts:
     - equal:
           path: spec.template.spec.containers[0].image
-          value: solarwinds/swi-opentelemetry-collector:1.0.0-nanoserver-ltsc2022
+          value: solarwinds/swi-opentelemetry-collector:1.0.0-nanoserver
   - it: Image should be correct when overriden tag
     template: node-collector-daemon-set-windows.yaml
     set:
-      otel.image_windows.tag: "beta1-nanoserver-ltsc2022"
+      otel.image_windows.tag: "beta1-nanoserver"
     asserts:
     - equal:
           path: spec.template.spec.containers[0].image
-          value: solarwinds/swi-opentelemetry-collector:beta1-nanoserver-ltsc2022
+          value: solarwinds/swi-opentelemetry-collector:beta1-nanoserver
   - it: Image should be correct when overriden by azure
     template: node-collector-daemon-set-windows.yaml
     set:


### PR DESCRIPTION
* Using 0.8.13 which has both Windows OS supported in it
* using `-nanoserver` tag (see https://hub.docker.com/layers/solarwinds/swi-opentelemetry-collector/0.8.13-nanoserver/images/sha256-54b9a100b02d930ab64dd79058cb710ecb07365aff335680e849e61c68e00705?context=repo)

the image obviously has multiple OS versions in it, hopefully windows node will pick the one it needs
`docker manifest inspect solarwinds/swi-opentelemetry-collector:0.8.13-nanoserver`:

```
{
   "schemaVersion": 2,
   "mediaType": "application/vnd.docker.distribution.manifest.list.v2+json",
   "manifests": [
      {
         "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
         "size": 1369,
         "digest": "sha256:54b9a100b02d930ab64dd79058cb710ecb07365aff335680e849e61c68e00705",
         "platform": {
            "architecture": "amd64",
            "os": "windows",
            "os.version": "10.0.17763.5122"
         }
      },
      {
         "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
         "size": 1369,
         "digest": "sha256:4f35e2593cc2b601f9f1b317fe94e8f0f7894afd6adf443504c7d6a6cecde841",
         "platform": {
            "architecture": "amd64",
            "os": "windows",
            "os.version": "10.0.20348.2113"
         }
      }
   ]
}
```
