### PR TITLE
Disable Docker image attestations

### DIFF
--- a/.github/workflows/buildAndDeploy.yml
+++ b/.github/workflows/buildAndDeploy.yml
@@ -319,6 +319,8 @@ jobs:
           context: .
           file: build/docker/Dockerfile
           platforms: linux/amd64,linux/arm64
+          provenance: false
+          sbom: false
           push: true
           tags: ${{ env.DOCKERHUB_IMAGE }}:${{ steps.vars.outputs.tag }}
 


### PR DESCRIPTION
It's a workaround for AWS security scanner, which cannot handle images with such data