### PR TITLE
Fix collecting Journal logs from `/var/log/journal`

### DIFF
--- a/deploy/helm/CHANGELOG.md
+++ b/deploy/helm/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Fixed
+- Fixed Journal log collection on EKS (and other environments where journal logs are stored in `/var/log/journal`)
+
 ## [3.3.0-alpha.1]
 
 ### Added

--- a/deploy/helm/node-collector-config.yaml
+++ b/deploy/helm/node-collector-config.yaml
@@ -369,6 +369,7 @@ connectors:
 receivers:
 {{- if and (not .isWindows) .Values.otel.logs.journal }}
   journald:
+    files: ["/*/log/journal/**/*"]
     units:
       - kubelet
       - docker

--- a/deploy/helm/tests/__snapshot__/node-collector-config-map_test.yaml.snap
+++ b/deploy/helm/tests/__snapshot__/node-collector-config-map_test.yaml.snap
@@ -1044,6 +1044,8 @@ Node collector config should match snapshot when autodiscovery is disabled:
           start_at: end
           storage: file_storage/checkpoints
         journald:
+          files:
+          - /*/log/journal/**/*
           units:
           - kubelet
           - docker
@@ -2204,6 +2206,8 @@ Node collector config should match snapshot when fargate is enabled:
           start_at: end
           storage: file_storage/checkpoints
         journald:
+          files:
+          - /*/log/journal/**/*
           units:
           - kubelet
           - docker
@@ -3333,6 +3337,8 @@ Node collector config should match snapshot when fargate is enabled and autodisc
           start_at: end
           storage: file_storage/checkpoints
         journald:
+          files:
+          - /*/log/journal/**/*
           units:
           - kubelet
           - docker
@@ -4424,6 +4430,8 @@ Node collector config should match snapshot when using default values:
           start_at: end
           storage: file_storage/checkpoints
         journald:
+          files:
+          - /*/log/journal/**/*
           units:
           - kubelet
           - docker


### PR DESCRIPTION
Using a single file glob (`--file`) for both `/var/log/journal/` and `/run/log/journal/`.

If they are specified separately, or using a directory (`--directory`) instead of a file blob, the journalctl will return error when one of the paths does not contain journal logs. And the OTEL `journaldreceiver` will stop working when that happens.

Using merge (`--merge`) would work, too, but that is not supported by the `journaldreceiver`.