### PR TITLE
Fix disabled autodiscovery

### DIFF
--- a/deploy/helm/CHANGELOG.md
+++ b/deploy/helm/CHANGELOG.md
@@ -7,9 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## [3.2.0-alpha.15] - 2024-01-17
+
+### Fixed
+
+- Fixed restarts of the collector when automatic discovery and scraping of prometheus endpoints (`otel.metrics.autodiscovery.prometheusEndpoints.enabled`) was disabled
+
 ## [3.2.0-alpha.14] - 2024-01-12
 
 - Publish custom Istio metrics, when available: `k8s.istio_request_bytes.delta`, `k8s.istio_response_bytes.delta`, `k8s.istio_requests.rate`, `k8s.istio_tcp_sent_bytes.rate`, `k8s.istio_tcp_received_bytes.rate`, `k8s.istio_requests.delta`, `k8s.istio_tcp_sent_bytes.delta`, `k8s.istio_tcp_received_bytes.delta`
+- Disable opencost metrics by default
 
 ## [3.2.0-alpha.13] - 2024-01-08
 

--- a/deploy/helm/Chart.yaml
+++ b/deploy/helm/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: swo-k8s-collector
-version: 3.2.0-alpha.14
+version: 3.2.0-alpha.15
 appVersion: "0.9.2"
 description: SolarWinds Kubernetes Integration
 keywords:

--- a/deploy/helm/node-collector-config.yaml
+++ b/deploy/helm/node-collector-config.yaml
@@ -29,7 +29,7 @@ extensions:
   memory_ballast:
 {{ toYaml .Values.otel.logs.memory_ballast | indent 4 }}
 {{- end }}
-{{- if and .Values.otel.metrics.enabled .Values.otel.metrics.autodiscovery.prometheusEndpoints.enabled }}
+{{- if and .Values.otel.metrics.enabled (or (not .Values.aws_fargate.enabled) .Values.otel.metrics.autodiscovery.prometheusEndpoints.enabled) }}
   k8s_observer:
     auth_type: serviceAccount
     node: ${NODE_NAME}
@@ -578,7 +578,7 @@ service:
 {{- if .Values.otel.logs.memory_ballast }}
     - memory_ballast
 {{- end}}
-{{- if and .Values.otel.metrics.enabled .Values.otel.metrics.autodiscovery.prometheusEndpoints.enabled }}
+{{- if and .Values.otel.metrics.enabled (or (not .Values.aws_fargate.enabled) .Values.otel.metrics.autodiscovery.prometheusEndpoints.enabled) }}
     - k8s_observer
 {{- end}}
   pipelines:

--- a/deploy/helm/tests/__snapshot__/logs-fargate-config-map_test.yaml.snap
+++ b/deploy/helm/tests/__snapshot__/logs-fargate-config-map_test.yaml.snap
@@ -24,7 +24,7 @@ Fargate logging ConfigMap spec should include additional filters when they are c
           Match *
           Add sw.k8s.cluster.uid <CLUSTER_UID>
           Add sw.k8s.log.type container
-          Add sw.k8s.agent.manifest.version "3.2.0-alpha.14"
+          Add sw.k8s.agent.manifest.version "3.2.0-alpha.15"
     flb_log_cw: "false"
     output.conf: |
       [OUTPUT]
@@ -64,7 +64,7 @@ Fargate logging ConfigMap spec should match snapshot when Fargate logging is ena
           Match *
           Add sw.k8s.cluster.uid <CLUSTER_UID>
           Add sw.k8s.log.type container
-          Add sw.k8s.agent.manifest.version "3.2.0-alpha.14"
+          Add sw.k8s.agent.manifest.version "3.2.0-alpha.15"
     flb_log_cw: "false"
     output.conf: |
       [OUTPUT]

--- a/deploy/helm/tests/__snapshot__/node-collector-config-map_test.yaml.snap
+++ b/deploy/helm/tests/__snapshot__/node-collector-config-map_test.yaml.snap
@@ -1,3 +1,1152 @@
+Node collector config should match snapshot when autodiscovery is disabled:
+  1: |
+    common.proto: ""
+    logs.config: |
+      connectors:
+        forward/logs-exporter: null
+        forward/metric-exporter: null
+      exporters:
+        otlp:
+          endpoint: ${OTEL_ENVOY_ADDRESS}
+          headers:
+            Authorization: Bearer ${SOLARWINDS_API_TOKEN}
+          retry_on_failure:
+            enabled: true
+            initial_interval: 10s
+            max_elapsed_time: 300s
+            max_interval: 30s
+          sending_queue:
+            enabled: true
+            num_consumers: 20
+            queue_size: 1000
+          tls:
+            insecure: ${OTEL_ENVOY_ADDRESS_TLS_INSECURE}
+      extensions:
+        file_storage/checkpoints:
+          directory: /var/lib/swo/checkpoints
+          timeout: 5s
+        health_check: {}
+        k8s_observer:
+          auth_type: serviceAccount
+          node: ${NODE_NAME}
+          observe_nodes: true
+          observe_pods: true
+      processors:
+        attributes/remove_prometheus_attributes:
+          actions:
+          - action: delete
+            key: prometheus
+          - action: delete
+            key: prometheus_replica
+        attributes/remove_temp:
+          actions:
+          - action: delete
+            key: temp
+            pattern: (.*_temp$)|(^\$.*)
+          include:
+            match_type: regexp
+            metric_names:
+            - .*
+        attributes/unify_node_attribute:
+          actions:
+          - action: insert
+            from_attribute: node
+            key: k8s.node.name
+          - action: insert
+            from_attribute: kubernetes_io_hostname
+            key: k8s.node.name
+          include:
+            match_type: regexp
+            metric_names:
+            - container_.*
+        batch/logs:
+          send_batch_max_size: 512
+          send_batch_size: 512
+          timeout: 1s
+        batch/metrics:
+          send_batch_max_size: 512
+          send_batch_size: 512
+          timeout: 1s
+        cumulativetodelta/cadvisor:
+          include:
+            match_type: strict
+            metrics:
+            - k8s.node.cpu.usage.seconds.rate
+            - k8s.pod.cpu.usage.seconds.rate
+            - k8s.container.fs.iops
+            - k8s.container.fs.throughput
+            - k8s.container.cpu.usage.seconds.rate
+            - k8s.container.network.bytes_received
+            - k8s.container.network.bytes_transmitted
+            - k8s.pod.fs.iops
+            - k8s.pod.fs.throughput
+            - k8s.pod.fs.reads.rate
+            - k8s.pod.fs.writes.rate
+            - k8s.pod.fs.reads.bytes.rate
+            - k8s.pod.fs.writes.bytes.rate
+            - k8s.pod.network.bytes_received
+            - k8s.pod.network.bytes_transmitted
+            - k8s.pod.network.packets_received
+            - k8s.pod.network.packets_transmitted
+            - k8s.pod.network.receive_packets_dropped
+            - k8s.pod.network.transmit_packets_dropped
+            - k8s.node.fs.iops
+            - k8s.node.fs.throughput
+            - k8s.node.network.bytes_received
+            - k8s.node.network.bytes_transmitted
+            - k8s.node.network.packets_received
+            - k8s.node.network.packets_transmitted
+            - k8s.node.network.receive_packets_dropped
+            - k8s.node.network.transmit_packets_dropped
+        cumulativetodelta/istio-metrics:
+          include:
+            match_type: strict
+            metrics:
+            - k8s.istio_request_bytes.rate
+            - k8s.istio_response_bytes.rate
+            - k8s.istio_request_duration_milliseconds.rate
+            - k8s.istio_requests.rate
+            - k8s.istio_tcp_sent_bytes.rate
+            - k8s.istio_tcp_received_bytes.rate
+            - k8s.istio_request_bytes.delta
+            - k8s.istio_response_bytes.delta
+            - k8s.istio_requests.delta
+            - k8s.istio_tcp_sent_bytes.delta
+            - k8s.istio_tcp_received_bytes.delta
+        deltatorate/cadvisor:
+          metrics:
+          - k8s.node.cpu.usage.seconds.rate
+          - k8s.pod.cpu.usage.seconds.rate
+          - k8s.container.fs.iops
+          - k8s.container.fs.throughput
+          - k8s.container.cpu.usage.seconds.rate
+          - k8s.container.network.bytes_received
+          - k8s.container.network.bytes_transmitted
+          - k8s.pod.fs.iops
+          - k8s.pod.fs.throughput
+          - k8s.pod.fs.reads.rate
+          - k8s.pod.fs.writes.rate
+          - k8s.pod.fs.reads.bytes.rate
+          - k8s.pod.fs.writes.bytes.rate
+          - k8s.pod.network.bytes_received
+          - k8s.pod.network.bytes_transmitted
+          - k8s.pod.network.packets_received
+          - k8s.pod.network.packets_transmitted
+          - k8s.pod.network.receive_packets_dropped
+          - k8s.pod.network.transmit_packets_dropped
+          - k8s.node.fs.iops
+          - k8s.node.fs.throughput
+          - k8s.node.network.bytes_received
+          - k8s.node.network.bytes_transmitted
+          - k8s.node.network.packets_received
+          - k8s.node.network.packets_transmitted
+          - k8s.node.network.receive_packets_dropped
+          - k8s.node.network.transmit_packets_dropped
+        deltatorate/istio-metrics:
+          metrics:
+          - k8s.istio_request_bytes.rate
+          - k8s.istio_response_bytes.rate
+          - k8s.istio_request_duration_milliseconds.rate
+          - k8s.istio_requests.rate
+          - k8s.istio_tcp_sent_bytes.rate
+          - k8s.istio_tcp_received_bytes.rate
+        filter/histograms:
+          metrics:
+            metric:
+            - type == METRIC_DATA_TYPE_HISTOGRAM
+        filter/logs:
+          logs:
+            include:
+              match_type: regexp
+              record_attributes:
+              - key: k8s.namespace.name
+                value: ^kube-.*$
+        filter/metrics:
+          metrics:
+            exclude:
+              match_type: regexp
+              metric_names:
+              - .*_temp
+              - apiserver_request_total
+        filter/receiver:
+          metrics:
+            exclude:
+              match_type: strict
+              metric_names:
+              - scrape_duration_seconds
+              - scrape_samples_post_metric_relabeling
+              - scrape_samples_scraped
+              - scrape_series_added
+              - up
+        filter/remove_internal:
+          metrics:
+            datapoint:
+            - attributes["container"] == "POD" and IsMatch(metric.name, "container_network_.*")
+              == false
+        filter/remove_internal_postprocessing:
+          metrics:
+            datapoint:
+            - attributes["container"] == "POD" and IsMatch(metric.name, "container_network_.*|k8s.container.*")
+              == true
+        groupbyattrs/all:
+          keys:
+          - kubelet_version
+          - container_runtime_version
+          - provider_id
+          - os_image
+          - namespace
+          - uid
+          - k8s.pod.uid
+          - pod_ip
+          - host_ip
+          - created_by_kind
+          - created_by_name
+          - host_network
+          - priority_class
+          - container_id
+          - container
+          - image
+          - image_id
+          - k8s.node.name
+          - sw.k8s.pod.status
+          - sw.k8s.namespace.status
+          - sw.k8s.node.status
+          - sw.k8s.container.status
+          - sw.k8s.container.init
+          - daemonset
+          - statefulset
+          - deployment
+          - replicaset
+          - job_name
+          - cronjob
+          - git_version
+          - internal_ip
+          - job_condition
+          - persistentvolumeclaim
+          - persistentvolume
+          - sw.k8s.persistentvolumeclaim.status
+          - sw.k8s.persistentvolume.status
+          - storageclass
+          - access_mode
+          - k8s.service.name
+          - sw.k8s.service.external_name
+          - sw.k8s.service.type
+          - sw.k8s.cluster.ip
+        groupbyattrs/common-all:
+          keys:
+          - k8s.container.name
+          - k8s.namespace.name
+          - k8s.pod.name
+          - k8s.pod.uid
+          - host.name
+          - service.name
+        groupbyattrs/node:
+          keys:
+          - k8s.node.name
+        groupbyattrs/pod:
+          keys:
+          - namespace
+          - pod
+        k8sattributes:
+          auth_type: serviceAccount
+          extract:
+            annotations:
+            - from: pod
+              key_regex: (.*)
+              tag_name: k8s.pod.annotations.$$1
+            - from: namespace
+              key_regex: (.*)
+              tag_name: k8s.namespace.annotations.$$1
+            labels:
+            - from: pod
+              key_regex: (.*)
+              tag_name: k8s.pod.labels.$$1
+            - from: namespace
+              key_regex: (.*)
+              tag_name: k8s.namespace.labels.$$1
+            metadata:
+            - k8s.deployment.name
+            - k8s.replicaset.name
+            - k8s.daemonset.name
+            - k8s.job.name
+            - k8s.cronjob.name
+            - k8s.statefulset.name
+          filter:
+            node_from_env_var: NODE_NAME
+          passthrough: false
+          pod_association:
+          - sources:
+            - from: resource_attribute
+              name: k8s.pod.name
+            - from: resource_attribute
+              name: k8s.namespace.name
+        memory_limiter:
+          check_interval: 1s
+          limit_mib: 800
+          spike_limit_mib: 300
+        metricstransform/istio-metrics:
+          transforms:
+          - action: insert
+            include: k8s.istio_request_bytes.rate
+            new_name: k8s.istio_request_bytes.delta
+          - action: insert
+            include: k8s.istio_response_bytes.rate
+            new_name: k8s.istio_response_bytes.delta
+          - action: insert
+            include: k8s.istio_requests.rate
+            new_name: k8s.istio_requests.delta
+          - action: insert
+            include: k8s.istio_tcp_sent_bytes.rate
+            new_name: k8s.istio_tcp_sent_bytes.delta
+          - action: insert
+            include: k8s.istio_tcp_received_bytes.rate
+            new_name: k8s.istio_tcp_received_bytes.delta
+        metricstransform/preprocessing:
+          transforms:
+          - action: insert
+            include: k8s.container_fs_reads_total
+            new_name: k8s.container_fs_reads_total_temp
+          - action: insert
+            include: k8s.container_fs_writes_total
+            new_name: k8s.container_fs_writes_total_temp
+          - action: combine
+            experimental_match_labels:
+              container: \S+
+              namespace: \S+
+              pod: \S+
+            include: (k8s.container_fs_reads_total_temp|k8s.container_fs_writes_total_temp)
+            match_type: regexp
+            new_name: k8s.container.fs.iops
+            operations:
+            - action: aggregate_labels
+              aggregation_type: sum
+              label_set:
+              - container
+              - pod
+              - namespace
+            submatch_case: lower
+          - action: insert
+            include: k8s.container_fs_reads_bytes_total
+            new_name: k8s.container_fs_reads_bytes_total_temp
+          - action: insert
+            include: k8s.container_fs_writes_bytes_total
+            new_name: k8s.container_fs_writes_bytes_total_temp
+          - action: combine
+            experimental_match_labels:
+              container: \S+
+              namespace: \S+
+              pod: \S+
+            include: (k8s.container_fs_reads_bytes_total_temp|k8s.container_fs_writes_bytes_total_temp)
+            match_type: regexp
+            new_name: k8s.container.fs.throughput
+            operations:
+            - action: aggregate_labels
+              aggregation_type: sum
+              label_set:
+              - container
+              - pod
+              - namespace
+            submatch_case: lower
+          - action: insert
+            include: k8s.container_network_receive_bytes_total
+            new_name: k8s.container.network.bytes_received
+          - action: insert
+            include: k8s.container_network_transmit_bytes_total
+            new_name: k8s.container.network.bytes_transmitted
+          - action: insert
+            experimental_match_labels:
+              container: \S+
+              namespace: \S+
+              pod: \S+
+            include: k8s.container_cpu_usage_seconds_total
+            match_type: regexp
+            new_name: k8s.pod.cpu.usage.seconds.rate
+            operations:
+            - action: aggregate_labels
+              aggregation_type: sum
+              label_set:
+              - pod
+              - namespace
+              - k8s.node.name
+          - action: insert
+            include: k8s.container_cpu_usage_seconds_total
+            new_name: k8s.container.cpu.usage.seconds.rate
+          - action: insert
+            experimental_match_labels:
+              container: \S+
+              namespace: \S+
+              pod: \S+
+            include: k8s.container_memory_working_set_bytes
+            match_type: regexp
+            new_name: k8s.pod.memory.working_set
+            operations:
+            - action: aggregate_labels
+              aggregation_type: sum
+              label_set:
+              - pod
+              - namespace
+              - k8s.node.name
+          - action: insert
+            experimental_match_labels:
+              k8s.node.name: \S+
+              namespace: \S+
+              pod: \S+
+            include: k8s.container_network_receive_bytes_total
+            match_type: regexp
+            new_name: k8s.pod.network.bytes_received
+            operations:
+            - action: aggregate_labels
+              aggregation_type: sum
+              label_set:
+              - pod
+              - namespace
+              - k8s.node.name
+          - action: insert
+            experimental_match_labels:
+              k8s.node.name: \S+
+              namespace: \S+
+              pod: \S+
+            include: k8s.container_network_transmit_bytes_total
+            match_type: regexp
+            new_name: k8s.pod.network.bytes_transmitted
+            operations:
+            - action: aggregate_labels
+              aggregation_type: sum
+              label_set:
+              - pod
+              - namespace
+              - k8s.node.name
+          - action: insert
+            experimental_match_labels:
+              k8s.node.name: \S+
+              namespace: \S+
+              pod: \S+
+            include: k8s.container_network_receive_packets_total
+            match_type: regexp
+            new_name: k8s.pod.network.packets_received
+            operations:
+            - action: aggregate_labels
+              aggregation_type: sum
+              label_set:
+              - pod
+              - namespace
+              - k8s.node.name
+          - action: insert
+            experimental_match_labels:
+              k8s.node.name: \S+
+              namespace: \S+
+              pod: \S+
+            include: k8s.container_network_transmit_packets_total
+            match_type: regexp
+            new_name: k8s.pod.network.packets_transmitted
+            operations:
+            - action: aggregate_labels
+              aggregation_type: sum
+              label_set:
+              - pod
+              - namespace
+              - k8s.node.name
+          - action: insert
+            experimental_match_labels:
+              k8s.node.name: \S+
+              namespace: \S+
+              pod: \S+
+            include: k8s.container_network_receive_packets_dropped_total
+            match_type: regexp
+            new_name: k8s.pod.network.receive_packets_dropped
+            operations:
+            - action: aggregate_labels
+              aggregation_type: sum
+              label_set:
+              - pod
+              - namespace
+              - k8s.node.name
+          - action: insert
+            experimental_match_labels:
+              k8s.node.name: \S+
+              namespace: \S+
+              pod: \S+
+            include: k8s.container_network_transmit_packets_dropped_total
+            match_type: regexp
+            new_name: k8s.pod.network.transmit_packets_dropped
+            operations:
+            - action: aggregate_labels
+              aggregation_type: sum
+              label_set:
+              - pod
+              - namespace
+              - k8s.node.name
+          - action: insert
+            experimental_match_labels:
+              k8s.node.name: \S+
+              namespace: \S+
+              pod: \S+
+            include: k8s.container_fs_reads_total
+            match_type: regexp
+            new_name: k8s.pod.fs.reads.rate
+            operations:
+            - action: aggregate_labels
+              aggregation_type: sum
+              label_set:
+              - pod
+              - namespace
+              - k8s.node.name
+          - action: insert
+            experimental_match_labels:
+              k8s.node.name: \S+
+              namespace: \S+
+              pod: \S+
+            include: k8s.container_fs_writes_total
+            match_type: regexp
+            new_name: k8s.pod.fs.writes.rate
+            operations:
+            - action: aggregate_labels
+              aggregation_type: sum
+              label_set:
+              - pod
+              - namespace
+              - k8s.node.name
+          - action: insert
+            experimental_match_labels:
+              k8s.node.name: \S+
+              namespace: \S+
+              pod: \S+
+            include: k8s.container_fs_reads_bytes_total
+            match_type: regexp
+            new_name: k8s.pod.fs.reads.bytes.rate
+            operations:
+            - action: aggregate_labels
+              aggregation_type: sum
+              label_set:
+              - pod
+              - namespace
+              - k8s.node.name
+          - action: insert
+            experimental_match_labels:
+              k8s.node.name: \S+
+              namespace: \S+
+              pod: \S+
+            include: k8s.container_fs_writes_bytes_total
+            match_type: regexp
+            new_name: k8s.pod.fs.writes.bytes.rate
+            operations:
+            - action: aggregate_labels
+              aggregation_type: sum
+              label_set:
+              - pod
+              - namespace
+              - k8s.node.name
+          - action: insert
+            include: k8s.pod.fs.reads.rate
+            new_name: k8s.pod.fs.reads.rate_temp
+          - action: insert
+            include: k8s.pod.fs.writes.rate
+            new_name: k8s.pod.fs.writes.rate_temp
+          - action: combine
+            include: (k8s.pod.fs.reads.rate_temp|k8s.pod.fs.writes.rate_temp)
+            match_type: regexp
+            new_name: k8s.pod.fs.iops
+            operations:
+            - action: aggregate_labels
+              aggregation_type: sum
+              label_set:
+              - pod
+              - namespace
+              - k8s.node.name
+            submatch_case: lower
+          - action: insert
+            include: k8s.pod.fs.reads.bytes.rate
+            new_name: k8s.pod.fs.reads.bytes.rate_temp
+          - action: insert
+            include: k8s.pod.fs.writes.bytes.rate
+            new_name: k8s.pod.fs.writes.bytes.rate_temp
+          - action: combine
+            include: (k8s.pod.fs.reads.bytes.rate_temp|k8s.pod.fs.writes.bytes.rate_temp)
+            match_type: regexp
+            new_name: k8s.pod.fs.throughput
+            operations:
+            - action: aggregate_labels
+              aggregation_type: sum
+              label_set:
+              - pod
+              - namespace
+              - k8s.node.name
+            submatch_case: lower
+          - action: insert
+            experimental_match_labels:
+              k8s.node.name: \S+
+              namespace: \S+
+              pod: \S+
+            include: k8s.container_fs_usage_bytes
+            match_type: regexp
+            new_name: k8s.pod.fs.usage.bytes
+            operations:
+            - action: aggregate_labels
+              aggregation_type: sum
+              label_set:
+              - pod
+              - namespace
+              - k8s.node.name
+          - action: insert
+            experimental_match_labels:
+              id: /
+            include: k8s.container_cpu_usage_seconds_total
+            new_name: k8s.node.cpu.usage.seconds.rate
+          - action: insert
+            experimental_match_labels:
+              id: /
+            include: k8s.container_memory_working_set_bytes
+            new_name: k8s.node.memory.working_set
+          - action: insert
+            experimental_match_labels:
+              id: /
+              k8s.node.name: \S+
+            include: k8s.container_network_receive_bytes_total
+            match_type: regexp
+            new_name: k8s.node.network.bytes_received
+            operations:
+            - action: aggregate_labels
+              aggregation_type: sum
+              label_set:
+              - k8s.node.name
+          - action: insert
+            experimental_match_labels:
+              id: /
+              k8s.node.name: \S+
+            include: k8s.container_network_transmit_bytes_total
+            match_type: regexp
+            new_name: k8s.node.network.bytes_transmitted
+            operations:
+            - action: aggregate_labels
+              aggregation_type: sum
+              label_set:
+              - k8s.node.name
+          - action: insert
+            experimental_match_labels:
+              id: /
+              k8s.node.name: \S+
+            include: k8s.container_network_receive_packets_total
+            match_type: regexp
+            new_name: k8s.node.network.packets_received
+            operations:
+            - action: aggregate_labels
+              aggregation_type: sum
+              label_set:
+              - k8s.node.name
+          - action: insert
+            experimental_match_labels:
+              id: /
+              k8s.node.name: \S+
+            include: k8s.container_network_transmit_packets_total
+            match_type: regexp
+            new_name: k8s.node.network.packets_transmitted
+            operations:
+            - action: aggregate_labels
+              aggregation_type: sum
+              label_set:
+              - k8s.node.name
+          - action: insert
+            experimental_match_labels:
+              id: /
+              k8s.node.name: \S+
+            include: k8s.container_network_receive_packets_dropped_total
+            match_type: regexp
+            new_name: k8s.node.network.receive_packets_dropped
+            operations:
+            - action: aggregate_labels
+              aggregation_type: sum
+              label_set:
+              - k8s.node.name
+          - action: insert
+            experimental_match_labels:
+              id: /
+              k8s.node.name: \S+
+            include: k8s.container_network_transmit_packets_dropped_total
+            match_type: regexp
+            new_name: k8s.node.network.transmit_packets_dropped
+            operations:
+            - action: aggregate_labels
+              aggregation_type: sum
+              label_set:
+              - k8s.node.name
+          - action: insert
+            include: k8s.pod.fs.reads.rate
+            new_name: k8s.node.fs.reads.rate_temp
+            operations:
+            - action: aggregate_labels
+              aggregation_type: sum
+              label_set:
+              - k8s.node.name
+          - action: insert
+            include: k8s.pod.fs.writes.rate
+            new_name: k8s.node.fs.writes.rate_temp
+            operations:
+            - action: aggregate_labels
+              aggregation_type: sum
+              label_set:
+              - k8s.node.name
+          - action: insert
+            include: k8s.pod.fs.reads.bytes.rate
+            new_name: k8s.node.fs.reads.bytes.rate_temp
+            operations:
+            - action: aggregate_labels
+              aggregation_type: sum
+              label_set:
+              - k8s.node.name
+          - action: insert
+            include: k8s.pod.fs.writes.bytes.rate
+            new_name: k8s.node.fs.writes.bytes.rate_temp
+            operations:
+            - action: aggregate_labels
+              aggregation_type: sum
+              label_set:
+              - k8s.node.name
+          - action: combine
+            include: (k8s.node.fs.reads.rate_temp|k8s.node.fs.writes.rate_temp)
+            match_type: regexp
+            new_name: k8s.node.fs.iops
+            operations:
+            - action: aggregate_labels
+              aggregation_type: sum
+              label_set:
+              - k8s.node.name
+            submatch_case: lower
+          - action: combine
+            include: (k8s.node.fs.reads.bytes.rate_temp|k8s.node.fs.writes.bytes.rate_temp)
+            match_type: regexp
+            new_name: k8s.node.fs.throughput
+            operations:
+            - action: aggregate_labels
+              aggregation_type: sum
+              label_set:
+              - k8s.node.name
+            submatch_case: lower
+          - action: insert
+            include: k8s.pod.fs.usage.bytes
+            new_name: k8s.node.fs.usage
+            operations:
+            - action: aggregate_labels
+              aggregation_type: sum
+              label_set:
+              - k8s.node.name
+        metricstransform/rename:
+          transforms:
+          - action: update
+            include: ^(.*)$$
+            match_type: regexp
+            new_name: k8s.$${1}
+        resource/all:
+          attributes:
+          - action: insert
+            key: sw.k8s.agent.manifest.version
+            value: ${MANIFEST_VERSION}
+          - action: insert
+            key: sw.k8s.agent.app.version
+            value: ${APP_VERSION}
+          - action: insert
+            key: sw.k8s.cluster.uid
+            value: ${CLUSTER_UID}
+          - action: insert
+            key: k8s.cluster.name
+            value: ${CLUSTER_NAME}
+          - action: upsert
+            key: k8s.node.name
+            value: ${NODE_NAME}
+        resource/container:
+          attributes:
+          - action: insert
+            key: sw.k8s.log.type
+            value: container
+          - action: insert
+            key: sw.k8s.agent.manifest.version
+            value: ${MANIFEST_VERSION}
+          - action: insert
+            key: sw.k8s.agent.app.version
+            value: ${APP_VERSION}
+          - action: insert
+            key: sw.k8s.cluster.uid
+            value: ${CLUSTER_UID}
+          - action: insert
+            key: k8s.cluster.name
+            value: ${CLUSTER_NAME}
+          - action: insert
+            key: k8s.node.name
+            value: ${NODE_NAME}
+        resource/journal:
+          attributes:
+          - action: insert
+            key: sw.k8s.log.type
+            value: journal
+          - action: insert
+            key: sw.k8s.agent.manifest.version
+            value: ${MANIFEST_VERSION}
+          - action: insert
+            key: sw.k8s.agent.app.version
+            value: ${APP_VERSION}
+          - action: insert
+            key: sw.k8s.cluster.uid
+            value: ${CLUSTER_UID}
+          - action: insert
+            key: k8s.cluster.name
+            value: ${CLUSTER_NAME}
+          - action: insert
+            key: k8s.node.name
+            value: ${NODE_NAME}
+        resource/metrics:
+          attributes:
+          - action: delete
+            key: service.name
+          - action: delete
+            key: service.instance.id
+          - action: delete
+            key: net.host.name
+          - action: delete
+            key: net.host.port
+          - action: delete
+            key: http.scheme
+          - action: insert
+            key: sw.k8s.agent.manifest.version
+            value: ${MANIFEST_VERSION}
+          - action: insert
+            key: sw.k8s.agent.app.version
+            value: ${APP_VERSION}
+          - action: insert
+            key: sw.k8s.cluster.uid
+            value: ${CLUSTER_UID}
+          - action: insert
+            key: k8s.cluster.name
+            value: ${CLUSTER_NAME}
+          - action: insert
+            from_attribute: git_version
+            key: sw.k8s.cluster.version
+          - action: insert
+            from_attribute: kubelet_version
+            key: sw.k8s.node.version
+          - action: insert
+            from_attribute: container_runtime_version
+            key: sw.k8s.node.container.runtime.version
+          - action: insert
+            from_attribute: provider_id
+            key: sw.k8s.node.provider.id
+          - action: insert
+            from_attribute: os_image
+            key: sw.k8s.node.os.image
+          - action: insert
+            from_attribute: internal_ip
+            key: sw.k8s.node.ip.internal
+          - action: insert
+            from_attribute: namespace
+            key: k8s.namespace.name
+          - action: insert
+            from_attribute: pod
+            key: k8s.pod.name
+          - action: insert
+            from_attribute: pod_ip
+            key: sw.k8s.pod.ip
+          - action: insert
+            from_attribute: host_ip
+            key: sw.k8s.pod.host.ip
+          - action: insert
+            from_attribute: created_by_kind
+            key: sw.k8s.pod.createdby.kind
+          - action: insert
+            from_attribute: created_by_name
+            key: sw.k8s.pod.createdby.name
+          - action: insert
+            from_attribute: host_network
+            key: sw.k8s.pod.host.network
+          - action: insert
+            from_attribute: priority_class
+            key: sw.k8s.pod.priority_class
+          - action: extract
+            key: container_id
+            pattern: ^(?P<extracted_container_runtime>[^:]+)://(?P<extracted_container_id>[^/]+)$
+          - action: insert
+            from_attribute: extracted_container_id
+            key: container.id
+          - action: insert
+            from_attribute: extracted_container_runtime
+            key: container.runtime
+          - action: insert
+            from_attribute: container
+            key: k8s.container.name
+          - action: insert
+            from_attribute: image_id
+            key: k8s.container.image.id
+          - action: insert
+            from_attribute: image
+            key: k8s.container.image.name
+          - action: insert
+            from_attribute: replicaset
+            key: k8s.replicaset.name
+          - action: insert
+            from_attribute: deployment
+            key: k8s.deployment.name
+          - action: insert
+            from_attribute: statefulset
+            key: k8s.statefulset.name
+          - action: insert
+            from_attribute: daemonset
+            key: k8s.daemonset.name
+          - action: insert
+            from_attribute: job_name
+            key: k8s.job.name
+          - action: insert
+            from_attribute: job_condition
+            key: k8s.job.condition
+          - action: insert
+            from_attribute: cronjob
+            key: k8s.cronjob.name
+          - action: insert
+            from_attribute: persistentvolume
+            key: k8s.persistentvolume.name
+          - action: insert
+            from_attribute: persistentvolumeclaim
+            key: k8s.persistentvolumeclaim.name
+        transform/istio-metrics:
+          metric_statements:
+          - context: metric
+            statements:
+            - extract_sum_metric(true) where (name == "k8s.istio_request_bytes" or name
+              == "k8s.istio_response_bytes" or name == "k8s.istio_request_duration_milliseconds")
+            - set(name, "k8s.istio_request_bytes.rate") where name == "k8s.istio_request_bytes_sum"
+            - set(name, "k8s.istio_response_bytes.rate") where name == "k8s.istio_response_bytes_sum"
+            - set(name, "k8s.istio_request_duration_milliseconds.rate") where name == "k8s.istio_request_duration_milliseconds_sum"
+            - set(name, "k8s.istio_requests.rate") where name == "k8s.istio_requests_total"
+            - set(name, "k8s.istio_tcp_sent_bytes.rate") where name == "k8s.istio_tcp_sent_bytes_total"
+            - set(name, "k8s.istio_tcp_received_bytes.rate") where name == "k8s.istio_tcp_received_bytes_total"
+        transform/syslogify:
+          error_mode: ignore
+          log_statements:
+          - context: log
+            statements:
+            - set( attributes["host.name"], attributes["k8s.pod.name"])
+            - set( attributes["service.name"], attributes["k8s.container.name"])
+        transform/unify_node_attribute:
+          metric_statements:
+          - context: datapoint
+            statements:
+            - set(attributes["k8s.node.name"], resource.attributes["service.instance.id"])
+              where IsMatch(metric.name, "^(container_.*)$") == true and attributes["k8s.node.name"]
+              == nil
+      receivers:
+        filelog:
+          encoding: utf-8
+          exclude:
+          - /var/log/pods/${POD_NAMESPACE}_${POD_NAME}*_*/swi-opentelemetry-collector/*.log
+          fingerprint_size: 1kb
+          include:
+          - /var/log/pods/*/*/*.log
+          include_file_name: false
+          include_file_path: true
+          max_concurrent_files: 10
+          max_log_size: 1MiB
+          operators:
+          - id: get-format
+            routes:
+            - expr: body matches "^\\{"
+              output: parser-docker
+            - expr: body matches "^[^ Z]+ "
+              output: parser-crio
+            - expr: body matches "^[^ Z]+Z"
+              output: parser-containerd
+            type: router
+          - id: parser-crio
+            output: merge-cri-lines
+            parse_to: body
+            regex: ^(?P<time>[^ Z]+) (?P<stream>stdout|stderr) (?P<logtag>[^ ]*)( |)(?P<log>.*)$
+            timestamp:
+              layout: "2006-01-02T15:04:05.999999999-07:00"
+              layout_type: gotime
+              parse_from: body.time
+            type: regex_parser
+          - id: parser-containerd
+            output: merge-cri-lines
+            parse_to: body
+            regex: ^(?P<time>[^ ^Z]+Z) (?P<stream>stdout|stderr) (?P<logtag>[^ ]*)( |)(?P<log>.*)$
+            timestamp:
+              layout: '%Y-%m-%dT%H:%M:%S.%LZ'
+              parse_from: body.time
+            type: regex_parser
+          - id: parser-docker
+            output: merge-docker-lines
+            parse_to: body
+            timestamp:
+              layout: '%Y-%m-%dT%H:%M:%S.%LZ'
+              parse_from: body.time
+            type: json_parser
+          - combine_field: body.log
+            combine_with: ""
+            id: merge-docker-lines
+            is_last_entry: body.log matches "\n$"
+            output: merge-multiline-logs
+            source_identifier: attributes["log.file.path"]
+            type: recombine
+          - combine_field: body.log
+            combine_with: ""
+            id: merge-cri-lines
+            is_last_entry: body.logtag == "F"
+            output: merge-multiline-logs
+            overwrite_with: newest
+            source_identifier: attributes["log.file.path"]
+            type: recombine
+          - combine_field: body.log
+            combine_with: ""
+            id: merge-multiline-logs
+            is_first_entry: body.log matches "^\\[?\\d{4}-\\d{1,2}-\\d{1,2}.\\d{2}:\\d{2}:\\d{2}.*"
+            output: extract-metadata-from-filepath
+            source_identifier: attributes["log.file.path"]
+            type: recombine
+          - id: extract-metadata-from-filepath
+            parse_from: attributes["log.file.path"]
+            regex: ^.*\/(?P<namespace>[^_]+)_(?P<pod_name>[^_]+)_(?P<uid>[a-f0-9\-]+)\/(?P<container_name>[^\._]+)\/(?P<run_id>\d+)\.log$
+            type: regex_parser
+          - from: body.stream
+            id: move-attributes
+            to: attributes["stream"]
+            type: move
+          - from: attributes.container_name
+            to: attributes["k8s.container.name"]
+            type: move
+          - from: attributes.namespace
+            to: attributes["k8s.namespace.name"]
+            type: move
+          - from: attributes.pod_name
+            to: attributes["k8s.pod.name"]
+            type: move
+          - field: attributes.run_id
+            type: remove
+          - from: attributes.uid
+            to: attributes["k8s.pod.uid"]
+            type: move
+          - field: attributes["log.file.path"]
+            type: remove
+          - field: body.time
+            type: remove
+          - from: body.log
+            to: body
+            type: move
+          poll_interval: 200ms
+          start_at: end
+          storage: file_storage/checkpoints
+        journald:
+          units:
+          - kubelet
+          - docker
+          - containerd
+        receiver_creator/node:
+          receivers:
+            prometheus/node:
+              config:
+                config:
+                  scrape_configs:
+                  - bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
+                    honor_labels: true
+                    honor_timestamps: false
+                    job_name: kubernetes-nodes-cadvisor
+                    metrics_path: /metrics/cadvisor
+                    scheme: https
+                    scrape_interval: 60s
+                    scrape_timeout: 10s
+                    static_configs:
+                    - targets:
+                      - '`endpoint`:`kubelet_endpoint_port`'
+                    tls_config:
+                      ca_file: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+                      insecure_skip_verify: true
+                  - bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
+                    honor_labels: true
+                    honor_timestamps: false
+                    job_name: kubernetes-nodes
+                    metrics_path: /metrics
+                    scheme: https
+                    scrape_interval: 60s
+                    scrape_timeout: 10s
+                    static_configs:
+                    - targets:
+                      - '`endpoint`:`kubelet_endpoint_port`'
+                    tls_config:
+                      ca_file: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+                      insecure_skip_verify: true
+              rule: type == "k8s.node"
+          watch_observers:
+          - k8s_observer
+      service:
+        extensions:
+        - file_storage/checkpoints
+        - health_check
+        - k8s_observer
+        pipelines:
+          logs:
+            exporters:
+            - otlp
+            processors:
+            - memory_limiter
+            - batch/logs
+            receivers:
+            - forward/logs-exporter
+          logs/container:
+            exporters:
+            - forward/logs-exporter
+            processors:
+            - memory_limiter
+            - filter/logs
+            - transform/syslogify
+            - groupbyattrs/common-all
+            - resource/container
+            receivers:
+            - filelog
+          logs/journal:
+            exporters:
+            - forward/logs-exporter
+            processors:
+            - memory_limiter
+            - groupbyattrs/common-all
+            - resource/journal
+            receivers:
+            - journald
+          metrics:
+            exporters:
+            - otlp
+            processors:
+            - memory_limiter
+            - filter/histograms
+            - k8sattributes
+            - batch/metrics
+            receivers:
+            - forward/metric-exporter
+          metrics/node:
+            exporters:
+            - forward/metric-exporter
+            processors:
+            - memory_limiter
+            - filter/receiver
+            - filter/remove_internal
+            - attributes/remove_prometheus_attributes
+            - attributes/unify_node_attribute
+            - transform/unify_node_attribute
+            - metricstransform/rename
+            - metricstransform/preprocessing
+            - filter/remove_internal_postprocessing
+            - attributes/remove_temp
+            - cumulativetodelta/cadvisor
+            - deltatorate/cadvisor
+            - groupbyattrs/node
+            - groupbyattrs/pod
+            - groupbyattrs/all
+            - filter/metrics
+            - resource/metrics
+            - resource/all
+            receivers:
+            - receiver_creator/node
+        telemetry:
+          logs:
+            level: info
+          metrics:
+            address: 0.0.0.0:8888
+    logs.proto: ""
+    logs_service.proto: ""
+    resource.proto: ""
 Node collector config should match snapshot when fargate is enabled:
   1: |
     common.proto: ""

--- a/deploy/helm/tests/node-collector-config-map_test.yaml
+++ b/deploy/helm/tests/node-collector-config-map_test.yaml
@@ -8,6 +8,13 @@ tests:
     asserts:
       - matchSnapshot:
           path: data
+  - it: Node collector config should match snapshot when autodiscovery is disabled
+    template: node-collector-config-map.yaml
+    set:
+      otel.metrics.autodiscovery.prometheusEndpoints.enabled: false
+    asserts:
+      - matchSnapshot:
+          path: data
   - it: Node collector config should match snapshot when fargate is enabled
     template: node-collector-config-map.yaml
     set:


### PR DESCRIPTION
When both Prometheus autodiscovery and Fargate support were disabled, the `k8s_observer` extension would not be configured, even though the pipeline would still depend on it.