### PR TITLE
Fix service releases

### DIFF
--- a/.github/cr.sh
+++ b/.github/cr.sh
@@ -12,14 +12,6 @@ main() {
 
     rm -rf .cr-index
     mkdir -p .cr-index
-    
-    export APP_VERSION=$(git tag --sort=version:refname | grep -E '^[0-9]+.[0-9]+.[0-9]+$' | tail -n 1)
-    export CHART_VERSION=$(git tag --sort=version:refname | grep -E  '^swo-k8s-collector-' | tail -n 1 | awk -F'swo-k8s-collector-' '{print $2}')
-    echo "App Version=$APP_VERSION"
-    echo "Chart Version=$CHART_VERSION"
-    
-    yq eval '.appVersion = env(APP_VERSION)' -i deploy/helm/Chart.yaml
-    yq eval '.version = env(CHART_VERSION)' -i deploy/helm/Chart.yaml
 
     echo "Packaging chart ..."
     cr package "deploy/helm"

--- a/.github/workflows/buildAndDeploy.yml
+++ b/.github/workflows/buildAndDeploy.yml
@@ -8,10 +8,6 @@ on:
       - deploy/helm/*.md
     tags:
       - '*.*.*'
-    branches: 
-      - master
-      - release/**
-
 
   pull_request:
     branches: 

--- a/.github/workflows/buildAndTestHelm.yml
+++ b/.github/workflows/buildAndTestHelm.yml
@@ -1,18 +1,13 @@
-name: Build and Release Helm
+name: Build and Test Helm
 
 on:
-  push:
-    tags:
-      - 'swo-k8s-collector-*'      
+  push:  
     paths-ignore:
       - docs/**
       - README.md
       - deploy/helm/*.md
       - build/**
       - src/**
-    branches: 
-      - master
-      - release/**
   pull_request:
     branches: 
       - master
@@ -60,8 +55,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
 
       - name: Deploy skaffold
         uses: ./.github/actions/deploy-skaffold
@@ -72,13 +65,6 @@ jobs:
       - name: Add dependency chart repos
         run: |
           helm repo add prometheus-community https://prometheus-community.github.io/helm-charts
-      
-      - name: Update Chart.yaml
-        run: |
-            export APP_VERSION=$(git tag --sort=version:refname | grep -E '^[0-9]+.[0-9]+.[0-9]+$' | tail -n 1)
-            export CHART_VERSION=$(git tag --sort=version:refname | grep -E  '^swo-k8s-collector-' | tail -n 1 | awk -F'swo-k8s-collector-' '{print $2}')
-            yq eval '.appVersion = env(APP_VERSION)' -i deploy/helm/Chart.yaml
-            yq eval '.version = env(CHART_VERSION)' -i deploy/helm/Chart.yaml
 
       - name: Build
         run: skaffold build -p=ci-helm-e2e --file-output=/tmp/tags.json
@@ -96,8 +82,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
 
       - name: Deploy Kubernetes
         uses: ./.github/actions/deploy-kubernetes
@@ -121,13 +105,6 @@ jobs:
           EXPOSE 5000
           CMD ["python", "-m", "http.server", "5000"]
           EOF
-
-      - name: Update Chart.yaml
-        run: |
-            export APP_VERSION=$(git tag --sort=version:refname | grep -E '^[0-9]+.[0-9]+.[0-9]+$' | tail -n 1)
-            export CHART_VERSION=$(git tag --sort=version:refname | grep -E  '^swo-k8s-collector-' | tail -n 1 | awk -F'swo-k8s-collector-' '{print $2}')
-            yq eval '.appVersion = env(APP_VERSION)' -i deploy/helm/Chart.yaml
-            yq eval '.version = env(CHART_VERSION)' -i deploy/helm/Chart.yaml
 
       - name: Package and build Helm repository image
         run: |
@@ -225,46 +202,3 @@ jobs:
         if: ${{ always() }}
         run: |
           kubectl logs jobs/helm-autoupdate-manual-trigger -n swo-k8s-collector --all-containers=true
-
-
-  deploy_helm:
-    runs-on: ubuntu-latest
-    if: startsWith(github.ref, 'refs/tags/') && contains(github.ref, 'swo-k8s-collector')
-    needs:
-      - helm_e2e
-      - helm_test_auto_update_against_last_published
-    permissions:
-      contents: write # to push chart release and create a release (helm/chart-releaser-action)
-      id-token: write # needed for signing
-      pull-requests: write # needed to create pull-request
-    name: Deploy Helm chart to GitHub pages
-    steps:
-      - name: Checkout Code
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 0          
-          submodules: true
-
-      - name: Set up Helm
-        uses: azure/setup-helm@v3.5
-        with:
-          version: v3.9.2
-
-      - name: Add dependency chart repos
-        run: |
-          helm repo add prometheus-community https://prometheus-community.github.io/helm-charts
-
-      - name: Set env
-        run: |
-          echo "CR_GIT_REPO=$(cut -d '/' -f 2 <<< $GITHUB_REPOSITORY)" >> $GITHUB_ENV
-          echo "CR_OWNER=$(cut -d '/' -f 1 <<< $GITHUB_REPOSITORY)" >> $GITHUB_ENV
-
-      - name: Run chart-releaser
-        env:
-          # for chart-releaser (it is required although probably not used)
-          CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
-          # for gh cli
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          "./.github/cr.sh"
-        shell: bash

--- a/.github/workflows/releaseHelm.yml
+++ b/.github/workflows/releaseHelm.yml
@@ -1,0 +1,46 @@
+name: Release Helm
+
+on:
+  push:  
+    paths:
+      - deploy/helm/Chart.yaml
+    branches: 
+      - master
+      - release/**
+jobs:
+  deploy_helm:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write # to push chart release and create a release (helm/chart-releaser-action)
+      id-token: write # needed for signing
+      pull-requests: write # needed to create pull-request
+    name: Deploy Helm chart to GitHub pages
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v4
+        with:     
+          submodules: true
+
+      - name: Set up Helm
+        uses: azure/setup-helm@v3.5
+        with:
+          version: v3.9.2
+
+      - name: Add dependency chart repos
+        run: |
+          helm repo add prometheus-community https://prometheus-community.github.io/helm-charts
+
+      - name: Set env
+        run: |
+          echo "CR_GIT_REPO=$(cut -d '/' -f 2 <<< $GITHUB_REPOSITORY)" >> $GITHUB_ENV
+          echo "CR_OWNER=$(cut -d '/' -f 1 <<< $GITHUB_REPOSITORY)" >> $GITHUB_ENV
+
+      - name: Run chart-releaser
+        env:
+          # for chart-releaser (it is required although probably not used)
+          CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+          # for gh cli
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          "./.github/cr.sh"
+        shell: bash

--- a/deploy/helm/Chart.yaml
+++ b/deploy/helm/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: swo-k8s-collector
-version: "0.0.0"
-appVersion: "0.0.0"
+version: 4.1.0-alpha.3
+appVersion: 0.11.5
 description: SolarWinds Kubernetes Integration
 keywords:
   - monitoring

--- a/deploy/helm/templates/autoupdate/autoupdate-cronjob.yaml
+++ b/deploy/helm/templates/autoupdate/autoupdate-cronjob.yaml
@@ -17,6 +17,8 @@ spec:
           imagePullSecrets:
             {{- toYaml .Values.imagePullSecrets | nindent 12 }}
           {{- end }}
+          nodeSelector:
+            kubernetes.io/os: linux
           containers:
           - name: helm-upgrade
             image: "{{ include "common.image" (tuple . .Values.autoupdate (tuple "image" "autoupdate")) }}"

--- a/deploy/helm/templates/autoupdate/autoupdate-cronjob.yaml
+++ b/deploy/helm/templates/autoupdate/autoupdate-cronjob.yaml
@@ -17,8 +17,20 @@ spec:
           imagePullSecrets:
             {{- toYaml .Values.imagePullSecrets | nindent 12 }}
           {{- end }}
-          nodeSelector:
-            kubernetes.io/os: linux
+          affinity:
+            nodeAffinity:
+              requiredDuringSchedulingIgnoredDuringExecution:
+                nodeSelectorTerms:
+                - matchExpressions:
+                  - key: kubernetes.io/arch
+                    operator: In
+                    values:
+                    - amd64
+                    - arm64
+                  - key: kubernetes.io/os
+                    operator: In
+                    values:
+                    - linux
           containers:
           - name: helm-upgrade
             image: "{{ include "common.image" (tuple . .Values.autoupdate (tuple "image" "autoupdate")) }}"

--- a/doc/development.md
+++ b/doc/development.md
@@ -228,13 +228,8 @@ The Helm chart is bundled also in AKS/EKS addons. Make sure that any changes are
 ### Helm Chart
 
 
-1. Create the tag you want to release and push it to origin. For a pre-release, use the `-alpha.1` suffix:
-
-    ```
-    git tag swo-k8s-collector-1.2.3[-alpha.1]
-    git push origin swo-k8s-collector-1.2.3
-    ```
-1. GitHub Action will be triggered to build the release and open a PR to the `gh-pages` branch.
+1. Create PR with version change into [Chart.yaml](../deploy/helm/Chart.yaml)
+1. Once the PR is merged, GitHub Action will be triggered to build the release and open a PR to the `gh-pages` branch.
 1. Review the PR created for changes to the `gh-pages` branch (which hosts the Helm charts), and merge it.
 1. Once the PR is merged, the Helm chart is published to <https://helm.solarwinds.com>.
 1. Find the relevant release in GitHub, edit it, and summarize all changes recorded in [CHANGELOG.md](../deploy/helm/CHANGELOG.md) into the release description.


### PR DESCRIPTION
# Another refactor of Helm Release process

After good discussion with @pstranak-sw we came out with idea to change form `create&push tag` to` create a PR with version change` which fixes several problems:
* local helm template/install for testing
* cloud extensions pipeline
* release without approval


## Release for image:
* `git tag x.v.y`, 
* `git push origin x.z.y`

## Release for Helm
* Open PR with change to Chart.yaml
* Get it approved & merged
* Approve  & merge PR created by GH Action

Includes changes from #716 as it does not require version change in test anymore. 
