### PR TITLE
Fix filtering with the new syntax for journal logs

### DIFF
--- a/deploy/helm/CHANGELOG.md
+++ b/deploy/helm/CHANGELOG.md
@@ -7,7 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
-## [4.0.0-alpha.1] - 2024-05-29
+## [4.0.0-alpha.2] - 2024-05-30
+
+## Fixed
+
+- Filtering journal logs stopped working in 3.4.0-alpha.2
+
+## [4.0.0-alpha.1] - 2024-05-30
 
 ### Changed
 

--- a/deploy/helm/Chart.yaml
+++ b/deploy/helm/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: swo-k8s-collector
-version: 4.0.0-alpha.1
+version: 4.0.0-alpha.2
 appVersion: "0.10.0"
 description: SolarWinds Kubernetes Integration
 keywords:

--- a/deploy/helm/node-collector-config.yaml
+++ b/deploy/helm/node-collector-config.yaml
@@ -635,6 +635,9 @@ service:
 {{- if not (empty .Values.otel.logs.k8s_instrumentation.annotations.excludePattern) }}
         - resource/k8sattributes_logs_annotations_filter
 {{- end }}
+{{- if eq (include "isDeprecatedFilterSyntax" .Values.otel.logs.filter) "false" }}
+        - filter/logs
+{{- end }}
       receivers:
         - filelog
 {{- end }}
@@ -655,9 +658,6 @@ service:
         - otlp
       processors:
         - memory_limiter
-{{- if eq (include "isDeprecatedFilterSyntax" .Values.otel.logs.filter) "false" }}
-        - filter/logs
-{{- end }}
         - batch/logs
       receivers:
         - forward/logs-exporter

--- a/deploy/helm/tests/__snapshot__/logs-fargate-config-map_test.yaml.snap
+++ b/deploy/helm/tests/__snapshot__/logs-fargate-config-map_test.yaml.snap
@@ -22,7 +22,7 @@ Fargate logging ConfigMap spec should include additional filters when they are c
           Match *
           Add sw.k8s.cluster.uid <CLUSTER_UID>
           Add sw.k8s.log.type container
-          Add sw.k8s.agent.manifest.version "4.0.0-alpha.1"
+          Add sw.k8s.agent.manifest.version "4.0.0-alpha.2"
     flb_log_cw: "false"
     output.conf: |
       [OUTPUT]
@@ -60,7 +60,7 @@ Fargate logging ConfigMap spec should match snapshot when Fargate logging is ena
           Match *
           Add sw.k8s.cluster.uid <CLUSTER_UID>
           Add sw.k8s.log.type container
-          Add sw.k8s.agent.manifest.version "4.0.0-alpha.1"
+          Add sw.k8s.agent.manifest.version "4.0.0-alpha.2"
     flb_log_cw: "false"
     output.conf: |
       [OUTPUT]

--- a/deploy/helm/tests/__snapshot__/node-collector-config-map-windows_test.yaml.snap
+++ b/deploy/helm/tests/__snapshot__/node-collector-config-map-windows_test.yaml.snap
@@ -1096,7 +1096,6 @@ Node collector config for windows nodes should match snapshot when using default
             - otlp
             processors:
             - memory_limiter
-            - filter/logs
             - batch/logs
             receivers:
             - forward/logs-exporter
@@ -1111,6 +1110,7 @@ Node collector config for windows nodes should match snapshot when using default
             - k8sattributes
             - resource/k8sattributes_logs_labels_filter
             - resource/k8sattributes_logs_annotations_filter
+            - filter/logs
             receivers:
             - filelog
           metrics:

--- a/deploy/helm/tests/__snapshot__/node-collector-config-map_test.yaml.snap
+++ b/deploy/helm/tests/__snapshot__/node-collector-config-map_test.yaml.snap
@@ -1123,7 +1123,6 @@ Custom logs filter with new syntax:
             - otlp
             processors:
             - memory_limiter
-            - filter/logs
             - batch/logs
             receivers:
             - forward/logs-exporter
@@ -1138,6 +1137,7 @@ Custom logs filter with new syntax:
             - k8sattributes
             - resource/k8sattributes_logs_labels_filter
             - resource/k8sattributes_logs_annotations_filter
+            - filter/logs
             receivers:
             - filelog
           logs/journal:
@@ -3522,7 +3522,6 @@ Node collector config should match snapshot when autodiscovery is disabled:
             - otlp
             processors:
             - memory_limiter
-            - filter/logs
             - batch/logs
             receivers:
             - forward/logs-exporter
@@ -3537,6 +3536,7 @@ Node collector config should match snapshot when autodiscovery is disabled:
             - k8sattributes
             - resource/k8sattributes_logs_labels_filter
             - resource/k8sattributes_logs_annotations_filter
+            - filter/logs
             receivers:
             - filelog
           logs/journal:
@@ -4675,7 +4675,6 @@ Node collector config should match snapshot when fargate is enabled:
             - otlp
             processors:
             - memory_limiter
-            - filter/logs
             - batch/logs
             receivers:
             - forward/logs-exporter
@@ -4690,6 +4689,7 @@ Node collector config should match snapshot when fargate is enabled:
             - k8sattributes
             - resource/k8sattributes_logs_labels_filter
             - resource/k8sattributes_logs_annotations_filter
+            - filter/logs
             receivers:
             - filelog
           logs/journal:
@@ -5793,7 +5793,6 @@ Node collector config should match snapshot when fargate is enabled and autodisc
             - otlp
             processors:
             - memory_limiter
-            - filter/logs
             - batch/logs
             receivers:
             - forward/logs-exporter
@@ -5808,6 +5807,7 @@ Node collector config should match snapshot when fargate is enabled and autodisc
             - k8sattributes
             - resource/k8sattributes_logs_labels_filter
             - resource/k8sattributes_logs_annotations_filter
+            - filter/logs
             receivers:
             - filelog
           logs/journal:
@@ -6952,7 +6952,6 @@ Node collector config should match snapshot when using default values:
             - otlp
             processors:
             - memory_limiter
-            - filter/logs
             - batch/logs
             receivers:
             - forward/logs-exporter
@@ -6967,6 +6966,7 @@ Node collector config should match snapshot when using default values:
             - k8sattributes
             - resource/k8sattributes_logs_labels_filter
             - resource/k8sattributes_logs_annotations_filter
+            - filter/logs
             receivers:
             - filelog
           logs/journal:


### PR DESCRIPTION
Restore the behavior from the last stable k8s collector (3.3.x) and remove filtering of journal logs. They do not contain as many attributes as normal logs, so most of the filters would cause us to drop all journal logs.