### PR TITLE
Adding HTTP Proxy configuration option

### DIFF
--- a/deploy/helm/CHANGELOG.md
+++ b/deploy/helm/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Added
+- Added `otel.http_proxy_url` to support HTTP proxy
+
 ## [4.0.0-alpha.8] - 2024-08-15
 
 ### Changed

--- a/deploy/helm/templates/common-env-config-map.yaml
+++ b/deploy/helm/templates/common-env-config-map.yaml
@@ -15,3 +15,6 @@ data:
 {{ if .Values.otel.https_proxy_url }}
   HTTPS_PROXY: {{ quote .Values.otel.https_proxy_url }}
 {{ end }}
+{{ if .Values.otel.http_proxy_url }}
+  HTTP_PROXY: {{ quote .Values.otel.http_proxy_url }}
+{{ end }}

--- a/deploy/helm/values.schema.json
+++ b/deploy/helm/values.schema.json
@@ -684,6 +684,9 @@
                 "https_proxy_url": {
                     "type": "string"
                 },
+                "http_proxy_url": {
+                    "type": "string"
+                },
                 "image": {
                     "$ref": "#/definitions/imageDefinition"
                 },

--- a/deploy/helm/values.yaml
+++ b/deploy/helm/values.yaml
@@ -22,6 +22,9 @@ otel:
   # proxy here. e.g. https_proxy: "https://myproxy.mydomain.com:8080"
   https_proxy_url: ""
 
+  # Similarly as `https_proxy_url`, the OTEL collector supports an HTTP proxy.
+  http_proxy_url: ""
+
   image:
     repository: solarwinds/swi-opentelemetry-collector
     # if not set appVersion field from Chart.yaml is used


### PR DESCRIPTION
Adding `otel.http_proxy_url` configuration option to values.yaml which will add `HTTP_PROXY` environment variable to every single OTEL collector deployed as part of SWO K8s Collector