### PR TITLE
Use `container-parser` operator in `filelogreceiver` instead of custom configuration

### DIFF
--- a/deploy/helm/CHANGELOG.md
+++ b/deploy/helm/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Changed
+
+- Switched to using `container` parser in the `filelog` receiver for parsing container logs and their metadata
+
 ## [4.0.0-alpha.9] - 2024-08-23
 
 ### Changed

--- a/deploy/helm/node-collector-config.yaml
+++ b/deploy/helm/node-collector-config.yaml
@@ -225,8 +225,13 @@ processors:
     log_statements:
       - context: log
         statements:
+{{- if eq (include "isDeprecatedFilterSyntax" .Values.otel.logs.filter) "true" }}
           - set( attributes["host.name"], attributes["k8s.pod.name"])
           - set( attributes["service.name"], attributes["k8s.container.name"])
+{{- else }}
+          - set( attributes["host.name"], resource.attributes["k8s.pod.name"])
+          - set( attributes["service.name"], resource.attributes["k8s.container.name"])
+{{- end }}
 
   batch/logs:
 {{ toYaml .Values.otel.logs.batch | indent 4 }}
@@ -405,6 +410,7 @@ receivers:
     fingerprint_size: {{ .Values.otel.logs.receiver.fingerprint_size }}
     encoding: {{ .Values.otel.logs.receiver.encoding }}
     poll_interval: {{ .Values.otel.logs.receiver.poll_interval }}
+{{- if eq (include "isDeprecatedFilterSyntax" .Values.otel.logs.filter) "true" }}
     operators:
       # Find out which format is used by kubernetes
       - type: router
@@ -511,6 +517,26 @@ receivers:
       - type: move
         from: body.log
         to: body
+{{- else }}
+    operators:
+# The 'container' operator has hardcoded that 'log.file.path' must use '/' as a separator, whic is not true on Windows
+{{- if (.isWindows) }}
+      - type: add
+        field: attributes["log.file.path.windows"]
+        value: 'EXPR(replace(attributes["log.file.path"], "\\", "/"))'
+      - type: remove
+        field: attributes["log.file.path"]
+      - type: move
+        from: attributes["log.file.path.windows"]
+        to: attributes["log.file.path"]
+{{- end }}
+      - id: container-parser
+        type: container
+      - type: remove
+        field: resource["k8s.container.restart_count"]
+      - type: remove
+        field: attributes["log.file.path"]
+{{- end }}
 
 {{- if and .Values.otel.metrics.enabled .Values.otel.metrics.autodiscovery.prometheusEndpoints.enabled }}
   receiver_creator/discovery:

--- a/deploy/helm/templates/node-collector-daemon-set-windows.yaml
+++ b/deploy/helm/templates/node-collector-daemon-set-windows.yaml
@@ -69,6 +69,7 @@ spec:
             - c:\wrapper.exe
             - c:\swi-otelcol.exe
             - --config=c:\conf\relay.yaml
+            - --feature-gates=filelog.container.removeOriginalTimeField
           env:
             - name: CHECKPOINT_DIR
               value: c:{{ .Values.otel.logs.filestorage.directory }}

--- a/deploy/helm/templates/node-collector-daemon-set.yaml
+++ b/deploy/helm/templates/node-collector-daemon-set.yaml
@@ -80,6 +80,7 @@ spec:
             - /wrapper
             - /swi-otelcol
             - --config=/conf/relay.yaml
+            - --feature-gates=filelog.container.removeOriginalTimeField
           env:
             - name: CHECKPOINT_DIR
               value: {{ .Values.otel.logs.filestorage.directory }}

--- a/deploy/helm/tests/__snapshot__/node-collector-config-map-windows_test.yaml.snap
+++ b/deploy/helm/tests/__snapshot__/node-collector-config-map-windows_test.yaml.snap
@@ -909,6 +909,1104 @@ Node collector config for windows nodes should match snapshot when using default
           log_statements:
           - context: log
             statements:
+            - set( attributes["host.name"], resource.attributes["k8s.pod.name"])
+            - set( attributes["service.name"], resource.attributes["k8s.container.name"])
+        transform/unify_node_attribute:
+          metric_statements:
+          - context: datapoint
+            statements:
+            - set(attributes["k8s.node.name"], resource.attributes["service.instance.id"])
+              where IsMatch(metric.name, "^(container_.*)$") == true and attributes["k8s.node.name"]
+              == nil
+      receivers:
+        filelog:
+          encoding: utf-8
+          exclude:
+          - \var\log\pods\${POD_NAMESPACE}_${POD_NAME}*_*\swi-opentelemetry-collector\*.log
+          fingerprint_size: 1kb
+          include:
+          - \var\log\pods\*\*\*.log
+          include_file_name: false
+          include_file_path: true
+          max_concurrent_files: 10
+          max_log_size: 1MiB
+          operators:
+          - field: attributes["log.file.path.windows"]
+            type: add
+            value: EXPR(replace(attributes["log.file.path"], "\\", "/"))
+          - field: attributes["log.file.path"]
+            type: remove
+          - from: attributes["log.file.path.windows"]
+            to: attributes["log.file.path"]
+            type: move
+          - id: container-parser
+            type: container
+          - field: resource["k8s.container.restart_count"]
+            type: remove
+          - field: attributes["log.file.path"]
+            type: remove
+          poll_interval: 200ms
+          start_at: end
+          storage: file_storage/checkpoints
+        receiver_creator/discovery:
+          receivers:
+            prometheus/discovery:
+              config:
+                config:
+                  scrape_configs:
+                  - honor_labels: true
+                    honor_timestamps: false
+                    job_name: pod
+                    metrics_path: '`"prometheus.io/path" in annotations ? annotations["prometheus.io/path"]
+                      : "/metrics"`'
+                    scheme: http
+                    scrape_interval: 60s
+                    static_configs:
+                    - targets:
+                      - '`endpoint`:`"prometheus.io/port" in annotations ? annotations["prometheus.io/port"]
+                        : 9090`'
+              rule: type == "pod" && annotations["prometheus.io/scrape"] == "true"
+          watch_observers:
+          - k8s_observer
+        receiver_creator/node:
+          receivers:
+            prometheus/node:
+              config:
+                config:
+                  scrape_configs:
+                  - bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
+                    honor_labels: true
+                    honor_timestamps: false
+                    job_name: kubernetes-nodes-cadvisor
+                    metrics_path: /metrics/cadvisor
+                    scheme: https
+                    scrape_interval: 60s
+                    scrape_timeout: 10s
+                    static_configs:
+                    - targets:
+                      - '`endpoint`:`kubelet_endpoint_port`'
+                    tls_config:
+                      ca_file: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+                      insecure_skip_verify: true
+                  - bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
+                    honor_labels: true
+                    honor_timestamps: false
+                    job_name: kubernetes-nodes
+                    metrics_path: /metrics
+                    scheme: https
+                    scrape_interval: 60s
+                    scrape_timeout: 10s
+                    static_configs:
+                    - targets:
+                      - '`endpoint`:`kubelet_endpoint_port`'
+                    tls_config:
+                      ca_file: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+                      insecure_skip_verify: true
+              rule: type == "k8s.node"
+          watch_observers:
+          - k8s_observer
+      service:
+        extensions:
+        - file_storage/checkpoints
+        - health_check
+        - k8s_observer
+        pipelines:
+          logs:
+            exporters:
+            - otlp
+            processors:
+            - memory_limiter
+            - batch/logs
+            receivers:
+            - forward/logs-exporter
+          logs/container:
+            exporters:
+            - forward/logs-exporter
+            processors:
+            - memory_limiter
+            - transform/syslogify
+            - groupbyattrs/common-all
+            - resource/container
+            - swk8sattributes
+            - resource/swk8sattributes_logs_labels_filter
+            - resource/swk8sattributes_logs_annotations_filter
+            receivers:
+            - filelog
+          metrics:
+            exporters:
+            - otlp
+            processors:
+            - memory_limiter
+            - filter/histograms
+            - swk8sattributes
+            - filter/remove_temporary_metrics
+            - batch/metrics
+            receivers:
+            - forward/metric-exporter
+          metrics/discovery:
+            exporters:
+            - forward/metric-exporter
+            processors:
+            - memory_limiter
+            - metricstransform/rename
+            - transform/istio-metrics
+            - metricstransform/istio-metrics
+            - cumulativetodelta/istio-metrics
+            - deltatorate/istio-metrics
+            - experimental_metricsgeneration/istio-metrics
+            - groupbyattrs/common-all
+            - resource/all
+            receivers:
+            - receiver_creator/discovery
+          metrics/node:
+            exporters:
+            - forward/metric-exporter
+            processors:
+            - memory_limiter
+            - filter/receiver
+            - filter/remove_internal
+            - attributes/remove_prometheus_attributes
+            - attributes/unify_node_attribute
+            - transform/unify_node_attribute
+            - metricstransform/rename
+            - metricstransform/preprocessing
+            - filter/remove_internal_postprocessing
+            - attributes/remove_temp
+            - cumulativetodelta/cadvisor
+            - deltatorate/cadvisor
+            - groupbyattrs/node
+            - groupbyattrs/pod
+            - groupbyattrs/all
+            - resource/metrics
+            - resource/all
+            receivers:
+            - receiver_creator/node
+        telemetry:
+          logs:
+            level: info
+          metrics:
+            address: 0.0.0.0:8888
+    logs.proto: ""
+    logs_service.proto: ""
+    resource.proto: ""
+Node collector config for windows nodes should match snapshot when using legacy filter:
+  1: |
+    common.proto: ""
+    logs.config: |
+      connectors:
+        forward/logs-exporter: null
+        forward/metric-exporter: null
+      exporters:
+        otlp:
+          endpoint: ${OTEL_ENVOY_ADDRESS}
+          headers:
+            Authorization: Bearer ${SOLARWINDS_API_TOKEN}
+          retry_on_failure:
+            enabled: true
+            initial_interval: 10s
+            max_elapsed_time: 300s
+            max_interval: 30s
+          sending_queue:
+            enabled: true
+            num_consumers: 20
+            queue_size: 1000
+          timeout: 15s
+          tls:
+            insecure: ${OTEL_ENVOY_ADDRESS_TLS_INSECURE}
+      extensions:
+        file_storage/checkpoints:
+          directory: /var/lib/swo/checkpoints
+          timeout: 5s
+        health_check:
+          endpoint: 0.0.0.0:13133
+        k8s_observer:
+          auth_type: serviceAccount
+          node: ${NODE_NAME}
+          observe_nodes: true
+          observe_pods: true
+      processors:
+        attributes/remove_prometheus_attributes:
+          actions:
+          - action: delete
+            key: prometheus
+          - action: delete
+            key: prometheus_replica
+        attributes/remove_temp:
+          actions:
+          - action: delete
+            key: temp
+            pattern: (.*_temp$)|(^\$.*)
+          include:
+            match_type: regexp
+            metric_names:
+            - .*
+        attributes/unify_node_attribute:
+          actions:
+          - action: insert
+            from_attribute: node
+            key: k8s.node.name
+          - action: insert
+            from_attribute: kubernetes_io_hostname
+            key: k8s.node.name
+          include:
+            match_type: regexp
+            metric_names:
+            - container_.*
+        batch/logs:
+          send_batch_max_size: 512
+          send_batch_size: 512
+          timeout: 1s
+        batch/metrics:
+          send_batch_max_size: 512
+          send_batch_size: 512
+          timeout: 1s
+        cumulativetodelta/cadvisor:
+          include:
+            match_type: strict
+            metrics:
+            - k8s.node.cpu.usage.seconds.rate
+            - k8s.pod.cpu.usage.seconds.rate
+            - k8s.container.fs.iops
+            - k8s.container.fs.throughput
+            - k8s.container.cpu.usage.seconds.rate
+            - k8s.container.network.bytes_received
+            - k8s.container.network.bytes_transmitted
+            - k8s.pod.fs.iops
+            - k8s.pod.fs.throughput
+            - k8s.pod.fs.reads.rate
+            - k8s.pod.fs.writes.rate
+            - k8s.pod.fs.reads.bytes.rate
+            - k8s.pod.fs.writes.bytes.rate
+            - k8s.pod.network.bytes_received
+            - k8s.pod.network.bytes_transmitted
+            - k8s.pod.network.packets_received
+            - k8s.pod.network.packets_transmitted
+            - k8s.pod.network.receive_packets_dropped
+            - k8s.pod.network.transmit_packets_dropped
+            - k8s.node.fs.iops
+            - k8s.node.fs.throughput
+            - k8s.node.network.bytes_received
+            - k8s.node.network.bytes_transmitted
+            - k8s.node.network.packets_received
+            - k8s.node.network.packets_transmitted
+            - k8s.node.network.receive_packets_dropped
+            - k8s.node.network.transmit_packets_dropped
+        cumulativetodelta/istio-metrics:
+          include:
+            match_type: strict
+            metrics:
+            - k8s.istio_request_bytes.rate
+            - k8s.istio_response_bytes.rate
+            - k8s.istio_request_duration_milliseconds_sum_temp
+            - k8s.istio_request_duration_milliseconds_count_temp
+            - k8s.istio_requests.rate
+            - k8s.istio_tcp_sent_bytes.rate
+            - k8s.istio_tcp_received_bytes.rate
+            - k8s.istio_request_bytes.delta
+            - k8s.istio_response_bytes.delta
+            - k8s.istio_requests.delta
+            - k8s.istio_tcp_sent_bytes.delta
+            - k8s.istio_tcp_received_bytes.delta
+        deltatorate/cadvisor:
+          metrics:
+          - k8s.node.cpu.usage.seconds.rate
+          - k8s.pod.cpu.usage.seconds.rate
+          - k8s.container.fs.iops
+          - k8s.container.fs.throughput
+          - k8s.container.cpu.usage.seconds.rate
+          - k8s.container.network.bytes_received
+          - k8s.container.network.bytes_transmitted
+          - k8s.pod.fs.iops
+          - k8s.pod.fs.throughput
+          - k8s.pod.fs.reads.rate
+          - k8s.pod.fs.writes.rate
+          - k8s.pod.fs.reads.bytes.rate
+          - k8s.pod.fs.writes.bytes.rate
+          - k8s.pod.network.bytes_received
+          - k8s.pod.network.bytes_transmitted
+          - k8s.pod.network.packets_received
+          - k8s.pod.network.packets_transmitted
+          - k8s.pod.network.receive_packets_dropped
+          - k8s.pod.network.transmit_packets_dropped
+          - k8s.node.fs.iops
+          - k8s.node.fs.throughput
+          - k8s.node.network.bytes_received
+          - k8s.node.network.bytes_transmitted
+          - k8s.node.network.packets_received
+          - k8s.node.network.packets_transmitted
+          - k8s.node.network.receive_packets_dropped
+          - k8s.node.network.transmit_packets_dropped
+        deltatorate/istio-metrics:
+          metrics:
+          - k8s.istio_request_bytes.rate
+          - k8s.istio_response_bytes.rate
+          - k8s.istio_request_duration_milliseconds_sum_temp
+          - k8s.istio_request_duration_milliseconds_count_temp
+          - k8s.istio_requests.rate
+          - k8s.istio_tcp_sent_bytes.rate
+          - k8s.istio_tcp_received_bytes.rate
+        experimental_metricsgeneration/istio-metrics:
+          rules:
+          - metric1: k8s.istio_request_duration_milliseconds_sum_temp
+            metric2: k8s.istio_request_duration_milliseconds_count_temp
+            name: k8s.istio_request_duration_milliseconds.rate
+            operation: divide
+            type: calculate
+        filter/histograms:
+          metrics:
+            metric:
+            - type == METRIC_DATA_TYPE_HISTOGRAM
+        filter/logs:
+          logs:
+            include:
+              match_type: regexp
+              record_attributes:
+              - key: k8s.namespace.name
+                value: ^.*$
+        filter/receiver:
+          metrics:
+            metric:
+            - name == "scrape_duration_seconds"
+            - name == "scrape_samples_post_metric_relabeling"
+            - name == "scrape_samples_scraped"
+            - name == "scrape_series_added"
+            - name == "up"
+        filter/remove_internal:
+          metrics:
+            datapoint:
+            - attributes["container"] == "POD" and IsMatch(metric.name, "container_network_.*")
+              == false
+        filter/remove_internal_postprocessing:
+          metrics:
+            datapoint:
+            - attributes["container"] == "POD" and IsMatch(metric.name, "container_network_.*|k8s.container.*")
+              == true
+        filter/remove_temporary_metrics:
+          metrics:
+            metric:
+            - IsMatch(name , ".*_temp")
+            - name == "apiserver_request_total"
+        groupbyattrs/all:
+          keys:
+          - kubelet_version
+          - container_runtime_version
+          - provider_id
+          - os_image
+          - namespace
+          - uid
+          - k8s.pod.uid
+          - pod_ip
+          - host_ip
+          - created_by_kind
+          - created_by_name
+          - host_network
+          - priority_class
+          - container_id
+          - container
+          - image
+          - image_id
+          - k8s.node.name
+          - sw.k8s.pod.status
+          - sw.k8s.namespace.status
+          - sw.k8s.node.status
+          - sw.k8s.container.status
+          - sw.k8s.container.init
+          - daemonset
+          - statefulset
+          - deployment
+          - replicaset
+          - job_name
+          - cronjob
+          - sw.k8s.cluster.version
+          - internal_ip
+          - job_condition
+          - persistentvolumeclaim
+          - persistentvolume
+          - sw.k8s.persistentvolumeclaim.status
+          - sw.k8s.persistentvolume.status
+          - storageclass
+          - access_mode
+          - k8s.service.name
+          - sw.k8s.service.external_name
+          - sw.k8s.service.type
+          - sw.k8s.cluster.ip
+        groupbyattrs/common-all:
+          keys:
+          - k8s.container.name
+          - k8s.namespace.name
+          - k8s.pod.name
+          - k8s.pod.uid
+          - host.name
+          - service.name
+        groupbyattrs/node:
+          keys:
+          - k8s.node.name
+        groupbyattrs/pod:
+          keys:
+          - namespace
+          - pod
+        memory_limiter:
+          check_interval: 1s
+          limit_mib: 800
+          spike_limit_mib: 300
+        metricstransform/istio-metrics:
+          transforms:
+          - action: insert
+            include: k8s.istio_request_bytes.rate
+            new_name: k8s.istio_request_bytes.delta
+          - action: insert
+            include: k8s.istio_response_bytes.rate
+            new_name: k8s.istio_response_bytes.delta
+          - action: insert
+            include: k8s.istio_requests.rate
+            new_name: k8s.istio_requests.delta
+          - action: insert
+            include: k8s.istio_tcp_sent_bytes.rate
+            new_name: k8s.istio_tcp_sent_bytes.delta
+          - action: insert
+            include: k8s.istio_tcp_received_bytes.rate
+            new_name: k8s.istio_tcp_received_bytes.delta
+        metricstransform/preprocessing:
+          transforms:
+          - action: insert
+            include: k8s.container_fs_reads_total
+            new_name: k8s.container_fs_reads_total_temp
+          - action: insert
+            include: k8s.container_fs_writes_total
+            new_name: k8s.container_fs_writes_total_temp
+          - action: combine
+            experimental_match_labels:
+              container: \S+
+              namespace: \S+
+              pod: \S+
+            include: (k8s.container_fs_reads_total_temp|k8s.container_fs_writes_total_temp)
+            match_type: regexp
+            new_name: k8s.container.fs.iops
+            operations:
+            - action: aggregate_labels
+              aggregation_type: sum
+              label_set:
+              - container
+              - pod
+              - namespace
+            submatch_case: lower
+          - action: insert
+            include: k8s.container_fs_reads_bytes_total
+            new_name: k8s.container_fs_reads_bytes_total_temp
+          - action: insert
+            include: k8s.container_fs_writes_bytes_total
+            new_name: k8s.container_fs_writes_bytes_total_temp
+          - action: combine
+            experimental_match_labels:
+              container: \S+
+              namespace: \S+
+              pod: \S+
+            include: (k8s.container_fs_reads_bytes_total_temp|k8s.container_fs_writes_bytes_total_temp)
+            match_type: regexp
+            new_name: k8s.container.fs.throughput
+            operations:
+            - action: aggregate_labels
+              aggregation_type: sum
+              label_set:
+              - container
+              - pod
+              - namespace
+            submatch_case: lower
+          - action: insert
+            include: k8s.container_network_receive_bytes_total
+            new_name: k8s.container.network.bytes_received
+          - action: insert
+            include: k8s.container_network_transmit_bytes_total
+            new_name: k8s.container.network.bytes_transmitted
+          - action: insert
+            experimental_match_labels:
+              container: \S+
+              namespace: \S+
+              pod: \S+
+            include: k8s.container_cpu_usage_seconds_total
+            match_type: regexp
+            new_name: k8s.pod.cpu.usage.seconds.rate
+            operations:
+            - action: aggregate_labels
+              aggregation_type: sum
+              label_set:
+              - pod
+              - namespace
+              - k8s.node.name
+          - action: insert
+            include: k8s.container_cpu_usage_seconds_total
+            new_name: k8s.container.cpu.usage.seconds.rate
+          - action: insert
+            experimental_match_labels:
+              container: \S+
+              namespace: \S+
+              pod: \S+
+            include: k8s.container_memory_working_set_bytes
+            match_type: regexp
+            new_name: k8s.pod.memory.working_set
+            operations:
+            - action: aggregate_labels
+              aggregation_type: sum
+              label_set:
+              - pod
+              - namespace
+              - k8s.node.name
+          - action: insert
+            experimental_match_labels:
+              k8s.node.name: \S+
+              namespace: \S+
+              pod: \S+
+            include: k8s.container_network_receive_bytes_total
+            match_type: regexp
+            new_name: k8s.pod.network.bytes_received
+            operations:
+            - action: aggregate_labels
+              aggregation_type: sum
+              label_set:
+              - pod
+              - namespace
+              - k8s.node.name
+          - action: insert
+            experimental_match_labels:
+              k8s.node.name: \S+
+              namespace: \S+
+              pod: \S+
+            include: k8s.container_network_transmit_bytes_total
+            match_type: regexp
+            new_name: k8s.pod.network.bytes_transmitted
+            operations:
+            - action: aggregate_labels
+              aggregation_type: sum
+              label_set:
+              - pod
+              - namespace
+              - k8s.node.name
+          - action: insert
+            experimental_match_labels:
+              k8s.node.name: \S+
+              namespace: \S+
+              pod: \S+
+            include: k8s.container_network_receive_packets_total
+            match_type: regexp
+            new_name: k8s.pod.network.packets_received
+            operations:
+            - action: aggregate_labels
+              aggregation_type: sum
+              label_set:
+              - pod
+              - namespace
+              - k8s.node.name
+          - action: insert
+            experimental_match_labels:
+              k8s.node.name: \S+
+              namespace: \S+
+              pod: \S+
+            include: k8s.container_network_transmit_packets_total
+            match_type: regexp
+            new_name: k8s.pod.network.packets_transmitted
+            operations:
+            - action: aggregate_labels
+              aggregation_type: sum
+              label_set:
+              - pod
+              - namespace
+              - k8s.node.name
+          - action: insert
+            experimental_match_labels:
+              k8s.node.name: \S+
+              namespace: \S+
+              pod: \S+
+            include: k8s.container_network_receive_packets_dropped_total
+            match_type: regexp
+            new_name: k8s.pod.network.receive_packets_dropped
+            operations:
+            - action: aggregate_labels
+              aggregation_type: sum
+              label_set:
+              - pod
+              - namespace
+              - k8s.node.name
+          - action: insert
+            experimental_match_labels:
+              k8s.node.name: \S+
+              namespace: \S+
+              pod: \S+
+            include: k8s.container_network_transmit_packets_dropped_total
+            match_type: regexp
+            new_name: k8s.pod.network.transmit_packets_dropped
+            operations:
+            - action: aggregate_labels
+              aggregation_type: sum
+              label_set:
+              - pod
+              - namespace
+              - k8s.node.name
+          - action: insert
+            experimental_match_labels:
+              k8s.node.name: \S+
+              namespace: \S+
+              pod: \S+
+            include: k8s.container_fs_reads_total
+            match_type: regexp
+            new_name: k8s.pod.fs.reads.rate
+            operations:
+            - action: aggregate_labels
+              aggregation_type: sum
+              label_set:
+              - pod
+              - namespace
+              - k8s.node.name
+          - action: insert
+            experimental_match_labels:
+              k8s.node.name: \S+
+              namespace: \S+
+              pod: \S+
+            include: k8s.container_fs_writes_total
+            match_type: regexp
+            new_name: k8s.pod.fs.writes.rate
+            operations:
+            - action: aggregate_labels
+              aggregation_type: sum
+              label_set:
+              - pod
+              - namespace
+              - k8s.node.name
+          - action: insert
+            experimental_match_labels:
+              k8s.node.name: \S+
+              namespace: \S+
+              pod: \S+
+            include: k8s.container_fs_reads_bytes_total
+            match_type: regexp
+            new_name: k8s.pod.fs.reads.bytes.rate
+            operations:
+            - action: aggregate_labels
+              aggregation_type: sum
+              label_set:
+              - pod
+              - namespace
+              - k8s.node.name
+          - action: insert
+            experimental_match_labels:
+              k8s.node.name: \S+
+              namespace: \S+
+              pod: \S+
+            include: k8s.container_fs_writes_bytes_total
+            match_type: regexp
+            new_name: k8s.pod.fs.writes.bytes.rate
+            operations:
+            - action: aggregate_labels
+              aggregation_type: sum
+              label_set:
+              - pod
+              - namespace
+              - k8s.node.name
+          - action: insert
+            include: k8s.pod.fs.reads.rate
+            new_name: k8s.pod.fs.reads.rate_temp
+          - action: insert
+            include: k8s.pod.fs.writes.rate
+            new_name: k8s.pod.fs.writes.rate_temp
+          - action: combine
+            include: (k8s.pod.fs.reads.rate_temp|k8s.pod.fs.writes.rate_temp)
+            match_type: regexp
+            new_name: k8s.pod.fs.iops
+            operations:
+            - action: aggregate_labels
+              aggregation_type: sum
+              label_set:
+              - pod
+              - namespace
+              - k8s.node.name
+            submatch_case: lower
+          - action: insert
+            include: k8s.pod.fs.reads.bytes.rate
+            new_name: k8s.pod.fs.reads.bytes.rate_temp
+          - action: insert
+            include: k8s.pod.fs.writes.bytes.rate
+            new_name: k8s.pod.fs.writes.bytes.rate_temp
+          - action: combine
+            include: (k8s.pod.fs.reads.bytes.rate_temp|k8s.pod.fs.writes.bytes.rate_temp)
+            match_type: regexp
+            new_name: k8s.pod.fs.throughput
+            operations:
+            - action: aggregate_labels
+              aggregation_type: sum
+              label_set:
+              - pod
+              - namespace
+              - k8s.node.name
+            submatch_case: lower
+          - action: insert
+            experimental_match_labels:
+              k8s.node.name: \S+
+              namespace: \S+
+              pod: \S+
+            include: k8s.container_fs_usage_bytes
+            match_type: regexp
+            new_name: k8s.pod.fs.usage.bytes
+            operations:
+            - action: aggregate_labels
+              aggregation_type: sum
+              label_set:
+              - pod
+              - namespace
+              - k8s.node.name
+          - action: insert
+            experimental_match_labels:
+              id: /
+            include: k8s.container_cpu_usage_seconds_total
+            new_name: k8s.node.cpu.usage.seconds.rate
+          - action: insert
+            experimental_match_labels:
+              id: /
+            include: k8s.container_memory_working_set_bytes
+            new_name: k8s.node.memory.working_set
+          - action: insert
+            experimental_match_labels:
+              id: /
+              k8s.node.name: \S+
+            include: k8s.container_network_receive_bytes_total
+            match_type: regexp
+            new_name: k8s.node.network.bytes_received
+            operations:
+            - action: aggregate_labels
+              aggregation_type: sum
+              label_set:
+              - k8s.node.name
+          - action: insert
+            experimental_match_labels:
+              id: /
+              k8s.node.name: \S+
+            include: k8s.container_network_transmit_bytes_total
+            match_type: regexp
+            new_name: k8s.node.network.bytes_transmitted
+            operations:
+            - action: aggregate_labels
+              aggregation_type: sum
+              label_set:
+              - k8s.node.name
+          - action: insert
+            experimental_match_labels:
+              id: /
+              k8s.node.name: \S+
+            include: k8s.container_network_receive_packets_total
+            match_type: regexp
+            new_name: k8s.node.network.packets_received
+            operations:
+            - action: aggregate_labels
+              aggregation_type: sum
+              label_set:
+              - k8s.node.name
+          - action: insert
+            experimental_match_labels:
+              id: /
+              k8s.node.name: \S+
+            include: k8s.container_network_transmit_packets_total
+            match_type: regexp
+            new_name: k8s.node.network.packets_transmitted
+            operations:
+            - action: aggregate_labels
+              aggregation_type: sum
+              label_set:
+              - k8s.node.name
+          - action: insert
+            experimental_match_labels:
+              id: /
+              k8s.node.name: \S+
+            include: k8s.container_network_receive_packets_dropped_total
+            match_type: regexp
+            new_name: k8s.node.network.receive_packets_dropped
+            operations:
+            - action: aggregate_labels
+              aggregation_type: sum
+              label_set:
+              - k8s.node.name
+          - action: insert
+            experimental_match_labels:
+              id: /
+              k8s.node.name: \S+
+            include: k8s.container_network_transmit_packets_dropped_total
+            match_type: regexp
+            new_name: k8s.node.network.transmit_packets_dropped
+            operations:
+            - action: aggregate_labels
+              aggregation_type: sum
+              label_set:
+              - k8s.node.name
+          - action: insert
+            include: k8s.pod.fs.reads.rate
+            new_name: k8s.node.fs.reads.rate_temp
+            operations:
+            - action: aggregate_labels
+              aggregation_type: sum
+              label_set:
+              - k8s.node.name
+          - action: insert
+            include: k8s.pod.fs.writes.rate
+            new_name: k8s.node.fs.writes.rate_temp
+            operations:
+            - action: aggregate_labels
+              aggregation_type: sum
+              label_set:
+              - k8s.node.name
+          - action: insert
+            include: k8s.pod.fs.reads.bytes.rate
+            new_name: k8s.node.fs.reads.bytes.rate_temp
+            operations:
+            - action: aggregate_labels
+              aggregation_type: sum
+              label_set:
+              - k8s.node.name
+          - action: insert
+            include: k8s.pod.fs.writes.bytes.rate
+            new_name: k8s.node.fs.writes.bytes.rate_temp
+            operations:
+            - action: aggregate_labels
+              aggregation_type: sum
+              label_set:
+              - k8s.node.name
+          - action: combine
+            include: (k8s.node.fs.reads.rate_temp|k8s.node.fs.writes.rate_temp)
+            match_type: regexp
+            new_name: k8s.node.fs.iops
+            operations:
+            - action: aggregate_labels
+              aggregation_type: sum
+              label_set:
+              - k8s.node.name
+            submatch_case: lower
+          - action: combine
+            include: (k8s.node.fs.reads.bytes.rate_temp|k8s.node.fs.writes.bytes.rate_temp)
+            match_type: regexp
+            new_name: k8s.node.fs.throughput
+            operations:
+            - action: aggregate_labels
+              aggregation_type: sum
+              label_set:
+              - k8s.node.name
+            submatch_case: lower
+          - action: insert
+            include: k8s.pod.fs.usage.bytes
+            new_name: k8s.node.fs.usage
+            operations:
+            - action: aggregate_labels
+              aggregation_type: sum
+              label_set:
+              - k8s.node.name
+        metricstransform/rename:
+          transforms:
+          - action: update
+            include: ^(.*)$$
+            match_type: regexp
+            new_name: k8s.$${1}
+        resource/all:
+          attributes:
+          - action: insert
+            key: sw.k8s.agent.manifest.version
+            value: ${MANIFEST_VERSION}
+          - action: insert
+            key: sw.k8s.agent.app.version
+            value: ${APP_VERSION}
+          - action: insert
+            key: sw.k8s.cluster.uid
+            value: ${CLUSTER_UID}
+          - action: insert
+            key: k8s.cluster.name
+            value: ${CLUSTER_NAME}
+          - action: upsert
+            key: k8s.node.name
+            value: ${NODE_NAME}
+        resource/container:
+          attributes:
+          - action: insert
+            key: sw.k8s.log.type
+            value: container
+          - action: insert
+            key: sw.k8s.agent.manifest.version
+            value: ${MANIFEST_VERSION}
+          - action: insert
+            key: sw.k8s.agent.app.version
+            value: ${APP_VERSION}
+          - action: insert
+            key: sw.k8s.cluster.uid
+            value: ${CLUSTER_UID}
+          - action: insert
+            key: k8s.cluster.name
+            value: ${CLUSTER_NAME}
+          - action: insert
+            key: k8s.node.name
+            value: ${NODE_NAME}
+        resource/metrics:
+          attributes:
+          - action: delete
+            key: service.name
+          - action: delete
+            key: service.instance.id
+          - action: delete
+            key: net.host.name
+          - action: delete
+            key: net.host.port
+          - action: delete
+            key: http.scheme
+          - action: insert
+            key: sw.k8s.agent.manifest.version
+            value: ${MANIFEST_VERSION}
+          - action: insert
+            key: sw.k8s.agent.app.version
+            value: ${APP_VERSION}
+          - action: insert
+            key: sw.k8s.cluster.uid
+            value: ${CLUSTER_UID}
+          - action: insert
+            key: k8s.cluster.name
+            value: ${CLUSTER_NAME}
+          - action: insert
+            from_attribute: kubelet_version
+            key: sw.k8s.node.version
+          - action: insert
+            from_attribute: container_runtime_version
+            key: sw.k8s.node.container.runtime.version
+          - action: insert
+            from_attribute: provider_id
+            key: sw.k8s.node.provider.id
+          - action: insert
+            from_attribute: os_image
+            key: sw.k8s.node.os.image
+          - action: insert
+            from_attribute: internal_ip
+            key: sw.k8s.node.ip.internal
+          - action: insert
+            from_attribute: namespace
+            key: k8s.namespace.name
+          - action: insert
+            from_attribute: pod
+            key: k8s.pod.name
+          - action: insert
+            from_attribute: pod_ip
+            key: sw.k8s.pod.ip
+          - action: insert
+            from_attribute: host_ip
+            key: sw.k8s.pod.host.ip
+          - action: insert
+            from_attribute: created_by_kind
+            key: sw.k8s.pod.createdby.kind
+          - action: insert
+            from_attribute: created_by_name
+            key: sw.k8s.pod.createdby.name
+          - action: insert
+            from_attribute: host_network
+            key: sw.k8s.pod.host.network
+          - action: insert
+            from_attribute: priority_class
+            key: sw.k8s.pod.priority_class
+          - action: extract
+            key: container_id
+            pattern: ^(?P<extracted_container_runtime>[^:]+)://(?P<extracted_container_id>[^/]+)$
+          - action: insert
+            from_attribute: extracted_container_id
+            key: container.id
+          - action: insert
+            from_attribute: extracted_container_runtime
+            key: container.runtime
+          - action: insert
+            from_attribute: container
+            key: k8s.container.name
+          - action: insert
+            from_attribute: image_id
+            key: k8s.container.image.id
+          - action: insert
+            from_attribute: image
+            key: k8s.container.image.name
+          - action: insert
+            from_attribute: replicaset
+            key: k8s.replicaset.name
+          - action: insert
+            from_attribute: deployment
+            key: k8s.deployment.name
+          - action: insert
+            from_attribute: statefulset
+            key: k8s.statefulset.name
+          - action: insert
+            from_attribute: daemonset
+            key: k8s.daemonset.name
+          - action: insert
+            from_attribute: job_name
+            key: k8s.job.name
+          - action: insert
+            from_attribute: job_condition
+            key: k8s.job.condition
+          - action: insert
+            from_attribute: cronjob
+            key: k8s.cronjob.name
+          - action: insert
+            from_attribute: persistentvolume
+            key: k8s.persistentvolume.name
+          - action: insert
+            from_attribute: persistentvolumeclaim
+            key: k8s.persistentvolumeclaim.name
+        resource/swk8sattributes_logs_annotations_filter:
+          attributes:
+          - action: delete
+            pattern: k8s\.\w+\.annotations\..*
+        resource/swk8sattributes_logs_labels_filter:
+          attributes:
+          - action: delete
+            pattern: k8s\.\w+\.labels\..*
+        swk8sattributes:
+          auth_type: serviceAccount
+          extract:
+            annotations:
+            - from: pod
+              key_regex: (.*)
+              tag_name: k8s.pod.annotations.$$1
+            - from: namespace
+              key_regex: (.*)
+              tag_name: k8s.namespace.annotations.$$1
+            labels:
+            - from: pod
+              key_regex: (.*)
+              tag_name: k8s.pod.labels.$$1
+            - from: namespace
+              key_regex: (.*)
+              tag_name: k8s.namespace.labels.$$1
+            metadata:
+            - k8s.deployment.name
+            - k8s.replicaset.name
+            - k8s.daemonset.name
+            - k8s.job.name
+            - k8s.cronjob.name
+            - k8s.statefulset.name
+          filter:
+            node_from_env_var: NODE_NAME
+          passthrough: false
+          pod_association:
+          - sources:
+            - from: resource_attribute
+              name: k8s.pod.name
+            - from: resource_attribute
+              name: k8s.namespace.name
+        transform/istio-metrics:
+          metric_statements:
+          - context: metric
+            statements:
+            - extract_sum_metric(true) where (name == "k8s.istio_request_bytes" or name
+              == "k8s.istio_response_bytes" or name == "k8s.istio_request_duration_milliseconds")
+            - extract_count_metric(true) where (name == "k8s.istio_request_duration_milliseconds")
+            - set(name, "k8s.istio_request_bytes.rate") where name == "k8s.istio_request_bytes_sum"
+            - set(name, "k8s.istio_response_bytes.rate") where name == "k8s.istio_response_bytes_sum"
+            - set(name, "k8s.istio_requests.rate") where name == "k8s.istio_requests_total"
+            - set(name, "k8s.istio_tcp_sent_bytes.rate") where name == "k8s.istio_tcp_sent_bytes_total"
+            - set(name, "k8s.istio_tcp_received_bytes.rate") where name == "k8s.istio_tcp_received_bytes_total"
+            - set(name, "k8s.istio_request_duration_milliseconds_sum_temp") where name ==
+              "k8s.istio_request_duration_milliseconds_sum"
+            - set(name, "k8s.istio_request_duration_milliseconds_count_temp") where name
+              == "k8s.istio_request_duration_milliseconds_count"
+        transform/syslogify:
+          error_mode: ignore
+          log_statements:
+          - context: log
+            statements:
             - set( attributes["host.name"], attributes["k8s.pod.name"])
             - set( attributes["service.name"], attributes["k8s.container.name"])
         transform/unify_node_attribute:
@@ -1097,6 +2195,7 @@ Node collector config for windows nodes should match snapshot when using default
             - forward/logs-exporter
             processors:
             - memory_limiter
+            - filter/logs
             - transform/syslogify
             - groupbyattrs/common-all
             - resource/container

--- a/deploy/helm/tests/__snapshot__/node-collector-config-map_test.yaml.snap
+++ b/deploy/helm/tests/__snapshot__/node-collector-config-map_test.yaml.snap
@@ -933,8 +933,8 @@ Custom logs filter with new syntax:
           log_statements:
           - context: log
             statements:
-            - set( attributes["host.name"], attributes["k8s.pod.name"])
-            - set( attributes["service.name"], attributes["k8s.container.name"])
+            - set( attributes["host.name"], resource.attributes["k8s.pod.name"])
+            - set( attributes["service.name"], resource.attributes["k8s.container.name"])
         transform/unify_node_attribute:
           metric_statements:
           - context: datapoint
@@ -955,93 +955,12 @@ Custom logs filter with new syntax:
           max_concurrent_files: 10
           max_log_size: 1MiB
           operators:
-          - id: get-format
-            routes:
-            - expr: body matches "^\\{"
-              output: parser-docker
-            - expr: body matches "^[^ Z]+ "
-              output: parser-crio
-            - expr: body matches "^[^ Z]+Z"
-              output: parser-containerd
-            type: router
-          - id: parser-crio
-            output: merge-cri-lines
-            parse_to: body
-            regex: ^(?P<time>[^ Z]+) (?P<stream>stdout|stderr) (?P<logtag>[^ ]*)( |)(?P<log>.*)$
-            timestamp:
-              layout: "2006-01-02T15:04:05.999999999-07:00"
-              layout_type: gotime
-              parse_from: body.time
-            type: regex_parser
-          - id: parser-containerd
-            output: merge-cri-lines
-            parse_to: body
-            regex: ^(?P<time>[^ ^Z]+Z) (?P<stream>stdout|stderr) (?P<logtag>[^ ]*)( |)(?P<log>.*)$
-            timestamp:
-              layout: '%Y-%m-%dT%H:%M:%S.%LZ'
-              parse_from: body.time
-            type: regex_parser
-          - id: parser-docker
-            output: merge-docker-lines
-            parse_to: body
-            timestamp:
-              layout: '%Y-%m-%dT%H:%M:%S.%LZ'
-              parse_from: body.time
-            type: json_parser
-          - combine_field: body.log
-            combine_with: ""
-            id: merge-docker-lines
-            is_last_entry: body.log matches "\n$"
-            max_unmatched_batch_size: 1
-            output: merge-multiline-logs
-            source_identifier: attributes["log.file.path"]
-            type: recombine
-          - combine_field: body.log
-            combine_with: ""
-            id: merge-cri-lines
-            is_last_entry: body.logtag == "F"
-            max_unmatched_batch_size: 1
-            output: merge-multiline-logs
-            overwrite_with: newest
-            source_identifier: attributes["log.file.path"]
-            type: recombine
-          - combine_field: body.log
-            combine_with: ""
-            id: merge-multiline-logs
-            is_first_entry: body.log matches "^\\[?\\d{4}-\\d{1,2}-\\d{1,2}.\\d{2}:\\d{2}:\\d{2}.*"
-            max_unmatched_batch_size: 1
-            output: extract-metadata-from-filepath
-            source_identifier: attributes["log.file.path"]
-            type: recombine
-          - id: extract-metadata-from-filepath
-            parse_from: attributes["log.file.path"]
-            regex: ^.*\/(?P<namespace>[^_]+)_(?P<pod_name>[^_]+)_(?P<uid>[a-f0-9\-]+)\/(?P<container_name>[^\._]+)\/(?P<run_id>\d+)\.log$
-            type: regex_parser
-          - from: body.stream
-            id: move-attributes
-            to: attributes["stream"]
-            type: move
-          - from: attributes.container_name
-            to: attributes["k8s.container.name"]
-            type: move
-          - from: attributes.namespace
-            to: attributes["k8s.namespace.name"]
-            type: move
-          - from: attributes.pod_name
-            to: attributes["k8s.pod.name"]
-            type: move
-          - field: attributes.run_id
+          - id: container-parser
+            type: container
+          - field: resource["k8s.container.restart_count"]
             type: remove
-          - from: attributes.uid
-            to: attributes["k8s.pod.uid"]
-            type: move
           - field: attributes["log.file.path"]
             type: remove
-          - field: body.time
-            type: remove
-          - from: body.log
-            to: body
-            type: move
           poll_interval: 200ms
           start_at: end
           storage: file_storage/checkpoints
@@ -3342,8 +3261,8 @@ Node collector config should match snapshot when autodiscovery is disabled:
           log_statements:
           - context: log
             statements:
-            - set( attributes["host.name"], attributes["k8s.pod.name"])
-            - set( attributes["service.name"], attributes["k8s.container.name"])
+            - set( attributes["host.name"], resource.attributes["k8s.pod.name"])
+            - set( attributes["service.name"], resource.attributes["k8s.container.name"])
         transform/unify_node_attribute:
           metric_statements:
           - context: datapoint
@@ -3364,93 +3283,12 @@ Node collector config should match snapshot when autodiscovery is disabled:
           max_concurrent_files: 10
           max_log_size: 1MiB
           operators:
-          - id: get-format
-            routes:
-            - expr: body matches "^\\{"
-              output: parser-docker
-            - expr: body matches "^[^ Z]+ "
-              output: parser-crio
-            - expr: body matches "^[^ Z]+Z"
-              output: parser-containerd
-            type: router
-          - id: parser-crio
-            output: merge-cri-lines
-            parse_to: body
-            regex: ^(?P<time>[^ Z]+) (?P<stream>stdout|stderr) (?P<logtag>[^ ]*)( |)(?P<log>.*)$
-            timestamp:
-              layout: "2006-01-02T15:04:05.999999999-07:00"
-              layout_type: gotime
-              parse_from: body.time
-            type: regex_parser
-          - id: parser-containerd
-            output: merge-cri-lines
-            parse_to: body
-            regex: ^(?P<time>[^ ^Z]+Z) (?P<stream>stdout|stderr) (?P<logtag>[^ ]*)( |)(?P<log>.*)$
-            timestamp:
-              layout: '%Y-%m-%dT%H:%M:%S.%LZ'
-              parse_from: body.time
-            type: regex_parser
-          - id: parser-docker
-            output: merge-docker-lines
-            parse_to: body
-            timestamp:
-              layout: '%Y-%m-%dT%H:%M:%S.%LZ'
-              parse_from: body.time
-            type: json_parser
-          - combine_field: body.log
-            combine_with: ""
-            id: merge-docker-lines
-            is_last_entry: body.log matches "\n$"
-            max_unmatched_batch_size: 1
-            output: merge-multiline-logs
-            source_identifier: attributes["log.file.path"]
-            type: recombine
-          - combine_field: body.log
-            combine_with: ""
-            id: merge-cri-lines
-            is_last_entry: body.logtag == "F"
-            max_unmatched_batch_size: 1
-            output: merge-multiline-logs
-            overwrite_with: newest
-            source_identifier: attributes["log.file.path"]
-            type: recombine
-          - combine_field: body.log
-            combine_with: ""
-            id: merge-multiline-logs
-            is_first_entry: body.log matches "^\\[?\\d{4}-\\d{1,2}-\\d{1,2}.\\d{2}:\\d{2}:\\d{2}.*"
-            max_unmatched_batch_size: 1
-            output: extract-metadata-from-filepath
-            source_identifier: attributes["log.file.path"]
-            type: recombine
-          - id: extract-metadata-from-filepath
-            parse_from: attributes["log.file.path"]
-            regex: ^.*\/(?P<namespace>[^_]+)_(?P<pod_name>[^_]+)_(?P<uid>[a-f0-9\-]+)\/(?P<container_name>[^\._]+)\/(?P<run_id>\d+)\.log$
-            type: regex_parser
-          - from: body.stream
-            id: move-attributes
-            to: attributes["stream"]
-            type: move
-          - from: attributes.container_name
-            to: attributes["k8s.container.name"]
-            type: move
-          - from: attributes.namespace
-            to: attributes["k8s.namespace.name"]
-            type: move
-          - from: attributes.pod_name
-            to: attributes["k8s.pod.name"]
-            type: move
-          - field: attributes.run_id
+          - id: container-parser
+            type: container
+          - field: resource["k8s.container.restart_count"]
             type: remove
-          - from: attributes.uid
-            to: attributes["k8s.pod.uid"]
-            type: move
           - field: attributes["log.file.path"]
             type: remove
-          - field: body.time
-            type: remove
-          - from: body.log
-            to: body
-            type: move
           poll_interval: 200ms
           start_at: end
           storage: file_storage/checkpoints
@@ -4504,8 +4342,8 @@ Node collector config should match snapshot when fargate is enabled:
           log_statements:
           - context: log
             statements:
-            - set( attributes["host.name"], attributes["k8s.pod.name"])
-            - set( attributes["service.name"], attributes["k8s.container.name"])
+            - set( attributes["host.name"], resource.attributes["k8s.pod.name"])
+            - set( attributes["service.name"], resource.attributes["k8s.container.name"])
         transform/unify_node_attribute:
           metric_statements:
           - context: datapoint
@@ -4526,93 +4364,12 @@ Node collector config should match snapshot when fargate is enabled:
           max_concurrent_files: 10
           max_log_size: 1MiB
           operators:
-          - id: get-format
-            routes:
-            - expr: body matches "^\\{"
-              output: parser-docker
-            - expr: body matches "^[^ Z]+ "
-              output: parser-crio
-            - expr: body matches "^[^ Z]+Z"
-              output: parser-containerd
-            type: router
-          - id: parser-crio
-            output: merge-cri-lines
-            parse_to: body
-            regex: ^(?P<time>[^ Z]+) (?P<stream>stdout|stderr) (?P<logtag>[^ ]*)( |)(?P<log>.*)$
-            timestamp:
-              layout: "2006-01-02T15:04:05.999999999-07:00"
-              layout_type: gotime
-              parse_from: body.time
-            type: regex_parser
-          - id: parser-containerd
-            output: merge-cri-lines
-            parse_to: body
-            regex: ^(?P<time>[^ ^Z]+Z) (?P<stream>stdout|stderr) (?P<logtag>[^ ]*)( |)(?P<log>.*)$
-            timestamp:
-              layout: '%Y-%m-%dT%H:%M:%S.%LZ'
-              parse_from: body.time
-            type: regex_parser
-          - id: parser-docker
-            output: merge-docker-lines
-            parse_to: body
-            timestamp:
-              layout: '%Y-%m-%dT%H:%M:%S.%LZ'
-              parse_from: body.time
-            type: json_parser
-          - combine_field: body.log
-            combine_with: ""
-            id: merge-docker-lines
-            is_last_entry: body.log matches "\n$"
-            max_unmatched_batch_size: 1
-            output: merge-multiline-logs
-            source_identifier: attributes["log.file.path"]
-            type: recombine
-          - combine_field: body.log
-            combine_with: ""
-            id: merge-cri-lines
-            is_last_entry: body.logtag == "F"
-            max_unmatched_batch_size: 1
-            output: merge-multiline-logs
-            overwrite_with: newest
-            source_identifier: attributes["log.file.path"]
-            type: recombine
-          - combine_field: body.log
-            combine_with: ""
-            id: merge-multiline-logs
-            is_first_entry: body.log matches "^\\[?\\d{4}-\\d{1,2}-\\d{1,2}.\\d{2}:\\d{2}:\\d{2}.*"
-            max_unmatched_batch_size: 1
-            output: extract-metadata-from-filepath
-            source_identifier: attributes["log.file.path"]
-            type: recombine
-          - id: extract-metadata-from-filepath
-            parse_from: attributes["log.file.path"]
-            regex: ^.*\/(?P<namespace>[^_]+)_(?P<pod_name>[^_]+)_(?P<uid>[a-f0-9\-]+)\/(?P<container_name>[^\._]+)\/(?P<run_id>\d+)\.log$
-            type: regex_parser
-          - from: body.stream
-            id: move-attributes
-            to: attributes["stream"]
-            type: move
-          - from: attributes.container_name
-            to: attributes["k8s.container.name"]
-            type: move
-          - from: attributes.namespace
-            to: attributes["k8s.namespace.name"]
-            type: move
-          - from: attributes.pod_name
-            to: attributes["k8s.pod.name"]
-            type: move
-          - field: attributes.run_id
+          - id: container-parser
+            type: container
+          - field: resource["k8s.container.restart_count"]
             type: remove
-          - from: attributes.uid
-            to: attributes["k8s.pod.uid"]
-            type: move
           - field: attributes["log.file.path"]
             type: remove
-          - field: body.time
-            type: remove
-          - from: body.log
-            to: body
-            type: move
           poll_interval: 200ms
           start_at: end
           storage: file_storage/checkpoints
@@ -5635,8 +5392,8 @@ Node collector config should match snapshot when fargate is enabled and autodisc
           log_statements:
           - context: log
             statements:
-            - set( attributes["host.name"], attributes["k8s.pod.name"])
-            - set( attributes["service.name"], attributes["k8s.container.name"])
+            - set( attributes["host.name"], resource.attributes["k8s.pod.name"])
+            - set( attributes["service.name"], resource.attributes["k8s.container.name"])
         transform/unify_node_attribute:
           metric_statements:
           - context: datapoint
@@ -5657,93 +5414,12 @@ Node collector config should match snapshot when fargate is enabled and autodisc
           max_concurrent_files: 10
           max_log_size: 1MiB
           operators:
-          - id: get-format
-            routes:
-            - expr: body matches "^\\{"
-              output: parser-docker
-            - expr: body matches "^[^ Z]+ "
-              output: parser-crio
-            - expr: body matches "^[^ Z]+Z"
-              output: parser-containerd
-            type: router
-          - id: parser-crio
-            output: merge-cri-lines
-            parse_to: body
-            regex: ^(?P<time>[^ Z]+) (?P<stream>stdout|stderr) (?P<logtag>[^ ]*)( |)(?P<log>.*)$
-            timestamp:
-              layout: "2006-01-02T15:04:05.999999999-07:00"
-              layout_type: gotime
-              parse_from: body.time
-            type: regex_parser
-          - id: parser-containerd
-            output: merge-cri-lines
-            parse_to: body
-            regex: ^(?P<time>[^ ^Z]+Z) (?P<stream>stdout|stderr) (?P<logtag>[^ ]*)( |)(?P<log>.*)$
-            timestamp:
-              layout: '%Y-%m-%dT%H:%M:%S.%LZ'
-              parse_from: body.time
-            type: regex_parser
-          - id: parser-docker
-            output: merge-docker-lines
-            parse_to: body
-            timestamp:
-              layout: '%Y-%m-%dT%H:%M:%S.%LZ'
-              parse_from: body.time
-            type: json_parser
-          - combine_field: body.log
-            combine_with: ""
-            id: merge-docker-lines
-            is_last_entry: body.log matches "\n$"
-            max_unmatched_batch_size: 1
-            output: merge-multiline-logs
-            source_identifier: attributes["log.file.path"]
-            type: recombine
-          - combine_field: body.log
-            combine_with: ""
-            id: merge-cri-lines
-            is_last_entry: body.logtag == "F"
-            max_unmatched_batch_size: 1
-            output: merge-multiline-logs
-            overwrite_with: newest
-            source_identifier: attributes["log.file.path"]
-            type: recombine
-          - combine_field: body.log
-            combine_with: ""
-            id: merge-multiline-logs
-            is_first_entry: body.log matches "^\\[?\\d{4}-\\d{1,2}-\\d{1,2}.\\d{2}:\\d{2}:\\d{2}.*"
-            max_unmatched_batch_size: 1
-            output: extract-metadata-from-filepath
-            source_identifier: attributes["log.file.path"]
-            type: recombine
-          - id: extract-metadata-from-filepath
-            parse_from: attributes["log.file.path"]
-            regex: ^.*\/(?P<namespace>[^_]+)_(?P<pod_name>[^_]+)_(?P<uid>[a-f0-9\-]+)\/(?P<container_name>[^\._]+)\/(?P<run_id>\d+)\.log$
-            type: regex_parser
-          - from: body.stream
-            id: move-attributes
-            to: attributes["stream"]
-            type: move
-          - from: attributes.container_name
-            to: attributes["k8s.container.name"]
-            type: move
-          - from: attributes.namespace
-            to: attributes["k8s.namespace.name"]
-            type: move
-          - from: attributes.pod_name
-            to: attributes["k8s.pod.name"]
-            type: move
-          - field: attributes.run_id
+          - id: container-parser
+            type: container
+          - field: resource["k8s.container.restart_count"]
             type: remove
-          - from: attributes.uid
-            to: attributes["k8s.pod.uid"]
-            type: move
           - field: attributes["log.file.path"]
             type: remove
-          - field: body.time
-            type: remove
-          - from: body.log
-            to: body
-            type: move
           poll_interval: 200ms
           start_at: end
           storage: file_storage/checkpoints
@@ -6728,8 +6404,8 @@ Node collector config should match snapshot when using default values:
           log_statements:
           - context: log
             statements:
-            - set( attributes["host.name"], attributes["k8s.pod.name"])
-            - set( attributes["service.name"], attributes["k8s.container.name"])
+            - set( attributes["host.name"], resource.attributes["k8s.pod.name"])
+            - set( attributes["service.name"], resource.attributes["k8s.container.name"])
         transform/unify_node_attribute:
           metric_statements:
           - context: datapoint
@@ -6750,93 +6426,12 @@ Node collector config should match snapshot when using default values:
           max_concurrent_files: 10
           max_log_size: 1MiB
           operators:
-          - id: get-format
-            routes:
-            - expr: body matches "^\\{"
-              output: parser-docker
-            - expr: body matches "^[^ Z]+ "
-              output: parser-crio
-            - expr: body matches "^[^ Z]+Z"
-              output: parser-containerd
-            type: router
-          - id: parser-crio
-            output: merge-cri-lines
-            parse_to: body
-            regex: ^(?P<time>[^ Z]+) (?P<stream>stdout|stderr) (?P<logtag>[^ ]*)( |)(?P<log>.*)$
-            timestamp:
-              layout: "2006-01-02T15:04:05.999999999-07:00"
-              layout_type: gotime
-              parse_from: body.time
-            type: regex_parser
-          - id: parser-containerd
-            output: merge-cri-lines
-            parse_to: body
-            regex: ^(?P<time>[^ ^Z]+Z) (?P<stream>stdout|stderr) (?P<logtag>[^ ]*)( |)(?P<log>.*)$
-            timestamp:
-              layout: '%Y-%m-%dT%H:%M:%S.%LZ'
-              parse_from: body.time
-            type: regex_parser
-          - id: parser-docker
-            output: merge-docker-lines
-            parse_to: body
-            timestamp:
-              layout: '%Y-%m-%dT%H:%M:%S.%LZ'
-              parse_from: body.time
-            type: json_parser
-          - combine_field: body.log
-            combine_with: ""
-            id: merge-docker-lines
-            is_last_entry: body.log matches "\n$"
-            max_unmatched_batch_size: 1
-            output: merge-multiline-logs
-            source_identifier: attributes["log.file.path"]
-            type: recombine
-          - combine_field: body.log
-            combine_with: ""
-            id: merge-cri-lines
-            is_last_entry: body.logtag == "F"
-            max_unmatched_batch_size: 1
-            output: merge-multiline-logs
-            overwrite_with: newest
-            source_identifier: attributes["log.file.path"]
-            type: recombine
-          - combine_field: body.log
-            combine_with: ""
-            id: merge-multiline-logs
-            is_first_entry: body.log matches "^\\[?\\d{4}-\\d{1,2}-\\d{1,2}.\\d{2}:\\d{2}:\\d{2}.*"
-            max_unmatched_batch_size: 1
-            output: extract-metadata-from-filepath
-            source_identifier: attributes["log.file.path"]
-            type: recombine
-          - id: extract-metadata-from-filepath
-            parse_from: attributes["log.file.path"]
-            regex: ^.*\/(?P<namespace>[^_]+)_(?P<pod_name>[^_]+)_(?P<uid>[a-f0-9\-]+)\/(?P<container_name>[^\._]+)\/(?P<run_id>\d+)\.log$
-            type: regex_parser
-          - from: body.stream
-            id: move-attributes
-            to: attributes["stream"]
-            type: move
-          - from: attributes.container_name
-            to: attributes["k8s.container.name"]
-            type: move
-          - from: attributes.namespace
-            to: attributes["k8s.namespace.name"]
-            type: move
-          - from: attributes.pod_name
-            to: attributes["k8s.pod.name"]
-            type: move
-          - field: attributes.run_id
+          - id: container-parser
+            type: container
+          - field: resource["k8s.container.restart_count"]
             type: remove
-          - from: attributes.uid
-            to: attributes["k8s.pod.uid"]
-            type: move
           - field: attributes["log.file.path"]
             type: remove
-          - field: body.time
-            type: remove
-          - from: body.log
-            to: body
-            type: move
           poll_interval: 200ms
           start_at: end
           storage: file_storage/checkpoints

--- a/deploy/helm/tests/__snapshot__/node-collector-daemon-set-windows_test.yaml.snap
+++ b/deploy/helm/tests/__snapshot__/node-collector-daemon-set-windows_test.yaml.snap
@@ -14,6 +14,7 @@ DaemonSet spec for windows nodes should match snapshot when using default values
           - c:\wrapper.exe
           - c:\swi-otelcol.exe
           - --config=c:\conf\relay.yaml
+          - --feature-gates=filelog.container.removeOriginalTimeField
         env:
           - name: CHECKPOINT_DIR
             value: c:/var/lib/swo/checkpoints

--- a/deploy/helm/tests/__snapshot__/node-collector-daemon-set_test.yaml.snap
+++ b/deploy/helm/tests/__snapshot__/node-collector-daemon-set_test.yaml.snap
@@ -23,6 +23,7 @@ DaemonSet spec should match snapshot when ebpfNetworkMonitoring is enabled:
           - /wrapper
           - /swi-otelcol
           - --config=/conf/relay.yaml
+          - --feature-gates=filelog.container.removeOriginalTimeField
         env:
           - name: CHECKPOINT_DIR
             value: /var/lib/swo/checkpoints
@@ -152,6 +153,7 @@ DaemonSet spec should match snapshot when using default values:
           - /wrapper
           - /swi-otelcol
           - --config=/conf/relay.yaml
+          - --feature-gates=filelog.container.removeOriginalTimeField
         env:
           - name: CHECKPOINT_DIR
             value: /var/lib/swo/checkpoints

--- a/deploy/helm/tests/node-collector-config-map-windows_test.yaml
+++ b/deploy/helm/tests/node-collector-config-map-windows_test.yaml
@@ -9,3 +9,15 @@ tests:
     asserts:
       - matchSnapshot:
           path: data
+  - it: Node collector config for windows nodes should match snapshot when using legacy filter
+    template: node-collector-config-map-windows.yaml
+    set:
+      otel.logs.filter:
+        include:
+          match_type: regexp
+          record_attributes:
+            - key: k8s.namespace.name
+              value: ^.*$
+    asserts:
+      - matchSnapshot:
+          path: data


### PR DESCRIPTION
OTEL Collector [v0.101.0](https://github.com/open-telemetry/opentelemetry-collector-contrib/releases/tag/v0.101.0) added a new `container` parser to the `filelog` receiver.
The new parser should provide a unified way for parsing container logs and metadata from them. Plus, it should be more efficient than the combination of other parsers that is used usually.

This PR replaces the old combination of parsers with the new one.

Notes:
* The new parser has some breaking changes (e.g. moving stuff from `attributes` to `resource_attributes`). So, in situations, where customers depend on the old behavior, we still deploy the original configuration. When customers use the filtering syntax (which is a breaking change by itself), or no custom filters at all, we use the new parser.
  The behavior in SWO UI should not be affected. Except for the next point.
* The log records now contain an attribute called `log.iostream`.  It is a replacement for `stream`, compatible with OTEL SemConv. No one should be using that attribute as it is not mentioned in any of our documents. So, I did not try to undo the change in our configuration. But if we are not comfortable with this breaking change, we can rename it back to the old name.
* The new parser does not fully support Windows path, so there is a workaround for that.
* The new `container` parser by default adds a new `time` attribute. Our old implementation was not sending that attribute and the plan for the new parser is also to not send it. So, this PR enables the FF `filelog.container.removeOriginalTimeField` to get that behavior now.