### PR TITLE
Add support for new filtering syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ otel:
     filter:
       include:
         match_type: regexp
-        resource_attributes:
+        record_attributes:
           - key: k8s.namespace.name
             value: ^.*$
 ```

--- a/deploy/helm/CHANGELOG.md
+++ b/deploy/helm/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Changed
+
+- As a followup to 3.4.0-alpha.2, the `otel.metrics.filter`, `otel.logs.filter` and `otel.events.filter` are now again backwards compatible. If a customer is using the [old filtering syntax](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/v0.96.0/processor/filterprocessor#alternative-config-options), they behave like in 3.3.0 and previous versions. If a customer switches to using the [new syntax](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/processor/filterprocessor#configuration), some of the attributes, like `k8s.deployment.name`, become resource attributes.
+
 ## [3.4.0-alpha.2] - 2024-05-16
 
 ### Changed

--- a/deploy/helm/events-collector-config.yaml
+++ b/deploy/helm/events-collector-config.yaml
@@ -145,6 +145,9 @@ service:
         - otlp
       processors:
         - memory_limiter
+{{- if and .Values.otel.events.filter (eq (include "isDeprecatedFilterSyntax" .Values.otel.events.filter) "true") }}
+        - filter
+{{- end }}
         - transform/severity
         - transform/namespace
         - transform/entity_attributes
@@ -157,9 +160,9 @@ service:
         - resource/k8sattributes_annotations_filter
 {{- end }}
         - transform/cleanup_attributes_for_nonexisting_entities
-{{- if .Values.otel.events.filter }}
+{{- if and .Values.otel.events.filter (eq (include "isDeprecatedFilterSyntax" .Values.otel.events.filter) "false") }}
         - filter
-{{- end}}
+{{- end }}
         - batch
       receivers:
         - k8s_events

--- a/deploy/helm/metrics-collector-config.yaml
+++ b/deploy/helm/metrics-collector-config.yaml
@@ -786,6 +786,8 @@ processors:
 {{ toYaml .Values.otel.metrics.filter | indent 6 }}
 {{- end }}
 
+{{- include "common-config.filter-remove-temporary-metrics" . | nindent 2 }}
+
 {{- include "common-config.filter-reciever" . | nindent 2 }}
 
   attributes/attributes_namespace_status:
@@ -1286,6 +1288,7 @@ service:
 {{- if .Values.otel.metrics.filter }}
         - filter
 {{- end }}
+        - filter/remove_temporary_metrics
       receivers:
         - forward/prometheus
     metrics:

--- a/deploy/helm/node-collector-config.yaml
+++ b/deploy/helm/node-collector-config.yaml
@@ -42,11 +42,11 @@ processors:
   memory_limiter:
 {{ toYaml .Values.otel.logs.memory_limiter | indent 4 }}
 
-{{- if .Values.otel.logs.filter }}
+{{- if (include "logsFilter" .) }}
   # For more all the options about the filtering see https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/processor/filterprocessor
   filter/logs:
     logs:
-{{ toYaml .Values.otel.logs.filter | indent 6 }}
+{{ include "logsFilter" . | indent 6 }}
 {{- end }}
 
   {{- include "common-config.filter-reciever" . | nindent 2 }}
@@ -97,6 +97,8 @@ processors:
     metrics:
 {{ toYaml .Values.otel.metrics.filter | indent 6 }}
 {{- end }}
+
+{{- include "common-config.filter-remove-temporary-metrics" . | nindent 2 }}
 
   {{- include "common-config.resource-metrics" . | nindent 2 }}
 
@@ -620,6 +622,9 @@ service:
         - forward/logs-exporter
       processors:
         - memory_limiter
+{{- if eq (include "isDeprecatedFilterSyntax" .Values.otel.logs.filter) "true" }}
+        - filter/logs
+{{- end }}
         - transform/syslogify
         - groupbyattrs/common-all
         - resource/container
@@ -650,7 +655,7 @@ service:
         - otlp
       processors:
         - memory_limiter
-{{- if .Values.otel.logs.filter }}
+{{- if eq (include "isDeprecatedFilterSyntax" .Values.otel.logs.filter) "false" }}
         - filter/logs
 {{- end }}
         - batch/logs
@@ -724,6 +729,7 @@ service:
 {{- if .Values.otel.metrics.filter }}
         - filter/metrics
 {{- end }}
+        - filter/remove_temporary_metrics
         - batch/metrics
       receivers:
         - forward/metric-exporter

--- a/deploy/helm/templates/NOTES.txt
+++ b/deploy/helm/templates/NOTES.txt
@@ -4,12 +4,66 @@ WARNING: you rely on bundled Prometheus, but it was removed in this version. To 
 
 {{- end -}}
 {{- end -}}
+
 {{- if and .Values.otel.metrics.extra_scrape_metrics (and .Values.otel.metrics.autodiscovery.prometheusEndpoints.enabled (not .Values.otel.metrics.force_extra_scrape_metrics)) -}}
 WARNING: You have enabled autodiscovery of prometheus endpoints, so `extra_scrape_metrics` is ignored. If you are sure that those metrics won't be covered by autodiscovery set `otel.metrics.force_extra_scrape_metrics` to `true`.
 
 {{- end -}}
+
 {{- if (mustRegexMatch "otel-collector\\.dc-\\d\\d\\.cloud\\.solarwinds\\.com" .Values.otel.endpoint) -}}
 WARNING: The provided OTEL endpoint address ({{ quote .Values.otel.endpoint }}) has been deprecated. Please switch to a new one as soon as possible.
          A list of available endpoints: https://documentation.solarwinds.com/en/success_center/observability/content/system_requirements/endpoints.htm
 
+{{- end -}}
+
+{{- if eq (include "isDeprecatedFilterSyntax" .Values.otel.events.filter) "true" -}}
+WARNING: The provided custom configuration for `otel.events.filter` is using a deprecated syntax. Consider updating the configuration to use the new syntax (https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/processor/filterprocessor#configuration).
+         Additionally, when using the new syntax, some of the event-level attributes are available at the resource level, instead.
+
+         For example, a custom filter configuration looking like this:
+
+          filter:
+            include:
+            match_type: regexp
+            record_attributes:
+              - key: k8s.namespace.name
+                value: ^kube-.*$
+
+         should be replaced by this:
+
+          filter:
+            log_record:
+              - not(IsMatch(resource.attributes["k8s.namespace.name"], "^kube-.*$"))
+{{- println -}}
+{{- end -}}
+
+{{- if eq (include "isDeprecatedFilterSyntax" .Values.otel.logs.filter) "true" -}}
+WARNING: The provided custom configuration for `otel.logs.filter` is using a deprecated syntax. Consider updating the configuration to use the new syntax (https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/processor/filterprocessor#configuration).
+         Additionally, when using the new syntax, some of the log-level attributes are available at the resource level, instead.
+
+         For example, a custom filter configuration looking like this:
+
+          filter:
+            include:
+            match_type: regexp
+            record_attributes:
+              - key: k8s.namespace.name
+                value: ^kube-.*$
+
+         should be replaced by this:
+
+          filter:
+            log_record:
+              - not(IsMatch(resource.attributes["k8s.namespace.name"], "^kube-.*$"))
+{{- println -}}
+{{- end -}}
+
+{{- if eq (include "isDeprecatedFilterSyntax" .Values.otel.metrics.filter) "true" -}}
+WARNING: The provided custom configuration for `otel.metrics.filter` is using a deprecated syntax. Consider updating the configuration to use the new syntax (https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/processor/filterprocessor#configuration).
+{{- println -}}
+{{- end -}}
+
+{{- if eq (include "isDeprecatedFilterSyntax" .Values.otel.metrics.autodiscovery.prometheusEndpoints.filter) "true" -}}
+WARNING: The provided custom configuration for `otel.otel.metrics.autodiscovery.prometheusEndpoints.filter` is using a deprecated syntax. Consider updating the configuration to use the new syntax (https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/processor/filterprocessor#configuration).
+{{- println -}}
 {{- end -}}

--- a/deploy/helm/templates/_common-config.tpl
+++ b/deploy/helm/templates/_common-config.tpl
@@ -617,3 +617,14 @@ resource/metrics:
       from_attribute: persistentvolumeclaim
       action: insert
 {{- end }}
+
+{{- define "common-config.filter-remove-temporary-metrics" -}}
+# Remove metrics
+filter/remove_temporary_metrics:
+  metrics:
+    exclude:
+      match_type: regexp
+      metric_names:
+        - .*_temp
+        - apiserver_request_total
+{{- end }}

--- a/deploy/helm/templates/_helpers.tpl
+++ b/deploy/helm/templates/_helpers.tpl
@@ -306,3 +306,64 @@ Define name for the Secret
 {{- "solarwinds-api-token" }}
 {{- end }}
 {{- end -}}
+
+{{/*
+Check the used filtering version
+
+Usage:
+{{ isDeprecatedFilterSyntax (.Values.otel.events.filter) }}
+*/}}
+{{- define "isDeprecatedFilterSyntax" -}}
+{{- if . -}}
+{{- if or (index . "include") (index . "exclude") -}}
+true
+{{- else -}}
+false
+{{- end -}}
+{{- else -}}
+false
+{{- end -}}
+{{- end -}}
+
+{{- define "defaultDeprecatedLogsFilter" -}}
+include:
+  match_type: regexp
+  # a log has to match all expressions in the list to be included
+  # see https://github.com/google/re2/wiki/Syntax for regexp syntax
+  record_attributes:
+    # allow only system namespaces (kube-system, kube-public)
+    - key: k8s.namespace.name
+      value: ^kube-.*$
+{{- end }}
+
+{{- define "defaultLogsFilter" -}}
+# allow only system namespaces (kube-system, kube-public)
+log_record:
+  - 'not(IsMatch(resource.attributes["k8s.namespace.name"], "^kube-.*$"))'
+{{- end }}
+
+{{/*
+Get the log filter.
+The filter is a merge from the default filter and the user defined one.
+The default filter's syntax is chosen based on the syntax of the user defined filter.
+
+Usage:
+{{ include "logsFilter" . }}
+
+Returns:
+YAML with the filter.
+*/}}
+{{- define "logsFilter" -}}
+
+{{- $defaultFilter := (include "defaultLogsFilter" .) -}}
+{{- if eq (include "isDeprecatedFilterSyntax" .Values.otel.logs.filter) "true" -}}
+{{- $defaultFilter = (include "defaultDeprecatedLogsFilter" .) -}}
+{{- end -}}
+
+{{- $filter := dict -}}
+{{- if .Values.otel.logs.filter -}}
+{{- $filter = deepCopy .Values.otel.logs.filter -}}
+{{- end -}}
+{{- merge $filter (fromYaml $defaultFilter) | toYaml -}}
+
+{{- end -}}

--- a/deploy/helm/tests/__snapshot__/events-collector-config-map_test.yaml.snap
+++ b/deploy/helm/tests/__snapshot__/events-collector-config-map_test.yaml.snap
@@ -1,3 +1,656 @@
+Custom events filter with new syntax:
+  1: |
+    events.config: |-
+      exporters:
+        otlp:
+          endpoint: ${OTEL_ENVOY_ADDRESS}
+          headers:
+            Authorization: Bearer ${SOLARWINDS_API_TOKEN}
+          retry_on_failure:
+            enabled: true
+            initial_interval: 10s
+            max_elapsed_time: 300s
+            max_interval: 30s
+          sending_queue:
+            enabled: true
+            num_consumers: 10
+            queue_size: 1000
+          tls:
+            insecure: ${OTEL_ENVOY_ADDRESS_TLS_INSECURE}
+      extensions:
+        health_check: {}
+        memory_ballast:
+          size_mib: 300
+      processors:
+        batch:
+          send_batch_max_size: 512
+          send_batch_size: 512
+          timeout: 1s
+        filter:
+          logs:
+            log_record:
+            - not(IsMatch(resource.attributes["k8s.namespace.name"], "^.*$"))
+        k8sattributes:
+          auth_type: serviceAccount
+          cronjob:
+            association:
+            - sources:
+              - from: resource_attribute
+                name: k8s.cronjob.name
+              - from: resource_attribute
+                name: k8s.namespace.name
+            extract:
+              labels:
+              - from: cronjob
+                key_regex: (.*)
+                tag_name: k8s.cronjob.labels.$$1
+          daemonset:
+            association:
+            - sources:
+              - from: resource_attribute
+                name: k8s.daemonset.name
+              - from: resource_attribute
+                name: k8s.namespace.name
+            extract:
+              labels:
+              - from: daemonset
+                key_regex: (.*)
+                tag_name: k8s.daemonset.labels.$$1
+          deployment:
+            association:
+            - sources:
+              - from: resource_attribute
+                name: k8s.deployment.name
+              - from: resource_attribute
+                name: k8s.namespace.name
+            extract:
+              labels:
+              - from: deployment
+                key_regex: (.*)
+                tag_name: k8s.deployment.labels.$$1
+          extract:
+            labels:
+            - from: pod
+              key_regex: (.*)
+              tag_name: k8s.pod.labels.$$1
+            - from: namespace
+              key_regex: (.*)
+              tag_name: k8s.namespace.labels.$$1
+            metadata:
+            - k8s.deployment.name
+            - k8s.replicaset.name
+            - k8s.daemonset.name
+            - k8s.job.name
+            - k8s.cronjob.name
+            - k8s.statefulset.name
+            - k8s.node.name
+          job:
+            association:
+            - sources:
+              - from: resource_attribute
+                name: k8s.job.name
+              - from: resource_attribute
+                name: k8s.namespace.name
+            extract:
+              labels:
+              - from: job
+                key_regex: (.*)
+                tag_name: k8s.job.labels.$$1
+          node:
+            association:
+            - sources:
+              - from: resource_attribute
+                name: k8s.node.name
+            extract:
+              labels:
+              - from: node
+                key_regex: (.*)
+                tag_name: k8s.node.labels.$$1
+          passthrough: false
+          persistentvolume:
+            association:
+            - sources:
+              - from: resource_attribute
+                name: k8s.persistentvolume.name
+            extract:
+              labels:
+              - from: persistentvolume
+                key_regex: (.*)
+                tag_name: k8s.persistentvolume.labels.$$1
+          persistentvolumeclaim:
+            association:
+            - sources:
+              - from: resource_attribute
+                name: k8s.persistentvolumeclaim.name
+              - from: resource_attribute
+                name: k8s.namespace.name
+            extract:
+              labels:
+              - from: persistentvolumeclaim
+                key_regex: (.*)
+                tag_name: k8s.persistentvolumeclaim.labels.$$1
+          pod_association:
+          - sources:
+            - from: resource_attribute
+              name: k8s.pod.name
+            - from: resource_attribute
+              name: k8s.namespace.name
+          replicaset:
+            association:
+            - sources:
+              - from: resource_attribute
+                name: k8s.replicaset.name
+              - from: resource_attribute
+                name: k8s.namespace.name
+            extract:
+              labels:
+              - from: replicaset
+                key_regex: (.*)
+                tag_name: k8s.replicaset.labels.$$1
+          service:
+            association:
+            - sources:
+              - from: resource_attribute
+                name: k8s.service.name
+              - from: resource_attribute
+                name: k8s.namespace.name
+            extract:
+              labels:
+              - from: service
+                key_regex: (.*)
+                tag_name: k8s.service.labels.$$1
+          set_object_existence: true
+          statefulset:
+            association:
+            - sources:
+              - from: resource_attribute
+                name: k8s.statefulset.name
+              - from: resource_attribute
+                name: k8s.namespace.name
+            extract:
+              labels:
+              - from: statefulset
+                key_regex: (.*)
+                tag_name: k8s.statefulset.labels.$$1
+        memory_limiter:
+          check_interval: 1s
+          limit_mib: 512
+          spike_limit_mib: 128
+        resource/events:
+          attributes:
+          - action: insert
+            key: sw.k8s.agent.manifest.version
+            value: ${MANIFEST_VERSION}
+          - action: insert
+            key: sw.k8s.agent.app.version
+            value: ${APP_VERSION}
+          - action: insert
+            key: sw.k8s.cluster.uid
+            value: ${CLUSTER_UID}
+          - action: insert
+            key: k8s.cluster.name
+            value: ${CLUSTER_NAME}
+          - action: insert
+            key: sw.k8s.log.type
+            value: event
+        transform/cleanup_attributes_for_nonexisting_entities:
+          log_statements:
+          - context: log
+            statements:
+            - delete_key(resource.attributes, "k8s.pod.name") where resource.attributes["sw.k8s.pod.found"]
+              == "false"
+            - delete_key(resource.attributes, "k8s.deployment.name") where resource.attributes["sw.k8s.deployment.found"]
+              == "false"
+            - delete_key(resource.attributes, "k8s.statefulset.name") where resource.attributes["sw.k8s.statefulset.found"]
+              == "false"
+            - delete_key(resource.attributes, "k8s.replicaset.name") where resource.attributes["sw.k8s.replicaset.found"]
+              == "false"
+            - delete_key(resource.attributes, "k8s.daemonset.name") where resource.attributes["sw.k8s.daemonset.found"]
+              == "false"
+            - delete_key(resource.attributes, "k8s.job.name") where resource.attributes["sw.k8s.job.found"]
+              == "false"
+            - delete_key(resource.attributes, "k8s.cronjob.name") where resource.attributes["sw.k8s.cronjob.found"]
+              == "false"
+            - delete_key(resource.attributes, "k8s.node.name") where resource.attributes["sw.k8s.node.found"]
+              == "false"
+            - delete_key(resource.attributes, "sw.k8s.pod.found")
+            - delete_key(resource.attributes, "sw.k8s.deployment.found")
+            - delete_key(resource.attributes, "sw.k8s.statefulset.found")
+            - delete_key(resource.attributes, "sw.k8s.replicaset.found")
+            - delete_key(resource.attributes, "sw.k8s.daemonset.found")
+            - delete_key(resource.attributes, "sw.k8s.job.found")
+            - delete_key(resource.attributes, "sw.k8s.cronjob.found")
+            - delete_key(resource.attributes, "sw.k8s.node.found")
+        transform/entity_attributes:
+          log_statements:
+          - context: log
+            statements:
+            - set(resource.attributes["k8s.pod.name"], resource.attributes["k8s.object.name"])
+              where resource.attributes["k8s.object.kind"] == "Pod"
+            - set(resource.attributes["k8s.deployment.name"], resource.attributes["k8s.object.name"])
+              where resource.attributes["k8s.object.kind"] == "Deployment"
+            - set(resource.attributes["k8s.statefulset.name"], resource.attributes["k8s.object.name"])
+              where resource.attributes["k8s.object.kind"] == "StatefulSet"
+            - set(resource.attributes["k8s.replicaset.name"], resource.attributes["k8s.object.name"])
+              where resource.attributes["k8s.object.kind"] == "ReplicaSet"
+            - set(resource.attributes["k8s.daemonset.name"], resource.attributes["k8s.object.name"])
+              where resource.attributes["k8s.object.kind"] == "DaemonSet"
+            - set(resource.attributes["k8s.job.name"], resource.attributes["k8s.object.name"])
+              where resource.attributes["k8s.object.kind"] == "Job"
+            - set(resource.attributes["k8s.cronjob.name"], resource.attributes["k8s.object.name"])
+              where resource.attributes["k8s.object.kind"] == "CronJob"
+            - set(resource.attributes["k8s.node.name"], resource.attributes["k8s.object.name"])
+              where resource.attributes["k8s.object.kind"] == "Node"
+            - set(resource.attributes["k8s.namespace.name"], attributes["k8s.namespace.name"])
+              where attributes["k8s.namespace.name"] != nil
+            - delete_key(attributes, "k8s.namespace.name") where attributes["k8s.namespace.name"]
+              != nil
+        transform/namespace:
+          log_statements:
+          - context: log
+            statements:
+            - set(attributes["sw.namespace"], "sw.events.inframon.k8s")
+        transform/severity:
+          log_statements:
+          - context: log
+            statements:
+            - set(severity_text, "Error") where attributes["k8s.event.reason"] == "Failed"
+              or attributes["k8s.event.reason"] == "BackOff" or attributes["k8s.event.reason"]
+              == "FailedKillPod" or attributes["k8s.event.reason"] == "FailedCreatePodContainer"
+              or attributes["k8s.event.reason"] == "NetworkNotReady" or attributes["k8s.event.reason"]
+              == "InspectFailed" or attributes["k8s.event.reason"] == "ErrImageNeverPull"
+              or attributes["k8s.event.reason"] == "NodeNotReady" or attributes["k8s.event.reason"]
+              == "NodeNotSchedulable" or attributes["k8s.event.reason"] == "KubeletSetupFailed"
+              or attributes["k8s.event.reason"] == "FailedAttachVolume" or attributes["k8s.event.reason"]
+              == "FailedMount" or attributes["k8s.event.reason"] == "VolumeResizeFailed"
+              or attributes["k8s.event.reason"] == "FileSystemResizeFailed" or attributes["k8s.event.reason"]
+              == "FailedMapVolume" or attributes["k8s.event.reason"] == "ContainerGCFailed"
+              or attributes["k8s.event.reason"] == "ImageGCFailed" or attributes["k8s.event.reason"]
+              == "FailedNodeAllocatableEnforcement" or attributes["k8s.event.reason"] ==
+              "FailedCreatePodSandBox" or attributes["k8s.event.reason"] == "FailedPodSandBoxStatus"
+              or attributes["k8s.event.reason"] == "FailedMountOnFilesystemMismatch" or
+              attributes["k8s.event.reason"] == "InvalidDiskCapacity" or attributes["k8s.event.reason"]
+              == "FreeDiskSpaceFailed" or attributes["k8s.event.reason"] == "FailedSync"
+              or attributes["k8s.event.reason"] == "FailedValidation" or attributes["k8s.event.reason"]
+              == "FailedPostStartHook" or attributes["k8s.event.reason"] == "FailedPreStopHook"
+            - set(severity_number, 17) where attributes["k8s.event.reason"] == "Failed"
+              or attributes["k8s.event.reason"] == "BackOff" or attributes["k8s.event.reason"]
+              == "FailedKillPod" or attributes["k8s.event.reason"] == "FailedCreatePodContainer"
+              or attributes["k8s.event.reason"] == "NetworkNotReady" or attributes["k8s.event.reason"]
+              == "InspectFailed" or attributes["k8s.event.reason"] == "ErrImageNeverPull"
+              or attributes["k8s.event.reason"] == "NodeNotReady" or attributes["k8s.event.reason"]
+              == "NodeNotSchedulable" or attributes["k8s.event.reason"] == "KubeletSetupFailed"
+              or attributes["k8s.event.reason"] == "FailedAttachVolume" or attributes["k8s.event.reason"]
+              == "FailedMount" or attributes["k8s.event.reason"] == "VolumeResizeFailed"
+              or attributes["k8s.event.reason"] == "FileSystemResizeFailed" or attributes["k8s.event.reason"]
+              == "FailedMapVolume" or attributes["k8s.event.reason"] == "ContainerGCFailed"
+              or attributes["k8s.event.reason"] == "ImageGCFailed" or attributes["k8s.event.reason"]
+              == "FailedNodeAllocatableEnforcement" or attributes["k8s.event.reason"] ==
+              "FailedCreatePodSandBox" or attributes["k8s.event.reason"] == "FailedPodSandBoxStatus"
+              or attributes["k8s.event.reason"] == "FailedMountOnFilesystemMismatch" or
+              attributes["k8s.event.reason"] == "InvalidDiskCapacity" or attributes["k8s.event.reason"]
+              == "FreeDiskSpaceFailed" or attributes["k8s.event.reason"] == "FailedSync"
+              or attributes["k8s.event.reason"] == "FailedValidation" or attributes["k8s.event.reason"]
+              == "FailedPostStartHook" or attributes["k8s.event.reason"] == "FailedPreStopHook"
+            - set(severity_text, "Warning") where attributes["k8s.event.reason"] == "ProbeWarning"
+              or attributes["k8s.event.reason"] == "Unhealthy"
+            - set(severity_number, 13) where attributes["k8s.event.reason"] == "ProbeWarning"
+              or attributes["k8s.event.reason"] == "Unhealthy"
+      receivers:
+        k8s_events: null
+      service:
+        extensions:
+        - health_check
+        - memory_ballast
+        pipelines:
+          logs:
+            exporters:
+            - otlp
+            processors:
+            - memory_limiter
+            - transform/severity
+            - transform/namespace
+            - transform/entity_attributes
+            - resource/events
+            - k8sattributes
+            - transform/cleanup_attributes_for_nonexisting_entities
+            - filter
+            - batch
+            receivers:
+            - k8s_events
+        telemetry:
+          logs:
+            level: info
+          metrics:
+            address: 0.0.0.0:8888
+Custom events filter with old syntax:
+  1: |
+    events.config: |-
+      exporters:
+        otlp:
+          endpoint: ${OTEL_ENVOY_ADDRESS}
+          headers:
+            Authorization: Bearer ${SOLARWINDS_API_TOKEN}
+          retry_on_failure:
+            enabled: true
+            initial_interval: 10s
+            max_elapsed_time: 300s
+            max_interval: 30s
+          sending_queue:
+            enabled: true
+            num_consumers: 10
+            queue_size: 1000
+          tls:
+            insecure: ${OTEL_ENVOY_ADDRESS_TLS_INSECURE}
+      extensions:
+        health_check: {}
+        memory_ballast:
+          size_mib: 300
+      processors:
+        batch:
+          send_batch_max_size: 512
+          send_batch_size: 512
+          timeout: 1s
+        filter:
+          logs:
+            include:
+              match_type: regexp
+              record_attributes:
+              - key: k8s.namespace.name
+                value: ^.*$
+        k8sattributes:
+          auth_type: serviceAccount
+          cronjob:
+            association:
+            - sources:
+              - from: resource_attribute
+                name: k8s.cronjob.name
+              - from: resource_attribute
+                name: k8s.namespace.name
+            extract:
+              labels:
+              - from: cronjob
+                key_regex: (.*)
+                tag_name: k8s.cronjob.labels.$$1
+          daemonset:
+            association:
+            - sources:
+              - from: resource_attribute
+                name: k8s.daemonset.name
+              - from: resource_attribute
+                name: k8s.namespace.name
+            extract:
+              labels:
+              - from: daemonset
+                key_regex: (.*)
+                tag_name: k8s.daemonset.labels.$$1
+          deployment:
+            association:
+            - sources:
+              - from: resource_attribute
+                name: k8s.deployment.name
+              - from: resource_attribute
+                name: k8s.namespace.name
+            extract:
+              labels:
+              - from: deployment
+                key_regex: (.*)
+                tag_name: k8s.deployment.labels.$$1
+          extract:
+            labels:
+            - from: pod
+              key_regex: (.*)
+              tag_name: k8s.pod.labels.$$1
+            - from: namespace
+              key_regex: (.*)
+              tag_name: k8s.namespace.labels.$$1
+            metadata:
+            - k8s.deployment.name
+            - k8s.replicaset.name
+            - k8s.daemonset.name
+            - k8s.job.name
+            - k8s.cronjob.name
+            - k8s.statefulset.name
+            - k8s.node.name
+          job:
+            association:
+            - sources:
+              - from: resource_attribute
+                name: k8s.job.name
+              - from: resource_attribute
+                name: k8s.namespace.name
+            extract:
+              labels:
+              - from: job
+                key_regex: (.*)
+                tag_name: k8s.job.labels.$$1
+          node:
+            association:
+            - sources:
+              - from: resource_attribute
+                name: k8s.node.name
+            extract:
+              labels:
+              - from: node
+                key_regex: (.*)
+                tag_name: k8s.node.labels.$$1
+          passthrough: false
+          persistentvolume:
+            association:
+            - sources:
+              - from: resource_attribute
+                name: k8s.persistentvolume.name
+            extract:
+              labels:
+              - from: persistentvolume
+                key_regex: (.*)
+                tag_name: k8s.persistentvolume.labels.$$1
+          persistentvolumeclaim:
+            association:
+            - sources:
+              - from: resource_attribute
+                name: k8s.persistentvolumeclaim.name
+              - from: resource_attribute
+                name: k8s.namespace.name
+            extract:
+              labels:
+              - from: persistentvolumeclaim
+                key_regex: (.*)
+                tag_name: k8s.persistentvolumeclaim.labels.$$1
+          pod_association:
+          - sources:
+            - from: resource_attribute
+              name: k8s.pod.name
+            - from: resource_attribute
+              name: k8s.namespace.name
+          replicaset:
+            association:
+            - sources:
+              - from: resource_attribute
+                name: k8s.replicaset.name
+              - from: resource_attribute
+                name: k8s.namespace.name
+            extract:
+              labels:
+              - from: replicaset
+                key_regex: (.*)
+                tag_name: k8s.replicaset.labels.$$1
+          service:
+            association:
+            - sources:
+              - from: resource_attribute
+                name: k8s.service.name
+              - from: resource_attribute
+                name: k8s.namespace.name
+            extract:
+              labels:
+              - from: service
+                key_regex: (.*)
+                tag_name: k8s.service.labels.$$1
+          set_object_existence: true
+          statefulset:
+            association:
+            - sources:
+              - from: resource_attribute
+                name: k8s.statefulset.name
+              - from: resource_attribute
+                name: k8s.namespace.name
+            extract:
+              labels:
+              - from: statefulset
+                key_regex: (.*)
+                tag_name: k8s.statefulset.labels.$$1
+        memory_limiter:
+          check_interval: 1s
+          limit_mib: 512
+          spike_limit_mib: 128
+        resource/events:
+          attributes:
+          - action: insert
+            key: sw.k8s.agent.manifest.version
+            value: ${MANIFEST_VERSION}
+          - action: insert
+            key: sw.k8s.agent.app.version
+            value: ${APP_VERSION}
+          - action: insert
+            key: sw.k8s.cluster.uid
+            value: ${CLUSTER_UID}
+          - action: insert
+            key: k8s.cluster.name
+            value: ${CLUSTER_NAME}
+          - action: insert
+            key: sw.k8s.log.type
+            value: event
+        transform/cleanup_attributes_for_nonexisting_entities:
+          log_statements:
+          - context: log
+            statements:
+            - delete_key(resource.attributes, "k8s.pod.name") where resource.attributes["sw.k8s.pod.found"]
+              == "false"
+            - delete_key(resource.attributes, "k8s.deployment.name") where resource.attributes["sw.k8s.deployment.found"]
+              == "false"
+            - delete_key(resource.attributes, "k8s.statefulset.name") where resource.attributes["sw.k8s.statefulset.found"]
+              == "false"
+            - delete_key(resource.attributes, "k8s.replicaset.name") where resource.attributes["sw.k8s.replicaset.found"]
+              == "false"
+            - delete_key(resource.attributes, "k8s.daemonset.name") where resource.attributes["sw.k8s.daemonset.found"]
+              == "false"
+            - delete_key(resource.attributes, "k8s.job.name") where resource.attributes["sw.k8s.job.found"]
+              == "false"
+            - delete_key(resource.attributes, "k8s.cronjob.name") where resource.attributes["sw.k8s.cronjob.found"]
+              == "false"
+            - delete_key(resource.attributes, "k8s.node.name") where resource.attributes["sw.k8s.node.found"]
+              == "false"
+            - delete_key(resource.attributes, "sw.k8s.pod.found")
+            - delete_key(resource.attributes, "sw.k8s.deployment.found")
+            - delete_key(resource.attributes, "sw.k8s.statefulset.found")
+            - delete_key(resource.attributes, "sw.k8s.replicaset.found")
+            - delete_key(resource.attributes, "sw.k8s.daemonset.found")
+            - delete_key(resource.attributes, "sw.k8s.job.found")
+            - delete_key(resource.attributes, "sw.k8s.cronjob.found")
+            - delete_key(resource.attributes, "sw.k8s.node.found")
+        transform/entity_attributes:
+          log_statements:
+          - context: log
+            statements:
+            - set(resource.attributes["k8s.pod.name"], resource.attributes["k8s.object.name"])
+              where resource.attributes["k8s.object.kind"] == "Pod"
+            - set(resource.attributes["k8s.deployment.name"], resource.attributes["k8s.object.name"])
+              where resource.attributes["k8s.object.kind"] == "Deployment"
+            - set(resource.attributes["k8s.statefulset.name"], resource.attributes["k8s.object.name"])
+              where resource.attributes["k8s.object.kind"] == "StatefulSet"
+            - set(resource.attributes["k8s.replicaset.name"], resource.attributes["k8s.object.name"])
+              where resource.attributes["k8s.object.kind"] == "ReplicaSet"
+            - set(resource.attributes["k8s.daemonset.name"], resource.attributes["k8s.object.name"])
+              where resource.attributes["k8s.object.kind"] == "DaemonSet"
+            - set(resource.attributes["k8s.job.name"], resource.attributes["k8s.object.name"])
+              where resource.attributes["k8s.object.kind"] == "Job"
+            - set(resource.attributes["k8s.cronjob.name"], resource.attributes["k8s.object.name"])
+              where resource.attributes["k8s.object.kind"] == "CronJob"
+            - set(resource.attributes["k8s.node.name"], resource.attributes["k8s.object.name"])
+              where resource.attributes["k8s.object.kind"] == "Node"
+            - set(resource.attributes["k8s.namespace.name"], attributes["k8s.namespace.name"])
+              where attributes["k8s.namespace.name"] != nil
+            - delete_key(attributes, "k8s.namespace.name") where attributes["k8s.namespace.name"]
+              != nil
+        transform/namespace:
+          log_statements:
+          - context: log
+            statements:
+            - set(attributes["sw.namespace"], "sw.events.inframon.k8s")
+        transform/severity:
+          log_statements:
+          - context: log
+            statements:
+            - set(severity_text, "Error") where attributes["k8s.event.reason"] == "Failed"
+              or attributes["k8s.event.reason"] == "BackOff" or attributes["k8s.event.reason"]
+              == "FailedKillPod" or attributes["k8s.event.reason"] == "FailedCreatePodContainer"
+              or attributes["k8s.event.reason"] == "NetworkNotReady" or attributes["k8s.event.reason"]
+              == "InspectFailed" or attributes["k8s.event.reason"] == "ErrImageNeverPull"
+              or attributes["k8s.event.reason"] == "NodeNotReady" or attributes["k8s.event.reason"]
+              == "NodeNotSchedulable" or attributes["k8s.event.reason"] == "KubeletSetupFailed"
+              or attributes["k8s.event.reason"] == "FailedAttachVolume" or attributes["k8s.event.reason"]
+              == "FailedMount" or attributes["k8s.event.reason"] == "VolumeResizeFailed"
+              or attributes["k8s.event.reason"] == "FileSystemResizeFailed" or attributes["k8s.event.reason"]
+              == "FailedMapVolume" or attributes["k8s.event.reason"] == "ContainerGCFailed"
+              or attributes["k8s.event.reason"] == "ImageGCFailed" or attributes["k8s.event.reason"]
+              == "FailedNodeAllocatableEnforcement" or attributes["k8s.event.reason"] ==
+              "FailedCreatePodSandBox" or attributes["k8s.event.reason"] == "FailedPodSandBoxStatus"
+              or attributes["k8s.event.reason"] == "FailedMountOnFilesystemMismatch" or
+              attributes["k8s.event.reason"] == "InvalidDiskCapacity" or attributes["k8s.event.reason"]
+              == "FreeDiskSpaceFailed" or attributes["k8s.event.reason"] == "FailedSync"
+              or attributes["k8s.event.reason"] == "FailedValidation" or attributes["k8s.event.reason"]
+              == "FailedPostStartHook" or attributes["k8s.event.reason"] == "FailedPreStopHook"
+            - set(severity_number, 17) where attributes["k8s.event.reason"] == "Failed"
+              or attributes["k8s.event.reason"] == "BackOff" or attributes["k8s.event.reason"]
+              == "FailedKillPod" or attributes["k8s.event.reason"] == "FailedCreatePodContainer"
+              or attributes["k8s.event.reason"] == "NetworkNotReady" or attributes["k8s.event.reason"]
+              == "InspectFailed" or attributes["k8s.event.reason"] == "ErrImageNeverPull"
+              or attributes["k8s.event.reason"] == "NodeNotReady" or attributes["k8s.event.reason"]
+              == "NodeNotSchedulable" or attributes["k8s.event.reason"] == "KubeletSetupFailed"
+              or attributes["k8s.event.reason"] == "FailedAttachVolume" or attributes["k8s.event.reason"]
+              == "FailedMount" or attributes["k8s.event.reason"] == "VolumeResizeFailed"
+              or attributes["k8s.event.reason"] == "FileSystemResizeFailed" or attributes["k8s.event.reason"]
+              == "FailedMapVolume" or attributes["k8s.event.reason"] == "ContainerGCFailed"
+              or attributes["k8s.event.reason"] == "ImageGCFailed" or attributes["k8s.event.reason"]
+              == "FailedNodeAllocatableEnforcement" or attributes["k8s.event.reason"] ==
+              "FailedCreatePodSandBox" or attributes["k8s.event.reason"] == "FailedPodSandBoxStatus"
+              or attributes["k8s.event.reason"] == "FailedMountOnFilesystemMismatch" or
+              attributes["k8s.event.reason"] == "InvalidDiskCapacity" or attributes["k8s.event.reason"]
+              == "FreeDiskSpaceFailed" or attributes["k8s.event.reason"] == "FailedSync"
+              or attributes["k8s.event.reason"] == "FailedValidation" or attributes["k8s.event.reason"]
+              == "FailedPostStartHook" or attributes["k8s.event.reason"] == "FailedPreStopHook"
+            - set(severity_text, "Warning") where attributes["k8s.event.reason"] == "ProbeWarning"
+              or attributes["k8s.event.reason"] == "Unhealthy"
+            - set(severity_number, 13) where attributes["k8s.event.reason"] == "ProbeWarning"
+              or attributes["k8s.event.reason"] == "Unhealthy"
+      receivers:
+        k8s_events: null
+      service:
+        extensions:
+        - health_check
+        - memory_ballast
+        pipelines:
+          logs:
+            exporters:
+            - otlp
+            processors:
+            - memory_limiter
+            - filter
+            - transform/severity
+            - transform/namespace
+            - transform/entity_attributes
+            - resource/events
+            - k8sattributes
+            - transform/cleanup_attributes_for_nonexisting_entities
+            - batch
+            receivers:
+            - k8s_events
+        telemetry:
+          logs:
+            level: info
+          metrics:
+            address: 0.0.0.0:8888
 Events config should match snapshot when using default values:
   1: |
     events.config: |-

--- a/deploy/helm/tests/__snapshot__/metrics-collector-config-map-fargate_test.yaml.snap
+++ b/deploy/helm/tests/__snapshot__/metrics-collector-config-map-fargate_test.yaml.snap
@@ -505,13 +505,6 @@ Metrics config should match snapshot when using default values:
             operation: percent
             type: calculate
             unit: Percent
-        filter:
-          metrics:
-            exclude:
-              match_type: regexp
-              metric_names:
-              - .*_temp
-              - apiserver_request_total
         filter/ebpf:
           metrics:
             exclude:
@@ -653,6 +646,13 @@ Metrics config should match snapshot when using default values:
             datapoint:
             - attributes["container"] == "POD" and IsMatch(metric.name, "container_network_.*|k8s.container.*")
               == true
+        filter/remove_temporary_metrics:
+          metrics:
+            exclude:
+              match_type: regexp
+              metric_names:
+              - .*_temp
+              - apiserver_request_total
         groupbyattrs/all:
           keys:
           - kubelet_version
@@ -2276,7 +2276,7 @@ Metrics config should match snapshot when using default values:
             - resource/metrics
             - k8sattributes
             - transform/cleanup_attributes_for_nonexisting_entities
-            - filter
+            - filter/remove_temporary_metrics
             receivers:
             - forward/prometheus
           metrics/prometheus-node-metrics:

--- a/deploy/helm/tests/__snapshot__/metrics-collector-config-map_test.yaml.snap
+++ b/deploy/helm/tests/__snapshot__/metrics-collector-config-map_test.yaml.snap
@@ -505,13 +505,6 @@ Metrics config should match snapshot when fargate is enabled:
             operation: percent
             type: calculate
             unit: Percent
-        filter:
-          metrics:
-            exclude:
-              match_type: regexp
-              metric_names:
-              - .*_temp
-              - apiserver_request_total
         filter/ebpf:
           metrics:
             exclude:
@@ -653,6 +646,13 @@ Metrics config should match snapshot when fargate is enabled:
             datapoint:
             - attributes["container"] == "POD" and IsMatch(metric.name, "container_network_.*|k8s.container.*")
               == true
+        filter/remove_temporary_metrics:
+          metrics:
+            exclude:
+              match_type: regexp
+              metric_names:
+              - .*_temp
+              - apiserver_request_total
         groupbyattrs/all:
           keys:
           - kubelet_version
@@ -2276,7 +2276,7 @@ Metrics config should match snapshot when fargate is enabled:
             - resource/metrics
             - k8sattributes
             - transform/cleanup_attributes_for_nonexisting_entities
-            - filter
+            - filter/remove_temporary_metrics
             receivers:
             - forward/prometheus
           metrics/prometheus-node-metrics:
@@ -2840,13 +2840,6 @@ Metrics config should match snapshot when using Prometheus url with extra_scrape
             operation: percent
             type: calculate
             unit: Percent
-        filter:
-          metrics:
-            exclude:
-              match_type: regexp
-              metric_names:
-              - .*_temp
-              - apiserver_request_total
         filter/ebpf:
           metrics:
             exclude:
@@ -2988,6 +2981,13 @@ Metrics config should match snapshot when using Prometheus url with extra_scrape
             datapoint:
             - attributes["container"] == "POD" and IsMatch(metric.name, "container_network_.*|k8s.container.*")
               == true
+        filter/remove_temporary_metrics:
+          metrics:
+            exclude:
+              match_type: regexp
+              metric_names:
+              - .*_temp
+              - apiserver_request_total
         groupbyattrs/all:
           keys:
           - kubelet_version
@@ -4546,7 +4546,7 @@ Metrics config should match snapshot when using Prometheus url with extra_scrape
             - resource/metrics
             - k8sattributes
             - transform/cleanup_attributes_for_nonexisting_entities
-            - filter
+            - filter/remove_temporary_metrics
             receivers:
             - forward/prometheus
           metrics/prometheus-node-metrics:
@@ -5117,13 +5117,6 @@ Metrics config should match snapshot when using default values:
             operation: percent
             type: calculate
             unit: Percent
-        filter:
-          metrics:
-            exclude:
-              match_type: regexp
-              metric_names:
-              - .*_temp
-              - apiserver_request_total
         filter/ebpf:
           metrics:
             exclude:
@@ -5265,6 +5258,13 @@ Metrics config should match snapshot when using default values:
             datapoint:
             - attributes["container"] == "POD" and IsMatch(metric.name, "container_network_.*|k8s.container.*")
               == true
+        filter/remove_temporary_metrics:
+          metrics:
+            exclude:
+              match_type: regexp
+              metric_names:
+              - .*_temp
+              - apiserver_request_total
         groupbyattrs/all:
           keys:
           - kubelet_version
@@ -6808,7 +6808,7 @@ Metrics config should match snapshot when using default values:
             - resource/metrics
             - k8sattributes
             - transform/cleanup_attributes_for_nonexisting_entities
-            - filter
+            - filter/remove_temporary_metrics
             receivers:
             - forward/prometheus
           metrics/prometheus-node-metrics:

--- a/deploy/helm/tests/__snapshot__/node-collector-config-map-windows_test.yaml.snap
+++ b/deploy/helm/tests/__snapshot__/node-collector-config-map-windows_test.yaml.snap
@@ -166,18 +166,8 @@ Node collector config for windows nodes should match snapshot when using default
             - type == METRIC_DATA_TYPE_HISTOGRAM
         filter/logs:
           logs:
-            include:
-              match_type: regexp
-              resource_attributes:
-              - key: k8s.namespace.name
-                value: ^kube-.*$
-        filter/metrics:
-          metrics:
-            exclude:
-              match_type: regexp
-              metric_names:
-              - .*_temp
-              - apiserver_request_total
+            log_record:
+            - not(IsMatch(resource.attributes["k8s.namespace.name"], "^kube-.*$"))
         filter/receiver:
           metrics:
             exclude:
@@ -198,6 +188,13 @@ Node collector config for windows nodes should match snapshot when using default
             datapoint:
             - attributes["container"] == "POD" and IsMatch(metric.name, "container_network_.*|k8s.container.*")
               == true
+        filter/remove_temporary_metrics:
+          metrics:
+            exclude:
+              match_type: regexp
+              metric_names:
+              - .*_temp
+              - apiserver_request_total
         groupbyattrs/all:
           keys:
           - kubelet_version
@@ -1123,7 +1120,7 @@ Node collector config for windows nodes should match snapshot when using default
             - memory_limiter
             - filter/histograms
             - k8sattributes
-            - filter/metrics
+            - filter/remove_temporary_metrics
             - batch/metrics
             receivers:
             - forward/metric-exporter

--- a/deploy/helm/tests/__snapshot__/node-collector-config-map_test.yaml.snap
+++ b/deploy/helm/tests/__snapshot__/node-collector-config-map_test.yaml.snap
@@ -1,4 +1,1212 @@
-Node collector config should match snapshot when autodiscovery is disabled:
+Custom logs filter with new syntax:
+  1: |
+    common.proto: ""
+    logs.config: |
+      connectors:
+        forward/logs-exporter: null
+        forward/metric-exporter: null
+      exporters:
+        otlp:
+          endpoint: ${OTEL_ENVOY_ADDRESS}
+          headers:
+            Authorization: Bearer ${SOLARWINDS_API_TOKEN}
+          retry_on_failure:
+            enabled: true
+            initial_interval: 10s
+            max_elapsed_time: 300s
+            max_interval: 30s
+          sending_queue:
+            enabled: true
+            num_consumers: 20
+            queue_size: 1000
+          timeout: 15s
+          tls:
+            insecure: ${OTEL_ENVOY_ADDRESS_TLS_INSECURE}
+      extensions:
+        file_storage/checkpoints:
+          directory: /var/lib/swo/checkpoints
+          timeout: 5s
+        health_check: {}
+        k8s_observer:
+          auth_type: serviceAccount
+          node: ${NODE_NAME}
+          observe_nodes: true
+          observe_pods: true
+      processors:
+        attributes/remove_prometheus_attributes:
+          actions:
+          - action: delete
+            key: prometheus
+          - action: delete
+            key: prometheus_replica
+        attributes/remove_temp:
+          actions:
+          - action: delete
+            key: temp
+            pattern: (.*_temp$)|(^\$.*)
+          include:
+            match_type: regexp
+            metric_names:
+            - .*
+        attributes/unify_node_attribute:
+          actions:
+          - action: insert
+            from_attribute: node
+            key: k8s.node.name
+          - action: insert
+            from_attribute: kubernetes_io_hostname
+            key: k8s.node.name
+          include:
+            match_type: regexp
+            metric_names:
+            - container_.*
+        batch/logs:
+          send_batch_max_size: 512
+          send_batch_size: 512
+          timeout: 1s
+        batch/metrics:
+          send_batch_max_size: 512
+          send_batch_size: 512
+          timeout: 1s
+        cumulativetodelta/cadvisor:
+          include:
+            match_type: strict
+            metrics:
+            - k8s.node.cpu.usage.seconds.rate
+            - k8s.pod.cpu.usage.seconds.rate
+            - k8s.container.fs.iops
+            - k8s.container.fs.throughput
+            - k8s.container.cpu.usage.seconds.rate
+            - k8s.container.network.bytes_received
+            - k8s.container.network.bytes_transmitted
+            - k8s.pod.fs.iops
+            - k8s.pod.fs.throughput
+            - k8s.pod.fs.reads.rate
+            - k8s.pod.fs.writes.rate
+            - k8s.pod.fs.reads.bytes.rate
+            - k8s.pod.fs.writes.bytes.rate
+            - k8s.pod.network.bytes_received
+            - k8s.pod.network.bytes_transmitted
+            - k8s.pod.network.packets_received
+            - k8s.pod.network.packets_transmitted
+            - k8s.pod.network.receive_packets_dropped
+            - k8s.pod.network.transmit_packets_dropped
+            - k8s.node.fs.iops
+            - k8s.node.fs.throughput
+            - k8s.node.network.bytes_received
+            - k8s.node.network.bytes_transmitted
+            - k8s.node.network.packets_received
+            - k8s.node.network.packets_transmitted
+            - k8s.node.network.receive_packets_dropped
+            - k8s.node.network.transmit_packets_dropped
+        cumulativetodelta/istio-metrics:
+          include:
+            match_type: strict
+            metrics:
+            - k8s.istio_request_bytes.rate
+            - k8s.istio_response_bytes.rate
+            - k8s.istio_request_duration_milliseconds_sum_temp
+            - k8s.istio_request_duration_milliseconds_count_temp
+            - k8s.istio_requests.rate
+            - k8s.istio_tcp_sent_bytes.rate
+            - k8s.istio_tcp_received_bytes.rate
+            - k8s.istio_request_bytes.delta
+            - k8s.istio_response_bytes.delta
+            - k8s.istio_requests.delta
+            - k8s.istio_tcp_sent_bytes.delta
+            - k8s.istio_tcp_received_bytes.delta
+        deltatorate/cadvisor:
+          metrics:
+          - k8s.node.cpu.usage.seconds.rate
+          - k8s.pod.cpu.usage.seconds.rate
+          - k8s.container.fs.iops
+          - k8s.container.fs.throughput
+          - k8s.container.cpu.usage.seconds.rate
+          - k8s.container.network.bytes_received
+          - k8s.container.network.bytes_transmitted
+          - k8s.pod.fs.iops
+          - k8s.pod.fs.throughput
+          - k8s.pod.fs.reads.rate
+          - k8s.pod.fs.writes.rate
+          - k8s.pod.fs.reads.bytes.rate
+          - k8s.pod.fs.writes.bytes.rate
+          - k8s.pod.network.bytes_received
+          - k8s.pod.network.bytes_transmitted
+          - k8s.pod.network.packets_received
+          - k8s.pod.network.packets_transmitted
+          - k8s.pod.network.receive_packets_dropped
+          - k8s.pod.network.transmit_packets_dropped
+          - k8s.node.fs.iops
+          - k8s.node.fs.throughput
+          - k8s.node.network.bytes_received
+          - k8s.node.network.bytes_transmitted
+          - k8s.node.network.packets_received
+          - k8s.node.network.packets_transmitted
+          - k8s.node.network.receive_packets_dropped
+          - k8s.node.network.transmit_packets_dropped
+        deltatorate/istio-metrics:
+          metrics:
+          - k8s.istio_request_bytes.rate
+          - k8s.istio_response_bytes.rate
+          - k8s.istio_request_duration_milliseconds_sum_temp
+          - k8s.istio_request_duration_milliseconds_count_temp
+          - k8s.istio_requests.rate
+          - k8s.istio_tcp_sent_bytes.rate
+          - k8s.istio_tcp_received_bytes.rate
+        experimental_metricsgeneration/istio-metrics:
+          rules:
+          - metric1: k8s.istio_request_duration_milliseconds_sum_temp
+            metric2: k8s.istio_request_duration_milliseconds_count_temp
+            name: k8s.istio_request_duration_milliseconds.rate
+            operation: divide
+            type: calculate
+        filter/histograms:
+          metrics:
+            metric:
+            - type == METRIC_DATA_TYPE_HISTOGRAM
+        filter/logs:
+          logs:
+            log_record:
+            - not(IsMatch(resource.attributes["k8s.namespace.name"], "^.*$"))
+        filter/receiver:
+          metrics:
+            exclude:
+              match_type: strict
+              metric_names:
+              - scrape_duration_seconds
+              - scrape_samples_post_metric_relabeling
+              - scrape_samples_scraped
+              - scrape_series_added
+              - up
+        filter/remove_internal:
+          metrics:
+            datapoint:
+            - attributes["container"] == "POD" and IsMatch(metric.name, "container_network_.*")
+              == false
+        filter/remove_internal_postprocessing:
+          metrics:
+            datapoint:
+            - attributes["container"] == "POD" and IsMatch(metric.name, "container_network_.*|k8s.container.*")
+              == true
+        filter/remove_temporary_metrics:
+          metrics:
+            exclude:
+              match_type: regexp
+              metric_names:
+              - .*_temp
+              - apiserver_request_total
+        groupbyattrs/all:
+          keys:
+          - kubelet_version
+          - container_runtime_version
+          - provider_id
+          - os_image
+          - namespace
+          - uid
+          - k8s.pod.uid
+          - pod_ip
+          - host_ip
+          - created_by_kind
+          - created_by_name
+          - host_network
+          - priority_class
+          - container_id
+          - container
+          - image
+          - image_id
+          - k8s.node.name
+          - sw.k8s.pod.status
+          - sw.k8s.namespace.status
+          - sw.k8s.node.status
+          - sw.k8s.container.status
+          - sw.k8s.container.init
+          - daemonset
+          - statefulset
+          - deployment
+          - replicaset
+          - job_name
+          - cronjob
+          - sw.k8s.cluster.version
+          - internal_ip
+          - job_condition
+          - persistentvolumeclaim
+          - persistentvolume
+          - sw.k8s.persistentvolumeclaim.status
+          - sw.k8s.persistentvolume.status
+          - storageclass
+          - access_mode
+          - k8s.service.name
+          - sw.k8s.service.external_name
+          - sw.k8s.service.type
+          - sw.k8s.cluster.ip
+        groupbyattrs/common-all:
+          keys:
+          - k8s.container.name
+          - k8s.namespace.name
+          - k8s.pod.name
+          - k8s.pod.uid
+          - host.name
+          - service.name
+        groupbyattrs/node:
+          keys:
+          - k8s.node.name
+        groupbyattrs/pod:
+          keys:
+          - namespace
+          - pod
+        k8sattributes:
+          auth_type: serviceAccount
+          extract:
+            annotations:
+            - from: pod
+              key_regex: (.*)
+              tag_name: k8s.pod.annotations.$$1
+            - from: namespace
+              key_regex: (.*)
+              tag_name: k8s.namespace.annotations.$$1
+            labels:
+            - from: pod
+              key_regex: (.*)
+              tag_name: k8s.pod.labels.$$1
+            - from: namespace
+              key_regex: (.*)
+              tag_name: k8s.namespace.labels.$$1
+            metadata:
+            - k8s.deployment.name
+            - k8s.replicaset.name
+            - k8s.daemonset.name
+            - k8s.job.name
+            - k8s.cronjob.name
+            - k8s.statefulset.name
+          filter:
+            node_from_env_var: NODE_NAME
+          passthrough: false
+          pod_association:
+          - sources:
+            - from: resource_attribute
+              name: k8s.pod.name
+            - from: resource_attribute
+              name: k8s.namespace.name
+        memory_limiter:
+          check_interval: 1s
+          limit_mib: 800
+          spike_limit_mib: 300
+        metricstransform/istio-metrics:
+          transforms:
+          - action: insert
+            include: k8s.istio_request_bytes.rate
+            new_name: k8s.istio_request_bytes.delta
+          - action: insert
+            include: k8s.istio_response_bytes.rate
+            new_name: k8s.istio_response_bytes.delta
+          - action: insert
+            include: k8s.istio_requests.rate
+            new_name: k8s.istio_requests.delta
+          - action: insert
+            include: k8s.istio_tcp_sent_bytes.rate
+            new_name: k8s.istio_tcp_sent_bytes.delta
+          - action: insert
+            include: k8s.istio_tcp_received_bytes.rate
+            new_name: k8s.istio_tcp_received_bytes.delta
+        metricstransform/preprocessing:
+          transforms:
+          - action: insert
+            include: k8s.container_fs_reads_total
+            new_name: k8s.container_fs_reads_total_temp
+          - action: insert
+            include: k8s.container_fs_writes_total
+            new_name: k8s.container_fs_writes_total_temp
+          - action: combine
+            experimental_match_labels:
+              container: \S+
+              namespace: \S+
+              pod: \S+
+            include: (k8s.container_fs_reads_total_temp|k8s.container_fs_writes_total_temp)
+            match_type: regexp
+            new_name: k8s.container.fs.iops
+            operations:
+            - action: aggregate_labels
+              aggregation_type: sum
+              label_set:
+              - container
+              - pod
+              - namespace
+            submatch_case: lower
+          - action: insert
+            include: k8s.container_fs_reads_bytes_total
+            new_name: k8s.container_fs_reads_bytes_total_temp
+          - action: insert
+            include: k8s.container_fs_writes_bytes_total
+            new_name: k8s.container_fs_writes_bytes_total_temp
+          - action: combine
+            experimental_match_labels:
+              container: \S+
+              namespace: \S+
+              pod: \S+
+            include: (k8s.container_fs_reads_bytes_total_temp|k8s.container_fs_writes_bytes_total_temp)
+            match_type: regexp
+            new_name: k8s.container.fs.throughput
+            operations:
+            - action: aggregate_labels
+              aggregation_type: sum
+              label_set:
+              - container
+              - pod
+              - namespace
+            submatch_case: lower
+          - action: insert
+            include: k8s.container_network_receive_bytes_total
+            new_name: k8s.container.network.bytes_received
+          - action: insert
+            include: k8s.container_network_transmit_bytes_total
+            new_name: k8s.container.network.bytes_transmitted
+          - action: insert
+            experimental_match_labels:
+              container: \S+
+              namespace: \S+
+              pod: \S+
+            include: k8s.container_cpu_usage_seconds_total
+            match_type: regexp
+            new_name: k8s.pod.cpu.usage.seconds.rate
+            operations:
+            - action: aggregate_labels
+              aggregation_type: sum
+              label_set:
+              - pod
+              - namespace
+              - k8s.node.name
+          - action: insert
+            include: k8s.container_cpu_usage_seconds_total
+            new_name: k8s.container.cpu.usage.seconds.rate
+          - action: insert
+            experimental_match_labels:
+              container: \S+
+              namespace: \S+
+              pod: \S+
+            include: k8s.container_memory_working_set_bytes
+            match_type: regexp
+            new_name: k8s.pod.memory.working_set
+            operations:
+            - action: aggregate_labels
+              aggregation_type: sum
+              label_set:
+              - pod
+              - namespace
+              - k8s.node.name
+          - action: insert
+            experimental_match_labels:
+              k8s.node.name: \S+
+              namespace: \S+
+              pod: \S+
+            include: k8s.container_network_receive_bytes_total
+            match_type: regexp
+            new_name: k8s.pod.network.bytes_received
+            operations:
+            - action: aggregate_labels
+              aggregation_type: sum
+              label_set:
+              - pod
+              - namespace
+              - k8s.node.name
+          - action: insert
+            experimental_match_labels:
+              k8s.node.name: \S+
+              namespace: \S+
+              pod: \S+
+            include: k8s.container_network_transmit_bytes_total
+            match_type: regexp
+            new_name: k8s.pod.network.bytes_transmitted
+            operations:
+            - action: aggregate_labels
+              aggregation_type: sum
+              label_set:
+              - pod
+              - namespace
+              - k8s.node.name
+          - action: insert
+            experimental_match_labels:
+              k8s.node.name: \S+
+              namespace: \S+
+              pod: \S+
+            include: k8s.container_network_receive_packets_total
+            match_type: regexp
+            new_name: k8s.pod.network.packets_received
+            operations:
+            - action: aggregate_labels
+              aggregation_type: sum
+              label_set:
+              - pod
+              - namespace
+              - k8s.node.name
+          - action: insert
+            experimental_match_labels:
+              k8s.node.name: \S+
+              namespace: \S+
+              pod: \S+
+            include: k8s.container_network_transmit_packets_total
+            match_type: regexp
+            new_name: k8s.pod.network.packets_transmitted
+            operations:
+            - action: aggregate_labels
+              aggregation_type: sum
+              label_set:
+              - pod
+              - namespace
+              - k8s.node.name
+          - action: insert
+            experimental_match_labels:
+              k8s.node.name: \S+
+              namespace: \S+
+              pod: \S+
+            include: k8s.container_network_receive_packets_dropped_total
+            match_type: regexp
+            new_name: k8s.pod.network.receive_packets_dropped
+            operations:
+            - action: aggregate_labels
+              aggregation_type: sum
+              label_set:
+              - pod
+              - namespace
+              - k8s.node.name
+          - action: insert
+            experimental_match_labels:
+              k8s.node.name: \S+
+              namespace: \S+
+              pod: \S+
+            include: k8s.container_network_transmit_packets_dropped_total
+            match_type: regexp
+            new_name: k8s.pod.network.transmit_packets_dropped
+            operations:
+            - action: aggregate_labels
+              aggregation_type: sum
+              label_set:
+              - pod
+              - namespace
+              - k8s.node.name
+          - action: insert
+            experimental_match_labels:
+              k8s.node.name: \S+
+              namespace: \S+
+              pod: \S+
+            include: k8s.container_fs_reads_total
+            match_type: regexp
+            new_name: k8s.pod.fs.reads.rate
+            operations:
+            - action: aggregate_labels
+              aggregation_type: sum
+              label_set:
+              - pod
+              - namespace
+              - k8s.node.name
+          - action: insert
+            experimental_match_labels:
+              k8s.node.name: \S+
+              namespace: \S+
+              pod: \S+
+            include: k8s.container_fs_writes_total
+            match_type: regexp
+            new_name: k8s.pod.fs.writes.rate
+            operations:
+            - action: aggregate_labels
+              aggregation_type: sum
+              label_set:
+              - pod
+              - namespace
+              - k8s.node.name
+          - action: insert
+            experimental_match_labels:
+              k8s.node.name: \S+
+              namespace: \S+
+              pod: \S+
+            include: k8s.container_fs_reads_bytes_total
+            match_type: regexp
+            new_name: k8s.pod.fs.reads.bytes.rate
+            operations:
+            - action: aggregate_labels
+              aggregation_type: sum
+              label_set:
+              - pod
+              - namespace
+              - k8s.node.name
+          - action: insert
+            experimental_match_labels:
+              k8s.node.name: \S+
+              namespace: \S+
+              pod: \S+
+            include: k8s.container_fs_writes_bytes_total
+            match_type: regexp
+            new_name: k8s.pod.fs.writes.bytes.rate
+            operations:
+            - action: aggregate_labels
+              aggregation_type: sum
+              label_set:
+              - pod
+              - namespace
+              - k8s.node.name
+          - action: insert
+            include: k8s.pod.fs.reads.rate
+            new_name: k8s.pod.fs.reads.rate_temp
+          - action: insert
+            include: k8s.pod.fs.writes.rate
+            new_name: k8s.pod.fs.writes.rate_temp
+          - action: combine
+            include: (k8s.pod.fs.reads.rate_temp|k8s.pod.fs.writes.rate_temp)
+            match_type: regexp
+            new_name: k8s.pod.fs.iops
+            operations:
+            - action: aggregate_labels
+              aggregation_type: sum
+              label_set:
+              - pod
+              - namespace
+              - k8s.node.name
+            submatch_case: lower
+          - action: insert
+            include: k8s.pod.fs.reads.bytes.rate
+            new_name: k8s.pod.fs.reads.bytes.rate_temp
+          - action: insert
+            include: k8s.pod.fs.writes.bytes.rate
+            new_name: k8s.pod.fs.writes.bytes.rate_temp
+          - action: combine
+            include: (k8s.pod.fs.reads.bytes.rate_temp|k8s.pod.fs.writes.bytes.rate_temp)
+            match_type: regexp
+            new_name: k8s.pod.fs.throughput
+            operations:
+            - action: aggregate_labels
+              aggregation_type: sum
+              label_set:
+              - pod
+              - namespace
+              - k8s.node.name
+            submatch_case: lower
+          - action: insert
+            experimental_match_labels:
+              k8s.node.name: \S+
+              namespace: \S+
+              pod: \S+
+            include: k8s.container_fs_usage_bytes
+            match_type: regexp
+            new_name: k8s.pod.fs.usage.bytes
+            operations:
+            - action: aggregate_labels
+              aggregation_type: sum
+              label_set:
+              - pod
+              - namespace
+              - k8s.node.name
+          - action: insert
+            experimental_match_labels:
+              id: /
+            include: k8s.container_cpu_usage_seconds_total
+            new_name: k8s.node.cpu.usage.seconds.rate
+          - action: insert
+            experimental_match_labels:
+              id: /
+            include: k8s.container_memory_working_set_bytes
+            new_name: k8s.node.memory.working_set
+          - action: insert
+            experimental_match_labels:
+              id: /
+              k8s.node.name: \S+
+            include: k8s.container_network_receive_bytes_total
+            match_type: regexp
+            new_name: k8s.node.network.bytes_received
+            operations:
+            - action: aggregate_labels
+              aggregation_type: sum
+              label_set:
+              - k8s.node.name
+          - action: insert
+            experimental_match_labels:
+              id: /
+              k8s.node.name: \S+
+            include: k8s.container_network_transmit_bytes_total
+            match_type: regexp
+            new_name: k8s.node.network.bytes_transmitted
+            operations:
+            - action: aggregate_labels
+              aggregation_type: sum
+              label_set:
+              - k8s.node.name
+          - action: insert
+            experimental_match_labels:
+              id: /
+              k8s.node.name: \S+
+            include: k8s.container_network_receive_packets_total
+            match_type: regexp
+            new_name: k8s.node.network.packets_received
+            operations:
+            - action: aggregate_labels
+              aggregation_type: sum
+              label_set:
+              - k8s.node.name
+          - action: insert
+            experimental_match_labels:
+              id: /
+              k8s.node.name: \S+
+            include: k8s.container_network_transmit_packets_total
+            match_type: regexp
+            new_name: k8s.node.network.packets_transmitted
+            operations:
+            - action: aggregate_labels
+              aggregation_type: sum
+              label_set:
+              - k8s.node.name
+          - action: insert
+            experimental_match_labels:
+              id: /
+              k8s.node.name: \S+
+            include: k8s.container_network_receive_packets_dropped_total
+            match_type: regexp
+            new_name: k8s.node.network.receive_packets_dropped
+            operations:
+            - action: aggregate_labels
+              aggregation_type: sum
+              label_set:
+              - k8s.node.name
+          - action: insert
+            experimental_match_labels:
+              id: /
+              k8s.node.name: \S+
+            include: k8s.container_network_transmit_packets_dropped_total
+            match_type: regexp
+            new_name: k8s.node.network.transmit_packets_dropped
+            operations:
+            - action: aggregate_labels
+              aggregation_type: sum
+              label_set:
+              - k8s.node.name
+          - action: insert
+            include: k8s.pod.fs.reads.rate
+            new_name: k8s.node.fs.reads.rate_temp
+            operations:
+            - action: aggregate_labels
+              aggregation_type: sum
+              label_set:
+              - k8s.node.name
+          - action: insert
+            include: k8s.pod.fs.writes.rate
+            new_name: k8s.node.fs.writes.rate_temp
+            operations:
+            - action: aggregate_labels
+              aggregation_type: sum
+              label_set:
+              - k8s.node.name
+          - action: insert
+            include: k8s.pod.fs.reads.bytes.rate
+            new_name: k8s.node.fs.reads.bytes.rate_temp
+            operations:
+            - action: aggregate_labels
+              aggregation_type: sum
+              label_set:
+              - k8s.node.name
+          - action: insert
+            include: k8s.pod.fs.writes.bytes.rate
+            new_name: k8s.node.fs.writes.bytes.rate_temp
+            operations:
+            - action: aggregate_labels
+              aggregation_type: sum
+              label_set:
+              - k8s.node.name
+          - action: combine
+            include: (k8s.node.fs.reads.rate_temp|k8s.node.fs.writes.rate_temp)
+            match_type: regexp
+            new_name: k8s.node.fs.iops
+            operations:
+            - action: aggregate_labels
+              aggregation_type: sum
+              label_set:
+              - k8s.node.name
+            submatch_case: lower
+          - action: combine
+            include: (k8s.node.fs.reads.bytes.rate_temp|k8s.node.fs.writes.bytes.rate_temp)
+            match_type: regexp
+            new_name: k8s.node.fs.throughput
+            operations:
+            - action: aggregate_labels
+              aggregation_type: sum
+              label_set:
+              - k8s.node.name
+            submatch_case: lower
+          - action: insert
+            include: k8s.pod.fs.usage.bytes
+            new_name: k8s.node.fs.usage
+            operations:
+            - action: aggregate_labels
+              aggregation_type: sum
+              label_set:
+              - k8s.node.name
+        metricstransform/rename:
+          transforms:
+          - action: update
+            include: ^(.*)$$
+            match_type: regexp
+            new_name: k8s.$${1}
+        resource/all:
+          attributes:
+          - action: insert
+            key: sw.k8s.agent.manifest.version
+            value: ${MANIFEST_VERSION}
+          - action: insert
+            key: sw.k8s.agent.app.version
+            value: ${APP_VERSION}
+          - action: insert
+            key: sw.k8s.cluster.uid
+            value: ${CLUSTER_UID}
+          - action: insert
+            key: k8s.cluster.name
+            value: ${CLUSTER_NAME}
+          - action: upsert
+            key: k8s.node.name
+            value: ${NODE_NAME}
+        resource/container:
+          attributes:
+          - action: insert
+            key: sw.k8s.log.type
+            value: container
+          - action: insert
+            key: sw.k8s.agent.manifest.version
+            value: ${MANIFEST_VERSION}
+          - action: insert
+            key: sw.k8s.agent.app.version
+            value: ${APP_VERSION}
+          - action: insert
+            key: sw.k8s.cluster.uid
+            value: ${CLUSTER_UID}
+          - action: insert
+            key: k8s.cluster.name
+            value: ${CLUSTER_NAME}
+          - action: insert
+            key: k8s.node.name
+            value: ${NODE_NAME}
+        resource/journal:
+          attributes:
+          - action: insert
+            key: sw.k8s.log.type
+            value: journal
+          - action: insert
+            key: sw.k8s.agent.manifest.version
+            value: ${MANIFEST_VERSION}
+          - action: insert
+            key: sw.k8s.agent.app.version
+            value: ${APP_VERSION}
+          - action: insert
+            key: sw.k8s.cluster.uid
+            value: ${CLUSTER_UID}
+          - action: insert
+            key: k8s.cluster.name
+            value: ${CLUSTER_NAME}
+          - action: insert
+            key: k8s.node.name
+            value: ${NODE_NAME}
+        resource/k8sattributes_logs_annotations_filter:
+          attributes:
+          - action: delete
+            pattern: k8s\.\w+\.annotations\..*
+        resource/k8sattributes_logs_labels_filter:
+          attributes:
+          - action: delete
+            pattern: k8s\.\w+\.labels\..*
+        resource/metrics:
+          attributes:
+          - action: delete
+            key: service.name
+          - action: delete
+            key: service.instance.id
+          - action: delete
+            key: net.host.name
+          - action: delete
+            key: net.host.port
+          - action: delete
+            key: http.scheme
+          - action: insert
+            key: sw.k8s.agent.manifest.version
+            value: ${MANIFEST_VERSION}
+          - action: insert
+            key: sw.k8s.agent.app.version
+            value: ${APP_VERSION}
+          - action: insert
+            key: sw.k8s.cluster.uid
+            value: ${CLUSTER_UID}
+          - action: insert
+            key: k8s.cluster.name
+            value: ${CLUSTER_NAME}
+          - action: insert
+            from_attribute: kubelet_version
+            key: sw.k8s.node.version
+          - action: insert
+            from_attribute: container_runtime_version
+            key: sw.k8s.node.container.runtime.version
+          - action: insert
+            from_attribute: provider_id
+            key: sw.k8s.node.provider.id
+          - action: insert
+            from_attribute: os_image
+            key: sw.k8s.node.os.image
+          - action: insert
+            from_attribute: internal_ip
+            key: sw.k8s.node.ip.internal
+          - action: insert
+            from_attribute: namespace
+            key: k8s.namespace.name
+          - action: insert
+            from_attribute: pod
+            key: k8s.pod.name
+          - action: insert
+            from_attribute: pod_ip
+            key: sw.k8s.pod.ip
+          - action: insert
+            from_attribute: host_ip
+            key: sw.k8s.pod.host.ip
+          - action: insert
+            from_attribute: created_by_kind
+            key: sw.k8s.pod.createdby.kind
+          - action: insert
+            from_attribute: created_by_name
+            key: sw.k8s.pod.createdby.name
+          - action: insert
+            from_attribute: host_network
+            key: sw.k8s.pod.host.network
+          - action: insert
+            from_attribute: priority_class
+            key: sw.k8s.pod.priority_class
+          - action: extract
+            key: container_id
+            pattern: ^(?P<extracted_container_runtime>[^:]+)://(?P<extracted_container_id>[^/]+)$
+          - action: insert
+            from_attribute: extracted_container_id
+            key: container.id
+          - action: insert
+            from_attribute: extracted_container_runtime
+            key: container.runtime
+          - action: insert
+            from_attribute: container
+            key: k8s.container.name
+          - action: insert
+            from_attribute: image_id
+            key: k8s.container.image.id
+          - action: insert
+            from_attribute: image
+            key: k8s.container.image.name
+          - action: insert
+            from_attribute: replicaset
+            key: k8s.replicaset.name
+          - action: insert
+            from_attribute: deployment
+            key: k8s.deployment.name
+          - action: insert
+            from_attribute: statefulset
+            key: k8s.statefulset.name
+          - action: insert
+            from_attribute: daemonset
+            key: k8s.daemonset.name
+          - action: insert
+            from_attribute: job_name
+            key: k8s.job.name
+          - action: insert
+            from_attribute: job_condition
+            key: k8s.job.condition
+          - action: insert
+            from_attribute: cronjob
+            key: k8s.cronjob.name
+          - action: insert
+            from_attribute: persistentvolume
+            key: k8s.persistentvolume.name
+          - action: insert
+            from_attribute: persistentvolumeclaim
+            key: k8s.persistentvolumeclaim.name
+        transform/istio-metrics:
+          metric_statements:
+          - context: metric
+            statements:
+            - extract_sum_metric(true) where (name == "k8s.istio_request_bytes" or name
+              == "k8s.istio_response_bytes" or name == "k8s.istio_request_duration_milliseconds")
+            - extract_count_metric(true) where (name == "k8s.istio_request_duration_milliseconds")
+            - set(name, "k8s.istio_request_bytes.rate") where name == "k8s.istio_request_bytes_sum"
+            - set(name, "k8s.istio_response_bytes.rate") where name == "k8s.istio_response_bytes_sum"
+            - set(name, "k8s.istio_requests.rate") where name == "k8s.istio_requests_total"
+            - set(name, "k8s.istio_tcp_sent_bytes.rate") where name == "k8s.istio_tcp_sent_bytes_total"
+            - set(name, "k8s.istio_tcp_received_bytes.rate") where name == "k8s.istio_tcp_received_bytes_total"
+            - set(name, "k8s.istio_request_duration_milliseconds_sum_temp") where name ==
+              "k8s.istio_request_duration_milliseconds_sum"
+            - set(name, "k8s.istio_request_duration_milliseconds_count_temp") where name
+              == "k8s.istio_request_duration_milliseconds_count"
+        transform/syslogify:
+          error_mode: ignore
+          log_statements:
+          - context: log
+            statements:
+            - set( attributes["host.name"], attributes["k8s.pod.name"])
+            - set( attributes["service.name"], attributes["k8s.container.name"])
+        transform/unify_node_attribute:
+          metric_statements:
+          - context: datapoint
+            statements:
+            - set(attributes["k8s.node.name"], resource.attributes["service.instance.id"])
+              where IsMatch(metric.name, "^(container_.*)$") == true and attributes["k8s.node.name"]
+              == nil
+      receivers:
+        filelog:
+          encoding: utf-8
+          exclude:
+          - /var/log/pods/${POD_NAMESPACE}_${POD_NAME}*_*/swi-opentelemetry-collector/*.log
+          fingerprint_size: 1kb
+          include:
+          - /var/log/pods/*/*/*.log
+          include_file_name: false
+          include_file_path: true
+          max_concurrent_files: 10
+          max_log_size: 1MiB
+          operators:
+          - id: get-format
+            routes:
+            - expr: body matches "^\\{"
+              output: parser-docker
+            - expr: body matches "^[^ Z]+ "
+              output: parser-crio
+            - expr: body matches "^[^ Z]+Z"
+              output: parser-containerd
+            type: router
+          - id: parser-crio
+            output: merge-cri-lines
+            parse_to: body
+            regex: ^(?P<time>[^ Z]+) (?P<stream>stdout|stderr) (?P<logtag>[^ ]*)( |)(?P<log>.*)$
+            timestamp:
+              layout: "2006-01-02T15:04:05.999999999-07:00"
+              layout_type: gotime
+              parse_from: body.time
+            type: regex_parser
+          - id: parser-containerd
+            output: merge-cri-lines
+            parse_to: body
+            regex: ^(?P<time>[^ ^Z]+Z) (?P<stream>stdout|stderr) (?P<logtag>[^ ]*)( |)(?P<log>.*)$
+            timestamp:
+              layout: '%Y-%m-%dT%H:%M:%S.%LZ'
+              parse_from: body.time
+            type: regex_parser
+          - id: parser-docker
+            output: merge-docker-lines
+            parse_to: body
+            timestamp:
+              layout: '%Y-%m-%dT%H:%M:%S.%LZ'
+              parse_from: body.time
+            type: json_parser
+          - combine_field: body.log
+            combine_with: ""
+            id: merge-docker-lines
+            is_last_entry: body.log matches "\n$"
+            max_unmatched_batch_size: 1
+            output: merge-multiline-logs
+            source_identifier: attributes["log.file.path"]
+            type: recombine
+          - combine_field: body.log
+            combine_with: ""
+            id: merge-cri-lines
+            is_last_entry: body.logtag == "F"
+            max_unmatched_batch_size: 1
+            output: merge-multiline-logs
+            overwrite_with: newest
+            source_identifier: attributes["log.file.path"]
+            type: recombine
+          - combine_field: body.log
+            combine_with: ""
+            id: merge-multiline-logs
+            is_first_entry: body.log matches "^\\[?\\d{4}-\\d{1,2}-\\d{1,2}.\\d{2}:\\d{2}:\\d{2}.*"
+            max_unmatched_batch_size: 1
+            output: extract-metadata-from-filepath
+            source_identifier: attributes["log.file.path"]
+            type: recombine
+          - id: extract-metadata-from-filepath
+            parse_from: attributes["log.file.path"]
+            regex: ^.*\/(?P<namespace>[^_]+)_(?P<pod_name>[^_]+)_(?P<uid>[a-f0-9\-]+)\/(?P<container_name>[^\._]+)\/(?P<run_id>\d+)\.log$
+            type: regex_parser
+          - from: body.stream
+            id: move-attributes
+            to: attributes["stream"]
+            type: move
+          - from: attributes.container_name
+            to: attributes["k8s.container.name"]
+            type: move
+          - from: attributes.namespace
+            to: attributes["k8s.namespace.name"]
+            type: move
+          - from: attributes.pod_name
+            to: attributes["k8s.pod.name"]
+            type: move
+          - field: attributes.run_id
+            type: remove
+          - from: attributes.uid
+            to: attributes["k8s.pod.uid"]
+            type: move
+          - field: attributes["log.file.path"]
+            type: remove
+          - field: body.time
+            type: remove
+          - from: body.log
+            to: body
+            type: move
+          poll_interval: 200ms
+          start_at: end
+          storage: file_storage/checkpoints
+        journald:
+          files:
+          - /*/log/journal/**/*
+          units:
+          - kubelet
+          - docker
+          - containerd
+        receiver_creator/discovery:
+          receivers:
+            prometheus/discovery:
+              config:
+                config:
+                  scrape_configs:
+                  - honor_labels: true
+                    honor_timestamps: false
+                    job_name: pod
+                    metrics_path: '`"prometheus.io/path" in annotations ? annotations["prometheus.io/path"]
+                      : "/metrics"`'
+                    scheme: http
+                    scrape_interval: 60s
+                    static_configs:
+                    - targets:
+                      - '`endpoint`:`"prometheus.io/port" in annotations ? annotations["prometheus.io/port"]
+                        : 9090`'
+              rule: type == "pod" && annotations["prometheus.io/scrape"] == "true"
+          watch_observers:
+          - k8s_observer
+        receiver_creator/node:
+          receivers:
+            prometheus/node:
+              config:
+                config:
+                  scrape_configs:
+                  - bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
+                    honor_labels: true
+                    honor_timestamps: false
+                    job_name: kubernetes-nodes-cadvisor
+                    metrics_path: /metrics/cadvisor
+                    scheme: https
+                    scrape_interval: 60s
+                    scrape_timeout: 10s
+                    static_configs:
+                    - targets:
+                      - '`endpoint`:`kubelet_endpoint_port`'
+                    tls_config:
+                      ca_file: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+                      insecure_skip_verify: true
+                  - bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
+                    honor_labels: true
+                    honor_timestamps: false
+                    job_name: kubernetes-nodes
+                    metrics_path: /metrics
+                    scheme: https
+                    scrape_interval: 60s
+                    scrape_timeout: 10s
+                    static_configs:
+                    - targets:
+                      - '`endpoint`:`kubelet_endpoint_port`'
+                    tls_config:
+                      ca_file: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+                      insecure_skip_verify: true
+              rule: type == "k8s.node"
+          watch_observers:
+          - k8s_observer
+      service:
+        extensions:
+        - file_storage/checkpoints
+        - health_check
+        - k8s_observer
+        pipelines:
+          logs:
+            exporters:
+            - otlp
+            processors:
+            - memory_limiter
+            - filter/logs
+            - batch/logs
+            receivers:
+            - forward/logs-exporter
+          logs/container:
+            exporters:
+            - forward/logs-exporter
+            processors:
+            - memory_limiter
+            - transform/syslogify
+            - groupbyattrs/common-all
+            - resource/container
+            - k8sattributes
+            - resource/k8sattributes_logs_labels_filter
+            - resource/k8sattributes_logs_annotations_filter
+            receivers:
+            - filelog
+          logs/journal:
+            exporters:
+            - forward/logs-exporter
+            processors:
+            - memory_limiter
+            - groupbyattrs/common-all
+            - resource/journal
+            receivers:
+            - journald
+          metrics:
+            exporters:
+            - otlp
+            processors:
+            - memory_limiter
+            - filter/histograms
+            - k8sattributes
+            - filter/remove_temporary_metrics
+            - batch/metrics
+            receivers:
+            - forward/metric-exporter
+          metrics/discovery:
+            exporters:
+            - forward/metric-exporter
+            processors:
+            - memory_limiter
+            - metricstransform/rename
+            - transform/istio-metrics
+            - metricstransform/istio-metrics
+            - cumulativetodelta/istio-metrics
+            - deltatorate/istio-metrics
+            - experimental_metricsgeneration/istio-metrics
+            - groupbyattrs/common-all
+            - resource/all
+            receivers:
+            - receiver_creator/discovery
+          metrics/node:
+            exporters:
+            - forward/metric-exporter
+            processors:
+            - memory_limiter
+            - filter/receiver
+            - filter/remove_internal
+            - attributes/remove_prometheus_attributes
+            - attributes/unify_node_attribute
+            - transform/unify_node_attribute
+            - metricstransform/rename
+            - metricstransform/preprocessing
+            - filter/remove_internal_postprocessing
+            - attributes/remove_temp
+            - cumulativetodelta/cadvisor
+            - deltatorate/cadvisor
+            - groupbyattrs/node
+            - groupbyattrs/pod
+            - groupbyattrs/all
+            - resource/metrics
+            - resource/all
+            receivers:
+            - receiver_creator/node
+        telemetry:
+          logs:
+            level: info
+          metrics:
+            address: 0.0.0.0:8888
+    logs.proto: ""
+    logs_service.proto: ""
+    resource.proto: ""
+Custom logs filter with old syntax:
   1: |
     common.proto: ""
     logs.config: |
@@ -168,16 +1376,9 @@ Node collector config should match snapshot when autodiscovery is disabled:
           logs:
             include:
               match_type: regexp
-              resource_attributes:
+              record_attributes:
               - key: k8s.namespace.name
-                value: ^kube-.*$
-        filter/metrics:
-          metrics:
-            exclude:
-              match_type: regexp
-              metric_names:
-              - .*_temp
-              - apiserver_request_total
+                value: ^.*$
         filter/receiver:
           metrics:
             exclude:
@@ -198,6 +1399,1221 @@ Node collector config should match snapshot when autodiscovery is disabled:
             datapoint:
             - attributes["container"] == "POD" and IsMatch(metric.name, "container_network_.*|k8s.container.*")
               == true
+        filter/remove_temporary_metrics:
+          metrics:
+            exclude:
+              match_type: regexp
+              metric_names:
+              - .*_temp
+              - apiserver_request_total
+        groupbyattrs/all:
+          keys:
+          - kubelet_version
+          - container_runtime_version
+          - provider_id
+          - os_image
+          - namespace
+          - uid
+          - k8s.pod.uid
+          - pod_ip
+          - host_ip
+          - created_by_kind
+          - created_by_name
+          - host_network
+          - priority_class
+          - container_id
+          - container
+          - image
+          - image_id
+          - k8s.node.name
+          - sw.k8s.pod.status
+          - sw.k8s.namespace.status
+          - sw.k8s.node.status
+          - sw.k8s.container.status
+          - sw.k8s.container.init
+          - daemonset
+          - statefulset
+          - deployment
+          - replicaset
+          - job_name
+          - cronjob
+          - sw.k8s.cluster.version
+          - internal_ip
+          - job_condition
+          - persistentvolumeclaim
+          - persistentvolume
+          - sw.k8s.persistentvolumeclaim.status
+          - sw.k8s.persistentvolume.status
+          - storageclass
+          - access_mode
+          - k8s.service.name
+          - sw.k8s.service.external_name
+          - sw.k8s.service.type
+          - sw.k8s.cluster.ip
+        groupbyattrs/common-all:
+          keys:
+          - k8s.container.name
+          - k8s.namespace.name
+          - k8s.pod.name
+          - k8s.pod.uid
+          - host.name
+          - service.name
+        groupbyattrs/node:
+          keys:
+          - k8s.node.name
+        groupbyattrs/pod:
+          keys:
+          - namespace
+          - pod
+        k8sattributes:
+          auth_type: serviceAccount
+          extract:
+            annotations:
+            - from: pod
+              key_regex: (.*)
+              tag_name: k8s.pod.annotations.$$1
+            - from: namespace
+              key_regex: (.*)
+              tag_name: k8s.namespace.annotations.$$1
+            labels:
+            - from: pod
+              key_regex: (.*)
+              tag_name: k8s.pod.labels.$$1
+            - from: namespace
+              key_regex: (.*)
+              tag_name: k8s.namespace.labels.$$1
+            metadata:
+            - k8s.deployment.name
+            - k8s.replicaset.name
+            - k8s.daemonset.name
+            - k8s.job.name
+            - k8s.cronjob.name
+            - k8s.statefulset.name
+          filter:
+            node_from_env_var: NODE_NAME
+          passthrough: false
+          pod_association:
+          - sources:
+            - from: resource_attribute
+              name: k8s.pod.name
+            - from: resource_attribute
+              name: k8s.namespace.name
+        memory_limiter:
+          check_interval: 1s
+          limit_mib: 800
+          spike_limit_mib: 300
+        metricstransform/istio-metrics:
+          transforms:
+          - action: insert
+            include: k8s.istio_request_bytes.rate
+            new_name: k8s.istio_request_bytes.delta
+          - action: insert
+            include: k8s.istio_response_bytes.rate
+            new_name: k8s.istio_response_bytes.delta
+          - action: insert
+            include: k8s.istio_requests.rate
+            new_name: k8s.istio_requests.delta
+          - action: insert
+            include: k8s.istio_tcp_sent_bytes.rate
+            new_name: k8s.istio_tcp_sent_bytes.delta
+          - action: insert
+            include: k8s.istio_tcp_received_bytes.rate
+            new_name: k8s.istio_tcp_received_bytes.delta
+        metricstransform/preprocessing:
+          transforms:
+          - action: insert
+            include: k8s.container_fs_reads_total
+            new_name: k8s.container_fs_reads_total_temp
+          - action: insert
+            include: k8s.container_fs_writes_total
+            new_name: k8s.container_fs_writes_total_temp
+          - action: combine
+            experimental_match_labels:
+              container: \S+
+              namespace: \S+
+              pod: \S+
+            include: (k8s.container_fs_reads_total_temp|k8s.container_fs_writes_total_temp)
+            match_type: regexp
+            new_name: k8s.container.fs.iops
+            operations:
+            - action: aggregate_labels
+              aggregation_type: sum
+              label_set:
+              - container
+              - pod
+              - namespace
+            submatch_case: lower
+          - action: insert
+            include: k8s.container_fs_reads_bytes_total
+            new_name: k8s.container_fs_reads_bytes_total_temp
+          - action: insert
+            include: k8s.container_fs_writes_bytes_total
+            new_name: k8s.container_fs_writes_bytes_total_temp
+          - action: combine
+            experimental_match_labels:
+              container: \S+
+              namespace: \S+
+              pod: \S+
+            include: (k8s.container_fs_reads_bytes_total_temp|k8s.container_fs_writes_bytes_total_temp)
+            match_type: regexp
+            new_name: k8s.container.fs.throughput
+            operations:
+            - action: aggregate_labels
+              aggregation_type: sum
+              label_set:
+              - container
+              - pod
+              - namespace
+            submatch_case: lower
+          - action: insert
+            include: k8s.container_network_receive_bytes_total
+            new_name: k8s.container.network.bytes_received
+          - action: insert
+            include: k8s.container_network_transmit_bytes_total
+            new_name: k8s.container.network.bytes_transmitted
+          - action: insert
+            experimental_match_labels:
+              container: \S+
+              namespace: \S+
+              pod: \S+
+            include: k8s.container_cpu_usage_seconds_total
+            match_type: regexp
+            new_name: k8s.pod.cpu.usage.seconds.rate
+            operations:
+            - action: aggregate_labels
+              aggregation_type: sum
+              label_set:
+              - pod
+              - namespace
+              - k8s.node.name
+          - action: insert
+            include: k8s.container_cpu_usage_seconds_total
+            new_name: k8s.container.cpu.usage.seconds.rate
+          - action: insert
+            experimental_match_labels:
+              container: \S+
+              namespace: \S+
+              pod: \S+
+            include: k8s.container_memory_working_set_bytes
+            match_type: regexp
+            new_name: k8s.pod.memory.working_set
+            operations:
+            - action: aggregate_labels
+              aggregation_type: sum
+              label_set:
+              - pod
+              - namespace
+              - k8s.node.name
+          - action: insert
+            experimental_match_labels:
+              k8s.node.name: \S+
+              namespace: \S+
+              pod: \S+
+            include: k8s.container_network_receive_bytes_total
+            match_type: regexp
+            new_name: k8s.pod.network.bytes_received
+            operations:
+            - action: aggregate_labels
+              aggregation_type: sum
+              label_set:
+              - pod
+              - namespace
+              - k8s.node.name
+          - action: insert
+            experimental_match_labels:
+              k8s.node.name: \S+
+              namespace: \S+
+              pod: \S+
+            include: k8s.container_network_transmit_bytes_total
+            match_type: regexp
+            new_name: k8s.pod.network.bytes_transmitted
+            operations:
+            - action: aggregate_labels
+              aggregation_type: sum
+              label_set:
+              - pod
+              - namespace
+              - k8s.node.name
+          - action: insert
+            experimental_match_labels:
+              k8s.node.name: \S+
+              namespace: \S+
+              pod: \S+
+            include: k8s.container_network_receive_packets_total
+            match_type: regexp
+            new_name: k8s.pod.network.packets_received
+            operations:
+            - action: aggregate_labels
+              aggregation_type: sum
+              label_set:
+              - pod
+              - namespace
+              - k8s.node.name
+          - action: insert
+            experimental_match_labels:
+              k8s.node.name: \S+
+              namespace: \S+
+              pod: \S+
+            include: k8s.container_network_transmit_packets_total
+            match_type: regexp
+            new_name: k8s.pod.network.packets_transmitted
+            operations:
+            - action: aggregate_labels
+              aggregation_type: sum
+              label_set:
+              - pod
+              - namespace
+              - k8s.node.name
+          - action: insert
+            experimental_match_labels:
+              k8s.node.name: \S+
+              namespace: \S+
+              pod: \S+
+            include: k8s.container_network_receive_packets_dropped_total
+            match_type: regexp
+            new_name: k8s.pod.network.receive_packets_dropped
+            operations:
+            - action: aggregate_labels
+              aggregation_type: sum
+              label_set:
+              - pod
+              - namespace
+              - k8s.node.name
+          - action: insert
+            experimental_match_labels:
+              k8s.node.name: \S+
+              namespace: \S+
+              pod: \S+
+            include: k8s.container_network_transmit_packets_dropped_total
+            match_type: regexp
+            new_name: k8s.pod.network.transmit_packets_dropped
+            operations:
+            - action: aggregate_labels
+              aggregation_type: sum
+              label_set:
+              - pod
+              - namespace
+              - k8s.node.name
+          - action: insert
+            experimental_match_labels:
+              k8s.node.name: \S+
+              namespace: \S+
+              pod: \S+
+            include: k8s.container_fs_reads_total
+            match_type: regexp
+            new_name: k8s.pod.fs.reads.rate
+            operations:
+            - action: aggregate_labels
+              aggregation_type: sum
+              label_set:
+              - pod
+              - namespace
+              - k8s.node.name
+          - action: insert
+            experimental_match_labels:
+              k8s.node.name: \S+
+              namespace: \S+
+              pod: \S+
+            include: k8s.container_fs_writes_total
+            match_type: regexp
+            new_name: k8s.pod.fs.writes.rate
+            operations:
+            - action: aggregate_labels
+              aggregation_type: sum
+              label_set:
+              - pod
+              - namespace
+              - k8s.node.name
+          - action: insert
+            experimental_match_labels:
+              k8s.node.name: \S+
+              namespace: \S+
+              pod: \S+
+            include: k8s.container_fs_reads_bytes_total
+            match_type: regexp
+            new_name: k8s.pod.fs.reads.bytes.rate
+            operations:
+            - action: aggregate_labels
+              aggregation_type: sum
+              label_set:
+              - pod
+              - namespace
+              - k8s.node.name
+          - action: insert
+            experimental_match_labels:
+              k8s.node.name: \S+
+              namespace: \S+
+              pod: \S+
+            include: k8s.container_fs_writes_bytes_total
+            match_type: regexp
+            new_name: k8s.pod.fs.writes.bytes.rate
+            operations:
+            - action: aggregate_labels
+              aggregation_type: sum
+              label_set:
+              - pod
+              - namespace
+              - k8s.node.name
+          - action: insert
+            include: k8s.pod.fs.reads.rate
+            new_name: k8s.pod.fs.reads.rate_temp
+          - action: insert
+            include: k8s.pod.fs.writes.rate
+            new_name: k8s.pod.fs.writes.rate_temp
+          - action: combine
+            include: (k8s.pod.fs.reads.rate_temp|k8s.pod.fs.writes.rate_temp)
+            match_type: regexp
+            new_name: k8s.pod.fs.iops
+            operations:
+            - action: aggregate_labels
+              aggregation_type: sum
+              label_set:
+              - pod
+              - namespace
+              - k8s.node.name
+            submatch_case: lower
+          - action: insert
+            include: k8s.pod.fs.reads.bytes.rate
+            new_name: k8s.pod.fs.reads.bytes.rate_temp
+          - action: insert
+            include: k8s.pod.fs.writes.bytes.rate
+            new_name: k8s.pod.fs.writes.bytes.rate_temp
+          - action: combine
+            include: (k8s.pod.fs.reads.bytes.rate_temp|k8s.pod.fs.writes.bytes.rate_temp)
+            match_type: regexp
+            new_name: k8s.pod.fs.throughput
+            operations:
+            - action: aggregate_labels
+              aggregation_type: sum
+              label_set:
+              - pod
+              - namespace
+              - k8s.node.name
+            submatch_case: lower
+          - action: insert
+            experimental_match_labels:
+              k8s.node.name: \S+
+              namespace: \S+
+              pod: \S+
+            include: k8s.container_fs_usage_bytes
+            match_type: regexp
+            new_name: k8s.pod.fs.usage.bytes
+            operations:
+            - action: aggregate_labels
+              aggregation_type: sum
+              label_set:
+              - pod
+              - namespace
+              - k8s.node.name
+          - action: insert
+            experimental_match_labels:
+              id: /
+            include: k8s.container_cpu_usage_seconds_total
+            new_name: k8s.node.cpu.usage.seconds.rate
+          - action: insert
+            experimental_match_labels:
+              id: /
+            include: k8s.container_memory_working_set_bytes
+            new_name: k8s.node.memory.working_set
+          - action: insert
+            experimental_match_labels:
+              id: /
+              k8s.node.name: \S+
+            include: k8s.container_network_receive_bytes_total
+            match_type: regexp
+            new_name: k8s.node.network.bytes_received
+            operations:
+            - action: aggregate_labels
+              aggregation_type: sum
+              label_set:
+              - k8s.node.name
+          - action: insert
+            experimental_match_labels:
+              id: /
+              k8s.node.name: \S+
+            include: k8s.container_network_transmit_bytes_total
+            match_type: regexp
+            new_name: k8s.node.network.bytes_transmitted
+            operations:
+            - action: aggregate_labels
+              aggregation_type: sum
+              label_set:
+              - k8s.node.name
+          - action: insert
+            experimental_match_labels:
+              id: /
+              k8s.node.name: \S+
+            include: k8s.container_network_receive_packets_total
+            match_type: regexp
+            new_name: k8s.node.network.packets_received
+            operations:
+            - action: aggregate_labels
+              aggregation_type: sum
+              label_set:
+              - k8s.node.name
+          - action: insert
+            experimental_match_labels:
+              id: /
+              k8s.node.name: \S+
+            include: k8s.container_network_transmit_packets_total
+            match_type: regexp
+            new_name: k8s.node.network.packets_transmitted
+            operations:
+            - action: aggregate_labels
+              aggregation_type: sum
+              label_set:
+              - k8s.node.name
+          - action: insert
+            experimental_match_labels:
+              id: /
+              k8s.node.name: \S+
+            include: k8s.container_network_receive_packets_dropped_total
+            match_type: regexp
+            new_name: k8s.node.network.receive_packets_dropped
+            operations:
+            - action: aggregate_labels
+              aggregation_type: sum
+              label_set:
+              - k8s.node.name
+          - action: insert
+            experimental_match_labels:
+              id: /
+              k8s.node.name: \S+
+            include: k8s.container_network_transmit_packets_dropped_total
+            match_type: regexp
+            new_name: k8s.node.network.transmit_packets_dropped
+            operations:
+            - action: aggregate_labels
+              aggregation_type: sum
+              label_set:
+              - k8s.node.name
+          - action: insert
+            include: k8s.pod.fs.reads.rate
+            new_name: k8s.node.fs.reads.rate_temp
+            operations:
+            - action: aggregate_labels
+              aggregation_type: sum
+              label_set:
+              - k8s.node.name
+          - action: insert
+            include: k8s.pod.fs.writes.rate
+            new_name: k8s.node.fs.writes.rate_temp
+            operations:
+            - action: aggregate_labels
+              aggregation_type: sum
+              label_set:
+              - k8s.node.name
+          - action: insert
+            include: k8s.pod.fs.reads.bytes.rate
+            new_name: k8s.node.fs.reads.bytes.rate_temp
+            operations:
+            - action: aggregate_labels
+              aggregation_type: sum
+              label_set:
+              - k8s.node.name
+          - action: insert
+            include: k8s.pod.fs.writes.bytes.rate
+            new_name: k8s.node.fs.writes.bytes.rate_temp
+            operations:
+            - action: aggregate_labels
+              aggregation_type: sum
+              label_set:
+              - k8s.node.name
+          - action: combine
+            include: (k8s.node.fs.reads.rate_temp|k8s.node.fs.writes.rate_temp)
+            match_type: regexp
+            new_name: k8s.node.fs.iops
+            operations:
+            - action: aggregate_labels
+              aggregation_type: sum
+              label_set:
+              - k8s.node.name
+            submatch_case: lower
+          - action: combine
+            include: (k8s.node.fs.reads.bytes.rate_temp|k8s.node.fs.writes.bytes.rate_temp)
+            match_type: regexp
+            new_name: k8s.node.fs.throughput
+            operations:
+            - action: aggregate_labels
+              aggregation_type: sum
+              label_set:
+              - k8s.node.name
+            submatch_case: lower
+          - action: insert
+            include: k8s.pod.fs.usage.bytes
+            new_name: k8s.node.fs.usage
+            operations:
+            - action: aggregate_labels
+              aggregation_type: sum
+              label_set:
+              - k8s.node.name
+        metricstransform/rename:
+          transforms:
+          - action: update
+            include: ^(.*)$$
+            match_type: regexp
+            new_name: k8s.$${1}
+        resource/all:
+          attributes:
+          - action: insert
+            key: sw.k8s.agent.manifest.version
+            value: ${MANIFEST_VERSION}
+          - action: insert
+            key: sw.k8s.agent.app.version
+            value: ${APP_VERSION}
+          - action: insert
+            key: sw.k8s.cluster.uid
+            value: ${CLUSTER_UID}
+          - action: insert
+            key: k8s.cluster.name
+            value: ${CLUSTER_NAME}
+          - action: upsert
+            key: k8s.node.name
+            value: ${NODE_NAME}
+        resource/container:
+          attributes:
+          - action: insert
+            key: sw.k8s.log.type
+            value: container
+          - action: insert
+            key: sw.k8s.agent.manifest.version
+            value: ${MANIFEST_VERSION}
+          - action: insert
+            key: sw.k8s.agent.app.version
+            value: ${APP_VERSION}
+          - action: insert
+            key: sw.k8s.cluster.uid
+            value: ${CLUSTER_UID}
+          - action: insert
+            key: k8s.cluster.name
+            value: ${CLUSTER_NAME}
+          - action: insert
+            key: k8s.node.name
+            value: ${NODE_NAME}
+        resource/journal:
+          attributes:
+          - action: insert
+            key: sw.k8s.log.type
+            value: journal
+          - action: insert
+            key: sw.k8s.agent.manifest.version
+            value: ${MANIFEST_VERSION}
+          - action: insert
+            key: sw.k8s.agent.app.version
+            value: ${APP_VERSION}
+          - action: insert
+            key: sw.k8s.cluster.uid
+            value: ${CLUSTER_UID}
+          - action: insert
+            key: k8s.cluster.name
+            value: ${CLUSTER_NAME}
+          - action: insert
+            key: k8s.node.name
+            value: ${NODE_NAME}
+        resource/k8sattributes_logs_annotations_filter:
+          attributes:
+          - action: delete
+            pattern: k8s\.\w+\.annotations\..*
+        resource/k8sattributes_logs_labels_filter:
+          attributes:
+          - action: delete
+            pattern: k8s\.\w+\.labels\..*
+        resource/metrics:
+          attributes:
+          - action: delete
+            key: service.name
+          - action: delete
+            key: service.instance.id
+          - action: delete
+            key: net.host.name
+          - action: delete
+            key: net.host.port
+          - action: delete
+            key: http.scheme
+          - action: insert
+            key: sw.k8s.agent.manifest.version
+            value: ${MANIFEST_VERSION}
+          - action: insert
+            key: sw.k8s.agent.app.version
+            value: ${APP_VERSION}
+          - action: insert
+            key: sw.k8s.cluster.uid
+            value: ${CLUSTER_UID}
+          - action: insert
+            key: k8s.cluster.name
+            value: ${CLUSTER_NAME}
+          - action: insert
+            from_attribute: kubelet_version
+            key: sw.k8s.node.version
+          - action: insert
+            from_attribute: container_runtime_version
+            key: sw.k8s.node.container.runtime.version
+          - action: insert
+            from_attribute: provider_id
+            key: sw.k8s.node.provider.id
+          - action: insert
+            from_attribute: os_image
+            key: sw.k8s.node.os.image
+          - action: insert
+            from_attribute: internal_ip
+            key: sw.k8s.node.ip.internal
+          - action: insert
+            from_attribute: namespace
+            key: k8s.namespace.name
+          - action: insert
+            from_attribute: pod
+            key: k8s.pod.name
+          - action: insert
+            from_attribute: pod_ip
+            key: sw.k8s.pod.ip
+          - action: insert
+            from_attribute: host_ip
+            key: sw.k8s.pod.host.ip
+          - action: insert
+            from_attribute: created_by_kind
+            key: sw.k8s.pod.createdby.kind
+          - action: insert
+            from_attribute: created_by_name
+            key: sw.k8s.pod.createdby.name
+          - action: insert
+            from_attribute: host_network
+            key: sw.k8s.pod.host.network
+          - action: insert
+            from_attribute: priority_class
+            key: sw.k8s.pod.priority_class
+          - action: extract
+            key: container_id
+            pattern: ^(?P<extracted_container_runtime>[^:]+)://(?P<extracted_container_id>[^/]+)$
+          - action: insert
+            from_attribute: extracted_container_id
+            key: container.id
+          - action: insert
+            from_attribute: extracted_container_runtime
+            key: container.runtime
+          - action: insert
+            from_attribute: container
+            key: k8s.container.name
+          - action: insert
+            from_attribute: image_id
+            key: k8s.container.image.id
+          - action: insert
+            from_attribute: image
+            key: k8s.container.image.name
+          - action: insert
+            from_attribute: replicaset
+            key: k8s.replicaset.name
+          - action: insert
+            from_attribute: deployment
+            key: k8s.deployment.name
+          - action: insert
+            from_attribute: statefulset
+            key: k8s.statefulset.name
+          - action: insert
+            from_attribute: daemonset
+            key: k8s.daemonset.name
+          - action: insert
+            from_attribute: job_name
+            key: k8s.job.name
+          - action: insert
+            from_attribute: job_condition
+            key: k8s.job.condition
+          - action: insert
+            from_attribute: cronjob
+            key: k8s.cronjob.name
+          - action: insert
+            from_attribute: persistentvolume
+            key: k8s.persistentvolume.name
+          - action: insert
+            from_attribute: persistentvolumeclaim
+            key: k8s.persistentvolumeclaim.name
+        transform/istio-metrics:
+          metric_statements:
+          - context: metric
+            statements:
+            - extract_sum_metric(true) where (name == "k8s.istio_request_bytes" or name
+              == "k8s.istio_response_bytes" or name == "k8s.istio_request_duration_milliseconds")
+            - extract_count_metric(true) where (name == "k8s.istio_request_duration_milliseconds")
+            - set(name, "k8s.istio_request_bytes.rate") where name == "k8s.istio_request_bytes_sum"
+            - set(name, "k8s.istio_response_bytes.rate") where name == "k8s.istio_response_bytes_sum"
+            - set(name, "k8s.istio_requests.rate") where name == "k8s.istio_requests_total"
+            - set(name, "k8s.istio_tcp_sent_bytes.rate") where name == "k8s.istio_tcp_sent_bytes_total"
+            - set(name, "k8s.istio_tcp_received_bytes.rate") where name == "k8s.istio_tcp_received_bytes_total"
+            - set(name, "k8s.istio_request_duration_milliseconds_sum_temp") where name ==
+              "k8s.istio_request_duration_milliseconds_sum"
+            - set(name, "k8s.istio_request_duration_milliseconds_count_temp") where name
+              == "k8s.istio_request_duration_milliseconds_count"
+        transform/syslogify:
+          error_mode: ignore
+          log_statements:
+          - context: log
+            statements:
+            - set( attributes["host.name"], attributes["k8s.pod.name"])
+            - set( attributes["service.name"], attributes["k8s.container.name"])
+        transform/unify_node_attribute:
+          metric_statements:
+          - context: datapoint
+            statements:
+            - set(attributes["k8s.node.name"], resource.attributes["service.instance.id"])
+              where IsMatch(metric.name, "^(container_.*)$") == true and attributes["k8s.node.name"]
+              == nil
+      receivers:
+        filelog:
+          encoding: utf-8
+          exclude:
+          - /var/log/pods/${POD_NAMESPACE}_${POD_NAME}*_*/swi-opentelemetry-collector/*.log
+          fingerprint_size: 1kb
+          include:
+          - /var/log/pods/*/*/*.log
+          include_file_name: false
+          include_file_path: true
+          max_concurrent_files: 10
+          max_log_size: 1MiB
+          operators:
+          - id: get-format
+            routes:
+            - expr: body matches "^\\{"
+              output: parser-docker
+            - expr: body matches "^[^ Z]+ "
+              output: parser-crio
+            - expr: body matches "^[^ Z]+Z"
+              output: parser-containerd
+            type: router
+          - id: parser-crio
+            output: merge-cri-lines
+            parse_to: body
+            regex: ^(?P<time>[^ Z]+) (?P<stream>stdout|stderr) (?P<logtag>[^ ]*)( |)(?P<log>.*)$
+            timestamp:
+              layout: "2006-01-02T15:04:05.999999999-07:00"
+              layout_type: gotime
+              parse_from: body.time
+            type: regex_parser
+          - id: parser-containerd
+            output: merge-cri-lines
+            parse_to: body
+            regex: ^(?P<time>[^ ^Z]+Z) (?P<stream>stdout|stderr) (?P<logtag>[^ ]*)( |)(?P<log>.*)$
+            timestamp:
+              layout: '%Y-%m-%dT%H:%M:%S.%LZ'
+              parse_from: body.time
+            type: regex_parser
+          - id: parser-docker
+            output: merge-docker-lines
+            parse_to: body
+            timestamp:
+              layout: '%Y-%m-%dT%H:%M:%S.%LZ'
+              parse_from: body.time
+            type: json_parser
+          - combine_field: body.log
+            combine_with: ""
+            id: merge-docker-lines
+            is_last_entry: body.log matches "\n$"
+            max_unmatched_batch_size: 1
+            output: merge-multiline-logs
+            source_identifier: attributes["log.file.path"]
+            type: recombine
+          - combine_field: body.log
+            combine_with: ""
+            id: merge-cri-lines
+            is_last_entry: body.logtag == "F"
+            max_unmatched_batch_size: 1
+            output: merge-multiline-logs
+            overwrite_with: newest
+            source_identifier: attributes["log.file.path"]
+            type: recombine
+          - combine_field: body.log
+            combine_with: ""
+            id: merge-multiline-logs
+            is_first_entry: body.log matches "^\\[?\\d{4}-\\d{1,2}-\\d{1,2}.\\d{2}:\\d{2}:\\d{2}.*"
+            max_unmatched_batch_size: 1
+            output: extract-metadata-from-filepath
+            source_identifier: attributes["log.file.path"]
+            type: recombine
+          - id: extract-metadata-from-filepath
+            parse_from: attributes["log.file.path"]
+            regex: ^.*\/(?P<namespace>[^_]+)_(?P<pod_name>[^_]+)_(?P<uid>[a-f0-9\-]+)\/(?P<container_name>[^\._]+)\/(?P<run_id>\d+)\.log$
+            type: regex_parser
+          - from: body.stream
+            id: move-attributes
+            to: attributes["stream"]
+            type: move
+          - from: attributes.container_name
+            to: attributes["k8s.container.name"]
+            type: move
+          - from: attributes.namespace
+            to: attributes["k8s.namespace.name"]
+            type: move
+          - from: attributes.pod_name
+            to: attributes["k8s.pod.name"]
+            type: move
+          - field: attributes.run_id
+            type: remove
+          - from: attributes.uid
+            to: attributes["k8s.pod.uid"]
+            type: move
+          - field: attributes["log.file.path"]
+            type: remove
+          - field: body.time
+            type: remove
+          - from: body.log
+            to: body
+            type: move
+          poll_interval: 200ms
+          start_at: end
+          storage: file_storage/checkpoints
+        journald:
+          files:
+          - /*/log/journal/**/*
+          units:
+          - kubelet
+          - docker
+          - containerd
+        receiver_creator/discovery:
+          receivers:
+            prometheus/discovery:
+              config:
+                config:
+                  scrape_configs:
+                  - honor_labels: true
+                    honor_timestamps: false
+                    job_name: pod
+                    metrics_path: '`"prometheus.io/path" in annotations ? annotations["prometheus.io/path"]
+                      : "/metrics"`'
+                    scheme: http
+                    scrape_interval: 60s
+                    static_configs:
+                    - targets:
+                      - '`endpoint`:`"prometheus.io/port" in annotations ? annotations["prometheus.io/port"]
+                        : 9090`'
+              rule: type == "pod" && annotations["prometheus.io/scrape"] == "true"
+          watch_observers:
+          - k8s_observer
+        receiver_creator/node:
+          receivers:
+            prometheus/node:
+              config:
+                config:
+                  scrape_configs:
+                  - bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
+                    honor_labels: true
+                    honor_timestamps: false
+                    job_name: kubernetes-nodes-cadvisor
+                    metrics_path: /metrics/cadvisor
+                    scheme: https
+                    scrape_interval: 60s
+                    scrape_timeout: 10s
+                    static_configs:
+                    - targets:
+                      - '`endpoint`:`kubelet_endpoint_port`'
+                    tls_config:
+                      ca_file: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+                      insecure_skip_verify: true
+                  - bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
+                    honor_labels: true
+                    honor_timestamps: false
+                    job_name: kubernetes-nodes
+                    metrics_path: /metrics
+                    scheme: https
+                    scrape_interval: 60s
+                    scrape_timeout: 10s
+                    static_configs:
+                    - targets:
+                      - '`endpoint`:`kubelet_endpoint_port`'
+                    tls_config:
+                      ca_file: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+                      insecure_skip_verify: true
+              rule: type == "k8s.node"
+          watch_observers:
+          - k8s_observer
+      service:
+        extensions:
+        - file_storage/checkpoints
+        - health_check
+        - k8s_observer
+        pipelines:
+          logs:
+            exporters:
+            - otlp
+            processors:
+            - memory_limiter
+            - batch/logs
+            receivers:
+            - forward/logs-exporter
+          logs/container:
+            exporters:
+            - forward/logs-exporter
+            processors:
+            - memory_limiter
+            - filter/logs
+            - transform/syslogify
+            - groupbyattrs/common-all
+            - resource/container
+            - k8sattributes
+            - resource/k8sattributes_logs_labels_filter
+            - resource/k8sattributes_logs_annotations_filter
+            receivers:
+            - filelog
+          logs/journal:
+            exporters:
+            - forward/logs-exporter
+            processors:
+            - memory_limiter
+            - groupbyattrs/common-all
+            - resource/journal
+            receivers:
+            - journald
+          metrics:
+            exporters:
+            - otlp
+            processors:
+            - memory_limiter
+            - filter/histograms
+            - k8sattributes
+            - filter/remove_temporary_metrics
+            - batch/metrics
+            receivers:
+            - forward/metric-exporter
+          metrics/discovery:
+            exporters:
+            - forward/metric-exporter
+            processors:
+            - memory_limiter
+            - metricstransform/rename
+            - transform/istio-metrics
+            - metricstransform/istio-metrics
+            - cumulativetodelta/istio-metrics
+            - deltatorate/istio-metrics
+            - experimental_metricsgeneration/istio-metrics
+            - groupbyattrs/common-all
+            - resource/all
+            receivers:
+            - receiver_creator/discovery
+          metrics/node:
+            exporters:
+            - forward/metric-exporter
+            processors:
+            - memory_limiter
+            - filter/receiver
+            - filter/remove_internal
+            - attributes/remove_prometheus_attributes
+            - attributes/unify_node_attribute
+            - transform/unify_node_attribute
+            - metricstransform/rename
+            - metricstransform/preprocessing
+            - filter/remove_internal_postprocessing
+            - attributes/remove_temp
+            - cumulativetodelta/cadvisor
+            - deltatorate/cadvisor
+            - groupbyattrs/node
+            - groupbyattrs/pod
+            - groupbyattrs/all
+            - resource/metrics
+            - resource/all
+            receivers:
+            - receiver_creator/node
+        telemetry:
+          logs:
+            level: info
+          metrics:
+            address: 0.0.0.0:8888
+    logs.proto: ""
+    logs_service.proto: ""
+    resource.proto: ""
+Node collector config should match snapshot when autodiscovery is disabled:
+  1: |
+    common.proto: ""
+    logs.config: |
+      connectors:
+        forward/logs-exporter: null
+        forward/metric-exporter: null
+      exporters:
+        otlp:
+          endpoint: ${OTEL_ENVOY_ADDRESS}
+          headers:
+            Authorization: Bearer ${SOLARWINDS_API_TOKEN}
+          retry_on_failure:
+            enabled: true
+            initial_interval: 10s
+            max_elapsed_time: 300s
+            max_interval: 30s
+          sending_queue:
+            enabled: true
+            num_consumers: 20
+            queue_size: 1000
+          timeout: 15s
+          tls:
+            insecure: ${OTEL_ENVOY_ADDRESS_TLS_INSECURE}
+      extensions:
+        file_storage/checkpoints:
+          directory: /var/lib/swo/checkpoints
+          timeout: 5s
+        health_check: {}
+        k8s_observer:
+          auth_type: serviceAccount
+          node: ${NODE_NAME}
+          observe_nodes: true
+          observe_pods: true
+      processors:
+        attributes/remove_prometheus_attributes:
+          actions:
+          - action: delete
+            key: prometheus
+          - action: delete
+            key: prometheus_replica
+        attributes/remove_temp:
+          actions:
+          - action: delete
+            key: temp
+            pattern: (.*_temp$)|(^\$.*)
+          include:
+            match_type: regexp
+            metric_names:
+            - .*
+        attributes/unify_node_attribute:
+          actions:
+          - action: insert
+            from_attribute: node
+            key: k8s.node.name
+          - action: insert
+            from_attribute: kubernetes_io_hostname
+            key: k8s.node.name
+          include:
+            match_type: regexp
+            metric_names:
+            - container_.*
+        batch/logs:
+          send_batch_max_size: 512
+          send_batch_size: 512
+          timeout: 1s
+        batch/metrics:
+          send_batch_max_size: 512
+          send_batch_size: 512
+          timeout: 1s
+        cumulativetodelta/cadvisor:
+          include:
+            match_type: strict
+            metrics:
+            - k8s.node.cpu.usage.seconds.rate
+            - k8s.pod.cpu.usage.seconds.rate
+            - k8s.container.fs.iops
+            - k8s.container.fs.throughput
+            - k8s.container.cpu.usage.seconds.rate
+            - k8s.container.network.bytes_received
+            - k8s.container.network.bytes_transmitted
+            - k8s.pod.fs.iops
+            - k8s.pod.fs.throughput
+            - k8s.pod.fs.reads.rate
+            - k8s.pod.fs.writes.rate
+            - k8s.pod.fs.reads.bytes.rate
+            - k8s.pod.fs.writes.bytes.rate
+            - k8s.pod.network.bytes_received
+            - k8s.pod.network.bytes_transmitted
+            - k8s.pod.network.packets_received
+            - k8s.pod.network.packets_transmitted
+            - k8s.pod.network.receive_packets_dropped
+            - k8s.pod.network.transmit_packets_dropped
+            - k8s.node.fs.iops
+            - k8s.node.fs.throughput
+            - k8s.node.network.bytes_received
+            - k8s.node.network.bytes_transmitted
+            - k8s.node.network.packets_received
+            - k8s.node.network.packets_transmitted
+            - k8s.node.network.receive_packets_dropped
+            - k8s.node.network.transmit_packets_dropped
+        cumulativetodelta/istio-metrics:
+          include:
+            match_type: strict
+            metrics:
+            - k8s.istio_request_bytes.rate
+            - k8s.istio_response_bytes.rate
+            - k8s.istio_request_duration_milliseconds_sum_temp
+            - k8s.istio_request_duration_milliseconds_count_temp
+            - k8s.istio_requests.rate
+            - k8s.istio_tcp_sent_bytes.rate
+            - k8s.istio_tcp_received_bytes.rate
+            - k8s.istio_request_bytes.delta
+            - k8s.istio_response_bytes.delta
+            - k8s.istio_requests.delta
+            - k8s.istio_tcp_sent_bytes.delta
+            - k8s.istio_tcp_received_bytes.delta
+        deltatorate/cadvisor:
+          metrics:
+          - k8s.node.cpu.usage.seconds.rate
+          - k8s.pod.cpu.usage.seconds.rate
+          - k8s.container.fs.iops
+          - k8s.container.fs.throughput
+          - k8s.container.cpu.usage.seconds.rate
+          - k8s.container.network.bytes_received
+          - k8s.container.network.bytes_transmitted
+          - k8s.pod.fs.iops
+          - k8s.pod.fs.throughput
+          - k8s.pod.fs.reads.rate
+          - k8s.pod.fs.writes.rate
+          - k8s.pod.fs.reads.bytes.rate
+          - k8s.pod.fs.writes.bytes.rate
+          - k8s.pod.network.bytes_received
+          - k8s.pod.network.bytes_transmitted
+          - k8s.pod.network.packets_received
+          - k8s.pod.network.packets_transmitted
+          - k8s.pod.network.receive_packets_dropped
+          - k8s.pod.network.transmit_packets_dropped
+          - k8s.node.fs.iops
+          - k8s.node.fs.throughput
+          - k8s.node.network.bytes_received
+          - k8s.node.network.bytes_transmitted
+          - k8s.node.network.packets_received
+          - k8s.node.network.packets_transmitted
+          - k8s.node.network.receive_packets_dropped
+          - k8s.node.network.transmit_packets_dropped
+        deltatorate/istio-metrics:
+          metrics:
+          - k8s.istio_request_bytes.rate
+          - k8s.istio_response_bytes.rate
+          - k8s.istio_request_duration_milliseconds_sum_temp
+          - k8s.istio_request_duration_milliseconds_count_temp
+          - k8s.istio_requests.rate
+          - k8s.istio_tcp_sent_bytes.rate
+          - k8s.istio_tcp_received_bytes.rate
+        experimental_metricsgeneration/istio-metrics:
+          rules:
+          - metric1: k8s.istio_request_duration_milliseconds_sum_temp
+            metric2: k8s.istio_request_duration_milliseconds_count_temp
+            name: k8s.istio_request_duration_milliseconds.rate
+            operation: divide
+            type: calculate
+        filter/histograms:
+          metrics:
+            metric:
+            - type == METRIC_DATA_TYPE_HISTOGRAM
+        filter/logs:
+          logs:
+            log_record:
+            - not(IsMatch(resource.attributes["k8s.namespace.name"], "^kube-.*$"))
+        filter/receiver:
+          metrics:
+            exclude:
+              match_type: strict
+              metric_names:
+              - scrape_duration_seconds
+              - scrape_samples_post_metric_relabeling
+              - scrape_samples_scraped
+              - scrape_series_added
+              - up
+        filter/remove_internal:
+          metrics:
+            datapoint:
+            - attributes["container"] == "POD" and IsMatch(metric.name, "container_network_.*")
+              == false
+        filter/remove_internal_postprocessing:
+          metrics:
+            datapoint:
+            - attributes["container"] == "POD" and IsMatch(metric.name, "container_network_.*|k8s.container.*")
+              == true
+        filter/remove_temporary_metrics:
+          metrics:
+            exclude:
+              match_type: regexp
+              metric_names:
+              - .*_temp
+              - apiserver_request_total
         groupbyattrs/all:
           keys:
           - kubelet_version
@@ -1139,7 +3555,7 @@ Node collector config should match snapshot when autodiscovery is disabled:
             - memory_limiter
             - filter/histograms
             - k8sattributes
-            - filter/metrics
+            - filter/remove_temporary_metrics
             - batch/metrics
             receivers:
             - forward/metric-exporter
@@ -1339,18 +3755,8 @@ Node collector config should match snapshot when fargate is enabled:
             - type == METRIC_DATA_TYPE_HISTOGRAM
         filter/logs:
           logs:
-            include:
-              match_type: regexp
-              resource_attributes:
-              - key: k8s.namespace.name
-                value: ^kube-.*$
-        filter/metrics:
-          metrics:
-            exclude:
-              match_type: regexp
-              metric_names:
-              - .*_temp
-              - apiserver_request_total
+            log_record:
+            - not(IsMatch(resource.attributes["k8s.namespace.name"], "^kube-.*$"))
         filter/receiver:
           metrics:
             exclude:
@@ -1371,6 +3777,13 @@ Node collector config should match snapshot when fargate is enabled:
             datapoint:
             - attributes["container"] == "POD" and IsMatch(metric.name, "container_network_.*|k8s.container.*")
               == true
+        filter/remove_temporary_metrics:
+          metrics:
+            exclude:
+              match_type: regexp
+              metric_names:
+              - .*_temp
+              - apiserver_request_total
         groupbyattrs/all:
           keys:
           - kubelet_version
@@ -2295,7 +4708,7 @@ Node collector config should match snapshot when fargate is enabled:
             - memory_limiter
             - filter/histograms
             - k8sattributes
-            - filter/metrics
+            - filter/remove_temporary_metrics
             - batch/metrics
             receivers:
             - forward/metric-exporter
@@ -2481,18 +4894,8 @@ Node collector config should match snapshot when fargate is enabled and autodisc
             - type == METRIC_DATA_TYPE_HISTOGRAM
         filter/logs:
           logs:
-            include:
-              match_type: regexp
-              resource_attributes:
-              - key: k8s.namespace.name
-                value: ^kube-.*$
-        filter/metrics:
-          metrics:
-            exclude:
-              match_type: regexp
-              metric_names:
-              - .*_temp
-              - apiserver_request_total
+            log_record:
+            - not(IsMatch(resource.attributes["k8s.namespace.name"], "^kube-.*$"))
         filter/receiver:
           metrics:
             exclude:
@@ -2513,6 +4916,13 @@ Node collector config should match snapshot when fargate is enabled and autodisc
             datapoint:
             - attributes["container"] == "POD" and IsMatch(metric.name, "container_network_.*|k8s.container.*")
               == true
+        filter/remove_temporary_metrics:
+          metrics:
+            exclude:
+              match_type: regexp
+              metric_names:
+              - .*_temp
+              - apiserver_request_total
         groupbyattrs/all:
           keys:
           - kubelet_version
@@ -3585,18 +5995,8 @@ Node collector config should match snapshot when using default values:
             - type == METRIC_DATA_TYPE_HISTOGRAM
         filter/logs:
           logs:
-            include:
-              match_type: regexp
-              resource_attributes:
-              - key: k8s.namespace.name
-                value: ^kube-.*$
-        filter/metrics:
-          metrics:
-            exclude:
-              match_type: regexp
-              metric_names:
-              - .*_temp
-              - apiserver_request_total
+            log_record:
+            - not(IsMatch(resource.attributes["k8s.namespace.name"], "^kube-.*$"))
         filter/receiver:
           metrics:
             exclude:
@@ -3617,6 +6017,13 @@ Node collector config should match snapshot when using default values:
             datapoint:
             - attributes["container"] == "POD" and IsMatch(metric.name, "container_network_.*|k8s.container.*")
               == true
+        filter/remove_temporary_metrics:
+          metrics:
+            exclude:
+              match_type: regexp
+              metric_names:
+              - .*_temp
+              - apiserver_request_total
         groupbyattrs/all:
           keys:
           - kubelet_version
@@ -4578,7 +6985,7 @@ Node collector config should match snapshot when using default values:
             - memory_limiter
             - filter/histograms
             - k8sattributes
-            - filter/metrics
+            - filter/remove_temporary_metrics
             - batch/metrics
             receivers:
             - forward/metric-exporter

--- a/deploy/helm/tests/events-collector-config-map_test.yaml
+++ b/deploy/helm/tests/events-collector-config-map_test.yaml
@@ -8,3 +8,24 @@ tests:
     asserts:
       - matchSnapshot:
           path: data
+  - it: Custom events filter with old syntax
+    template: events-collector-config-map.yaml
+    set:
+      otel.events.filter:
+        include:
+          match_type: regexp
+          record_attributes:
+            - key: k8s.namespace.name
+              value: ^.*$
+    asserts:
+      - matchSnapshot:
+          path: data
+  - it: Custom events filter with new syntax
+    template: events-collector-config-map.yaml
+    set:
+      otel.events.filter:
+        log_record:
+          - not(IsMatch(resource.attributes["k8s.namespace.name"], "^.*$"))
+    asserts:
+      - matchSnapshot:
+          path: data

--- a/deploy/helm/tests/node-collector-config-map_test.yaml
+++ b/deploy/helm/tests/node-collector-config-map_test.yaml
@@ -30,3 +30,24 @@ tests:
     asserts:
       - matchSnapshot:
           path: data
+  - it: Custom logs filter with old syntax
+    template: node-collector-config-map.yaml
+    set:
+      otel.logs.filter:
+        include:
+          match_type: regexp
+          record_attributes:
+            - key: k8s.namespace.name
+              value: ^.*$
+    asserts:
+      - matchSnapshot:
+          path: data
+  - it: Custom logs filter with new syntax
+    template: node-collector-config-map.yaml
+    set:
+      otel.logs.filter:
+        log_record:
+          - not(IsMatch(resource.attributes["k8s.namespace.name"], "^.*$"))
+    asserts:
+      - matchSnapshot:
+          path: data

--- a/deploy/helm/values.yaml
+++ b/deploy/helm/values.yaml
@@ -185,12 +185,7 @@ otel:
 
     # This filter is applied after metric processing, it is the place where metrics could be filtered out
     # https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/processor/filterprocessor for configuration reference
-    filter:
-      exclude:
-        match_type: regexp
-        metric_names:
-          - .*_temp
-          - apiserver_request_total
+    filter: {}
 
     # Use this configuration to scrape extra metrics from Prometheus. Multiple metrics can be specified.
     # See format in https://prometheus.io/docs/prometheus/latest/querying/basics/#instant-vector-selectors
@@ -294,7 +289,7 @@ otel:
 
     # This filter is applied after events processing, it is the place where events could be filtered out
     # https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/processor/filterprocessor for configuration reference
-    # filter:
+    filter: {}
 
     # Batching configuration for events
     # see https://github.com/open-telemetry/opentelemetry-collector/tree/main/processor/batchprocessor for configuration reference
@@ -440,15 +435,21 @@ otel:
 
     # This filter is applied after initial log processing, it is the place where logs could be filtered out
     # see https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/processor/filterprocessor for configuration reference
-    filter:
-      include:
-        match_type: regexp
-        # a log has to match all expressions in the list to be included
-        # see https://github.com/google/re2/wiki/Syntax for regexp syntax
-        resource_attributes:
-          # allow only system namespaces (kube-system, kube-public)
-          - key: k8s.namespace.name
-            value: ^kube-.*$
+    # default (prior to k8s collector 4.0.0):
+      # filter:
+      #   include:
+      #     match_type: regexp
+      #     # a log has to match all expressions in the list to be included
+      #     # see https://github.com/google/re2/wiki/Syntax for regexp syntax
+      #     record_attributes:
+      #       # allow only system namespaces (kube-system, kube-public)
+      #       - key: k8s.namespace.name
+      #         value: ^kube-.*$
+    # default (since k8s collector 4.0.0):
+      # filter:
+      #   log_record:
+      #     - not(IsMatch(resource.attributes["k8s.namespace.name"], "^kube-.*$"))
+    filter: {}
 
     # Batching configuration for logs
     # see https://github.com/open-telemetry/opentelemetry-collector/tree/main/processor/batchprocessor for configuration reference

--- a/skaffold.yaml
+++ b/skaffold.yaml
@@ -88,15 +88,8 @@ deploy:
                 offload_to_disk: true
             logs:
               filter:
-                include:
-                  resource_attributes:
-                    - key: k8s.namespace.name
-                      value: "^.*$"
-                exclude:
-                  match_type: strict
-                  resource_attributes:
-                    - key: k8s.namespace.name
-                      value: "test-namespace"
+                log_record:
+                  - resource.attributes["k8s.namespace.name"] == "test-namespace"
         upgradeOnChange: true
       
       # Deploy prometheus for development purposes. Metrics prefixed with `output_` contains metrics produced by the agent


### PR DESCRIPTION
A continuation of PR #628.

Restore backwards compatibility for `otel.metrics.filter`, `otel.logs.filter` and `otel.events.filter` (follow-up to 5b8d2c7)

The basic idea is that when users are setting the filters using old filtering syntax, we merge them with the default filters in the old syntax and use the old attributes behavior (they are in records).
And when they use the new syntax, we merge them with the default filters in the new syntax and use the new attributes behavior (they are in resources).

Because the new syntax and the old syntax are not compatible (they cannot be used both at the same time), and until now we forced users to use the old syntax (because our default filters were using the old syntax), we can use this as the "master" switch, allowing for backwards compatibility.