### PR TITLE
Fix support for proxy

### DIFF
--- a/deploy/helm/CHANGELOG.md
+++ b/deploy/helm/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Added workaround for a bug introduced in OTEL Collector to v0.106.0.
+- Adjusted setting `otel.https_proxy_url` to be applied also to SWO Agent and to disable SolarWinds Observability OTEL endpoint check init container.
 
 ## [4.0.0-alpha.8] - 2024-08-15
 

--- a/deploy/helm/templates/metrics-deployment.yaml
+++ b/deploy/helm/templates/metrics-deployment.yaml
@@ -60,7 +60,7 @@ spec:
                 values:
                 - linux
       {{- end }}
-      {{- if or (and .Values.otel.metrics.prometheus_check .Values.otel.metrics.prometheus.url) .Values.otel.metrics.swi_endpoint_check }}
+      {{- if or (and .Values.otel.metrics.prometheus_check .Values.otel.metrics.prometheus.url) (and .Values.otel.metrics.swi_endpoint_check (not .Values.otel.https_proxy_url)) }}
       {{- if .Values.imagePullSecrets }}
       imagePullSecrets:
         {{- toYaml .Values.imagePullSecrets | nindent 8 }}
@@ -75,7 +75,7 @@ spec:
             - configMapRef:
                 name: {{ include "common.fullname" (tuple . "-metrics-env-config") }}
         {{- end }}
-        {{- if .Values.otel.metrics.swi_endpoint_check }}
+        {{- if and .Values.otel.metrics.swi_endpoint_check (not .Values.otel.https_proxy_url) }}
         - name: otel-endpoint-check
           image: "{{ include "common.image" (tuple . .Values.otel.init_images "swi_endpoint_check") }}"
           imagePullPolicy: {{ .Values.otel.init_images.swi_endpoint_check.pullPolicy }}

--- a/deploy/helm/templates/swo-agent-statefulset.yaml
+++ b/deploy/helm/templates/swo-agent-statefulset.yaml
@@ -73,6 +73,12 @@ spec:
                 configMapKeyRef:
                   name: {{ include "common.fullname" (tuple . "-common-env") }}
                   key: MANIFEST_VERSION
+            - name: HTTPS_PROXY
+              valueFrom:
+                configMapKeyRef:
+                  name: {{ include "common.fullname" (tuple . "-common-env") }}
+                  key: HTTPS_PROXY
+                  optional: true
           volumeMounts:
             - name: uams-client-workdir
               mountPath: /uamsclient/workdir

--- a/deploy/helm/tests/metrics-deployment_test.yaml
+++ b/deploy/helm/tests/metrics-deployment_test.yaml
@@ -92,6 +92,14 @@ tests:
     - equal:
           path: spec.template.spec.initContainers[0].image
           value: azurek8s.azure.io/marketplaceimages/owngrpcurl:v1.2.3@abcd
+  - it: otel-endpoint-check should be disabled when proxy is enabled
+    template: metrics-deployment.yaml
+    set:
+      otel.metrics.swi_endpoint_check: true
+      otel.https_proxy_url: "http://example.com"
+    asserts:
+    - notExists:
+        path: spec.template.spec.initContainers
   - it: Image prometheus-check should be correct in default state
     template: metrics-deployment.yaml
     set:


### PR DESCRIPTION
When `otel.https_proxy_url` is set, apply it also to SWO Agent.
Additionally, disable SolarWinds Observability OTEL endpoint check init container because `grpcurl` doesn't support proxy.