### PR TITLE
Make `cluster.uid` optional

### DIFF
--- a/.github/workflows/buildAndDeployHelm.yml
+++ b/.github/workflows/buildAndDeployHelm.yml
@@ -180,7 +180,6 @@ jobs:
             --create-namespace \
             --namespace swo-k8s-collector \
             --set cluster.name=test-cluster \
-            --set cluster.uid=test-cluster \
             --set otel.endpoint=timeseries-mock-service:9082 \
             --set otel.api_token=not_set \
             --set autoupdate.enabled=true \

--- a/deploy/helm/CHANGELOG.md
+++ b/deploy/helm/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Changed
+
+- Setting `cluster.uid` is now optional. If not provided it defaults to value of `cluster.name`.
+
+## [4.1.0-alpha.3] - 2024-09-13
+
 ### Fixed
 
 - Configuring `otel.events.k8s_instrumentation.labels.excludePattern` or `otel.events.k8s_instrumentation.annotations.excludePattern` might cause the events collector to fail when manifest collection is enabled.

--- a/deploy/helm/README.md
+++ b/deploy/helm/README.md
@@ -10,7 +10,6 @@
 
 Walk through `Add a Kubernetes cluster` in [SolarWinds Observability](https://documentation.solarwinds.com/en/success_center/observability/default.htm#cshid=gh-k8s-collector)
 
-
 ## Configuration
 
 The [Helm chart](Chart.yaml) that you are about to deploy to your cluster has various configuration options. The full list, including the default settings, is available in [values.yaml](values.yaml).
@@ -33,6 +32,10 @@ In order to deploy the Helm chart, you need to prepare:
       name: <cluster-display-name>
       uid: <unique-cluster-identifier>
   ```
+
+#### Version 4.1.0 and newer
+
+Starting with version 4.1.0 setting `cluster.uid` is optional. If not provided it defaults to value of `cluster.name`.
 
 ### Metrics
 

--- a/deploy/helm/templates/_helpers.tpl
+++ b/deploy/helm/templates/_helpers.tpl
@@ -43,6 +43,15 @@ Usages:
 {{- end -}}
 
 {{/*
+Get cluster UID based on name and uid provided in .Values.cluster.
+Usage:
+  {{ include "common.cluster-uid" . }}
+*/}}
+{{- define "common.cluster-uid" -}}
+{{ default .Values.cluster.name .Values.cluster.uid }}
+{{- end -}}
+
+{{/*
 Common pod labels - those labels are included on every pod in the chart
 */}}
 {{- define "common.pod-labels" -}}

--- a/deploy/helm/templates/asserts.yaml
+++ b/deploy/helm/templates/asserts.yaml
@@ -1,3 +1,11 @@
 {{- if (mustRegexMatch "otel-collector\\.dc-\\d\\d\\.cloud\\.solarwinds\\.com" .Values.otel.endpoint) -}}
 {{ fail (printf "The provided OTEL endpoint address ('%s') has been deprecated. Please provide a new one (https://documentation.solarwinds.com/en/success_center/observability/content/system_requirements/endpoints.htm)." .Values.otel.endpoint) }}
 {{- end -}}
+
+{{- if empty (trim .Values.cluster.name) -}}
+{{ fail "Please specify the cluster name." }}
+{{- end -}}
+
+{{- if mustRegexMatch "^[\\s]+$" .Values.cluster.uid -}}
+{{ fail "If specified, the custom cluster UID should be a valid string." }}
+{{- end -}}

--- a/deploy/helm/templates/common-env-config-map.yaml
+++ b/deploy/helm/templates/common-env-config-map.yaml
@@ -7,7 +7,7 @@ metadata:
 {{ include "common.labels" . | indent 4 }}
 data:
   CLUSTER_NAME: {{ quote .Values.cluster.name }}
-  CLUSTER_UID: {{ quote .Values.cluster.uid }}
+  CLUSTER_UID: {{ quote (include "common.cluster-uid" .) }}
   OTEL_ENVOY_ADDRESS: {{ quote .Values.otel.endpoint }}
   OTEL_ENVOY_ADDRESS_TLS_INSECURE: {{ quote .Values.otel.tls_insecure }}
   MANIFEST_VERSION: {{ quote .Chart.Version }}

--- a/deploy/helm/templates/logs-fargate-config-map.yaml
+++ b/deploy/helm/templates/logs-fargate-config-map.yaml
@@ -1,7 +1,10 @@
 {{- if and .Values.aws_fargate.enabled .Values.aws_fargate.logs.enabled }}
 {{- $pattern := "[^a-zA-Z0-9\\.\\-_/#]" -}}
 {{- $replacement := "" -}}
-{{- $name := regexReplaceAll $pattern .Values.cluster.name $replacement | default .Values.cluster.uid | lower | trunc 512 -}}
+{{/* Set the log group name either to a sanitized cluster name, or to a cluster uid or to a hash of a cluster name */}}
+{{- $sanitizedName := regexReplaceAll $pattern .Values.cluster.name $replacement -}}
+{{- $sanitizedUid := regexReplaceAll $pattern (default "" .Values.cluster.uid) $replacement -}}
+{{- $name := default (default (sha256sum .Values.cluster.name) $sanitizedUid) $sanitizedName | lower | trunc 512 -}}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -30,7 +33,7 @@ data:
     [FILTER]
         Name modify
         Match *
-        Add sw.k8s.cluster.uid {{ .Values.cluster.uid }}
+        Add sw.k8s.cluster.uid {{ include "common.cluster-uid" . }}
         Add sw.k8s.log.type container
         Add sw.k8s.agent.manifest.version {{ quote .Chart.Version }}
   output.conf: |

--- a/deploy/helm/templates/metrics-deployment.yaml
+++ b/deploy/helm/templates/metrics-deployment.yaml
@@ -82,8 +82,8 @@ spec:
           command: ['/bin/grpcurl', '-expand-headers',
                     '-proto', 'opentelemetry/proto/collector/logs/v1/logs_service.proto',
                     '-H', 'Authorization: Bearer ${SOLARWINDS_API_TOKEN}',
-                    '-d', '{"resourceLogs":[{"resource":{"attributes":[{"key":"sw.k8s.cluster.uid","value":{"stringValue": "{{ .Values.cluster.uid }}"}}]},"scope_logs":{"log_records":[{"severityText":"INFO","body":{"stringValue":"otel-endpoint-check successful"}}]}}]}',
-                    '{{ .Values.otel.endpoint }}', 'opentelemetry.proto.collector.logs.v1.LogsService.Export']
+                    '-d', '{"resourceLogs":[{"resource":{"attributes":[{"key":"sw.k8s.cluster.uid","value":{"stringValue": "${CLUSTER_UID}"}}]},"scope_logs":{"log_records":[{"severityText":"INFO","body":{"stringValue":"otel-endpoint-check successful"}}]}}]}',
+                    '$(OTEL_ENVOY_ADDRESS)', 'opentelemetry.proto.collector.logs.v1.LogsService.Export']
           volumeMounts:
             - mountPath: opentelemetry/proto/collector/logs/v1/logs_service.proto
               name: opentelemetry-collector-configmap
@@ -108,6 +108,9 @@ spec:
                   name: {{ template "common.secret" . }}
                   key: SOLARWINDS_API_TOKEN
                   optional: true
+          envFrom:
+            - configMapRef:
+                name: {{ include "common.fullname" (tuple . "-common-env") }}
         {{- end }}
       {{- end }}
       containers:

--- a/deploy/helm/templates/node-collector-daemon-set-windows.yaml
+++ b/deploy/helm/templates/node-collector-daemon-set-windows.yaml
@@ -145,7 +145,7 @@ spec:
             path: c:\var\lib\docker\containers
         - name: logcheckpoints
           hostPath:
-            path: c:{{ printf "%s/%s" .Values.otel.logs.filestorage.directory (sha256sum .Values.cluster.uid) }}
+            path: c:{{ printf "%s/%s" .Values.otel.logs.filestorage.directory (sha256sum (include "common.cluster-uid" .)) }}
             type: DirectoryOrCreate
         - name: opentelemetry-collector-configmap
           configMap:
@@ -156,7 +156,7 @@ spec:
 {{- if .Values.otel.node_collector.sending_queue.persistent_storage.enabled }}
         - name: sending-queue
           hostPath:
-            path: c:{{ printf "%s/%s" .Values.otel.node_collector.sending_queue.persistent_storage.directory .Values.cluster.uid }}
+            path: c:{{ printf "%s/%s" .Values.otel.node_collector.sending_queue.persistent_storage.directory (sha256sum (include "common.cluster-uid" .)) }}
             type: DirectoryOrCreate
 {{- end }}
 {{- end }}

--- a/deploy/helm/templates/node-collector-daemon-set.yaml
+++ b/deploy/helm/templates/node-collector-daemon-set.yaml
@@ -168,7 +168,7 @@ spec:
             path: /var/log/journal
         - name: logcheckpoints
           hostPath:
-            path: {{ printf "%s/%s" .Values.otel.logs.filestorage.directory .Values.cluster.uid }}
+            path: {{ printf "%s/%s" .Values.otel.logs.filestorage.directory (sha256sum (include "common.cluster-uid" .)) }}
             type: DirectoryOrCreate
         - name: opentelemetry-collector-configmap
           configMap:
@@ -179,7 +179,7 @@ spec:
 {{- if .Values.otel.node_collector.sending_queue.persistent_storage.enabled }}
         - name: sending-queue
           hostPath:
-            path: {{ printf "%s/%s" .Values.otel.node_collector.sending_queue.persistent_storage.directory .Values.cluster.uid }}
+            path: {{ printf "%s/%s" .Values.otel.node_collector.sending_queue.persistent_storage.directory (sha256sum (include "common.cluster-uid" .)) }}
             type: DirectoryOrCreate
 {{- end }}
 {{- end }}

--- a/deploy/helm/templates/swo-agent-statefulset.yaml
+++ b/deploy/helm/templates/swo-agent-statefulset.yaml
@@ -50,7 +50,10 @@ spec:
           imagePullPolicy: {{ .Values.swoagent.image.pullPolicy }}
           env:
             - name: UAMS_CLIENT_ID_OVERRIDE_SOURCE_NAME
-              value: {{ .Values.cluster.uid }}
+              valueFrom:
+                configMapKeyRef:
+                  name: {{ include "common.fullname" (tuple . "-common-env") }}
+                  key: CLUSTER_UID
             - name: SWO_URL
               value: {{ .Values.otel.endpoint | trimPrefix "otel.collector." | trimPrefix "otel-collector." }}
             - name: UAMS_ACCESS_TOKEN

--- a/deploy/helm/tests/__snapshot__/logs-fargate-config-map_test.yaml.snap
+++ b/deploy/helm/tests/__snapshot__/logs-fargate-config-map_test.yaml.snap
@@ -20,9 +20,9 @@ Fargate logging ConfigMap spec should include additional filters when they are c
       [FILTER]
           Name modify
           Match *
-          Add sw.k8s.cluster.uid <CLUSTER_UID>
+          Add sw.k8s.cluster.uid <CLUSTER_NAME>
           Add sw.k8s.log.type container
-          Add sw.k8s.agent.manifest.version "0.0.0"
+          Add sw.k8s.agent.manifest.version "1.0.0"
     flb_log_cw: "false"
     output.conf: |
       [OUTPUT]
@@ -58,9 +58,47 @@ Fargate logging ConfigMap spec should match snapshot when Fargate logging is ena
       [FILTER]
           Name modify
           Match *
-          Add sw.k8s.cluster.uid <CLUSTER_UID>
+          Add sw.k8s.cluster.uid <CLUSTER_NAME>
           Add sw.k8s.log.type container
-          Add sw.k8s.agent.manifest.version "0.0.0"
+          Add sw.k8s.agent.manifest.version "1.0.0"
+    flb_log_cw: "false"
+    output.conf: |
+      [OUTPUT]
+          Name cloudwatch_logs
+          Match kube.*
+          region test-region
+          log_group_name /swo/fargate/cluster_name
+          log_stream_prefix from-fluent-bit-
+          log_retention_days 30
+          auto_create_group true
+    parsers.conf: |-
+      [PARSER]
+          Name crio
+          Format Regex
+          Regex ^(?<time>[^ ]+) (?<stream>stdout|stderr) (?<logtag>P|F) (?<log>.*)$
+          Time_Key time
+          Time_Format %Y-%m-%dT%H:%M:%S.%L%z
+Fargate logging ConfigMap spec should match snapshot when Fargate logging is enabled and cluster UID is overridden:
+  1: |
+    filters.conf: |
+      [FILTER]
+          Name parser
+          Match *
+          Key_name log
+          Parser crio
+      [FILTER]
+          Name kubernetes
+          Match kube.*
+          Buffer_Size 0
+          Kube_Meta_Cache_TTL 300s
+          Labels Off
+          Annotations Off
+      [FILTER]
+          Name modify
+          Match *
+          Add sw.k8s.cluster.uid customUid
+          Add sw.k8s.log.type container
+          Add sw.k8s.agent.manifest.version "1.0.0"
     flb_log_cw: "false"
     output.conf: |
       [OUTPUT]

--- a/deploy/helm/tests/__snapshot__/metrics-deployment_test.yaml.snap
+++ b/deploy/helm/tests/__snapshot__/metrics-deployment_test.yaml.snap
@@ -78,8 +78,8 @@ Metrics collector spec should match snapshot when using default values:
           - -H
           - 'Authorization: Bearer ${SOLARWINDS_API_TOKEN}'
           - -d
-          - '{"resourceLogs":[{"resource":{"attributes":[{"key":"sw.k8s.cluster.uid","value":{"stringValue": "<CLUSTER_UID>"}}]},"scope_logs":{"log_records":[{"severityText":"INFO","body":{"stringValue":"otel-endpoint-check successful"}}]}}]}'
-          - <OTEL_ENVOY_ADDRESS>
+          - '{"resourceLogs":[{"resource":{"attributes":[{"key":"sw.k8s.cluster.uid","value":{"stringValue": "${CLUSTER_UID}"}}]},"scope_logs":{"log_records":[{"severityText":"INFO","body":{"stringValue":"otel-endpoint-check successful"}}]}}]}'
+          - $(OTEL_ENVOY_ADDRESS)
           - opentelemetry.proto.collector.logs.v1.LogsService.Export
         env:
           - name: SOLARWINDS_API_TOKEN
@@ -88,6 +88,9 @@ Metrics collector spec should match snapshot when using default values:
                 key: SOLARWINDS_API_TOKEN
                 name: solarwinds-api-token
                 optional: true
+        envFrom:
+          - configMapRef:
+              name: RELEASE-NAME-swo-k8s-collector-common-env
         image: fullstorydev/grpcurl:v1.9.1
         imagePullPolicy: IfNotPresent
         name: otel-endpoint-check

--- a/deploy/helm/tests/__snapshot__/node-collector-daemon-set-windows_test.yaml.snap
+++ b/deploy/helm/tests/__snapshot__/node-collector-daemon-set-windows_test.yaml.snap
@@ -1,3 +1,111 @@
+DaemonSet spec for windows nodes should match snapshot when overriding cluster ID:
+  1: |
+    affinity:
+      nodeAffinity:
+        requiredDuringSchedulingIgnoredDuringExecution:
+          nodeSelectorTerms:
+            - matchExpressions:
+                - key: eks.amazonaws.com/compute-type
+                  operator: NotIn
+                  values:
+                    - fargate
+    containers:
+      - command:
+          - c:\wrapper.exe
+          - c:\swi-otelcol.exe
+          - --config=c:\conf\relay.yaml
+          - --feature-gates=filelog.container.removeOriginalTimeField
+        env:
+          - name: CHECKPOINT_DIR
+            value: c:/var/lib/swo/checkpoints
+          - name: POD_NAME
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.name
+          - name: POD_NAMESPACE
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.namespace
+          - name: NODE_NAME
+            valueFrom:
+              fieldRef:
+                fieldPath: spec.nodeName
+          - name: SOLARWINDS_API_TOKEN
+            valueFrom:
+              secretKeyRef:
+                key: SOLARWINDS_API_TOKEN
+                name: solarwinds-api-token
+                optional: true
+          - name: GOMEMLIMIT
+            valueFrom:
+              resourceFieldRef:
+                resource: limits.memory
+        envFrom:
+          - configMapRef:
+              name: RELEASE-NAME-swo-k8s-collector-common-env
+        image: solarwinds/swi-opentelemetry-collector:1.0.0-nanoserver
+        imagePullPolicy: IfNotPresent
+        livenessProbe:
+          httpGet:
+            path: /
+            port: 13133
+        name: swi-opentelemetry-collector
+        ports:
+          - containerPort: 8888
+            name: http
+            protocol: TCP
+        readinessProbe:
+          httpGet:
+            path: /
+            port: 13133
+        resources:
+          limits:
+            memory: 1Gi
+          requests:
+            memory: 50Mi
+        volumeMounts:
+          - mountPath: c:\var\log\pods
+            name: varlogpods
+            readOnly: true
+          - mountPath: c:\var\log\containers
+            name: varlogcontainers
+            readOnly: true
+          - mountPath: c:\var\lib\docker\containers
+            name: varlibdockercontainers
+            readOnly: true
+          - mountPath: c:\conf
+            name: opentelemetry-collector-configmap
+            readOnly: true
+          - mountPath: c:/var/lib/swo/checkpoints
+            name: logcheckpoints
+    nodeSelector:
+      kubernetes.io/arch: amd64
+      kubernetes.io/os: windows
+    serviceAccountName: RELEASE-NAME-swo-k8s-collector
+    terminationGracePeriodSeconds: 600
+    tolerations:
+      - effect: NoSchedule
+        operator: Exists
+    volumes:
+      - hostPath:
+          path: c:\var\log\pods
+        name: varlogpods
+      - hostPath:
+          path: c:\var\log\containers
+        name: varlogcontainers
+      - hostPath:
+          path: c:\var\lib\docker\containers
+        name: varlibdockercontainers
+      - hostPath:
+          path: c:/var/lib/swo/checkpoints/6eb3475096f465fb33e3929d08ca7e1913c2896feb5e001b3600a56f3964b4d9
+          type: DirectoryOrCreate
+        name: logcheckpoints
+      - configMap:
+          items:
+            - key: logs.config
+              path: relay.yaml
+          name: RELEASE-NAME-swo-k8s-collector-node-collector-config-windows
+        name: opentelemetry-collector-configmap
 DaemonSet spec for windows nodes should match snapshot when using default values:
   1: |
     affinity:
@@ -97,7 +205,7 @@ DaemonSet spec for windows nodes should match snapshot when using default values
           path: c:\var\lib\docker\containers
         name: varlibdockercontainers
       - hostPath:
-          path: c:/var/lib/swo/checkpoints/4d51349fb86079745afe70b8333fd96ee2255b88b63eb2b37417c92aefa73fcb
+          path: c:/var/lib/swo/checkpoints/7e819eda63eb48d6b9aee7eda8e239c756bfe327e64ac579b5469466b0ca1e2d
           type: DirectoryOrCreate
         name: logcheckpoints
       - configMap:

--- a/deploy/helm/tests/__snapshot__/node-collector-daemon-set_test.yaml.snap
+++ b/deploy/helm/tests/__snapshot__/node-collector-daemon-set_test.yaml.snap
@@ -119,7 +119,137 @@ DaemonSet spec should match snapshot when ebpfNetworkMonitoring is enabled:
           path: /var/log/journal
         name: varlogjournal
       - hostPath:
-          path: /var/lib/swo/checkpoints/<CLUSTER_UID>
+          path: /var/lib/swo/checkpoints/7e819eda63eb48d6b9aee7eda8e239c756bfe327e64ac579b5469466b0ca1e2d
+          type: DirectoryOrCreate
+        name: logcheckpoints
+      - configMap:
+          items:
+            - key: logs.config
+              path: relay.yaml
+          name: RELEASE-NAME-swo-k8s-collector-node-collector-config
+        name: opentelemetry-collector-configmap
+DaemonSet spec should match snapshot when overriding cluster ID:
+  1: |
+    affinity:
+      nodeAffinity:
+        requiredDuringSchedulingIgnoredDuringExecution:
+          nodeSelectorTerms:
+            - matchExpressions:
+                - key: eks.amazonaws.com/compute-type
+                  operator: NotIn
+                  values:
+                    - fargate
+                - key: kubernetes.io/arch
+                  operator: In
+                  values:
+                    - amd64
+                    - arm64
+                - key: kubernetes.io/os
+                  operator: In
+                  values:
+                    - linux
+    containers:
+      - command:
+          - /wrapper
+          - /swi-otelcol
+          - --config=/conf/relay.yaml
+          - --feature-gates=filelog.container.removeOriginalTimeField
+        env:
+          - name: CHECKPOINT_DIR
+            value: /var/lib/swo/checkpoints
+          - name: POD_NAME
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.name
+          - name: POD_NAMESPACE
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.namespace
+          - name: NODE_NAME
+            valueFrom:
+              fieldRef:
+                fieldPath: spec.nodeName
+          - name: SOLARWINDS_API_TOKEN
+            valueFrom:
+              secretKeyRef:
+                key: SOLARWINDS_API_TOKEN
+                name: solarwinds-api-token
+                optional: true
+          - name: GOMEMLIMIT
+            valueFrom:
+              resourceFieldRef:
+                resource: limits.memory
+        envFrom:
+          - configMapRef:
+              name: RELEASE-NAME-swo-k8s-collector-common-env
+        image: solarwinds/swi-opentelemetry-collector:1.0.0
+        imagePullPolicy: IfNotPresent
+        livenessProbe:
+          httpGet:
+            path: /
+            port: 13133
+        name: swi-opentelemetry-collector
+        ports:
+          - containerPort: 8888
+            name: http
+            protocol: TCP
+        readinessProbe:
+          httpGet:
+            path: /
+            port: 13133
+        resources:
+          limits:
+            memory: 1Gi
+          requests:
+            memory: 50Mi
+        volumeMounts:
+          - mountPath: /var/log/pods
+            name: varlogpods
+            readOnly: true
+          - mountPath: /var/log/containers
+            name: varlogcontainers
+            readOnly: true
+          - mountPath: /var/lib/docker/containers
+            name: varlibdockercontainers
+            readOnly: true
+          - mountPath: /conf
+            name: opentelemetry-collector-configmap
+            readOnly: true
+          - mountPath: /run/log/journal
+            name: runlogjournal
+            readOnly: true
+          - mountPath: /var/log/journal
+            name: varlogjournal
+            readOnly: true
+          - mountPath: /var/lib/swo/checkpoints
+            name: logcheckpoints
+    securityContext:
+      fsGroup: 0
+      runAsGroup: 0
+      runAsUser: 0
+    serviceAccountName: RELEASE-NAME-swo-k8s-collector
+    terminationGracePeriodSeconds: 600
+    tolerations:
+      - effect: NoSchedule
+        operator: Exists
+    volumes:
+      - hostPath:
+          path: /var/log/pods
+        name: varlogpods
+      - hostPath:
+          path: /var/log/containers
+        name: varlogcontainers
+      - hostPath:
+          path: /var/lib/docker/containers
+        name: varlibdockercontainers
+      - hostPath:
+          path: /run/log/journal
+        name: runlogjournal
+      - hostPath:
+          path: /var/log/journal
+        name: varlogjournal
+      - hostPath:
+          path: /var/lib/swo/checkpoints/6eb3475096f465fb33e3929d08ca7e1913c2896feb5e001b3600a56f3964b4d9
           type: DirectoryOrCreate
         name: logcheckpoints
       - configMap:
@@ -249,7 +379,7 @@ DaemonSet spec should match snapshot when using default values:
           path: /var/log/journal
         name: varlogjournal
       - hostPath:
-          path: /var/lib/swo/checkpoints/<CLUSTER_UID>
+          path: /var/lib/swo/checkpoints/7e819eda63eb48d6b9aee7eda8e239c756bfe327e64ac579b5469466b0ca1e2d
           type: DirectoryOrCreate
         name: logcheckpoints
       - configMap:

--- a/deploy/helm/tests/assert_test.yaml
+++ b/deploy/helm/tests/assert_test.yaml
@@ -7,3 +7,28 @@ tests:
     asserts:
       - failedTemplate:
           errorMessage: The provided OTEL endpoint address ('otel-collector.dc-01.cloud.solarwinds.com') has been deprecated. Please provide a new one (https://documentation.solarwinds.com/en/success_center/observability/content/system_requirements/endpoints.htm).
+  - it: should fail when empty cluster name is provided
+    set:
+      cluster.name: ""
+    asserts:
+      - failedTemplate:
+          errorMessage: Please specify the cluster name.
+  - it: should fail when invalid cluster name is provided (only whitespace)
+    set:
+      cluster.name: " "
+    asserts:
+      - failedTemplate:
+          errorMessage: Please specify the cluster name.
+  - it: should not fail when empty cluster uid is provided
+    set:
+      cluster.uid: ""
+    template: "asserts.yaml"
+    asserts:
+      - hasDocuments:
+          count: 0
+  - it: should fail when invalid cluster uid is provided (only whitespace)
+    set:
+      cluster.uid: " "
+    asserts:
+      - failedTemplate:
+          errorMessage: If specified, the custom cluster UID should be a valid string.

--- a/deploy/helm/tests/logs-fargate-config-map_test.yaml
+++ b/deploy/helm/tests/logs-fargate-config-map_test.yaml
@@ -2,6 +2,8 @@
 suite: Test for logs-fargate-config-map
 templates:
   - logs-fargate-config-map.yaml
+chart:
+  version: 1.0.0
 tests:
   - it: Fargate logging ConfigMap spec should match snapshot when Fargate logging is enabled
     template: logs-fargate-config-map.yaml
@@ -27,6 +29,16 @@ tests:
         [FILTER]
             Name filter_name
             Match *
+    asserts:
+      - matchSnapshot:
+          path: data
+  - it: Fargate logging ConfigMap spec should match snapshot when Fargate logging is enabled and cluster UID is overridden
+    template: logs-fargate-config-map.yaml
+    set:
+      aws_fargate.enabled: true
+      aws_fargate.logs.enabled: true
+      aws_fargate.logs.region: test-region
+      cluster.uid: customUid
     asserts:
       - matchSnapshot:
           path: data

--- a/deploy/helm/tests/node-collector-daemon-set-windows_test.yaml
+++ b/deploy/helm/tests/node-collector-daemon-set-windows_test.yaml
@@ -4,18 +4,16 @@ templates:
   - node-collector-daemon-set-windows.yaml
   - node-collector-config-map-windows.yaml
   - common-env-config-map.yaml
+chart:
+  appVersion: 1.0.0
 tests:
   - it: DaemonSet spec for windows nodes should match snapshot when using default values
     template: node-collector-daemon-set-windows.yaml
-    chart:
-      appVersion: 1.0.0
     asserts:
       - matchSnapshot:
           path: spec.template.spec
   - it: Image should be correct in default state
     template: node-collector-daemon-set-windows.yaml
-    chart:
-      appVersion: 1.0.0
     asserts:
     - equal:
           path: spec.template.spec.containers[0].image
@@ -39,3 +37,10 @@ tests:
     - equal:
           path: spec.template.spec.containers[0].image
           value: azurek8s.azure.io/marketplaceimages/swi-opentelemetry-collector:v1.2.3@abcd
+  - it: DaemonSet spec for windows nodes should match snapshot when overriding cluster ID
+    template: node-collector-daemon-set-windows.yaml
+    set:
+      cluster.uid: customUid
+    asserts:
+      - matchSnapshot:
+          path: spec.template.spec

--- a/deploy/helm/tests/node-collector-daemon-set_test.yaml
+++ b/deploy/helm/tests/node-collector-daemon-set_test.yaml
@@ -5,20 +5,25 @@ templates:
   - node-collector-config-map.yaml
   - common-env-config-map.yaml
   - network/configmap.yaml
+chart:
+  appVersion: 1.0.0
 tests:
   - it: DaemonSet spec should match snapshot when using default values
     template: node-collector-daemon-set.yaml
-    chart:
-      appVersion: 1.0.0
     asserts:
       - matchSnapshot:
           path: spec.template.spec
   - it: DaemonSet spec should match snapshot when ebpfNetworkMonitoring is enabled
     template: node-collector-daemon-set.yaml
-    chart:
-      appVersion: 1.0.0
     set:
       ebpfNetworkMonitoring.enabled: true
+    asserts:
+      - matchSnapshot:
+          path: spec.template.spec
+  - it: DaemonSet spec should match snapshot when overriding cluster ID
+    template: node-collector-daemon-set.yaml
+    set:
+      cluster.uid: customUid
     asserts:
       - matchSnapshot:
           path: spec.template.spec

--- a/deploy/helm/values.schema.json
+++ b/deploy/helm/values.schema.json
@@ -396,17 +396,16 @@
             "description": "Cluster identification.",
             "properties": {
                 "name": {
-                    "description": "The display name for the cluster entity in SolarWinds Observability.",
+                    "description": "A unique name of a cluster provided by user during deployment of the Helm chart.",
                     "type": "string"
                 },
                 "uid": {
-                    "description": "A unique ID that follows the following format: xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx.",
+                    "description": "An optional unique identifier for a cluster provided by user during deployment of the Helm chart. Useful for example if multiple clusters have to have the same name. Or when the name contains problematic characters.",
                     "type": "string"
                 }
             },
             "required": [
-                "name",
-                "uid"
+                "name"
             ],
             "additionalProperties": false
         },

--- a/deploy/helm/values.yaml
+++ b/deploy/helm/values.yaml
@@ -580,8 +580,12 @@ otel:
     filter: {}
 
 cluster:
+  # A unique name of a cluster provided by user during deployment of the Helm chart.
   name: <CLUSTER_NAME>
-  uid: <CLUSTER_UID>
+
+  # An optional unique identifier for a cluster provided by user during deployment of the Helm chart.
+  # Useful for example if multiple clusters have to have the same name. Or when the name contains problematic characters.
+  uid: ""
 
 # If enabled it creates CronJob that will periodically check for new versions of the Helm chart and upgrade if available
 # Keep in mind that in order to update resources the job has full access to the namespace where it is deployed and also have access to modify ClusterRole and ClusterRolBinding


### PR DESCRIPTION
Make `cluster.uid` optional. Use `cluster.name` if `cluster.uid` is not provided. Make sure it's safe to use in a file path. And add a values check for obviously incorrect `cluster.name` and `cluster.uid` values.

There is a change in behavior of how log checkpoint folders are named. And depending on the provided `cluster.uid` value, the Fargate config can also generate a different log group name.