### PR TITLE
Add JSON schema validation for the Helm chart

### DIFF
--- a/.github/workflows/buildAndDeploy.yml
+++ b/.github/workflows/buildAndDeploy.yml
@@ -149,10 +149,10 @@ jobs:
         run: helm dependency build deploy/helm
 
       - name: Lint helm
-        run: helm lint deploy/helm
+        run: helm lint deploy/helm --with-subcharts
 
       - name: Lint template
-        run: helm template deploy/helm
+        run: helm template deploy/helm --include-crds --no-hooks
 
       - name: Install Unit test plugin
         run: helm plugin install https://github.com/helm-unittest/helm-unittest.git

--- a/deploy/helm/CHANGELOG.md
+++ b/deploy/helm/CHANGELOG.md
@@ -5,17 +5,18 @@ All notable changes to Helm charts will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## Unreleased
+## [3.3.0-alpha.4] - 2024-04-10
 
 ### Changed
 
-- Added validation schema for the provided Helm configuration
+- Added validation schema for the provided Helm chart configuration.
 
 ## [3.3.0-alpha.3] - 2024-03-27
 
 ### Changed
 
 - Container logs from AWS EKS Fargate clusters are now sent to SWO as-is. `fluentbit.io/parser` and `fluentbit.io/exclude` annotations are ignored. This both fixes an issue with "empty" JSON logs sent to SWO and aligns the behavior with non-Fargate container logs.
+  This change is applied only to Pods that are started after the new `k8s collector` is deployed to the k8s cluster.
 
 ## [3.3.0-alpha.2] - 2024-03-21
 

--- a/deploy/helm/CHANGELOG.md
+++ b/deploy/helm/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Changed
+
+- Added validation schema for the provided Helm configuration
+
 ## [3.3.0-alpha.3] - 2024-03-27
 
 ### Changed

--- a/deploy/helm/Chart.yaml
+++ b/deploy/helm/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: swo-k8s-collector
-version: 3.3.0-alpha.3
+version: 3.3.0-alpha.4
 appVersion: "0.9.2"
 description: SolarWinds Kubernetes Integration
 keywords:

--- a/deploy/helm/templates/autoupdate/autoupdate-cronjob.yaml
+++ b/deploy/helm/templates/autoupdate/autoupdate-cronjob.yaml
@@ -19,7 +19,7 @@ spec:
           {{- end }}
           containers:
           - name: helm-upgrade
-            image: "{{ include "common.image" (tuple . .Values.autoupdate (tuple "image" "autoupdate") "alpine/k8s:1.27.8") }}"
+            image: "{{ include "common.image" (tuple . .Values.autoupdate (tuple "image" "autoupdate")) }}"
             imagePullPolicy: {{ .Values.otel.image.pullPolicy }}
             command: 
               - /bin/bash

--- a/deploy/helm/templates/metrics-deployment.yaml
+++ b/deploy/helm/templates/metrics-deployment.yaml
@@ -68,7 +68,7 @@ spec:
       initContainers:
         {{- if and .Values.otel.metrics.prometheus_check .Values.otel.metrics.prometheus.url }}
         - name: prometheus-check
-          image: "{{ include "common.image" (tuple . .Values.otel.init_images "busy_box" "busybox:1.36.1") }}"
+          image: "{{ include "common.image" (tuple . .Values.otel.init_images "busy_box") }}"
           imagePullPolicy: {{ .Values.otel.init_images.busy_box.pullPolicy }}
           command: ['sh', '-c', 'until $(wget --spider -nv $PROMETHEUS_URL/federate?); do echo waiting on prometheus; sleep 1; done && echo "Prometheus is available"']
           envFrom:
@@ -77,7 +77,7 @@ spec:
         {{- end }}
         {{- if .Values.otel.metrics.swi_endpoint_check }}
         - name: otel-endpoint-check
-          image: "{{ include "common.image" (tuple . .Values.otel.init_images "swi_endpoint_check" "fullstorydev/grpcurl:v1.8.9") }}"
+          image: "{{ include "common.image" (tuple . .Values.otel.init_images "swi_endpoint_check") }}"
           imagePullPolicy: {{ .Values.otel.init_images.swi_endpoint_check.pullPolicy }}
           command: ['/bin/grpcurl', '-expand-headers',
                     '-proto', 'opentelemetry/proto/collector/logs/v1/logs_service.proto',

--- a/deploy/helm/templates/network/k8s-collector-deployment.yaml
+++ b/deploy/helm/templates/network/k8s-collector-deployment.yaml
@@ -33,7 +33,7 @@ spec:
       {{- end }}
       initContainers:
         - name: wait-for-reducer
-          image: "{{ include "common.image" (tuple . .Values.otel.init_images "busy_box" "busybox:1.36.1") }}"
+          image: "{{ include "common.image" (tuple . .Values.otel.init_images "busy_box") }}"
           imagePullPolicy: {{ .Values.otel.init_images.busy_box.pullPolicy }}
           command: ['sh', '-c', 'until nc -zv $EBPF_NET_INTAKE_HOST $EBPF_NET_INTAKE_PORT; do echo "Waiting for reducer endpoint..."; sleep 5; done;']
           env:
@@ -42,13 +42,13 @@ spec:
             - name: "EBPF_NET_INTAKE_PORT"
               value: "{{ .Values.ebpfNetworkMonitoring.reducer.telemetryPort }}"
       containers:
-      - image: "{{ include "common.image" (tuple . .Values.ebpfNetworkMonitoring.k8sCollector.watcher (tuple "image" "ebpf_k8s_watcher") "otel/opentelemetry-ebpf-k8s-watcher:v0.10.1") }}"
+      - image: "{{ include "common.image" (tuple . .Values.ebpfNetworkMonitoring.k8sCollector.watcher (tuple "image" "ebpf_k8s_watcher")) }}"
         imagePullPolicy: {{ .Values.ebpfNetworkMonitoring.k8sCollector.watcher.image.pullPolicy }}
         name: k8s-watcher
         args:
           - --log-console
           - --log-level={{ .Values.ebpfNetworkMonitoring.k8sCollector.telemetry.logs.level }}
-      - image: "{{ include "common.image" (tuple . .Values.ebpfNetworkMonitoring.k8sCollector.relay (tuple "image" "ebpf_k8s_relay") "otel/opentelemetry-ebpf-k8s-relay:v0.10.1") }}"
+      - image: "{{ include "common.image" (tuple . .Values.ebpfNetworkMonitoring.k8sCollector.relay (tuple "image" "ebpf_k8s_relay")) }}"
         imagePullPolicy: {{ .Values.ebpfNetworkMonitoring.k8sCollector.relay.image.pullPolicy }}
         name: k8s-relay
         args:

--- a/deploy/helm/templates/network/kernel-collector-daemonset.yaml
+++ b/deploy/helm/templates/network/kernel-collector-daemonset.yaml
@@ -55,7 +55,7 @@ spec:
       {{- end }}
       initContainers:
         - name: wait-for-reducer
-          image: "{{ include "common.image" (tuple . .Values.otel.init_images "busy_box" "busybox:1.36.1") }}"
+          image: "{{ include "common.image" (tuple . .Values.otel.init_images "busy_box") }}"
           imagePullPolicy: {{ .Values.otel.init_images.busy_box.pullPolicy }}
           command: ['sh', '-c', 'until nc -zv $EBPF_NET_INTAKE_HOST $EBPF_NET_INTAKE_PORT; do echo "Waiting for reducer endpoint..."; sleep 5; done;']
           env:
@@ -65,8 +65,8 @@ spec:
               value: "{{ .Values.ebpfNetworkMonitoring.reducer.telemetryPort }}"
       containers:
         - name: swi-kernel-collector
-          image: "{{ include "common.image" (tuple . .Values.ebpfNetworkMonitoring.kernelCollector (tuple "image" "ebpf_kernel_collector") "otel/opentelemetry-ebpf-kernel-collector:v0.10.1") }}"
-          imagePullPolicy: {{ .Values.ebpfNetworkMonitoring.kernelCollector.image.pullPolicy | default "IfNotPresent" }}
+          image: "{{ include "common.image" (tuple . .Values.ebpfNetworkMonitoring.kernelCollector (tuple "image" "ebpf_kernel_collector")) }}"
+          imagePullPolicy: {{ .Values.ebpfNetworkMonitoring.kernelCollector.image.pullPolicy }}
           args:
             - --config-file=/etc/network-explorer/config.yaml
             - --disable-nomad-metadata

--- a/deploy/helm/templates/network/reducer-deployment.yaml
+++ b/deploy/helm/templates/network/reducer-deployment.yaml
@@ -30,7 +30,7 @@ spec:
       {{- end }}
       initContainers:
         - name: wait-for-metrics-collector
-          image: "{{ include "common.image" (tuple . .Values.otel.init_images "busy_box" "busybox:1.36.1") }}"
+          image: "{{ include "common.image" (tuple . .Values.otel.init_images "busy_box") }}"
           imagePullPolicy: {{ .Values.otel.init_images.busy_box.pullPolicy }}
           command: ['sh', '-c', 'until nc -zv $METRICS_COLLECTOR_HOST $METRICS_COLLECTOR_PORT; do echo "Waiting for metrics collector endpoint..."; sleep 5; done;']
           env:
@@ -40,7 +40,7 @@ spec:
               value: "{{ .Values.otel.metrics.otlp_endpoint.port }}"
       containers:
         - name: reducer
-          image: "{{ include "common.image" (tuple . .Values.ebpfNetworkMonitoring.reducer (tuple "image" "ebpf_reducer") "otel/opentelemetry-ebpf-reducer:v0.10.1") }}"
+          image: "{{ include "common.image" (tuple . .Values.ebpfNetworkMonitoring.reducer (tuple "image" "ebpf_reducer")) }}"
           imagePullPolicy: {{ .Values.ebpfNetworkMonitoring.reducer.image.pullPolicy }}
           args:
             - --port={{ .Values.ebpfNetworkMonitoring.reducer.telemetryPort }}

--- a/deploy/helm/templates/swo-agent-statefulset.yaml
+++ b/deploy/helm/templates/swo-agent-statefulset.yaml
@@ -38,7 +38,7 @@ spec:
       {{- end }}
       containers:
         - name: swo-agent
-          image: "{{ include "common.image" (tuple . .Values.swoagent (tuple "image" "swoagent") "solarwinds/swo-agent:v2.6.28") }}"
+          image: "{{ include "common.image" (tuple . .Values.swoagent (tuple "image" "swoagent")) }}"
           imagePullPolicy: {{ .Values.swoagent.image.pullPolicy }}
           env:
             - name: UAMS_CLIENT_ID_OVERRIDE_SOURCE_NAME

--- a/deploy/helm/tests/__snapshot__/logs-fargate-config-map_test.yaml.snap
+++ b/deploy/helm/tests/__snapshot__/logs-fargate-config-map_test.yaml.snap
@@ -22,7 +22,7 @@ Fargate logging ConfigMap spec should include additional filters when they are c
           Match *
           Add sw.k8s.cluster.uid <CLUSTER_UID>
           Add sw.k8s.log.type container
-          Add sw.k8s.agent.manifest.version "3.3.0-alpha.3"
+          Add sw.k8s.agent.manifest.version "3.3.0-alpha.4"
     flb_log_cw: "false"
     output.conf: |
       [OUTPUT]
@@ -60,7 +60,7 @@ Fargate logging ConfigMap spec should match snapshot when Fargate logging is ena
           Match *
           Add sw.k8s.cluster.uid <CLUSTER_UID>
           Add sw.k8s.log.type container
-          Add sw.k8s.agent.manifest.version "3.3.0-alpha.3"
+          Add sw.k8s.agent.manifest.version "3.3.0-alpha.4"
     flb_log_cw: "false"
     output.conf: |
       [OUTPUT]

--- a/deploy/helm/values.schema.json
+++ b/deploy/helm/values.schema.json
@@ -1,0 +1,1112 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "type": "object",
+    "definitions": {
+        "collectorBatch": {
+            "description": "Batching configuration for OTEL collector. More info: https://github.com/open-telemetry/opentelemetry-collector/tree/main/processor/batchprocessor/README.md.",
+            "type": "object",
+            "properties": {
+                "send_batch_max_size": {
+                    "type": "integer"
+                },
+                "send_batch_size": {
+                    "type": "integer"
+                },
+                "timeout": {
+                    "type": "string"
+                }
+            }
+        },
+        "collectorK8sLabelsAnnotationsInstrumentation": {
+            "description": "Label and Annotation instrumentation configuration for OTEL collector.",
+            "type": "object",
+            "properties": {
+                "annotations": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean"
+                        },
+                        "excludePattern": {
+                            "type": "string"
+                        }
+                    },
+                    "additionalProperties": false
+                },
+                "labels": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean"
+                        },
+                        "excludePattern": {
+                            "type": "string"
+                        }
+                    },
+                    "additionalProperties": false
+                }
+            },
+            "additionalProperties": false
+        },
+        "collectorMemoryBallast": {
+            "description": "Memory ballast configuration for OTEL collector. More info: https://github.com/open-telemetry/opentelemetry-collector/tree/main/extension/ballastextension/README.md.",
+            "type": "object",
+            "properties": {
+                "size_mib": {
+                    "type": "integer"
+                }
+            }
+        },
+        "collectorMemoryLimiter": {
+            "description": "Memory limiter configuration for OTEL collector. More info: https://github.com/open-telemetry/opentelemetry-collector/tree/main/processor/memorylimiterprocessor/README.md.",
+            "type": "object",
+            "properties": {
+                "check_interval": {
+                    "type": "string"
+                },
+                "limit_mib": {
+                    "type": "integer"
+                },
+                "spike_limit_mib": {
+                    "type": "integer"
+                }
+            }
+        },
+        "collectorRetryOnFailure": {
+            "description": "Retry configuration for sending data to OTEL endpoint. More info: https://github.com/open-telemetry/opentelemetry-collector/blob/main/exporter/exporterhelper/README.md.",
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean"
+                },
+                "initial_interval": {
+                    "type": "string"
+                },
+                "max_elapsed_time": {
+                    "type": "string"
+                },
+                "max_interval": {
+                    "type": "string"
+                }
+            },
+            "additionalProperties": false
+        },
+        "collectorSendingQueue": {
+            "description": "Send configuration for sending data to OTEL endpoint. More info: https://github.com/open-telemetry/opentelemetry-collector/blob/main/exporter/exporterhelper/README.md.",
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean"
+                },
+                "num_consumers": {
+                    "type": "integer"
+                },
+                "queue_size": {
+                    "type": "integer"
+                }
+            }
+        },
+        "collectorTimeout": {
+            "description": "Timeout for each attempt to send data to OTEL endpoint. More info: https://github.com/open-telemetry/opentelemetry-collector/blob/main/exporter/exporterhelper/README.md.",
+            "type": "string"
+        },
+        "collectorTelemetry": {
+            "description": "Telemetry configuration for OTEL collector. More info: https://github.com/open-telemetry/opentelemetry.io/blob/main/content/en/docs/collector/configuration.md#telemetry.",
+            "type": "object",
+            "properties": {
+                "logs": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean"
+                        },
+                        "level": {
+                            "type": "string"
+                        }
+                    },
+                    "additionalProperties": false
+                },
+                "metrics": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean"
+                        },
+                        "address": {
+                            "type": "string"
+                        },
+                        "podMonitor": {
+                            "type": "object",
+                            "properties": {
+                                "enabled": {
+                                    "type": "boolean"
+                                },
+                                "additionalLabels": {
+                                    "$ref": "#/definitions/k8sLabels"
+                                },
+                                "interval": {
+                                    "type": "string"
+                                },
+                                "namespace": {
+                                    "type": [
+                                        "string",
+                                        "null"
+                                    ]
+                                },
+                                "scrapeTimeout": {
+                                    "type": "string"
+                                }
+                            },
+                            "additionalProperties": false
+                        }
+                    },
+                    "additionalProperties": false
+                }
+            },
+            "additionalProperties": false
+        },
+        "ebpfTelemetry": {
+            "description": "Telemetry configuration for opentelemetry-network.",
+            "type": "object",
+            "properties": {
+                "logs": {
+                    "type": "object",
+                    "properties": {
+                        "level": {
+                            "type": "string"
+                        }
+                    },
+                    "additionalProperties": false
+                }
+            }
+        },
+        "imageDefinition": {
+            "description": "Container image definition.",
+            "type": "object",
+            "properties": {
+                "repository": {
+                    "description": "Image repository. Example: `solarwinds/swi-opentelemetry-collector`, `docker.io/solarwinds/swi-opentelemetry-collector`, `docker.io/solarwinds/swi-opentelemetry-collector:0.9.2`.",
+                    "type": "string"
+                },
+                "tag": {
+                    "description": "Image tag. Example: `0.9.2` - use when the `repository` does not already include `tag`.",
+                    "type": "string"
+                },
+                "pullPolicy": {
+                    "$ref": "#/definitions/k8sImagePullPolicy"
+                }
+            },
+            "additionalProperties": false
+        },
+        "imageDigest": {
+            "description": "Image digest.",
+            "type": "string"
+        },
+        "imageRegistry": {
+            "description": "Image registry.",
+            "type": "string"
+        },
+        "imageRepository": {
+            "description": "Image repository.",
+            "type": "string"
+        },
+        "imageTag": {
+            "description": "Image tag.",
+            "type": "string"
+        },
+        "k8sAffinity": {
+            "description": "Scheduling affinity. More info: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#affinity-and-anti-affinity.",
+            "type": "object",
+            "properties": {
+                "nodeAffinity": {
+                    "type": "object"
+                },
+                "podAffinity": {
+                    "type": "object"
+                },
+                "podAntiAffinity": {
+                    "type": "object"
+                }
+            }
+        },
+        "k8sImagePullPolicy": {
+            "description": "Image pull policy. More info: https://kubernetes.io/docs/concepts/containers/images#updating-images.",
+            "type": [
+                "string",
+                "null"
+            ],
+            "enum": [
+                "Always",
+                "Never",
+                "IfNotPresent",
+                ""
+            ]
+        },
+        "k8sLabels": {
+            "description": "Kubernetes labels. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels",
+            "type": "object",
+            "additionalProperties": {
+                "type": "string"
+            }
+        },
+        "k8sNodeSelector": {
+            "description": "NodeSelector definition. More info: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector",
+            "$ref": "#/definitions/k8sLabels"
+        },
+        "k8sResourceRequirements": {
+            "description": "Container resource requirements. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/.",
+            "type": "object",
+            "properties": {
+                "limits": {
+                    "type": "object",
+                    "additionalProperties": {
+                        "type": [
+                            "string",
+                            "number"
+                        ]
+                    }
+                },
+                "requests": {
+                    "type": "object",
+                    "additionalProperties": {
+                        "type": [
+                            "string",
+                            "number"
+                        ]
+                    }
+                }
+            }
+        },
+        "k8sTerminationGracePeriod": {
+            "description": "Pod graceful termination period. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#pod-termination.",
+            "type": "integer"
+        },
+        "k8sTolerations": {
+            "description": "Pod tolerations. More info: https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/.",
+            "type": "array",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "effect": {
+                        "type": "string"
+                    },
+                    "key": {
+                        "type": "string"
+                    },
+                    "operator": {
+                        "type": "string"
+                    },
+                    "tolerationSeconds": {
+                        "type": "integer"
+                    },
+                    "value": {
+                        "type": "string"
+                    }
+                }
+            }
+        },
+        "port": {
+            "description": "Port number.",
+            "type": "integer"
+        },
+        "schedule": {
+            "description": "Schedule in Cron format. More info: https://en.wikipedia.org/wiki/Cron.",
+            "type": "string"
+        }
+    },
+    "properties": {
+        "autoupdate": {
+            "description": "If enabled it creates CronJob that will periodically check for new versions of the Helm chart and upgrade if available.",
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean"
+                },
+                "devel": {
+                    "type": "boolean"
+                },
+                "image": {
+                    "$ref": "#/definitions/imageDefinition"
+                },
+                "schedule": {
+                    "$ref": "#/definitions/schedule"
+                }
+            },
+            "additionalProperties": false
+        },
+        "aws_fargate": {
+            "description": "Enable support for AWS EKS Fargate environment.",
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean"
+                },
+                "logs": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean"
+                        },
+                        "filters": {
+                            "type": "string"
+                        },
+                        "region": {
+                            "type": [
+                                "string",
+                                "null"
+                            ]
+                        }
+                    },
+                    "additionalProperties": false
+                }
+            },
+            "if": {
+                "properties": {
+                    "enabled": {
+                        "const": true
+                    },
+                    "logs": {
+                        "properties": {
+                            "enabled": {
+                                "const": true
+                            }
+                        }
+                    }
+                }
+            },
+            "then": {
+                "properties": {
+                    "logs": {
+                        "properties": {
+                            "region": {
+                                "type": "string"
+                            }
+                        },
+                        "required": [
+                            "region"
+                        ]
+                    }
+                }
+            },
+            "additionalProperties": false
+        },
+        "cluster": {
+            "type": "object",
+            "description": "Cluster identification.",
+            "properties": {
+                "name": {
+                    "type": "string",
+                    "description": "The display name for the cluster entity in SolarWinds Observability."
+                },
+                "uid": {
+                    "type": "string",
+                    "description": "A unique ID that follows the following format: xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx."
+                }
+            },
+            "required": [
+                "name",
+                "uid"
+            ],
+            "additionalProperties": false
+        },
+        "ebpfNetworkMonitoring": {
+            "description": "If enabled, deploys opentelemetry-network monitoring to the cluster.",
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean"
+                },
+                "k8sCollector": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean"
+                        },
+                        "relay": {
+                            "type": "object",
+                            "properties": {
+                                "image": {
+                                    "$ref": "#/definitions/imageDefinition"
+                                }
+                            },
+                            "additionalProperties": false
+                        },
+                        "telemetry": {
+                            "$ref": "#/definitions/ebpfTelemetry"
+                        },
+                        "watcher": {
+                            "type": "object",
+                            "properties": {
+                                "image": {
+                                    "$ref": "#/definitions/imageDefinition"
+                                }
+                            },
+                            "additionalProperties": false
+                        }
+                    },
+                    "additionalProperties": false
+                },
+                "kernelCollector": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean"
+                        },
+                        "affinity": {
+                            "$ref": "#/definitions/k8sAffinity"
+                        },
+                        "image": {
+                            "$ref": "#/definitions/imageDefinition"
+                        },
+                        "nodeSelector": {
+                            "$ref": "#/definitions/k8sNodeSelector"
+                        },
+                        "resources": {
+                            "$ref": "#/definitions/k8sResourceRequirements"
+                        },
+                        "telemetry": {
+                            "$ref": "#/definitions/ebpfTelemetry"
+                        },
+                        "tolerations": {
+                            "$ref": "#/definitions/k8sTolerations"
+                        }
+                    },
+                    "additionalProperties": false
+                },
+                "reducer": {
+                    "type": "object",
+                    "properties": {
+                        "disableMetrics": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        },
+                        "enableIdIdGeneration": {
+                            "type": "boolean"
+                        },
+                        "enableMetrics": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        },
+                        "image": {
+                            "$ref": "#/definitions/imageDefinition"
+                        },
+                        "numAggregationShards": {
+                            "type": "integer"
+                        },
+                        "numIngestShards": {
+                            "type": "integer"
+                        },
+                        "numMatchingShards": {
+                            "type": "integer"
+                        },
+                        "telemetry": {
+                            "type": "object",
+                            "allOf": [
+                                {
+                                    "$ref": "#/definitions/ebpfTelemetry"
+                                },
+                                {
+                                    "properties": {
+                                        "metrics": {
+                                            "type": "object",
+                                            "properties": {
+                                                "enabled": {
+                                                    "type": "boolean"
+                                                }
+                                            },
+                                            "additionalProperties": false
+                                        }
+                                    }
+                                }
+                            ]
+                        },
+                        "telemetryPort": {
+                            "$ref": "#/definitions/port"
+                        }
+                    },
+                    "additionalProperties": false
+                }
+            },
+            "additionalProperties": false
+        },
+        "fullnameOverride": {
+            "type": "string"
+        },
+        "imagePullSecrets": {
+            "type": "array"
+        },
+        "kube-state-metrics": {
+            "description": "If enabled, deploys kube-state-metrics to the cluster.",
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean"
+                },
+                "image": {
+                    "type": "object",
+                    "registry": {
+                        "$ref": "#/definitions/imageRegistry"
+                    },
+                    "repository": {
+                        "$ref": "#/definitions/imageRepository"
+                    },
+                    "tag": {
+                        "$ref": "#/definitions/imageTag"
+                    },
+                    "pullPolicy": {
+                        "$ref": "#/definitions/k8sImagePullPolicy"
+                    },
+                    "sha": {
+                        "$ref": "#/definitions/imageDigest"
+                    }
+                }
+            }
+        },
+        "nameOverride": {
+            "type": "string"
+        },
+        "opencost": {
+            "description": "If enabled, deploys opencost to the cluster.",
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean"
+                },
+                "opencost": {
+                    "type": "object",
+                    "properties": {
+                        "exporter": {
+                            "type": "object",
+                            "properties": {
+                                "image": {
+                                    "type": "object",
+                                    "properties": {
+                                        "pullPolicy": {
+                                            "$ref": "#/definitions/k8sImagePullPolicy"
+                                        },
+                                        "registry": {
+                                            "$ref": "#/definitions/imageRegistry"
+                                        },
+                                        "repository": {
+                                            "$ref": "#/definitions/imageRepository"
+                                        },
+                                        "tag": {
+                                            "$ref": "#/definitions/imageTag"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "otel": {
+            "type": "object",
+            "properties": {
+                "api_token": {
+                    "type": "string"
+                },
+                "endpoint": {
+                    "type": "string"
+                },
+                "events": {
+                    "type": "object",
+                    "properties": {
+                        "affinity": {
+                            "$ref": "#/definitions/k8sAffinity"
+                        },
+                        "batch": {
+                            "$ref": "#/definitions/collectorBatch"
+                        },
+                        "enabled": {
+                            "type": "boolean"
+                        },
+                        "k8s_instrumentation": {
+                            "$ref": "#/definitions/collectorK8sLabelsAnnotationsInstrumentation"
+                        },
+                        "memory_ballast": {
+                            "$ref": "#/definitions/collectorMemoryBallast"
+                        },
+                        "memory_limiter": {
+                            "$ref": "#/definitions/collectorMemoryLimiter"
+                        },
+                        "nodeSelector": {
+                            "$ref": "#/definitions/k8sNodeSelector"
+                        },
+                        "resources": {
+                            "$ref": "#/definitions/k8sResourceRequirements"
+                        },
+                        "retry_on_failure": {
+                            "$ref": "#/definitions/collectorRetryOnFailure"
+                        },
+                        "sending_queue": {
+                            "allOf": [
+                                {
+                                    "$ref": "#/definitions/collectorSendingQueue"
+                                },
+                                {
+                                    "properties": {
+                                        "offload_to_disk": {
+                                            "type": "boolean"
+                                        }
+                                    }
+                                }
+                            ]
+                        },
+                        "telemetry": {
+                            "$ref": "#/definitions/collectorTelemetry"
+                        },
+                        "terminationGracePeriodSeconds": {
+                            "$ref": "#/definitions/k8sTerminationGracePeriod"
+                        },
+                        "timeout": {
+                            "$ref": "#/definitions/collectorTimeout"
+                        },
+                        "tolerations": {
+                            "$ref": "#/definitions/k8sTolerations"
+                        }
+                    },
+                    "additionalProperties": false
+                },
+                "https_proxy_url": {
+                    "type": "string"
+                },
+                "image": {
+                    "$ref": "#/definitions/imageDefinition"
+                },
+                "init_images": {
+                    "type": "object",
+                    "properties": {
+                        "busy_box": {
+                            "$ref": "#/definitions/imageDefinition"
+                        },
+                        "swi_endpoint_check": {
+                            "$ref": "#/definitions/imageDefinition"
+                        }
+                    },
+                    "additionalProperties": false
+                },
+                "logs": {
+                    "type": "object",
+                    "properties": {
+                        "affinity": {
+                            "$ref": "#/definitions/k8sAffinity"
+                        },
+                        "batch": {
+                            "$ref": "#/definitions/collectorBatch"
+                        },
+                        "container": {
+                            "type": "boolean"
+                        },
+                        "enabled": {
+                            "type": "boolean"
+                        },
+                        "filestorage": {
+                            "type": "object",
+                            "properties": {
+                                "directory": {
+                                    "type": "string"
+                                },
+                                "timeout": {
+                                    "type": "string"
+                                }
+                            }
+                        },
+                        "filter": {
+                            "type": "object"
+                        },
+                        "journal": {
+                            "type": "boolean"
+                        },
+                        "memory_ballast": {
+                            "$ref": "#/definitions/collectorMemoryBallast"
+                        },
+                        "memory_limiter": {
+                            "$ref": "#/definitions/collectorMemoryLimiter"
+                        },
+                        "nodeSelector": {
+                            "$ref": "#/definitions/k8sNodeSelector"
+                        },
+                        "receiver": {
+                            "type": "object",
+                            "properties": {
+                                "encoding": {
+                                    "type": "string"
+                                },
+                                "fingerprint_size": {
+                                    "type": "string"
+                                },
+                                "max_concurrent_files": {
+                                    "type": "integer"
+                                },
+                                "max_log_size": {
+                                    "type": "string"
+                                },
+                                "poll_interval": {
+                                    "type": "string"
+                                },
+                                "start_at": {
+                                    "type": "string"
+                                }
+                            },
+                            "additionalProperties": false
+                        },
+                        "resources": {
+                            "$ref": "#/definitions/k8sResourceRequirements"
+                        },
+                        "telemetry": {
+                            "$ref": "#/definitions/collectorTelemetry"
+                        },
+                        "tolerations": {
+                            "$ref": "#/definitions/k8sTolerations"
+                        }
+                    },
+                    "additionalProperties": false
+                },
+                "metrics": {
+                    "type": "object",
+                    "properties": {
+                        "affinity": {
+                            "$ref": "#/definitions/k8sAffinity"
+                        },
+                        "autodiscovery": {
+                            "type": "object",
+                            "properties": {
+                                "prometheusEndpoints": {
+                                    "type": "object",
+                                    "properties": {
+                                        "additionalRules": {
+                                            "type": "string"
+                                        },
+                                        "customTransformations": {
+                                            "type": "object",
+                                            "properties": {
+                                                "counterToRate": {
+                                                    "type": "array",
+                                                    "items": {
+                                                        "type": "string"
+                                                    }
+                                                }
+                                            },
+                                            "additionalProperties": false
+                                        },
+                                        "enabled": {
+                                            "type": "boolean"
+                                        },
+                                        "filter": {
+                                            "type": "object"
+                                        },
+                                        "podMonitors": {
+                                            "type": "object",
+                                            "properties": {
+                                                "rules": {
+                                                    "type": "array"
+                                                }
+                                            }
+                                        }
+                                    },
+                                    "additionalProperties": false
+                                }
+                            },
+                            "additionalProperties": false
+                        },
+                        "batch": {
+                            "$ref": "#/definitions/collectorBatch"
+                        },
+                        "enabled": {
+                            "type": "boolean"
+                        },
+                        "extra_scrape_metrics": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        },
+                        "filter": {
+                            "type": "object"
+                        },
+                        "force_extra_scrape_metrics": {
+                            "type": "boolean"
+                        },
+                        "k8s_instrumentation": {
+                            "$ref": "#/definitions/collectorK8sLabelsAnnotationsInstrumentation"
+                        },
+                        "kube-state-metrics": {
+                            "type": "object",
+                            "properties": {
+                                "scheme": {
+                                    "type": "string"
+                                },
+                                "scrape_interval": {
+                                    "type": "string"
+                                },
+                                "url": {
+                                    "type": "string"
+                                }
+                            },
+                            "additionalProperties": false
+                        },
+                        "livenessProbe": {
+                            "type": "object",
+                            "properties": {
+                                "initialDelaySeconds": {
+                                    "type": "integer"
+                                }
+                            },
+                            "additionalProperties": false
+                        },
+                        "memory_ballast": {
+                            "$ref": "#/definitions/collectorMemoryBallast"
+                        },
+                        "memory_limiter": {
+                            "$ref": "#/definitions/collectorMemoryLimiter"
+                        },
+                        "nodeSelector": {
+                            "$ref": "#/definitions/k8sNodeSelector"
+                        },
+                        "otlp_endpoint": {
+                            "type": "object",
+                            "properties": {
+                                "port": {
+                                    "$ref": "#/definitions/port"
+                                }
+                            },
+                            "additionalProperties": false
+                        },
+                        "prometheus": {
+                            "type": "object",
+                            "properties": {
+                                "scheme": {
+                                    "type": "string"
+                                },
+                                "scrape_interval": {
+                                    "type": "string"
+                                },
+                                "url": {
+                                    "type": "string"
+                                }
+                            },
+                            "additionalProperties": false
+                        },
+                        "prometheus_check": {
+                            "type": "boolean"
+                        },
+                        "readinessProbe": {
+                            "type": "object",
+                            "properties": {
+                                "initialDelaySeconds": {
+                                    "type": "integer"
+                                }
+                            },
+                            "additionalProperties": false
+                        },
+                        "resources": {
+                            "$ref": "#/definitions/k8sResourceRequirements"
+                        },
+                        "retry_on_failure": {
+                            "$ref": "#/definitions/collectorRetryOnFailure"
+                        },
+                        "sending_queue": {
+                            "allOf": [
+                                {
+                                    "$ref": "#/definitions/collectorSendingQueue"
+                                },
+                                {
+                                    "properties": {
+                                        "offload_to_disk": {
+                                            "type": "boolean"
+                                        }
+                                    }
+                                }
+                            ]
+                        },
+                        "swi_endpoint_check": {
+                            "type": "boolean"
+                        },
+                        "telemetry": {
+                            "$ref": "#/definitions/collectorTelemetry"
+                        },
+                        "terminationGracePeriodSeconds": {
+                            "$ref": "#/definitions/k8sTerminationGracePeriod"
+                        },
+                        "timeout": {
+                            "$ref": "#/definitions/collectorTimeout"
+                        },
+                        "tolerations": {
+                            "$ref": "#/definitions/k8sTolerations"
+                        }
+                    },
+                    "additionalProperties": false
+                },
+                "node_collector": {
+                    "type": "object",
+                    "properties": {
+                        "retry_on_failure": {
+                            "$ref": "#/definitions/collectorRetryOnFailure"
+                        },
+                        "sending_queue": {
+                            "allOf": [
+                                {
+                                    "$ref": "#/definitions/collectorSendingQueue"
+                                },
+                                {
+                                    "properties": {
+                                        "persistent_storage": {
+                                            "type": "object",
+                                            "properties": {
+                                                "directory": {
+                                                    "type": "string"
+                                                },
+                                                "enabled": {
+                                                    "type": "boolean"
+                                                }
+                                            },
+                                            "additionalProperties": false
+                                        }
+                                    }
+                                }
+                            ]
+                        },
+                        "terminationGracePeriodSeconds": {
+                            "$ref": "#/definitions/k8sTerminationGracePeriod"
+                        },
+                        "timeout": {
+                            "$ref": "#/definitions/collectorTimeout"
+                        }
+                    },
+                    "additionalProperties": false
+                },
+                "tls_insecure": {
+                    "type": "boolean"
+                },
+                "windows": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean"
+                        },
+                        "image": {
+                            "$ref": "#/definitions/imageDefinition"
+                        }
+                    },
+                    "additionalProperties": false
+                }
+            },
+            "required": [
+                "endpoint"
+            ],
+            "additionalProperties": false
+        },
+        "prometheus": {
+            "description": "Prometheus is deployed only in case `opencost` section is enabled. Otherwise this section can be ignored.",
+            "type": "object",
+            "properties": {
+                "configmapReload": {
+                    "type": "object",
+                    "properties": {
+                        "prometheus": {
+                            "type": "object",
+                            "properties": {
+                                "image": {
+                                    "type": "object",
+                                    "properties": {
+                                        "digest": {
+                                            "$ref": "#/definitions/imageDigest"
+                                        },
+                                        "pullPolicy": {
+                                            "$ref": "#/definitions/k8sImagePullPolicy"
+                                        },
+                                        "repository": {
+                                            "$ref": "#/definitions/imageRepository"
+                                        },
+                                        "tag": {
+                                            "$ref": "#/definitions/imageTag"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
+                "server": {
+                    "type": "object",
+                    "properties": {
+                        "image": {
+                            "type": "object",
+                            "properties": {
+                                "digest": {
+                                    "$ref": "#/definitions/imageDigest"
+                                },
+                                "pullPolicy": {
+                                    "$ref": "#/definitions/k8sImagePullPolicy"
+                                },
+                                "repository": {
+                                    "$ref": "#/definitions/imageRepository"
+                                },
+                                "tag": {
+                                    "$ref": "#/definitions/imageTag"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "prometheus-node-exporter": {
+            "description": "Node exporter is deployed only in case `opencost` section is enabled. Otherwise this section can be ignored.",
+            "type": "object",
+            "properties": {
+                "image": {
+                    "type": "object",
+                    "registry": {
+                        "$ref": "#/definitions/imageRegistry"
+                    },
+                    "repository": {
+                        "$ref": "#/definitions/imageRepository"
+                    },
+                    "tag": {
+                        "$ref": "#/definitions/imageTag"
+                    },
+                    "pullPolicy": {
+                        "$ref": "#/definitions/k8sImagePullPolicy"
+                    },
+                    "digest": {
+                        "$ref": "#/definitions/imageDigest"
+                    }
+                }
+            }
+        },
+        "swoagent": {
+            "description": "Whether the SWO Agent should be deployed as part of this chart. If not, SWO Integrations are not available.",
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean"
+                },
+                "image": {
+                    "$ref": "#/definitions/imageDefinition"
+                },
+                "resources": {
+                    "$ref": "#/definitions/k8sResourceRequirements"
+                }
+            },
+            "additionalProperties": false
+        },
+        "aks":{
+            "type":"boolean"
+        },
+        "global": {
+            "type": "object"
+        }
+    },
+    "required": [
+        "cluster",
+        "otel"
+    ],
+    "additionalProperties": false
+}

--- a/deploy/helm/values.schema.json
+++ b/deploy/helm/values.schema.json
@@ -1,5 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
+    "description": "Configuration validation schema for Helm chart swo-k8s-collector. For more information, see https://github.com/solarwinds/swi-k8s-opentelemetry-collector/blob/master/deploy/helm/values.yaml.",
     "type": "object",
     "definitions": {
         "collectorBatch": {
@@ -395,12 +396,12 @@
             "description": "Cluster identification.",
             "properties": {
                 "name": {
-                    "type": "string",
-                    "description": "The display name for the cluster entity in SolarWinds Observability."
+                    "description": "The display name for the cluster entity in SolarWinds Observability.",
+                    "type": "string"
                 },
                 "uid": {
-                    "type": "string",
-                    "description": "A unique ID that follows the following format: xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx."
+                    "description": "A unique ID that follows the following format: xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx.",
+                    "type": "string"
                 }
             },
             "required": [
@@ -408,6 +409,9 @@
                 "uid"
             ],
             "additionalProperties": false
+        },
+        "commonLabels": {
+            "$ref": "#/definitions/k8sLabels"
         },
         "ebpfNetworkMonitoring": {
             "description": "If enabled, deploys opentelemetry-network monitoring to the cluster.",
@@ -628,6 +632,9 @@
                         },
                         "k8s_instrumentation": {
                             "$ref": "#/definitions/collectorK8sLabelsAnnotationsInstrumentation"
+                        },
+                        "filter": {
+                            "type": "object"
                         },
                         "memory_ballast": {
                             "$ref": "#/definitions/collectorMemoryBallast"

--- a/deploy/helm/values.yaml
+++ b/deploy/helm/values.yaml
@@ -7,7 +7,7 @@ nameOverride: ""
 fullnameOverride: ""
 
 # array of pair "name: secret"
-imagePullSecrets:
+imagePullSecrets: []
 
 otel:
   # e.g. otel.collector.na-01.cloud.solarwinds.com:443
@@ -38,13 +38,13 @@ otel:
 
   init_images:
     swi_endpoint_check:
-      repository: ""
-      tag: ""
+      repository: "fullstorydev/grpcurl"
+      tag: "v1.8.9"
       pullPolicy: IfNotPresent
 
     busy_box:
-      repository: ""
-      tag: ""
+      repository: "busybox"
+      tag: "1.36.1"
       pullPolicy: IfNotPresent
 
   node_collector:
@@ -103,7 +103,7 @@ otel:
         #   `labels` - map of labels set on the pod
         #   `annotations` - map of annotations set on the pod
         # Example: namespace == "test-namespace" && labels["app"] == "test-app"
-        additionalRules:
+        additionalRules: ""
 
         podMonitors:
           rules: []
@@ -116,16 +116,16 @@ otel:
 
         customTransformations:
           # list of metrics that are counters should be converted to rate
-          counterToRate:
+          counterToRate: []
 
         # This filter is applied after metric processing, it is the place where metrics could be filtered out
         # https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/processor/filterprocessor for configuration reference
-        filter:
+        filter: {}
 
     # Check if SWI OTEL endpoint is reachable
     swi_endpoint_check: true
 
-    # Check if Prometheus endpoint is reachable
+    # Check if Prometheus endpoint (provided by otel.metrics.prometheus.url) is reachable
     prometheus_check: false
 
     sending_queue:
@@ -238,7 +238,7 @@ otel:
         # Provide a regular expression pattern to exclude specific labels from instrumentation.
         # Example: To exclude labels with 'internal' or 'private' in their names, use the following pattern:
         # excludePattern: ".*internal.*|.*private.*"
-        excludePattern:
+        excludePattern: ""
 
       annotations:
         # Set 'enabled' to true to instrument Kubernetes annotations.
@@ -247,7 +247,7 @@ otel:
         # Provide a regular expression pattern to exclude specific annotations from instrumentation.
         # Example: To exclude annotations with 'internal' or 'private' in their names, use the following pattern:
         # excludePattern: ".*internal.*|.*private.*"
-        excludePattern:
+        excludePattern: ""
 
     # Telemetry information of the collector
     # see https://github.com/open-telemetry/opentelemetry-collector/blob/main/docs/troubleshooting.md#observability for configuration reference
@@ -263,7 +263,7 @@ otel:
           enabled: false
 
           # Additional labels
-          additionalLabels:
+          additionalLabels: {}
           # key: value
 
           # Override namespace (default is the same as K8s collector)
@@ -367,7 +367,7 @@ otel:
           enabled: false
 
           # Additional labels
-          additionalLabels:
+          additionalLabels: {}
           # key: value
 
           # Override namespace (default is the same as K8s collector)
@@ -389,7 +389,7 @@ otel:
         # Provide a regular expression pattern to exclude specific labels from instrumentation.
         # Example: To exclude labels with 'internal' or 'private' in their names, use the following pattern:
         # excludePattern: ".*internal.*|.*private.*"
-        excludePattern:
+        excludePattern: ""
 
       annotations:
         # Set 'enabled' to true to instrument Kubernetes annotations.
@@ -398,13 +398,14 @@ otel:
         # Provide a regular expression pattern to exclude specific annotations from instrumentation.
         # Example: To exclude annotations with 'internal' or 'private' in their names, use the following pattern:
         # excludePattern: ".*internal.*|.*private.*"
-        excludePattern:
+        excludePattern: ""
 
     # Scheduling configurations
     # By default: set to run on linux amd64 nodes
     nodeSelector: {}
     tolerations: []
     affinity: {}
+
     terminationGracePeriodSeconds: 600
 
   # Configuration for Logs collection
@@ -470,7 +471,7 @@ otel:
           enabled: false
 
           # Additional labels
-          additionalLabels:
+          additionalLabels: {}
           # key: value
 
           # Override namespace (default is the same as K8s collector)
@@ -540,8 +541,8 @@ autoupdate:
   devel: false
 
   image:
-    repository: ""
-    tag: ""
+    repository: "alpine/k8s"
+    tag: "1.27.8"
     pullPolicy: IfNotPresent
 
 # Set labels to every deployed resource
@@ -591,7 +592,7 @@ swoagent:
   enabled: false
   image:
     repository: solarwinds/swo-agent
-    tag: ""
+    tag: "v2.6.28"
     pullPolicy: IfNotPresent
   resources:
     limits:
@@ -615,7 +616,7 @@ aws_fargate:
     # Include additional FluentBit filters
     # see https://docs.fluentbit.io/manual/pipeline/filters
     # NOTE: The FluentBit configuration expects four spaces as indentation within sections
-    filters:
+    filters: ""
 
 ebpfNetworkMonitoring:
   enabled: false
@@ -627,8 +628,8 @@ ebpfNetworkMonitoring:
         level: "warning"
 
     image:
-      repository: ""
-      tag: ""
+      repository: "otel/opentelemetry-ebpf-kernel-collector"
+      tag: "v0.10.1"
       pullPolicy: IfNotPresent
 
     resources:
@@ -651,14 +652,14 @@ ebpfNetworkMonitoring:
 
     watcher:
       image:
-        repository: ""
-        tag: ""
+        repository: "otel/opentelemetry-ebpf-k8s-watcher"
+        tag: "v0.10.1"
         pullPolicy: IfNotPresent
 
     relay:
       image:
-        repository: ""
-        tag: ""
+        repository: "otel/opentelemetry-ebpf-k8s-relay"
+        tag: "v0.10.1"
         pullPolicy: IfNotPresent
   reducer:
     disableMetrics: []
@@ -685,8 +686,8 @@ ebpfNetworkMonitoring:
         enabled: false
 
     image:
-      repository: ""
-      tag: ""
+      repository: "otel/opentelemetry-ebpf-reducer"
+      tag: "v0.10.1"
       pullPolicy: IfNotPresent
 
 # Prometheus is deployed only in case opencost section is enabled. Otherwise this section can be ignored.

--- a/doc/development.md
+++ b/doc/development.md
@@ -8,6 +8,7 @@
 - [Develop against remote prometheus](#develop-against-remote-prometheus)
 - [Integration tests](#integration-tests)
 - [Updating Chart dependencies](#updating-chart-dependencies)
+- [Updating Chart configuration](#updating-chart-configuration)
 - [Publishing](#publishing)
 
 ## Contribution Guidelines
@@ -198,6 +199,24 @@ To update a dependency of the Helm chart:
 
 3. Commit changes in [deploy/helm/Chart.lock](../deploy/helm/Chart.lock).
 4. *(Optional)* Delete `*.tgz` files in `/deploy/helm/charts/` - they will be re-downloaded automatically as needed.
+
+## Updating Chart configuration
+
+First and foremost, any changes to the default `values.yaml` or how the configuration required by the Helm templates must be backwards compatible. Breaking existing configurations prepared for previous versions of the software should be avoided, if possible.
+
+The Helm chart contains a JSON schema for the validation of the provided configuration [values.schema.json](../deploy/helm/values.schema.json).
+
+To use it during development, reference it by your YAML parser. For example, for software that supports the language server protocol, add `# yaml-language-server: $schema=values.schema.json` as a first line in your `values.yaml` file, adjusting the path (local, or URL) accordingly.
+
+To verify that the changes are compatible with the current schema, it's suggested to run also:
+
+```shell
+helm lint -f <values_yaml_for_testing> .\deploy\helm\ --with-subcharts
+```
+
+Basic linting is part of the build pipeline, though.
+
+The Helm chart is bundled also in AKS/EKS addons. Make sure that any changes are reflected there, too.
 
 ## Publishing
 


### PR DESCRIPTION
The Helm chart now contains `values.schema.json`, which is used to validate user-provided configuration during installation/upgrade.

Summary of changes:
* Added schema to `deploy/helm/values.schema.json`.
  * Subchart sections are included, but only to the extend that we want customers to configure. E.g. container images used in them.
  * Schemas for k8s objects are included directly in the schema. Unfortunately, there is no official JSON schema that could be referenced, instead.
  * The schema checks for typos and unexpected settings/sections. :warning: This means that if there are invalid settings in the `values.yaml` provided by customers, the validation will fail with an error.
    For example, if there is a setting `something_unexpected: "whatever"` in the file, this will be the error:
    ```
    Error: INSTALLATION FAILED: values don't meet the specifications of the schema(s) in the following chart(s):
    swo-k8s-collector:
    - (root): Additional property something_unexpected is not allowed
    ```
* Adjusted the default `deploy/helm/values.yaml` to be compatible with the schema.
  * This affects only the default configuration for empty (not configured) settings. E.g. `additionalLabels:` -> `additionalLabels: {}`.
  * If users have `values.yaml` files with those settings explicitly mentioned but uninitialized, automatic merging of their settings with the default ones will ensure, that their `values.yaml` files will still pass the validation.
* Moved default values for referenced containers from templates to the `values.yaml`. It's more in line with where default values should be specified. It's also useful for documenting how to change all these images, if needed.