### PR TITLE
Enable the automatic deployment of the OTEL Network Collector to the cluster

### DIFF
--- a/deploy/helm/CHANGELOG.md
+++ b/deploy/helm/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Changed
+
+- Enabled the automatic deployment of the OTEL Network Collector to the cluster.
+
 ## [4.0.0] - 2024-08-28
 
 ### Highlights

--- a/deploy/helm/tests/__snapshot__/k8s-collector-deployment_test.yaml.snap
+++ b/deploy/helm/tests/__snapshot__/k8s-collector-deployment_test.yaml.snap
@@ -1,4 +1,4 @@
-K8s Collector spec should match snapshot when using default values:
+Deployment spec should match snapshot when ebpfNetworkMonitoring is enabled:
   1: |
     containers:
       - args:

--- a/deploy/helm/tests/__snapshot__/metrics-collector-config-map-fargate_test.yaml.snap
+++ b/deploy/helm/tests/__snapshot__/metrics-collector-config-map-fargate_test.yaml.snap
@@ -2117,6 +2117,7 @@ Metrics config should match snapshot when using default values:
             - forward/metric-exporter
             processors:
             - memory_limiter
+            - filter/ebpf
             - metricstransform/rename-otel
             - resource/otlp-metrics
             receivers:

--- a/deploy/helm/tests/__snapshot__/metrics-collector-config-map_test.yaml.snap
+++ b/deploy/helm/tests/__snapshot__/metrics-collector-config-map_test.yaml.snap
@@ -2117,6 +2117,7 @@ Metrics config should match snapshot when fargate is enabled:
             - forward/metric-exporter
             processors:
             - memory_limiter
+            - filter/ebpf
             - metricstransform/rename-otel
             - resource/otlp-metrics
             receivers:
@@ -4268,6 +4269,7 @@ Metrics config should match snapshot when using Prometheus url with extra_scrape
             - forward/metric-exporter
             processors:
             - memory_limiter
+            - filter/ebpf
             - metricstransform/rename-otel
             - resource/otlp-metrics
             receivers:
@@ -6411,6 +6413,7 @@ Metrics config should match snapshot when using default values:
             - forward/metric-exporter
             processors:
             - memory_limiter
+            - filter/ebpf
             - metricstransform/rename-otel
             - resource/otlp-metrics
             receivers:

--- a/deploy/helm/tests/__snapshot__/reducer-deployment_test.yaml.snap
+++ b/deploy/helm/tests/__snapshot__/reducer-deployment_test.yaml.snap
@@ -1,4 +1,4 @@
-Reducer spec should match snapshot when using default values:
+Deployment spec should match snapshot when ebpfNetworkMonitoring is enabled:
   1: |
     containers:
       - args:

--- a/deploy/helm/tests/k8s-collector-deployment_test.yaml
+++ b/deploy/helm/tests/k8s-collector-deployment_test.yaml
@@ -4,10 +4,17 @@ templates:
   - network/k8s-collector-deployment.yaml
   - network/configmap.yaml
 tests:
-  - it: K8s Collector spec should match snapshot when using default values
+  - it: Deployment spec should match snapshot when ebpfNetworkMonitoring is enabled
     template: network/k8s-collector-deployment.yaml
     set:
       ebpfNetworkMonitoring.enabled: true
     asserts:
       - matchSnapshot:
           path: spec.template.spec
+  - it: Deployment should not be generated when ebpfNetworkMonitoring is disabled
+    template: network/k8s-collector-deployment.yaml
+    set:
+      ebpfNetworkMonitoring.enabled: false
+    asserts:
+      - hasDocuments:
+          count: 0

--- a/deploy/helm/tests/kernel-collector-daemonset_test.yaml
+++ b/deploy/helm/tests/kernel-collector-daemonset_test.yaml
@@ -11,3 +11,10 @@ tests:
     asserts:
       - matchSnapshot:
           path: spec.template.spec
+  - it: DaemonSet should not be generated when ebpfNetworkMonitoring is disabled
+    template: network/kernel-collector-daemonset.yaml
+    set:
+      ebpfNetworkMonitoring.enabled: false
+    asserts:
+      - hasDocuments:
+          count: 0

--- a/deploy/helm/tests/reducer-deployment_test.yaml
+++ b/deploy/helm/tests/reducer-deployment_test.yaml
@@ -4,10 +4,17 @@ templates:
   - network/reducer-deployment.yaml
   - network/configmap.yaml
 tests:
-  - it: Reducer spec should match snapshot when using default values
+  - it: Deployment spec should match snapshot when ebpfNetworkMonitoring is enabled
     template: network/reducer-deployment.yaml
     set:
       ebpfNetworkMonitoring.enabled: true
     asserts:
       - matchSnapshot:
           path: spec.template.spec
+  - it: Deployment should not be generated when ebpfNetworkMonitoring is disabled
+    template: network/reducer-deployment.yaml
+    set:
+      ebpfNetworkMonitoring.enabled: false
+    asserts:
+      - hasDocuments:
+          count: 0

--- a/deploy/helm/values.yaml
+++ b/deploy/helm/values.yaml
@@ -649,7 +649,7 @@ aws_fargate:
     filters: ""
 
 ebpfNetworkMonitoring:
-  enabled: false
+  enabled: true
   kernelCollector:
     enabled: true
 


### PR DESCRIPTION
The default setting is now:
```yaml
ebpfNetworkMonitoring:
  enabled: true
```