### PR TITLE
NH-69902: Fixing code signing for Helm releaser

### DIFF
--- a/.github/workflows/releaseHelm.yaml
+++ b/.github/workflows/releaseHelm.yaml
@@ -20,11 +20,6 @@ jobs:
       - name: Fetch history
         run: git fetch --prune --unshallow
 
-      - name: Configure Git
-        run: |
-          git config user.name "$GITHUB_ACTOR"
-          git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
-
       - name: Set up Helm
         uses: azure/setup-helm@v3.5
         with:
@@ -42,7 +37,10 @@ jobs:
 
       - name: Run chart-releaser
         env:
+          # for chart-releaser (it is required although probably not used)
           CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+          # for gh cli
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           "./.github/cr.sh"
         shell: bash


### PR DESCRIPTION
* removed `--pr` flag from `cr index` which means that `index.yaml` is produced locally
* pushing commit manually using gh cli as GitHub actions bot which is automatically signed
* creating PR manually using gh cli