### PR TITLE
Move to apline

### DIFF
--- a/build/docker/Dockerfile
+++ b/build/docker/Dockerfile
@@ -16,9 +16,6 @@ RUN if [[ -z "$CREATE_VENDOR_DIR" ]] ; then echo vendor creation skipped ; else 
 FROM base as tests
 RUN cd src/processor/swmetricstransformprocessor && go test ./...
 
-FROM alpine:3.19 as prep
-RUN apk --update add ca-certificates
-
 FROM debian:12.2 as journal
 RUN apt update
 RUN apt install -y systemd
@@ -30,12 +27,12 @@ FROM base as wrapper
 WORKDIR /src/src/wrapper
 RUN CGO_ENABLED=0 GOEXPERIMENT=boringcrypto go build -a -tags netgo -ldflags '-w -extldflags "-static"' -o /bin/wrapper && chmod +x /bin/wrapper
 
-FROM scratch
+FROM alpine:3.19
+RUN apk --update add ca-certificates
 
 ARG USER_UID=10001
 USER ${USER_UID}
 
-COPY --from=prep /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
 COPY --from=builder /src/swi-k8s-opentelemetry-collector /swi-otelcol
 COPY --from=wrapper /bin/wrapper /wrapper
 COPY --from=journal /journalctl-deps/ /

--- a/build/docker/structure-test.yaml
+++ b/build/docker/structure-test.yaml
@@ -17,4 +17,4 @@ commandTests:
   - name: "swi-otelcol is working in the image"
     command: "/swi-otelcol"
     args: ["-v"]
-    expectedOutput: ["swi-k8s-opentelemetry-collector version 0.9.0"]
+    expectedOutput: ["swi-k8s-opentelemetry-collector version 0.8.13"]

--- a/build/docker/structure-test.yaml
+++ b/build/docker/structure-test.yaml
@@ -17,4 +17,4 @@ commandTests:
   - name: "swi-otelcol is working in the image"
     command: "/swi-otelcol"
     args: ["-v"]
-    expectedOutput: ["swi-k8s-opentelemetry-collector version 0.8.13"]
+    expectedOutput: ["swi-k8s-opentelemetry-collector version 0.9.0"]

--- a/build/swi-k8s-opentelemetry-collector.yaml
+++ b/build/swi-k8s-opentelemetry-collector.yaml
@@ -2,7 +2,7 @@ dist:
   name: swi-k8s-opentelemetry-collector
   description: "SolarWinds distribution for OpenTelemetry"
   otelcol_version: "0.81.0"
-  version: "0.9.0"
+  version: "0.8.13"
 exporters:
   - gomod: go.opentelemetry.io/collector/exporter/otlpexporter v0.81.0
 

--- a/build/swi-k8s-opentelemetry-collector.yaml
+++ b/build/swi-k8s-opentelemetry-collector.yaml
@@ -2,7 +2,7 @@ dist:
   name: swi-k8s-opentelemetry-collector
   description: "SolarWinds distribution for OpenTelemetry"
   otelcol_version: "0.81.0"
-  version: "0.8.13"
+  version: "0.9.0"
 exporters:
   - gomod: go.opentelemetry.io/collector/exporter/otlpexporter v0.81.0
 

--- a/deploy/helm/Chart.yaml
+++ b/deploy/helm/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: swo-k8s-collector
 version: 3.2.0-alpha.7
-appVersion: "0.9.0"
+appVersion: "0.8.13"
 description: SolarWinds Kubernetes Integration
 keywords:
   - monitoring

--- a/deploy/helm/Chart.yaml
+++ b/deploy/helm/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: swo-k8s-collector
 version: 3.2.0-alpha.7
-appVersion: "0.8.13"
+appVersion: "0.9.0"
 description: SolarWinds Kubernetes Integration
 keywords:
   - monitoring


### PR DESCRIPTION
Since EKS Add-on require to image scans as part of validation, we need to move to supported base image.