### PR TITLE
Disable FluentBit log parsing on EKS Fargate

### DIFF
--- a/deploy/helm/CHANGELOG.md
+++ b/deploy/helm/CHANGELOG.md
@@ -7,9 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## [3.3.0-alpha.3] - 2024-03-27
+
+### Changed
+
+- Container logs from AWS EKS Fargate clusters are now sent to SWO as-is. `fluentbit.io/parser` and `fluentbit.io/exclude` annotations are ignored. This both fixes an issue with "empty" JSON logs sent to SWO and aligns the behavior with non-Fargate container logs.
+
 ## [3.3.0-alpha.2] - 2024-03-21
 
 ### Fixed
+
 - Fixed Journal log collection on EKS (and other environments where journal logs are stored in `/var/log/journal`)
 
 ## [3.3.0-alpha.1] - 2024-03-13

--- a/deploy/helm/Chart.yaml
+++ b/deploy/helm/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: swo-k8s-collector
-version: 3.3.0-alpha.2
+version: 3.3.0-alpha.3
 appVersion: "0.9.2"
 description: SolarWinds Kubernetes Integration
 keywords:

--- a/deploy/helm/templates/logs-fargate-config-map.yaml
+++ b/deploy/helm/templates/logs-fargate-config-map.yaml
@@ -20,8 +20,6 @@ data:
     [FILTER]
         Name kubernetes
         Match kube.*
-        Merge_Log On
-        Keep_Log Off
         Buffer_Size 0
         Kube_Meta_Cache_TTL 300s
         Labels Off

--- a/deploy/helm/tests/__snapshot__/logs-fargate-config-map_test.yaml.snap
+++ b/deploy/helm/tests/__snapshot__/logs-fargate-config-map_test.yaml.snap
@@ -9,8 +9,6 @@ Fargate logging ConfigMap spec should include additional filters when they are c
       [FILTER]
           Name kubernetes
           Match kube.*
-          Merge_Log On
-          Keep_Log Off
           Buffer_Size 0
           Kube_Meta_Cache_TTL 300s
           Labels Off
@@ -24,7 +22,7 @@ Fargate logging ConfigMap spec should include additional filters when they are c
           Match *
           Add sw.k8s.cluster.uid <CLUSTER_UID>
           Add sw.k8s.log.type container
-          Add sw.k8s.agent.manifest.version "3.3.0-alpha.2"
+          Add sw.k8s.agent.manifest.version "3.3.0-alpha.3"
     flb_log_cw: "false"
     output.conf: |
       [OUTPUT]
@@ -53,8 +51,6 @@ Fargate logging ConfigMap spec should match snapshot when Fargate logging is ena
       [FILTER]
           Name kubernetes
           Match kube.*
-          Merge_Log On
-          Keep_Log Off
           Buffer_Size 0
           Kube_Meta_Cache_TTL 300s
           Labels Off
@@ -64,7 +60,7 @@ Fargate logging ConfigMap spec should match snapshot when Fargate logging is ena
           Match *
           Add sw.k8s.cluster.uid <CLUSTER_UID>
           Add sw.k8s.log.type container
-          Add sw.k8s.agent.manifest.version "3.3.0-alpha.2"
+          Add sw.k8s.agent.manifest.version "3.3.0-alpha.3"
     flb_log_cw: "false"
     output.conf: |
       [OUTPUT]


### PR DESCRIPTION
Disable support for https://docs.fluentbit.io/manual/pipeline/filters/kubernetes#kubernetes-pod-annotations.

Container logs from AWS EKS Fargate clusters are now sent to SWO as-is. `fluentbit.io/parser` and `fluentbit.io/exclude` annotations are ignored. This both fixes an issue with "empty" JSON logs sent to SWO and aligns the behavior with non-Fargate container logs.