### PR TITLE
Revert "Allow filtering by resource attributes"

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ otel:
     filter:
       include:
         match_type: regexp
-        resource_attributes:
+        record_attributes:
           - key: k8s.namespace.name
             value: ^.*$
 ```

--- a/deploy/helm/CHANGELOG.md
+++ b/deploy/helm/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Changed
+
+- Reverted changes from 3.4.0-alpha.2
+
 ## [3.4.0-alpha.2] - 2024-05-16
 
 ### Changed

--- a/deploy/helm/events-collector-config.yaml
+++ b/deploy/helm/events-collector-config.yaml
@@ -145,6 +145,9 @@ service:
         - otlp
       processors:
         - memory_limiter
+{{- if .Values.otel.events.filter }}
+        - filter
+{{- end}}
         - transform/severity
         - transform/namespace
         - transform/entity_attributes
@@ -157,9 +160,6 @@ service:
         - resource/k8sattributes_annotations_filter
 {{- end }}
         - transform/cleanup_attributes_for_nonexisting_entities
-{{- if .Values.otel.events.filter }}
-        - filter
-{{- end}}
         - batch
       receivers:
         - k8s_events

--- a/deploy/helm/metrics-collector-config.yaml
+++ b/deploy/helm/metrics-collector-config.yaml
@@ -1274,6 +1274,9 @@ service:
         - groupbyattrs/pod
         - metricstransform/aggregate_pod_level
         - groupbyattrs/all
+{{- if .Values.otel.metrics.filter }}
+        - filter
+{{- end }}
         - resource/metrics
         - k8sattributes
 {{- if not (empty .Values.otel.metrics.k8s_instrumentation.labels.excludePattern) }}
@@ -1283,9 +1286,6 @@ service:
         - resource/k8sattributes_annotations_filter
 {{- end }}
         - transform/cleanup_attributes_for_nonexisting_entities
-{{- if .Values.otel.metrics.filter }}
-        - filter
-{{- end }}
       receivers:
         - forward/prometheus
     metrics:

--- a/deploy/helm/node-collector-config.yaml
+++ b/deploy/helm/node-collector-config.yaml
@@ -620,6 +620,9 @@ service:
         - forward/logs-exporter
       processors:
         - memory_limiter
+{{- if .Values.otel.logs.filter }}
+        - filter/logs
+{{- end }}
         - transform/syslogify
         - groupbyattrs/common-all
         - resource/container
@@ -650,9 +653,6 @@ service:
         - otlp
       processors:
         - memory_limiter
-{{- if .Values.otel.logs.filter }}
-        - filter/logs
-{{- end }}
         - batch/logs
       receivers:
         - forward/logs-exporter
@@ -678,6 +678,9 @@ service:
         - deltatorate/discovery
 {{- end }}
         - groupbyattrs/common-all
+{{- if .Values.otel.metrics.filter }}
+        - filter/metrics
+{{- end }}
         - resource/all
       receivers:
         - receiver_creator/discovery
@@ -702,6 +705,9 @@ service:
         - groupbyattrs/node
         - groupbyattrs/pod
         - groupbyattrs/all
+{{- if .Values.otel.metrics.filter }}
+        - filter/metrics
+{{- end }}
         - resource/metrics
         - resource/all
       receivers:
@@ -720,9 +726,6 @@ service:
 {{- end }}
 {{- if not (empty .Values.otel.metrics.k8s_instrumentation.annotations.excludePattern) }}
         - resource/k8sattributes_annotations_filter
-{{- end }}
-{{- if .Values.otel.metrics.filter }}
-        - filter/metrics
 {{- end }}
         - batch/metrics
       receivers:

--- a/deploy/helm/tests/__snapshot__/metrics-collector-config-map-fargate_test.yaml.snap
+++ b/deploy/helm/tests/__snapshot__/metrics-collector-config-map-fargate_test.yaml.snap
@@ -2273,10 +2273,10 @@ Metrics config should match snapshot when using default values:
             - groupbyattrs/pod
             - metricstransform/aggregate_pod_level
             - groupbyattrs/all
+            - filter
             - resource/metrics
             - k8sattributes
             - transform/cleanup_attributes_for_nonexisting_entities
-            - filter
             receivers:
             - forward/prometheus
           metrics/prometheus-node-metrics:

--- a/deploy/helm/tests/__snapshot__/metrics-collector-config-map_test.yaml.snap
+++ b/deploy/helm/tests/__snapshot__/metrics-collector-config-map_test.yaml.snap
@@ -2273,10 +2273,10 @@ Metrics config should match snapshot when fargate is enabled:
             - groupbyattrs/pod
             - metricstransform/aggregate_pod_level
             - groupbyattrs/all
+            - filter
             - resource/metrics
             - k8sattributes
             - transform/cleanup_attributes_for_nonexisting_entities
-            - filter
             receivers:
             - forward/prometheus
           metrics/prometheus-node-metrics:
@@ -4543,10 +4543,10 @@ Metrics config should match snapshot when using Prometheus url with extra_scrape
             - groupbyattrs/pod
             - metricstransform/aggregate_pod_level
             - groupbyattrs/all
+            - filter
             - resource/metrics
             - k8sattributes
             - transform/cleanup_attributes_for_nonexisting_entities
-            - filter
             receivers:
             - forward/prometheus
           metrics/prometheus-node-metrics:
@@ -6805,10 +6805,10 @@ Metrics config should match snapshot when using default values:
             - groupbyattrs/pod
             - metricstransform/aggregate_pod_level
             - groupbyattrs/all
+            - filter
             - resource/metrics
             - k8sattributes
             - transform/cleanup_attributes_for_nonexisting_entities
-            - filter
             receivers:
             - forward/prometheus
           metrics/prometheus-node-metrics:

--- a/deploy/helm/tests/__snapshot__/node-collector-config-map-windows_test.yaml.snap
+++ b/deploy/helm/tests/__snapshot__/node-collector-config-map-windows_test.yaml.snap
@@ -168,7 +168,7 @@ Node collector config for windows nodes should match snapshot when using default
           logs:
             include:
               match_type: regexp
-              resource_attributes:
+              record_attributes:
               - key: k8s.namespace.name
                 value: ^kube-.*$
         filter/metrics:
@@ -1099,7 +1099,6 @@ Node collector config for windows nodes should match snapshot when using default
             - otlp
             processors:
             - memory_limiter
-            - filter/logs
             - batch/logs
             receivers:
             - forward/logs-exporter
@@ -1108,6 +1107,7 @@ Node collector config for windows nodes should match snapshot when using default
             - forward/logs-exporter
             processors:
             - memory_limiter
+            - filter/logs
             - transform/syslogify
             - groupbyattrs/common-all
             - resource/container
@@ -1123,7 +1123,6 @@ Node collector config for windows nodes should match snapshot when using default
             - memory_limiter
             - filter/histograms
             - k8sattributes
-            - filter/metrics
             - batch/metrics
             receivers:
             - forward/metric-exporter
@@ -1139,6 +1138,7 @@ Node collector config for windows nodes should match snapshot when using default
             - deltatorate/istio-metrics
             - experimental_metricsgeneration/istio-metrics
             - groupbyattrs/common-all
+            - filter/metrics
             - resource/all
             receivers:
             - receiver_creator/discovery
@@ -1161,6 +1161,7 @@ Node collector config for windows nodes should match snapshot when using default
             - groupbyattrs/node
             - groupbyattrs/pod
             - groupbyattrs/all
+            - filter/metrics
             - resource/metrics
             - resource/all
             receivers:

--- a/deploy/helm/tests/__snapshot__/node-collector-config-map_test.yaml.snap
+++ b/deploy/helm/tests/__snapshot__/node-collector-config-map_test.yaml.snap
@@ -168,7 +168,7 @@ Node collector config should match snapshot when autodiscovery is disabled:
           logs:
             include:
               match_type: regexp
-              resource_attributes:
+              record_attributes:
               - key: k8s.namespace.name
                 value: ^kube-.*$
         filter/metrics:
@@ -1106,7 +1106,6 @@ Node collector config should match snapshot when autodiscovery is disabled:
             - otlp
             processors:
             - memory_limiter
-            - filter/logs
             - batch/logs
             receivers:
             - forward/logs-exporter
@@ -1115,6 +1114,7 @@ Node collector config should match snapshot when autodiscovery is disabled:
             - forward/logs-exporter
             processors:
             - memory_limiter
+            - filter/logs
             - transform/syslogify
             - groupbyattrs/common-all
             - resource/container
@@ -1139,7 +1139,6 @@ Node collector config should match snapshot when autodiscovery is disabled:
             - memory_limiter
             - filter/histograms
             - k8sattributes
-            - filter/metrics
             - batch/metrics
             receivers:
             - forward/metric-exporter
@@ -1162,6 +1161,7 @@ Node collector config should match snapshot when autodiscovery is disabled:
             - groupbyattrs/node
             - groupbyattrs/pod
             - groupbyattrs/all
+            - filter/metrics
             - resource/metrics
             - resource/all
             receivers:
@@ -1341,7 +1341,7 @@ Node collector config should match snapshot when fargate is enabled:
           logs:
             include:
               match_type: regexp
-              resource_attributes:
+              record_attributes:
               - key: k8s.namespace.name
                 value: ^kube-.*$
         filter/metrics:
@@ -2262,7 +2262,6 @@ Node collector config should match snapshot when fargate is enabled:
             - otlp
             processors:
             - memory_limiter
-            - filter/logs
             - batch/logs
             receivers:
             - forward/logs-exporter
@@ -2271,6 +2270,7 @@ Node collector config should match snapshot when fargate is enabled:
             - forward/logs-exporter
             processors:
             - memory_limiter
+            - filter/logs
             - transform/syslogify
             - groupbyattrs/common-all
             - resource/container
@@ -2295,7 +2295,6 @@ Node collector config should match snapshot when fargate is enabled:
             - memory_limiter
             - filter/histograms
             - k8sattributes
-            - filter/metrics
             - batch/metrics
             receivers:
             - forward/metric-exporter
@@ -2311,6 +2310,7 @@ Node collector config should match snapshot when fargate is enabled:
             - deltatorate/istio-metrics
             - experimental_metricsgeneration/istio-metrics
             - groupbyattrs/common-all
+            - filter/metrics
             - resource/all
             receivers:
             - receiver_creator/discovery
@@ -2483,7 +2483,7 @@ Node collector config should match snapshot when fargate is enabled and autodisc
           logs:
             include:
               match_type: regexp
-              resource_attributes:
+              record_attributes:
               - key: k8s.namespace.name
                 value: ^kube-.*$
         filter/metrics:
@@ -3383,7 +3383,6 @@ Node collector config should match snapshot when fargate is enabled and autodisc
             - otlp
             processors:
             - memory_limiter
-            - filter/logs
             - batch/logs
             receivers:
             - forward/logs-exporter
@@ -3392,6 +3391,7 @@ Node collector config should match snapshot when fargate is enabled and autodisc
             - forward/logs-exporter
             processors:
             - memory_limiter
+            - filter/logs
             - transform/syslogify
             - groupbyattrs/common-all
             - resource/container
@@ -3587,7 +3587,7 @@ Node collector config should match snapshot when using default values:
           logs:
             include:
               match_type: regexp
-              resource_attributes:
+              record_attributes:
               - key: k8s.namespace.name
                 value: ^kube-.*$
         filter/metrics:
@@ -4545,7 +4545,6 @@ Node collector config should match snapshot when using default values:
             - otlp
             processors:
             - memory_limiter
-            - filter/logs
             - batch/logs
             receivers:
             - forward/logs-exporter
@@ -4554,6 +4553,7 @@ Node collector config should match snapshot when using default values:
             - forward/logs-exporter
             processors:
             - memory_limiter
+            - filter/logs
             - transform/syslogify
             - groupbyattrs/common-all
             - resource/container
@@ -4578,7 +4578,6 @@ Node collector config should match snapshot when using default values:
             - memory_limiter
             - filter/histograms
             - k8sattributes
-            - filter/metrics
             - batch/metrics
             receivers:
             - forward/metric-exporter
@@ -4594,6 +4593,7 @@ Node collector config should match snapshot when using default values:
             - deltatorate/istio-metrics
             - experimental_metricsgeneration/istio-metrics
             - groupbyattrs/common-all
+            - filter/metrics
             - resource/all
             receivers:
             - receiver_creator/discovery
@@ -4616,6 +4616,7 @@ Node collector config should match snapshot when using default values:
             - groupbyattrs/node
             - groupbyattrs/pod
             - groupbyattrs/all
+            - filter/metrics
             - resource/metrics
             - resource/all
             receivers:

--- a/deploy/helm/values.yaml
+++ b/deploy/helm/values.yaml
@@ -445,7 +445,7 @@ otel:
         match_type: regexp
         # a log has to match all expressions in the list to be included
         # see https://github.com/google/re2/wiki/Syntax for regexp syntax
-        resource_attributes:
+        record_attributes:
           # allow only system namespaces (kube-system, kube-public)
           - key: k8s.namespace.name
             value: ^kube-.*$

--- a/skaffold.yaml
+++ b/skaffold.yaml
@@ -89,12 +89,12 @@ deploy:
             logs:
               filter:
                 include:
-                  resource_attributes:
+                  record_attributes:
                     - key: k8s.namespace.name
                       value: "^.*$"
                 exclude:
                   match_type: strict
-                  resource_attributes:
+                  record_attributes:
                     - key: k8s.namespace.name
                       value: "test-namespace"
         upgradeOnChange: true


### PR DESCRIPTION
Reverts solarwinds/swi-k8s-opentelemetry-collector#628

Revert changes to filtering until we decide whether we want to continue with this approach.