### PR TITLE
Release k8s collector `3.4.2`

### DIFF
--- a/build/docker/Dockerfile.Windows-2022
+++ b/build/docker/Dockerfile.Windows-2022
@@ -1,4 +1,4 @@
-FROM docker.io/library/golang:1.22.5-nanoserver-ltsc2022@sha256:0a134b8e83206a9b0d5374bea6982335727b3a1a375e53fe3917ba5faae59cf6 as base
+FROM docker.io/library/golang:1.22.5-nanoserver-ltsc2022@sha256:f5a16d5fbfa6c7b8235e489918b70dd15c387ee9adbe40592e3e6c9846429742 AS base
 WORKDIR /src
 COPY ["./src/", "./src/"]
 

--- a/build/docker/structure-test.yaml
+++ b/build/docker/structure-test.yaml
@@ -17,4 +17,4 @@ commandTests:
   - name: "swi-otelcol is working in the image"
     command: "/swi-otelcol"
     args: ["-v"]
-    expectedOutput: ["swi-k8s-opentelemetry-collector version 0.10.2"]
+    expectedOutput: ["swi-k8s-opentelemetry-collector version 0.10.3"]

--- a/deploy/helm/CHANGELOG.md
+++ b/deploy/helm/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## [3.4.2] - 2024-07-31
+
+### Changed
+
+- Upgraded collector image to `0.10.3` which brings following changes:
+  - Bumped 3rd party dependencies and Docker images.
+
 ## [3.4.1] - 2024-07-19
 
 ### Changed

--- a/deploy/helm/Chart.yaml
+++ b/deploy/helm/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: swo-k8s-collector
-version: 3.4.1
-appVersion: "0.10.2"
+version: 3.4.2
+appVersion: "0.10.3"
 description: SolarWinds Kubernetes Integration
 keywords:
   - monitoring

--- a/deploy/helm/tests/__snapshot__/logs-fargate-config-map_test.yaml.snap
+++ b/deploy/helm/tests/__snapshot__/logs-fargate-config-map_test.yaml.snap
@@ -22,7 +22,7 @@ Fargate logging ConfigMap spec should include additional filters when they are c
           Match *
           Add sw.k8s.cluster.uid <CLUSTER_UID>
           Add sw.k8s.log.type container
-          Add sw.k8s.agent.manifest.version "3.4.1"
+          Add sw.k8s.agent.manifest.version "3.4.2"
     flb_log_cw: "false"
     output.conf: |
       [OUTPUT]
@@ -60,7 +60,7 @@ Fargate logging ConfigMap spec should match snapshot when Fargate logging is ena
           Match *
           Add sw.k8s.cluster.uid <CLUSTER_UID>
           Add sw.k8s.log.type container
-          Add sw.k8s.agent.manifest.version "3.4.1"
+          Add sw.k8s.agent.manifest.version "3.4.2"
     flb_log_cw: "false"
     output.conf: |
       [OUTPUT]

--- a/src/cmd/go.mod
+++ b/src/cmd/go.mod
@@ -78,7 +78,7 @@ require (
 	github.com/dennwc/varint v1.0.0 // indirect
 	github.com/digitalocean/godo v1.109.0 // indirect
 	github.com/distribution/reference v0.5.0 // indirect
-	github.com/docker/docker v25.0.5+incompatible // indirect
+	github.com/docker/docker v25.0.6+incompatible // indirect
 	github.com/docker/go-connections v0.5.0 // indirect
 	github.com/docker/go-units v0.5.0 // indirect
 	github.com/emicklei/go-restful/v3 v3.11.0 // indirect

--- a/src/cmd/go.sum
+++ b/src/cmd/go.sum
@@ -131,8 +131,8 @@ github.com/distribution/reference v0.5.0 h1:/FUIFXtfc/x2gpa5/VGfiGLuOIdYa1t65IKK
 github.com/distribution/reference v0.5.0/go.mod h1:BbU0aIcezP1/5jX/8MP0YiH4SdvB5Y4f/wlDRiLyi3E=
 github.com/dnaeon/go-vcr v1.2.0 h1:zHCHvJYTMh1N7xnV7zf1m1GPBF9Ad0Jk/whtQ1663qI=
 github.com/dnaeon/go-vcr v1.2.0/go.mod h1:R4UdLID7HZT3taECzJs4YgbbH6PIGXB6W/sc5OLb6RQ=
-github.com/docker/docker v25.0.5+incompatible h1:UmQydMduGkrD5nQde1mecF/YnSbTOaPeFIeP5C4W+DE=
-github.com/docker/docker v25.0.5+incompatible/go.mod h1:eEKB0N0r5NX/I1kEveEz05bcu8tLC/8azJZsviup8Sk=
+github.com/docker/docker v25.0.6+incompatible h1:5cPwbwriIcsua2REJe8HqQV+6WlWc1byg2QSXzBxBGg=
+github.com/docker/docker v25.0.6+incompatible/go.mod h1:eEKB0N0r5NX/I1kEveEz05bcu8tLC/8azJZsviup8Sk=
 github.com/docker/go-connections v0.5.0 h1:USnMq7hx7gwdVZq1L49hLXaFtUdTADjXGp+uj1Br63c=
 github.com/docker/go-connections v0.5.0/go.mod h1:ov60Kzw0kKElRwhNs9UlUHAE/F9Fe6GLaXnqyDdmEXc=
 github.com/docker/go-units v0.5.0 h1:69rxXcBk27SvSaaxTtLh/8llcHD8vYHT7WSdRZ/jvr4=

--- a/src/cmd/main.go
+++ b/src/cmd/main.go
@@ -26,7 +26,7 @@ func main() {
 	info := component.BuildInfo{
 		Command:     "swi-k8s-opentelemetry-collector",
 		Description: "SolarWinds distribution for OpenTelemetry",
-		Version:     "0.10.2",
+		Version:     "0.10.3",
 	}
 
 	if err := run(otelcol.CollectorSettings{BuildInfo: info, Factories: components}); err != nil {


### PR DESCRIPTION
- Upgraded collector image to `0.10.3`
  - https://github.com/solarwinds/swi-k8s-opentelemetry-collector/compare/0.10.2...0.10.3