### PR TITLE
Reconfiguring dependabot to do only security updates in go.mod

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -25,14 +25,15 @@ updates:
       - go
       - Skip Changelog
     schedule:
-      interval: weekly
-      day: sunday
+      interval: "daily"
     allow:
       # Allow both direct and indirect updates for all packages
       - dependency-type: "all"
     ignore:
       - dependency-name: "github.com/open-telemetry/opentelemetry-collector-contrib*"
       - dependency-name: "go.opentelemetry.io/collector*"
+    # Disable version updates
+    open-pull-requests-limit: 0
     groups:
       minor-and-patch:
         applies-to: security-updates
@@ -41,27 +42,3 @@ updates:
         update-types:
         - "patch"
         - "minor"
-  - package-ecosystem: gomod
-    directory: /src/processor/k8sattributesprocessor
-    labels:
-      - dependencies
-      - go
-      - Skip Changelog
-    schedule:
-      interval: weekly
-      day: sunday
-    ignore:
-      - dependency-name: "github.com/open-telemetry/opentelemetry-collector-contrib*"
-      - dependency-name: "go.opentelemetry.io/collector*"
-  - package-ecosystem: gomod
-    directory: /src/processor/swmetricstransformprocessor
-    labels:
-      - dependencies
-      - go
-      - Skip Changelog
-    schedule:
-      interval: weekly
-      day: sunday
-    ignore:
-      - dependency-name: "github.com/open-telemetry/opentelemetry-collector-contrib*"
-      - dependency-name: "go.opentelemetry.io/collector*"


### PR DESCRIPTION
This is what is written in [doc](https://docs.github.com/en/code-security/dependabot/dependabot-security-updates/configuring-dependabot-security-updates#overriding-the-default-behavior-with-a-configuration-file):
> If you only require security updates and want to exclude version updates, you can set open-pull-requests-limit to 0 in order to prevent version updates for a given package-ecosystem.

Changes in this PR:
* Removing updates of go.mod in custom processors (as it cannot be done without update of main go.mod anyway)
* Disabling version updates of main go.mod
* Scheduled to run daily