### PR TITLE
General fixes after 4.0.0-alpha.8

### DIFF
--- a/deploy/helm/CHANGELOG.md
+++ b/deploy/helm/CHANGELOG.md
@@ -24,12 +24,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - See Release notes for [0.11.4](https://github.com/solarwinds/swi-k8s-opentelemetry-collector/releases/tag/0.11.4).
   - Upgraded OTEL Collector to v0.107.0.
   - Removed deprecated `ballastextension`. The collector now uses environment variable `GOMEMLIMIT`.
+  - Bumped Go builder image to 1.22.6.
 - Upgraded SWO Agent image to `v2.9.3`
 
 ### Fixed
 
 - Fixed a typo in filter syntax warning
 
+## [3.4.2] - 2024-07-31
+
+### Changed
+
+- Upgraded collector image to `0.10.3` which brings following changes:
+  - Bumped 3rd party dependencies and Docker images.
 
 ## [4.0.0-alpha.7] - 2024-07-23
 

--- a/deploy/helm/CHANGELOG.md
+++ b/deploy/helm/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Fixed
+
+- Added workaround for a bug introduced in OTEL Collector to v0.106.0.
+
 ## [4.0.0-alpha.8] - 2024-08-15
 
 ### Changed

--- a/deploy/helm/CHANGELOG.md
+++ b/deploy/helm/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Changed
+
+- Upgraded grpcurl image to `v1.9.1`
+
 ### Fixed
 
 - Added workaround for a bug introduced in OTEL Collector to v0.106.0.

--- a/deploy/helm/metrics-collector-config.yaml
+++ b/deploy/helm/metrics-collector-config.yaml
@@ -457,77 +457,88 @@ processors:
         new_name: k8s.cluster.pods
         operations:
           - action: aggregate_labels
-            label_set: []
+            # use [dummy_label_workaround] instead of [] as a workaround for a bug introduced in metricstransform 0.106
+            label_set: [dummy_label_workaround]
             aggregation_type: sum
       - include: k8s.kube_node_info
         action: insert
         new_name: k8s.cluster.nodes
         operations:
           - action: aggregate_labels
-            label_set: []
+            # use [dummy_label_workaround] instead of [] as a workaround for a bug introduced in metricstransform 0.106
+            label_set: [dummy_label_workaround]
             aggregation_type: sum
       - include: k8s.node.status.condition.ready
         action: insert
         new_name: k8s.cluster.nodes.ready
         operations:
           - action: aggregate_labels
-            label_set: []
+            # use [dummy_label_workaround] instead of [] as a workaround for a bug introduced in metricstransform 0.106
+            label_set: [dummy_label_workaround]
             aggregation_type: sum
       - include: k8s.node.status.condition.ready
         action: insert
         new_name: k8s.cluster.nodes.ready.avg
         operations:
           - action: aggregate_labels
-            label_set: []
+            # use [dummy_label_workaround] instead of [] as a workaround for a bug introduced in metricstransform 0.106
+            label_set: [dummy_label_workaround]
             aggregation_type: mean
       - include: k8s.container.spec.memory.requests
         action: insert
         new_name: k8s.cluster.spec.memory.requests
         operations:
           - action: aggregate_labels
-            label_set: []
+            # use [dummy_label_workaround] instead of [] as a workaround for a bug introduced in metricstransform 0.106
+            label_set: [dummy_label_workaround]
             aggregation_type: sum
       - include: k8s.container.spec.cpu.requests
         action: insert
         new_name: k8s.cluster.spec.cpu.requests
         operations:
           - action: aggregate_labels
-            label_set: []
+            # use [dummy_label_workaround] instead of [] as a workaround for a bug introduced in metricstransform 0.106
+            label_set: [dummy_label_workaround]
             aggregation_type: sum
       - include: k8s.pod.status.phase.running_temp
         action: insert
         new_name: k8s.cluster.pods.running
         operations:
           - action: aggregate_labels
-            label_set: []
+            # use [dummy_label_workaround] instead of [] as a workaround for a bug introduced in metricstransform 0.106
+            label_set: [dummy_label_workaround]
             aggregation_type: sum
       - include: k8s.node.cpu.capacity
         action: insert
         new_name: k8s.cluster.cpu.capacity
         operations:
           - action: aggregate_labels
-            label_set: []
+            # use [dummy_label_workaround] instead of [] as a workaround for a bug introduced in metricstransform 0.106
+            label_set: [dummy_label_workaround]
             aggregation_type: sum
       - include: k8s.node.cpu.allocatable
         action: insert
         new_name: k8s.cluster.cpu.allocatable
         operations:
           - action: aggregate_labels
-            label_set: []
+            # use [dummy_label_workaround] instead of [] as a workaround for a bug introduced in metricstransform 0.106
+            label_set: [dummy_label_workaround]
             aggregation_type: sum
       - include: k8s.node.memory.capacity
         action: insert
         new_name: k8s.cluster.memory.capacity
         operations:
           - action: aggregate_labels
-            label_set: []
+            # use [dummy_label_workaround] instead of [] as a workaround for a bug introduced in metricstransform 0.106
+            label_set: [dummy_label_workaround]
             aggregation_type: sum
       - include: k8s.node.memory.allocatable
         action: insert
         new_name: k8s.cluster.memory.allocatable
         operations:
           - action: aggregate_labels
-            label_set: []
+            # use [dummy_label_workaround] instead of [] as a workaround for a bug introduced in metricstransform 0.106
+            label_set: [dummy_label_workaround]
             aggregation_type: sum
       - include: k8s.kubernetes_build_info
         action: insert
@@ -556,14 +567,16 @@ processors:
         new_name: apiserver_request_not_failed_temp
         operations:
           - action: aggregate_labels
-            label_set: []
+            # use [dummy_label_workaround] instead of [] as a workaround for a bug introduced in metricstransform 0.106
+            label_set: [dummy_label_workaround]
             aggregation_type: sum
       - include: apiserver_request_total
         action: insert
         new_name: apiserver_request_total_temp
         operations:
           - action: aggregate_labels
-            label_set: []
+            # use [dummy_label_workaround] instead of [] as a workaround for a bug introduced in metricstransform 0.106
+            label_set: [dummy_label_workaround]
             aggregation_type: sum
 
       # Job metrics
@@ -633,7 +646,8 @@ processors:
         new_name: k8s.node.pods
         operations:
           - action: aggregate_labels
-            label_set: []
+            # use [dummy_label_workaround] instead of [] as a workaround for a bug introduced in metricstransform 0.106
+            label_set: [dummy_label_workaround]
             aggregation_type: sum
   groupbyattrs/pod:
     keys:
@@ -647,7 +661,8 @@ processors:
         new_name: k8s.pod.containers
         operations:
           - action: aggregate_labels
-            label_set: []
+            # use [dummy_label_workaround] instead of [] as a workaround for a bug introduced in metricstransform 0.106
+            label_set: [dummy_label_workaround]
             aggregation_type: sum
   groupbyattrs/all:
     keys:

--- a/deploy/helm/templates/NOTES.txt
+++ b/deploy/helm/templates/NOTES.txt
@@ -63,16 +63,16 @@ WARNING: The provided custom configuration for `otel.metrics.autodiscovery.prome
 {{- end -}}
 
 {{- if .Values.otel.events.memory_ballast -}}
-WARNING: Configuration `.Values.otel.events.memory_ballast` was deprecated. Please remove the custom configuration.
+WARNING: Configuration `otel.events.memory_ballast` was deprecated. Please remove the custom configuration.
 {{- println -}}
 {{- end -}}
 
 {{- if .Values.otel.metrics.memory_ballast -}}
-WARNING: Configuration `.Values.otel.metrics.memory_ballast` was deprecated. Please remove the custom configuration.
+WARNING: Configuration `otel.metrics.memory_ballast` was deprecated. Please remove the custom configuration.
 {{- println -}}
 {{- end -}}
 
 {{- if .Values.otel.logs.memory_ballast -}}
-WARNING: Configuration `.Values.otel.logs.memory_ballast` was deprecated. Please remove the custom configuration.
+WARNING: Configuration `otel.logs.memory_ballast` was deprecated. Please remove the custom configuration.
 {{- println -}}
 {{- end -}}

--- a/deploy/helm/tests/__snapshot__/metrics-collector-config-map-fargate_test.yaml.snap
+++ b/deploy/helm/tests/__snapshot__/metrics-collector-config-map-fargate_test.yaml.snap
@@ -697,7 +697,8 @@ Metrics config should match snapshot when using default values:
             operations:
             - action: aggregate_labels
               aggregation_type: sum
-              label_set: []
+              label_set:
+              - dummy_label_workaround
         metricstransform/aggregate_pod_level:
           transforms:
           - action: insert
@@ -706,7 +707,8 @@ Metrics config should match snapshot when using default values:
             operations:
             - action: aggregate_labels
               aggregation_type: sum
-              label_set: []
+              label_set:
+              - dummy_label_workaround
         metricstransform/preprocessing:
           transforms:
           - action: insert
@@ -1453,77 +1455,88 @@ Metrics config should match snapshot when using default values:
             operations:
             - action: aggregate_labels
               aggregation_type: sum
-              label_set: []
+              label_set:
+              - dummy_label_workaround
           - action: insert
             include: k8s.kube_node_info
             new_name: k8s.cluster.nodes
             operations:
             - action: aggregate_labels
               aggregation_type: sum
-              label_set: []
+              label_set:
+              - dummy_label_workaround
           - action: insert
             include: k8s.node.status.condition.ready
             new_name: k8s.cluster.nodes.ready
             operations:
             - action: aggregate_labels
               aggregation_type: sum
-              label_set: []
+              label_set:
+              - dummy_label_workaround
           - action: insert
             include: k8s.node.status.condition.ready
             new_name: k8s.cluster.nodes.ready.avg
             operations:
             - action: aggregate_labels
               aggregation_type: mean
-              label_set: []
+              label_set:
+              - dummy_label_workaround
           - action: insert
             include: k8s.container.spec.memory.requests
             new_name: k8s.cluster.spec.memory.requests
             operations:
             - action: aggregate_labels
               aggregation_type: sum
-              label_set: []
+              label_set:
+              - dummy_label_workaround
           - action: insert
             include: k8s.container.spec.cpu.requests
             new_name: k8s.cluster.spec.cpu.requests
             operations:
             - action: aggregate_labels
               aggregation_type: sum
-              label_set: []
+              label_set:
+              - dummy_label_workaround
           - action: insert
             include: k8s.pod.status.phase.running_temp
             new_name: k8s.cluster.pods.running
             operations:
             - action: aggregate_labels
               aggregation_type: sum
-              label_set: []
+              label_set:
+              - dummy_label_workaround
           - action: insert
             include: k8s.node.cpu.capacity
             new_name: k8s.cluster.cpu.capacity
             operations:
             - action: aggregate_labels
               aggregation_type: sum
-              label_set: []
+              label_set:
+              - dummy_label_workaround
           - action: insert
             include: k8s.node.cpu.allocatable
             new_name: k8s.cluster.cpu.allocatable
             operations:
             - action: aggregate_labels
               aggregation_type: sum
-              label_set: []
+              label_set:
+              - dummy_label_workaround
           - action: insert
             include: k8s.node.memory.capacity
             new_name: k8s.cluster.memory.capacity
             operations:
             - action: aggregate_labels
               aggregation_type: sum
-              label_set: []
+              label_set:
+              - dummy_label_workaround
           - action: insert
             include: k8s.node.memory.allocatable
             new_name: k8s.cluster.memory.allocatable
             operations:
             - action: aggregate_labels
               aggregation_type: sum
-              label_set: []
+              label_set:
+              - dummy_label_workaround
           - action: insert
             experimental_match_labels:
               scrape_job: .*apiservers.*
@@ -1553,14 +1566,16 @@ Metrics config should match snapshot when using default values:
             operations:
             - action: aggregate_labels
               aggregation_type: sum
-              label_set: []
+              label_set:
+              - dummy_label_workaround
           - action: insert
             include: apiserver_request_total
             new_name: apiserver_request_total_temp
             operations:
             - action: aggregate_labels
               aggregation_type: sum
-              label_set: []
+              label_set:
+              - dummy_label_workaround
           - action: insert
             experimental_match_labels:
               owner_is_controller: "true"

--- a/deploy/helm/tests/__snapshot__/metrics-collector-config-map_test.yaml.snap
+++ b/deploy/helm/tests/__snapshot__/metrics-collector-config-map_test.yaml.snap
@@ -697,7 +697,8 @@ Metrics config should match snapshot when fargate is enabled:
             operations:
             - action: aggregate_labels
               aggregation_type: sum
-              label_set: []
+              label_set:
+              - dummy_label_workaround
         metricstransform/aggregate_pod_level:
           transforms:
           - action: insert
@@ -706,7 +707,8 @@ Metrics config should match snapshot when fargate is enabled:
             operations:
             - action: aggregate_labels
               aggregation_type: sum
-              label_set: []
+              label_set:
+              - dummy_label_workaround
         metricstransform/preprocessing:
           transforms:
           - action: insert
@@ -1453,77 +1455,88 @@ Metrics config should match snapshot when fargate is enabled:
             operations:
             - action: aggregate_labels
               aggregation_type: sum
-              label_set: []
+              label_set:
+              - dummy_label_workaround
           - action: insert
             include: k8s.kube_node_info
             new_name: k8s.cluster.nodes
             operations:
             - action: aggregate_labels
               aggregation_type: sum
-              label_set: []
+              label_set:
+              - dummy_label_workaround
           - action: insert
             include: k8s.node.status.condition.ready
             new_name: k8s.cluster.nodes.ready
             operations:
             - action: aggregate_labels
               aggregation_type: sum
-              label_set: []
+              label_set:
+              - dummy_label_workaround
           - action: insert
             include: k8s.node.status.condition.ready
             new_name: k8s.cluster.nodes.ready.avg
             operations:
             - action: aggregate_labels
               aggregation_type: mean
-              label_set: []
+              label_set:
+              - dummy_label_workaround
           - action: insert
             include: k8s.container.spec.memory.requests
             new_name: k8s.cluster.spec.memory.requests
             operations:
             - action: aggregate_labels
               aggregation_type: sum
-              label_set: []
+              label_set:
+              - dummy_label_workaround
           - action: insert
             include: k8s.container.spec.cpu.requests
             new_name: k8s.cluster.spec.cpu.requests
             operations:
             - action: aggregate_labels
               aggregation_type: sum
-              label_set: []
+              label_set:
+              - dummy_label_workaround
           - action: insert
             include: k8s.pod.status.phase.running_temp
             new_name: k8s.cluster.pods.running
             operations:
             - action: aggregate_labels
               aggregation_type: sum
-              label_set: []
+              label_set:
+              - dummy_label_workaround
           - action: insert
             include: k8s.node.cpu.capacity
             new_name: k8s.cluster.cpu.capacity
             operations:
             - action: aggregate_labels
               aggregation_type: sum
-              label_set: []
+              label_set:
+              - dummy_label_workaround
           - action: insert
             include: k8s.node.cpu.allocatable
             new_name: k8s.cluster.cpu.allocatable
             operations:
             - action: aggregate_labels
               aggregation_type: sum
-              label_set: []
+              label_set:
+              - dummy_label_workaround
           - action: insert
             include: k8s.node.memory.capacity
             new_name: k8s.cluster.memory.capacity
             operations:
             - action: aggregate_labels
               aggregation_type: sum
-              label_set: []
+              label_set:
+              - dummy_label_workaround
           - action: insert
             include: k8s.node.memory.allocatable
             new_name: k8s.cluster.memory.allocatable
             operations:
             - action: aggregate_labels
               aggregation_type: sum
-              label_set: []
+              label_set:
+              - dummy_label_workaround
           - action: insert
             experimental_match_labels:
               scrape_job: .*apiservers.*
@@ -1553,14 +1566,16 @@ Metrics config should match snapshot when fargate is enabled:
             operations:
             - action: aggregate_labels
               aggregation_type: sum
-              label_set: []
+              label_set:
+              - dummy_label_workaround
           - action: insert
             include: apiserver_request_total
             new_name: apiserver_request_total_temp
             operations:
             - action: aggregate_labels
               aggregation_type: sum
-              label_set: []
+              label_set:
+              - dummy_label_workaround
           - action: insert
             experimental_match_labels:
               owner_is_controller: "true"
@@ -2898,7 +2913,8 @@ Metrics config should match snapshot when using Prometheus url with extra_scrape
             operations:
             - action: aggregate_labels
               aggregation_type: sum
-              label_set: []
+              label_set:
+              - dummy_label_workaround
         metricstransform/aggregate_pod_level:
           transforms:
           - action: insert
@@ -2907,7 +2923,8 @@ Metrics config should match snapshot when using Prometheus url with extra_scrape
             operations:
             - action: aggregate_labels
               aggregation_type: sum
-              label_set: []
+              label_set:
+              - dummy_label_workaround
         metricstransform/preprocessing:
           transforms:
           - action: insert
@@ -3654,77 +3671,88 @@ Metrics config should match snapshot when using Prometheus url with extra_scrape
             operations:
             - action: aggregate_labels
               aggregation_type: sum
-              label_set: []
+              label_set:
+              - dummy_label_workaround
           - action: insert
             include: k8s.kube_node_info
             new_name: k8s.cluster.nodes
             operations:
             - action: aggregate_labels
               aggregation_type: sum
-              label_set: []
+              label_set:
+              - dummy_label_workaround
           - action: insert
             include: k8s.node.status.condition.ready
             new_name: k8s.cluster.nodes.ready
             operations:
             - action: aggregate_labels
               aggregation_type: sum
-              label_set: []
+              label_set:
+              - dummy_label_workaround
           - action: insert
             include: k8s.node.status.condition.ready
             new_name: k8s.cluster.nodes.ready.avg
             operations:
             - action: aggregate_labels
               aggregation_type: mean
-              label_set: []
+              label_set:
+              - dummy_label_workaround
           - action: insert
             include: k8s.container.spec.memory.requests
             new_name: k8s.cluster.spec.memory.requests
             operations:
             - action: aggregate_labels
               aggregation_type: sum
-              label_set: []
+              label_set:
+              - dummy_label_workaround
           - action: insert
             include: k8s.container.spec.cpu.requests
             new_name: k8s.cluster.spec.cpu.requests
             operations:
             - action: aggregate_labels
               aggregation_type: sum
-              label_set: []
+              label_set:
+              - dummy_label_workaround
           - action: insert
             include: k8s.pod.status.phase.running_temp
             new_name: k8s.cluster.pods.running
             operations:
             - action: aggregate_labels
               aggregation_type: sum
-              label_set: []
+              label_set:
+              - dummy_label_workaround
           - action: insert
             include: k8s.node.cpu.capacity
             new_name: k8s.cluster.cpu.capacity
             operations:
             - action: aggregate_labels
               aggregation_type: sum
-              label_set: []
+              label_set:
+              - dummy_label_workaround
           - action: insert
             include: k8s.node.cpu.allocatable
             new_name: k8s.cluster.cpu.allocatable
             operations:
             - action: aggregate_labels
               aggregation_type: sum
-              label_set: []
+              label_set:
+              - dummy_label_workaround
           - action: insert
             include: k8s.node.memory.capacity
             new_name: k8s.cluster.memory.capacity
             operations:
             - action: aggregate_labels
               aggregation_type: sum
-              label_set: []
+              label_set:
+              - dummy_label_workaround
           - action: insert
             include: k8s.node.memory.allocatable
             new_name: k8s.cluster.memory.allocatable
             operations:
             - action: aggregate_labels
               aggregation_type: sum
-              label_set: []
+              label_set:
+              - dummy_label_workaround
           - action: insert
             experimental_match_labels:
               scrape_job: .*apiservers.*
@@ -3754,14 +3782,16 @@ Metrics config should match snapshot when using Prometheus url with extra_scrape
             operations:
             - action: aggregate_labels
               aggregation_type: sum
-              label_set: []
+              label_set:
+              - dummy_label_workaround
           - action: insert
             include: apiserver_request_total
             new_name: apiserver_request_total_temp
             operations:
             - action: aggregate_labels
               aggregation_type: sum
-              label_set: []
+              label_set:
+              - dummy_label_workaround
           - action: insert
             experimental_match_labels:
               owner_is_controller: "true"
@@ -5041,7 +5071,8 @@ Metrics config should match snapshot when using default values:
             operations:
             - action: aggregate_labels
               aggregation_type: sum
-              label_set: []
+              label_set:
+              - dummy_label_workaround
         metricstransform/aggregate_pod_level:
           transforms:
           - action: insert
@@ -5050,7 +5081,8 @@ Metrics config should match snapshot when using default values:
             operations:
             - action: aggregate_labels
               aggregation_type: sum
-              label_set: []
+              label_set:
+              - dummy_label_workaround
         metricstransform/preprocessing:
           transforms:
           - action: insert
@@ -5797,77 +5829,88 @@ Metrics config should match snapshot when using default values:
             operations:
             - action: aggregate_labels
               aggregation_type: sum
-              label_set: []
+              label_set:
+              - dummy_label_workaround
           - action: insert
             include: k8s.kube_node_info
             new_name: k8s.cluster.nodes
             operations:
             - action: aggregate_labels
               aggregation_type: sum
-              label_set: []
+              label_set:
+              - dummy_label_workaround
           - action: insert
             include: k8s.node.status.condition.ready
             new_name: k8s.cluster.nodes.ready
             operations:
             - action: aggregate_labels
               aggregation_type: sum
-              label_set: []
+              label_set:
+              - dummy_label_workaround
           - action: insert
             include: k8s.node.status.condition.ready
             new_name: k8s.cluster.nodes.ready.avg
             operations:
             - action: aggregate_labels
               aggregation_type: mean
-              label_set: []
+              label_set:
+              - dummy_label_workaround
           - action: insert
             include: k8s.container.spec.memory.requests
             new_name: k8s.cluster.spec.memory.requests
             operations:
             - action: aggregate_labels
               aggregation_type: sum
-              label_set: []
+              label_set:
+              - dummy_label_workaround
           - action: insert
             include: k8s.container.spec.cpu.requests
             new_name: k8s.cluster.spec.cpu.requests
             operations:
             - action: aggregate_labels
               aggregation_type: sum
-              label_set: []
+              label_set:
+              - dummy_label_workaround
           - action: insert
             include: k8s.pod.status.phase.running_temp
             new_name: k8s.cluster.pods.running
             operations:
             - action: aggregate_labels
               aggregation_type: sum
-              label_set: []
+              label_set:
+              - dummy_label_workaround
           - action: insert
             include: k8s.node.cpu.capacity
             new_name: k8s.cluster.cpu.capacity
             operations:
             - action: aggregate_labels
               aggregation_type: sum
-              label_set: []
+              label_set:
+              - dummy_label_workaround
           - action: insert
             include: k8s.node.cpu.allocatable
             new_name: k8s.cluster.cpu.allocatable
             operations:
             - action: aggregate_labels
               aggregation_type: sum
-              label_set: []
+              label_set:
+              - dummy_label_workaround
           - action: insert
             include: k8s.node.memory.capacity
             new_name: k8s.cluster.memory.capacity
             operations:
             - action: aggregate_labels
               aggregation_type: sum
-              label_set: []
+              label_set:
+              - dummy_label_workaround
           - action: insert
             include: k8s.node.memory.allocatable
             new_name: k8s.cluster.memory.allocatable
             operations:
             - action: aggregate_labels
               aggregation_type: sum
-              label_set: []
+              label_set:
+              - dummy_label_workaround
           - action: insert
             experimental_match_labels:
               scrape_job: .*apiservers.*
@@ -5897,14 +5940,16 @@ Metrics config should match snapshot when using default values:
             operations:
             - action: aggregate_labels
               aggregation_type: sum
-              label_set: []
+              label_set:
+              - dummy_label_workaround
           - action: insert
             include: apiserver_request_total
             new_name: apiserver_request_total_temp
             operations:
             - action: aggregate_labels
               aggregation_type: sum
-              label_set: []
+              label_set:
+              - dummy_label_workaround
           - action: insert
             experimental_match_labels:
               owner_is_controller: "true"

--- a/deploy/helm/tests/__snapshot__/metrics-deployment_test.yaml.snap
+++ b/deploy/helm/tests/__snapshot__/metrics-deployment_test.yaml.snap
@@ -88,7 +88,7 @@ Metrics collector spec should match snapshot when using default values:
                 key: SOLARWINDS_API_TOKEN
                 name: solarwinds-api-token
                 optional: true
-        image: fullstorydev/grpcurl:v1.8.9
+        image: fullstorydev/grpcurl:v1.9.1
         imagePullPolicy: IfNotPresent
         name: otel-endpoint-check
         volumeMounts:

--- a/deploy/helm/tests/metrics-deployment_test.yaml
+++ b/deploy/helm/tests/metrics-deployment_test.yaml
@@ -61,7 +61,7 @@ tests:
     asserts:
     - equal:
           path: spec.template.spec.initContainers[0].image
-          value: fullstorydev/grpcurl:v1.8.9
+          value: fullstorydev/grpcurl:v1.9.1
   - it: Image otel-endpoint-check should be correct when overriden repository
     template: metrics-deployment.yaml
     set:
@@ -70,7 +70,7 @@ tests:
     asserts:
     - equal:
           path: spec.template.spec.initContainers[0].image
-          value: aws/test-grpcurl:v1.8.9
+          value: aws/test-grpcurl:v1.9.1
   - it: Image otel-endpoint-check should be correct when overriden tag
     template: metrics-deployment.yaml
     set:

--- a/deploy/helm/values.yaml
+++ b/deploy/helm/values.yaml
@@ -39,7 +39,7 @@ otel:
   init_images:
     swi_endpoint_check:
       repository: "fullstorydev/grpcurl"
-      tag: "v1.8.9"
+      tag: "v1.9.1"
       pullPolicy: IfNotPresent
 
     busy_box:


### PR DESCRIPTION
* Update grpcurl image from 1.8.9 to 1.9.1 for security fixes
* Update Readme to reflect the current state of the `k8s collector`
* Add a workaround for a broken metric aggregations - fix for a regression in 4.0.0-alpha.8
* Improve configuration warnings introduced in 4.0.0-alpha.8