### PR TITLE
NH-68604: Using distroless image as base

### DIFF
--- a/build/docker/Dockerfile
+++ b/build/docker/Dockerfile
@@ -27,8 +27,7 @@ FROM base as wrapper
 WORKDIR /src/src/wrapper
 RUN CGO_ENABLED=0 GOEXPERIMENT=boringcrypto go build -a -tags netgo -ldflags '-w -extldflags "-static"' -o /bin/wrapper && chmod +x /bin/wrapper
 
-FROM alpine:3.18
-RUN apk --update add ca-certificates
+FROM gcr.io/distroless/static@sha256:6706c73aae2afaa8201d63cc3dda48753c09bcd6c300762251065c0f7e602b25
 
 ARG USER_UID=10001
 USER ${USER_UID}

--- a/build/docker/structure-test.yaml
+++ b/build/docker/structure-test.yaml
@@ -17,4 +17,4 @@ commandTests:
   - name: "swi-otelcol is working in the image"
     command: "/swi-otelcol"
     args: ["-v"]
-    expectedOutput: ["swi-k8s-opentelemetry-collector version 0.9.1"]
+    expectedOutput: ["swi-k8s-opentelemetry-collector version 0.9.2"]

--- a/build/swi-k8s-opentelemetry-collector.yaml
+++ b/build/swi-k8s-opentelemetry-collector.yaml
@@ -2,7 +2,7 @@ dist:
   name: swi-k8s-opentelemetry-collector
   description: "SolarWinds distribution for OpenTelemetry"
   otelcol_version: "0.81.0"
-  version: "0.9.1"
+  version: "0.9.2"
 exporters:
   - gomod: go.opentelemetry.io/collector/exporter/otlpexporter v0.81.0
 


### PR DESCRIPTION
* That should not have security vulnerabilities. 
* Using last digest of multi-arch image, dependabot should update that every week
