### PR TITLE
Release k8s collector `3.4.1`

### DIFF
--- a/deploy/helm/CHANGELOG.md
+++ b/deploy/helm/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## [3.4.1] - 2024-07-19
+
+### Changed
+
+- Upgraded collector image to `0.10.2` which brings following changes:
+  - Bumped 3rd party dependencies and Docker images.
+- Upgraded SWO Agent image to `v2.8.90`
+
+### Fixed
+
+- Additional improvements to cluster version detection
+
 ## [3.4.0] - 2024-06-28
 
 ### Changed

--- a/deploy/helm/Chart.yaml
+++ b/deploy/helm/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: swo-k8s-collector
-version: 3.4.0
-appVersion: "0.10.1"
+version: 3.4.1
+appVersion: "0.10.2"
 description: SolarWinds Kubernetes Integration
 keywords:
   - monitoring

--- a/deploy/helm/metrics-collector-config.yaml
+++ b/deploy/helm/metrics-collector-config.yaml
@@ -641,12 +641,12 @@ processors:
         experimental_match_labels: { "scrape_job": '.*apiservers.*' }
         new_name: k8s.cluster.version
         operations:
-          - action: aggregate_labels
-            label_set: [git_version]
-            aggregation_type: sum
           - action: update_label
             label: git_version
-            new_label: sw.k8s.cluster.version            
+            new_label: sw.k8s.cluster.version
+          - action: aggregate_labels
+            label_set: [sw.k8s.cluster.version]
+            aggregation_type: sum
       - include: k8s.kubernetes_build_info
         action: update
         new_name: k8s.kubernetes_build_info_temp

--- a/deploy/helm/tests/__snapshot__/logs-fargate-config-map_test.yaml.snap
+++ b/deploy/helm/tests/__snapshot__/logs-fargate-config-map_test.yaml.snap
@@ -22,7 +22,7 @@ Fargate logging ConfigMap spec should include additional filters when they are c
           Match *
           Add sw.k8s.cluster.uid <CLUSTER_UID>
           Add sw.k8s.log.type container
-          Add sw.k8s.agent.manifest.version "3.4.0"
+          Add sw.k8s.agent.manifest.version "3.4.1"
     flb_log_cw: "false"
     output.conf: |
       [OUTPUT]
@@ -60,7 +60,7 @@ Fargate logging ConfigMap spec should match snapshot when Fargate logging is ena
           Match *
           Add sw.k8s.cluster.uid <CLUSTER_UID>
           Add sw.k8s.log.type container
-          Add sw.k8s.agent.manifest.version "3.4.0"
+          Add sw.k8s.agent.manifest.version "3.4.1"
     flb_log_cw: "false"
     output.conf: |
       [OUTPUT]

--- a/deploy/helm/tests/__snapshot__/metrics-collector-config-map-fargate_test.yaml.snap
+++ b/deploy/helm/tests/__snapshot__/metrics-collector-config-map-fargate_test.yaml.snap
@@ -1680,13 +1680,13 @@ Metrics config should match snapshot when using default values:
             match_type: regexp
             new_name: k8s.cluster.version
             operations:
-            - action: aggregate_labels
-              aggregation_type: sum
-              label_set:
-              - git_version
             - action: update_label
               label: git_version
               new_label: sw.k8s.cluster.version
+            - action: aggregate_labels
+              aggregation_type: sum
+              label_set:
+              - sw.k8s.cluster.version
           - action: update
             include: k8s.kubernetes_build_info
             new_name: k8s.kubernetes_build_info_temp

--- a/deploy/helm/tests/__snapshot__/metrics-collector-config-map_test.yaml.snap
+++ b/deploy/helm/tests/__snapshot__/metrics-collector-config-map_test.yaml.snap
@@ -1680,13 +1680,13 @@ Metrics config should match snapshot when fargate is enabled:
             match_type: regexp
             new_name: k8s.cluster.version
             operations:
-            - action: aggregate_labels
-              aggregation_type: sum
-              label_set:
-              - git_version
             - action: update_label
               label: git_version
               new_label: sw.k8s.cluster.version
+            - action: aggregate_labels
+              aggregation_type: sum
+              label_set:
+              - sw.k8s.cluster.version
           - action: update
             include: k8s.kubernetes_build_info
             new_name: k8s.kubernetes_build_info_temp
@@ -4015,13 +4015,13 @@ Metrics config should match snapshot when using Prometheus url with extra_scrape
             match_type: regexp
             new_name: k8s.cluster.version
             operations:
-            - action: aggregate_labels
-              aggregation_type: sum
-              label_set:
-              - git_version
             - action: update_label
               label: git_version
               new_label: sw.k8s.cluster.version
+            - action: aggregate_labels
+              aggregation_type: sum
+              label_set:
+              - sw.k8s.cluster.version
           - action: update
             include: k8s.kubernetes_build_info
             new_name: k8s.kubernetes_build_info_temp
@@ -6292,13 +6292,13 @@ Metrics config should match snapshot when using default values:
             match_type: regexp
             new_name: k8s.cluster.version
             operations:
-            - action: aggregate_labels
-              aggregation_type: sum
-              label_set:
-              - git_version
             - action: update_label
               label: git_version
               new_label: sw.k8s.cluster.version
+            - action: aggregate_labels
+              aggregation_type: sum
+              label_set:
+              - sw.k8s.cluster.version
           - action: update
             include: k8s.kubernetes_build_info
             new_name: k8s.kubernetes_build_info_temp

--- a/deploy/helm/tests/swo-agent-statefulset_test.yaml
+++ b/deploy/helm/tests/swo-agent-statefulset_test.yaml
@@ -10,7 +10,7 @@ tests:
     asserts:
     - equal:
           path: spec.template.spec.containers[0].image
-          value: solarwinds/swo-agent:v2.8.85
+          value: solarwinds/swo-agent:v2.8.90
   - it: Image should be correct when overriden tag
     template: swo-agent-statefulset.yaml
     set:

--- a/deploy/helm/values.yaml
+++ b/deploy/helm/values.yaml
@@ -616,7 +616,7 @@ swoagent:
   enabled: false
   image:
     repository: solarwinds/swo-agent
-    tag: "v2.8.85"
+    tag: "v2.8.90"
     pullPolicy: IfNotPresent
   resources:
     limits:


### PR DESCRIPTION
- Upgraded collector image to `0.10.2`
  - https://github.com/solarwinds/swi-k8s-opentelemetry-collector/compare/0.10.1...0.10.2
- Upgraded SWO Agent image to `v2.8.90`
- Additional improvements to cluster version detection _(backport from main)_