### PR TITLE
Added option to configure `timeout` for 3.3.0

### DIFF
--- a/deploy/helm/CHANGELOG.md
+++ b/deploy/helm/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## [3.3.0-alpha.1]
+
+### Added
+
+- Added option to configure `timeout`, which is time to wait per individual attempt to send data to SWO.
+  - default is `15s` (previously was `5s`) avoiding unnecessary retries when backend takes time to respond
+
 ## [3.2.0] - 2024-02-02
 
 ### Added

--- a/deploy/helm/Chart.yaml
+++ b/deploy/helm/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: swo-k8s-collector
-version: 3.2.0
+version: 3.3.0-alpha.1
 appVersion: "0.9.2"
 description: SolarWinds Kubernetes Integration
 keywords:

--- a/deploy/helm/events-collector-config.yaml
+++ b/deploy/helm/events-collector-config.yaml
@@ -16,6 +16,7 @@ exporters:
       queue_size: {{ .Values.otel.events.sending_queue.queue_size }}
 {{- if .Values.otel.events.sending_queue.offload_to_disk }}
       storage: file_storage/sending_queue
+    timeout: {{ .Values.otel.events.timeout }}
 {{- end }}
 extensions:
 {{- if .Values.otel.events.sending_queue.offload_to_disk }}

--- a/deploy/helm/metrics-collector-config.yaml
+++ b/deploy/helm/metrics-collector-config.yaml
@@ -16,6 +16,7 @@ exporters:
       queue_size: {{ .Values.otel.metrics.sending_queue.queue_size }}
 {{- if .Values.otel.metrics.sending_queue.offload_to_disk }}
       storage: file_storage/sending_queue
+    timeout: {{ .Values.otel.metrics.timeout }}
 {{- end }}
 extensions:
 {{- if .Values.otel.metrics.sending_queue.offload_to_disk }}

--- a/deploy/helm/node-collector-config.yaml
+++ b/deploy/helm/node-collector-config.yaml
@@ -17,6 +17,7 @@ exporters:
 {{- if .Values.otel.node_collector.sending_queue.persistent_storage.enabled }}
       storage: file_storage/sending_queue
 {{- end }}
+    timeout: {{ .Values.otel.node_collector.timeout }}
 extensions:
   file_storage/checkpoints:
 {{ toYaml .Values.otel.logs.filestorage | indent 4 }}

--- a/deploy/helm/tests/__snapshot__/logs-fargate-config-map_test.yaml.snap
+++ b/deploy/helm/tests/__snapshot__/logs-fargate-config-map_test.yaml.snap
@@ -24,7 +24,7 @@ Fargate logging ConfigMap spec should include additional filters when they are c
           Match *
           Add sw.k8s.cluster.uid <CLUSTER_UID>
           Add sw.k8s.log.type container
-          Add sw.k8s.agent.manifest.version "3.2.0"
+          Add sw.k8s.agent.manifest.version "3.3.0-alpha.1"
     flb_log_cw: "false"
     output.conf: |
       [OUTPUT]
@@ -64,7 +64,7 @@ Fargate logging ConfigMap spec should match snapshot when Fargate logging is ena
           Match *
           Add sw.k8s.cluster.uid <CLUSTER_UID>
           Add sw.k8s.log.type container
-          Add sw.k8s.agent.manifest.version "3.2.0"
+          Add sw.k8s.agent.manifest.version "3.3.0-alpha.1"
     flb_log_cw: "false"
     output.conf: |
       [OUTPUT]

--- a/deploy/helm/tests/__snapshot__/node-collector-config-map-windows_test.yaml.snap
+++ b/deploy/helm/tests/__snapshot__/node-collector-config-map-windows_test.yaml.snap
@@ -19,6 +19,7 @@ Node collector config for windows nodes should match snapshot when using default
             enabled: true
             num_consumers: 20
             queue_size: 1000
+          timeout: 15s
           tls:
             insecure: ${OTEL_ENVOY_ADDRESS_TLS_INSECURE}
       extensions:

--- a/deploy/helm/tests/__snapshot__/node-collector-config-map_test.yaml.snap
+++ b/deploy/helm/tests/__snapshot__/node-collector-config-map_test.yaml.snap
@@ -19,6 +19,7 @@ Node collector config should match snapshot when autodiscovery is disabled:
             enabled: true
             num_consumers: 20
             queue_size: 1000
+          timeout: 15s
           tls:
             insecure: ${OTEL_ENVOY_ADDRESS_TLS_INSECURE}
       extensions:
@@ -1181,6 +1182,7 @@ Node collector config should match snapshot when fargate is enabled:
             enabled: true
             num_consumers: 20
             queue_size: 1000
+          timeout: 15s
           tls:
             insecure: ${OTEL_ENVOY_ADDRESS_TLS_INSECURE}
       extensions:
@@ -2314,6 +2316,7 @@ Node collector config should match snapshot when fargate is enabled and autodisc
             enabled: true
             num_consumers: 20
             queue_size: 1000
+          timeout: 15s
           tls:
             insecure: ${OTEL_ENVOY_ADDRESS_TLS_INSECURE}
       extensions:
@@ -3396,6 +3399,7 @@ Node collector config should match snapshot when using default values:
             enabled: true
             num_consumers: 20
             queue_size: 1000
+          timeout: 15s
           tls:
             insecure: ${OTEL_ENVOY_ADDRESS_TLS_INSECURE}
       extensions:

--- a/deploy/helm/values.yaml
+++ b/deploy/helm/values.yaml
@@ -79,6 +79,9 @@ otel:
       # Is the maximum amount of time spent trying to send a batch; ignored if enabled is false
       max_elapsed_time: 300s
 
+    # Time to wait per individual attempt to send data to SWO
+    timeout: 15s
+
   # Configuration for metrics collection
   metrics:
     # Define whether metrics will be collected and sent
@@ -109,7 +112,6 @@ otel:
         #    - rule: labels["example"] == "value"
         #      metrics_path: "/metrics"
         #      endpoint_port: 8080
-
 
         customTransformations:
           # list of metrics that are counters should be converted to rate
@@ -162,6 +164,9 @@ otel:
 
       # How often the metrics are scraped from Prometheus
       scrape_interval: 60s
+
+    # Time to wait per individual attempt to send data to SWO
+    timeout: 15s
 
     # Configuration for endpoint on which metrics collector receives OpenTelemetry metrics
     otlp_endpoint:
@@ -324,6 +329,9 @@ otel:
 
       # Is the maximum amount of time spent trying to send a batch; ignored if enabled is false
       max_elapsed_time: 300s
+
+    # Time to wait per individual attempt to send data to SWO
+    timeout: 15s
 
     # Memory limiter configuration. The memory limiter is used to prevent out of memory situations on the collector.
     # See https://github.com/open-telemetry/opentelemetry-collector/tree/main/processor/memorylimiterprocessor for configuration reference


### PR DESCRIPTION
- Added option to configure `timeout`, which is time to wait per individual attempt to send data to SWO.
- default is `15s` (previously was `5s`) avoiding unnecessary retries when backend takes time to respond