### PR TITLE
Release k8s collector 4.0.0-alpha.7

### DIFF
--- a/.github/workflows/buildAndDeploy.yml
+++ b/.github/workflows/buildAndDeploy.yml
@@ -244,6 +244,7 @@ jobs:
             --set cluster.name=test-cluster \
             --set cluster.uid=test-cluster \
             --set otel.endpoint=timeseries-mock-service:9082 \
+            --set otel.api_token=not_set \
             --set prometheus.enabled=true \
             --set autoupdate.enabled=true \
             --set autoupdate.devel=true \

--- a/deploy/helm/CHANGELOG.md
+++ b/deploy/helm/CHANGELOG.md
@@ -7,15 +7,36 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## [4.0.0-alpha.7] - 2024-07-23
+
 ### Changed
 
 - Breaking: Add validation of the OTEL endpoint provided in `values.yaml`. In case a deprecated endpoint is detected, report an error during chart installation/update.
+- Upgraded collector image to `0.11.3` which brings following changes:
+  - See Release notes for [0.11.3](https://github.com/solarwinds/swi-k8s-opentelemetry-collector/releases/tag/0.11.3).
+  - Upgraded OTEL Collector to v0.105.0.
+- Upgraded SWO Agent image to `v2.8.90`
 
 ## [4.0.0-alpha.6] - 2024-07-22
 
 ### Changed
 
-- Internal `k8sattributes` has been renamed to `swk8sattributes`
+- Upgraded collector image to `0.11.2` which brings following changes:
+  - See Release notes for [0.11.2](https://github.com/solarwinds/swi-k8s-opentelemetry-collector/releases/tag/0.11.2).
+  - Bumped 3rd party dependencies and Docker images.
+  - Internal `k8sattributes` has been renamed to `swk8sattributes`
+
+## [3.4.1] - 2024-07-19
+
+### Changed
+
+- Upgraded collector image to `0.10.2` which brings following changes:
+  - Bumped 3rd party dependencies and Docker images.
+- Upgraded SWO Agent image to `v2.8.90`
+
+### Fixed
+
+- Additional improvements to cluster version detection
 
 ## [4.0.0-alpha.5] - 2024-07-16
 
@@ -25,7 +46,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Internal configuration of filterprocessor is using OTTL syntax now. 
+- Internal configuration of filterprocessor is using OTTL syntax now.
 
 
 ## [4.0.0-alpha.4] - 2024-07-11

--- a/deploy/helm/Chart.yaml
+++ b/deploy/helm/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: swo-k8s-collector
-version: 4.0.0-alpha.6
-appVersion: "0.11.2"
+version: 4.0.0-alpha.7
+appVersion: "0.11.3"
 description: SolarWinds Kubernetes Integration
 keywords:
   - monitoring

--- a/deploy/helm/tests/__snapshot__/logs-fargate-config-map_test.yaml.snap
+++ b/deploy/helm/tests/__snapshot__/logs-fargate-config-map_test.yaml.snap
@@ -22,7 +22,7 @@ Fargate logging ConfigMap spec should include additional filters when they are c
           Match *
           Add sw.k8s.cluster.uid <CLUSTER_UID>
           Add sw.k8s.log.type container
-          Add sw.k8s.agent.manifest.version "4.0.0-alpha.6"
+          Add sw.k8s.agent.manifest.version "4.0.0-alpha.7"
     flb_log_cw: "false"
     output.conf: |
       [OUTPUT]
@@ -60,7 +60,7 @@ Fargate logging ConfigMap spec should match snapshot when Fargate logging is ena
           Match *
           Add sw.k8s.cluster.uid <CLUSTER_UID>
           Add sw.k8s.log.type container
-          Add sw.k8s.agent.manifest.version "4.0.0-alpha.6"
+          Add sw.k8s.agent.manifest.version "4.0.0-alpha.7"
     flb_log_cw: "false"
     output.conf: |
       [OUTPUT]

--- a/deploy/helm/tests/swo-agent-statefulset_test.yaml
+++ b/deploy/helm/tests/swo-agent-statefulset_test.yaml
@@ -10,7 +10,7 @@ tests:
     asserts:
     - equal:
           path: spec.template.spec.containers[0].image
-          value: solarwinds/swo-agent:v2.8.85
+          value: solarwinds/swo-agent:v2.8.90
   - it: Image should be correct when overriden tag
     template: swo-agent-statefulset.yaml
     set:

--- a/deploy/helm/values.yaml
+++ b/deploy/helm/values.yaml
@@ -646,7 +646,7 @@ swoagent:
   enabled: false
   image:
     repository: solarwinds/swo-agent
-    tag: "v2.8.85"
+    tag: "v2.8.90"
     pullPolicy: IfNotPresent
   resources:
     limits:


### PR DESCRIPTION
Update image to [0.11.3](https://github.com/solarwinds/swi-k8s-opentelemetry-collector/releases/tag/0.11.3) and include changes from `k8s collector` [3.4.1](https://github.com/solarwinds/swi-k8s-opentelemetry-collector/releases/tag/swo-k8s-collector-3.4.1).