### PR TITLE
Allow filtering by resource attributes

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ otel:
     filter:
       include:
         match_type: regexp
-        record_attributes:
+        resource_attributes:
           - key: k8s.namespace.name
             value: ^.*$
 ```

--- a/deploy/helm/CHANGELOG.md
+++ b/deploy/helm/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## [3.4.0-alpha.2] - 2024-05-16
+
+### Changed
+
+- Changed the `otel.metrics.filter`, `otel.logs.filter` and `otel.events.filter` settings to be able to access resource attributes like `k8s.deployment.name`, ...
+  - This is a breaking change if anyone was using them before to include only metrics/logs/events with a specific non-resource attribute.
+
 ## [3.4.0-alpha.1] - 2024-05-09
 
 ### Fixed

--- a/deploy/helm/Chart.yaml
+++ b/deploy/helm/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: swo-k8s-collector
-version: 3.4.0-alpha.1
+version: 3.4.0-alpha.2
 appVersion: "0.10.0"
 description: SolarWinds Kubernetes Integration
 keywords:

--- a/deploy/helm/events-collector-config.yaml
+++ b/deploy/helm/events-collector-config.yaml
@@ -145,9 +145,6 @@ service:
         - otlp
       processors:
         - memory_limiter
-{{- if .Values.otel.events.filter }}
-        - filter
-{{- end}}
         - transform/severity
         - transform/namespace
         - transform/entity_attributes
@@ -160,6 +157,9 @@ service:
         - resource/k8sattributes_annotations_filter
 {{- end }}
         - transform/cleanup_attributes_for_nonexisting_entities
+{{- if .Values.otel.events.filter }}
+        - filter
+{{- end}}
         - batch
       receivers:
         - k8s_events

--- a/deploy/helm/metrics-collector-config.yaml
+++ b/deploy/helm/metrics-collector-config.yaml
@@ -1274,9 +1274,6 @@ service:
         - groupbyattrs/pod
         - metricstransform/aggregate_pod_level
         - groupbyattrs/all
-{{- if .Values.otel.metrics.filter }}
-        - filter
-{{- end }}
         - resource/metrics
         - k8sattributes
 {{- if not (empty .Values.otel.metrics.k8s_instrumentation.labels.excludePattern) }}
@@ -1286,6 +1283,9 @@ service:
         - resource/k8sattributes_annotations_filter
 {{- end }}
         - transform/cleanup_attributes_for_nonexisting_entities
+{{- if .Values.otel.metrics.filter }}
+        - filter
+{{- end }}
       receivers:
         - forward/prometheus
     metrics:

--- a/deploy/helm/node-collector-config.yaml
+++ b/deploy/helm/node-collector-config.yaml
@@ -620,9 +620,6 @@ service:
         - forward/logs-exporter
       processors:
         - memory_limiter
-{{- if .Values.otel.logs.filter }}
-        - filter/logs
-{{- end }}
         - transform/syslogify
         - groupbyattrs/common-all
         - resource/container
@@ -653,6 +650,9 @@ service:
         - otlp
       processors:
         - memory_limiter
+{{- if .Values.otel.logs.filter }}
+        - filter/logs
+{{- end }}
         - batch/logs
       receivers:
         - forward/logs-exporter
@@ -678,9 +678,6 @@ service:
         - deltatorate/discovery
 {{- end }}
         - groupbyattrs/common-all
-{{- if .Values.otel.metrics.filter }}
-        - filter/metrics
-{{- end }}
         - resource/all
       receivers:
         - receiver_creator/discovery
@@ -705,9 +702,6 @@ service:
         - groupbyattrs/node
         - groupbyattrs/pod
         - groupbyattrs/all
-{{- if .Values.otel.metrics.filter }}
-        - filter/metrics
-{{- end }}
         - resource/metrics
         - resource/all
       receivers:
@@ -726,6 +720,9 @@ service:
 {{- end }}
 {{- if not (empty .Values.otel.metrics.k8s_instrumentation.annotations.excludePattern) }}
         - resource/k8sattributes_annotations_filter
+{{- end }}
+{{- if .Values.otel.metrics.filter }}
+        - filter/metrics
 {{- end }}
         - batch/metrics
       receivers:

--- a/deploy/helm/tests/__snapshot__/logs-fargate-config-map_test.yaml.snap
+++ b/deploy/helm/tests/__snapshot__/logs-fargate-config-map_test.yaml.snap
@@ -22,7 +22,7 @@ Fargate logging ConfigMap spec should include additional filters when they are c
           Match *
           Add sw.k8s.cluster.uid <CLUSTER_UID>
           Add sw.k8s.log.type container
-          Add sw.k8s.agent.manifest.version "3.4.0-alpha.1"
+          Add sw.k8s.agent.manifest.version "3.4.0-alpha.2"
     flb_log_cw: "false"
     output.conf: |
       [OUTPUT]
@@ -60,7 +60,7 @@ Fargate logging ConfigMap spec should match snapshot when Fargate logging is ena
           Match *
           Add sw.k8s.cluster.uid <CLUSTER_UID>
           Add sw.k8s.log.type container
-          Add sw.k8s.agent.manifest.version "3.4.0-alpha.1"
+          Add sw.k8s.agent.manifest.version "3.4.0-alpha.2"
     flb_log_cw: "false"
     output.conf: |
       [OUTPUT]

--- a/deploy/helm/tests/__snapshot__/metrics-collector-config-map-fargate_test.yaml.snap
+++ b/deploy/helm/tests/__snapshot__/metrics-collector-config-map-fargate_test.yaml.snap
@@ -2273,10 +2273,10 @@ Metrics config should match snapshot when using default values:
             - groupbyattrs/pod
             - metricstransform/aggregate_pod_level
             - groupbyattrs/all
-            - filter
             - resource/metrics
             - k8sattributes
             - transform/cleanup_attributes_for_nonexisting_entities
+            - filter
             receivers:
             - forward/prometheus
           metrics/prometheus-node-metrics:

--- a/deploy/helm/tests/__snapshot__/metrics-collector-config-map_test.yaml.snap
+++ b/deploy/helm/tests/__snapshot__/metrics-collector-config-map_test.yaml.snap
@@ -2273,10 +2273,10 @@ Metrics config should match snapshot when fargate is enabled:
             - groupbyattrs/pod
             - metricstransform/aggregate_pod_level
             - groupbyattrs/all
-            - filter
             - resource/metrics
             - k8sattributes
             - transform/cleanup_attributes_for_nonexisting_entities
+            - filter
             receivers:
             - forward/prometheus
           metrics/prometheus-node-metrics:
@@ -4543,10 +4543,10 @@ Metrics config should match snapshot when using Prometheus url with extra_scrape
             - groupbyattrs/pod
             - metricstransform/aggregate_pod_level
             - groupbyattrs/all
-            - filter
             - resource/metrics
             - k8sattributes
             - transform/cleanup_attributes_for_nonexisting_entities
+            - filter
             receivers:
             - forward/prometheus
           metrics/prometheus-node-metrics:
@@ -6805,10 +6805,10 @@ Metrics config should match snapshot when using default values:
             - groupbyattrs/pod
             - metricstransform/aggregate_pod_level
             - groupbyattrs/all
-            - filter
             - resource/metrics
             - k8sattributes
             - transform/cleanup_attributes_for_nonexisting_entities
+            - filter
             receivers:
             - forward/prometheus
           metrics/prometheus-node-metrics:

--- a/deploy/helm/tests/__snapshot__/node-collector-config-map-windows_test.yaml.snap
+++ b/deploy/helm/tests/__snapshot__/node-collector-config-map-windows_test.yaml.snap
@@ -168,7 +168,7 @@ Node collector config for windows nodes should match snapshot when using default
           logs:
             include:
               match_type: regexp
-              record_attributes:
+              resource_attributes:
               - key: k8s.namespace.name
                 value: ^kube-.*$
         filter/metrics:
@@ -1099,6 +1099,7 @@ Node collector config for windows nodes should match snapshot when using default
             - otlp
             processors:
             - memory_limiter
+            - filter/logs
             - batch/logs
             receivers:
             - forward/logs-exporter
@@ -1107,7 +1108,6 @@ Node collector config for windows nodes should match snapshot when using default
             - forward/logs-exporter
             processors:
             - memory_limiter
-            - filter/logs
             - transform/syslogify
             - groupbyattrs/common-all
             - resource/container
@@ -1123,6 +1123,7 @@ Node collector config for windows nodes should match snapshot when using default
             - memory_limiter
             - filter/histograms
             - k8sattributes
+            - filter/metrics
             - batch/metrics
             receivers:
             - forward/metric-exporter
@@ -1138,7 +1139,6 @@ Node collector config for windows nodes should match snapshot when using default
             - deltatorate/istio-metrics
             - experimental_metricsgeneration/istio-metrics
             - groupbyattrs/common-all
-            - filter/metrics
             - resource/all
             receivers:
             - receiver_creator/discovery
@@ -1161,7 +1161,6 @@ Node collector config for windows nodes should match snapshot when using default
             - groupbyattrs/node
             - groupbyattrs/pod
             - groupbyattrs/all
-            - filter/metrics
             - resource/metrics
             - resource/all
             receivers:

--- a/deploy/helm/tests/__snapshot__/node-collector-config-map_test.yaml.snap
+++ b/deploy/helm/tests/__snapshot__/node-collector-config-map_test.yaml.snap
@@ -168,7 +168,7 @@ Node collector config should match snapshot when autodiscovery is disabled:
           logs:
             include:
               match_type: regexp
-              record_attributes:
+              resource_attributes:
               - key: k8s.namespace.name
                 value: ^kube-.*$
         filter/metrics:
@@ -1106,6 +1106,7 @@ Node collector config should match snapshot when autodiscovery is disabled:
             - otlp
             processors:
             - memory_limiter
+            - filter/logs
             - batch/logs
             receivers:
             - forward/logs-exporter
@@ -1114,7 +1115,6 @@ Node collector config should match snapshot when autodiscovery is disabled:
             - forward/logs-exporter
             processors:
             - memory_limiter
-            - filter/logs
             - transform/syslogify
             - groupbyattrs/common-all
             - resource/container
@@ -1139,6 +1139,7 @@ Node collector config should match snapshot when autodiscovery is disabled:
             - memory_limiter
             - filter/histograms
             - k8sattributes
+            - filter/metrics
             - batch/metrics
             receivers:
             - forward/metric-exporter
@@ -1161,7 +1162,6 @@ Node collector config should match snapshot when autodiscovery is disabled:
             - groupbyattrs/node
             - groupbyattrs/pod
             - groupbyattrs/all
-            - filter/metrics
             - resource/metrics
             - resource/all
             receivers:
@@ -1341,7 +1341,7 @@ Node collector config should match snapshot when fargate is enabled:
           logs:
             include:
               match_type: regexp
-              record_attributes:
+              resource_attributes:
               - key: k8s.namespace.name
                 value: ^kube-.*$
         filter/metrics:
@@ -2262,6 +2262,7 @@ Node collector config should match snapshot when fargate is enabled:
             - otlp
             processors:
             - memory_limiter
+            - filter/logs
             - batch/logs
             receivers:
             - forward/logs-exporter
@@ -2270,7 +2271,6 @@ Node collector config should match snapshot when fargate is enabled:
             - forward/logs-exporter
             processors:
             - memory_limiter
-            - filter/logs
             - transform/syslogify
             - groupbyattrs/common-all
             - resource/container
@@ -2295,6 +2295,7 @@ Node collector config should match snapshot when fargate is enabled:
             - memory_limiter
             - filter/histograms
             - k8sattributes
+            - filter/metrics
             - batch/metrics
             receivers:
             - forward/metric-exporter
@@ -2310,7 +2311,6 @@ Node collector config should match snapshot when fargate is enabled:
             - deltatorate/istio-metrics
             - experimental_metricsgeneration/istio-metrics
             - groupbyattrs/common-all
-            - filter/metrics
             - resource/all
             receivers:
             - receiver_creator/discovery
@@ -2483,7 +2483,7 @@ Node collector config should match snapshot when fargate is enabled and autodisc
           logs:
             include:
               match_type: regexp
-              record_attributes:
+              resource_attributes:
               - key: k8s.namespace.name
                 value: ^kube-.*$
         filter/metrics:
@@ -3383,6 +3383,7 @@ Node collector config should match snapshot when fargate is enabled and autodisc
             - otlp
             processors:
             - memory_limiter
+            - filter/logs
             - batch/logs
             receivers:
             - forward/logs-exporter
@@ -3391,7 +3392,6 @@ Node collector config should match snapshot when fargate is enabled and autodisc
             - forward/logs-exporter
             processors:
             - memory_limiter
-            - filter/logs
             - transform/syslogify
             - groupbyattrs/common-all
             - resource/container
@@ -3587,7 +3587,7 @@ Node collector config should match snapshot when using default values:
           logs:
             include:
               match_type: regexp
-              record_attributes:
+              resource_attributes:
               - key: k8s.namespace.name
                 value: ^kube-.*$
         filter/metrics:
@@ -4545,6 +4545,7 @@ Node collector config should match snapshot when using default values:
             - otlp
             processors:
             - memory_limiter
+            - filter/logs
             - batch/logs
             receivers:
             - forward/logs-exporter
@@ -4553,7 +4554,6 @@ Node collector config should match snapshot when using default values:
             - forward/logs-exporter
             processors:
             - memory_limiter
-            - filter/logs
             - transform/syslogify
             - groupbyattrs/common-all
             - resource/container
@@ -4578,6 +4578,7 @@ Node collector config should match snapshot when using default values:
             - memory_limiter
             - filter/histograms
             - k8sattributes
+            - filter/metrics
             - batch/metrics
             receivers:
             - forward/metric-exporter
@@ -4593,7 +4594,6 @@ Node collector config should match snapshot when using default values:
             - deltatorate/istio-metrics
             - experimental_metricsgeneration/istio-metrics
             - groupbyattrs/common-all
-            - filter/metrics
             - resource/all
             receivers:
             - receiver_creator/discovery
@@ -4616,7 +4616,6 @@ Node collector config should match snapshot when using default values:
             - groupbyattrs/node
             - groupbyattrs/pod
             - groupbyattrs/all
-            - filter/metrics
             - resource/metrics
             - resource/all
             receivers:

--- a/deploy/helm/values.yaml
+++ b/deploy/helm/values.yaml
@@ -445,7 +445,7 @@ otel:
         match_type: regexp
         # a log has to match all expressions in the list to be included
         # see https://github.com/google/re2/wiki/Syntax for regexp syntax
-        record_attributes:
+        resource_attributes:
           # allow only system namespaces (kube-system, kube-public)
           - key: k8s.namespace.name
             value: ^kube-.*$

--- a/skaffold.yaml
+++ b/skaffold.yaml
@@ -89,12 +89,12 @@ deploy:
             logs:
               filter:
                 include:
-                  record_attributes:
+                  resource_attributes:
                     - key: k8s.namespace.name
                       value: "^.*$"
                 exclude:
                   match_type: strict
-                  record_attributes:
+                  resource_attributes:
                     - key: k8s.namespace.name
                       value: "test-namespace"
         upgradeOnChange: true


### PR DESCRIPTION
Change the `otel.metrics.filter`, `otel.logs.filter` and `otel.events.filter` settings to be able to access resource attributes.

There are several useful resource attributes like `k8s.deployment.name`, ... that are added to metrics/logs/events during the processing pipeline. And the filter was applied before these attributes were added to the data.

⚠️ This is a breaking change for logs and events.
Event filtering is probably not used by anyone, anyway. But log filtering is - customers tend to adjust it to include all logs, not just the default subset. We could special case that common scenario in a future PR and make such configuration compatible with the changes in this PR. But I don't see how to resolve this automatically for any custom configuration.
The issue is with filters that `include` `record_attributes`. Most of them are moved into the resource attributes by the time k8s attributes are added to the records. `exclude` attributes could be handled automatically.

Example configuration to exclude all information about a specific Deployment, but include all other metrics/events/logs:
```yaml
otel:
  metrics:
    filter:
      exclude:
        resource_attributes:
          - key: k8s.deployment.name
            value: ^some_deployment$
  events:
    filter:
      exclude:
        match_type: regexp
        resource_attributes:
          - key: k8s.deployment.name
            value: ^some_deployment$
  logs:
    journal: false
    filter:
      exclude:
        match_type: regexp
        resource_attributes:
          - key: k8s.deployment.name
            value: ^some_deployment$
      include:
        match_type: regexp
        resource_attributes:
          - key: k8s.namespace.name
            value: ^.*$
```