### PR TITLE
NH-90272: Instead of using sha256 for hostPath it now replaces invalid characters

### DIFF
--- a/deploy/helm/templates/node-collector-daemon-set-windows.yaml
+++ b/deploy/helm/templates/node-collector-daemon-set-windows.yaml
@@ -145,7 +145,7 @@ spec:
             path: c:\var\lib\docker\containers
         - name: logcheckpoints
           hostPath:
-            path: c:{{ printf "%s/%s" .Values.otel.logs.filestorage.directory (sha256sum (include "common.cluster-uid" .)) }}
+            path: c:{{ printf "%s/%s" .Values.otel.logs.filestorage.directory ((regexReplaceAll "[^a-zA-Z0-9_\\-]" (include "common.cluster-uid" .) "") | default (sha256sum (include "common.cluster-uid" .))) }}
             type: DirectoryOrCreate
         - name: opentelemetry-collector-configmap
           configMap:
@@ -156,7 +156,7 @@ spec:
 {{- if .Values.otel.node_collector.sending_queue.persistent_storage.enabled }}
         - name: sending-queue
           hostPath:
-            path: c:{{ printf "%s/%s" .Values.otel.node_collector.sending_queue.persistent_storage.directory (sha256sum (include "common.cluster-uid" .)) }}
+            path: c:{{ printf "%s/%s" .Values.otel.node_collector.sending_queue.persistent_storage.directory ((regexReplaceAll "[^a-zA-Z0-9_\\-]" (include "common.cluster-uid" .) "") | default (sha256sum (include "common.cluster-uid" .))) }}
             type: DirectoryOrCreate
 {{- end }}
 {{- end }}

--- a/deploy/helm/templates/node-collector-daemon-set.yaml
+++ b/deploy/helm/templates/node-collector-daemon-set.yaml
@@ -168,7 +168,7 @@ spec:
             path: /var/log/journal
         - name: logcheckpoints
           hostPath:
-            path: {{ printf "%s/%s" .Values.otel.logs.filestorage.directory (sha256sum (include "common.cluster-uid" .)) }}
+            path: {{ printf "%s/%s" .Values.otel.logs.filestorage.directory ((regexReplaceAll "[^a-zA-Z0-9_\\-]" (include "common.cluster-uid" .) "") | default (sha256sum (include "common.cluster-uid" .))) }}
             type: DirectoryOrCreate
         - name: opentelemetry-collector-configmap
           configMap:
@@ -179,7 +179,7 @@ spec:
 {{- if .Values.otel.node_collector.sending_queue.persistent_storage.enabled }}
         - name: sending-queue
           hostPath:
-            path: {{ printf "%s/%s" .Values.otel.node_collector.sending_queue.persistent_storage.directory (sha256sum (include "common.cluster-uid" .)) }}
+            path: {{ printf "%s/%s" .Values.otel.node_collector.sending_queue.persistent_storage.directory ((regexReplaceAll "[^a-zA-Z0-9_\\-]" (include "common.cluster-uid" .) "") | default (sha256sum (include "common.cluster-uid" .))) }}
             type: DirectoryOrCreate
 {{- end }}
 {{- end }}

--- a/deploy/helm/tests/__snapshot__/node-collector-daemon-set-windows_test.yaml.snap
+++ b/deploy/helm/tests/__snapshot__/node-collector-daemon-set-windows_test.yaml.snap
@@ -97,7 +97,7 @@ DaemonSet spec for windows nodes should match snapshot when overriding cluster I
           path: c:\var\lib\docker\containers
         name: varlibdockercontainers
       - hostPath:
-          path: c:/var/lib/swo/checkpoints/6eb3475096f465fb33e3929d08ca7e1913c2896feb5e001b3600a56f3964b4d9
+          path: c:/var/lib/swo/checkpoints/customUid
           type: DirectoryOrCreate
         name: logcheckpoints
       - configMap:
@@ -205,7 +205,7 @@ DaemonSet spec for windows nodes should match snapshot when using default values
           path: c:\var\lib\docker\containers
         name: varlibdockercontainers
       - hostPath:
-          path: c:/var/lib/swo/checkpoints/7e819eda63eb48d6b9aee7eda8e239c756bfe327e64ac579b5469466b0ca1e2d
+          path: c:/var/lib/swo/checkpoints/CLUSTER_NAME
           type: DirectoryOrCreate
         name: logcheckpoints
       - configMap:

--- a/deploy/helm/tests/__snapshot__/node-collector-daemon-set_test.yaml.snap
+++ b/deploy/helm/tests/__snapshot__/node-collector-daemon-set_test.yaml.snap
@@ -119,7 +119,7 @@ DaemonSet spec should match snapshot when ebpfNetworkMonitoring is enabled:
           path: /var/log/journal
         name: varlogjournal
       - hostPath:
-          path: /var/lib/swo/checkpoints/7e819eda63eb48d6b9aee7eda8e239c756bfe327e64ac579b5469466b0ca1e2d
+          path: /var/lib/swo/checkpoints/CLUSTER_NAME
           type: DirectoryOrCreate
         name: logcheckpoints
       - configMap:
@@ -249,7 +249,137 @@ DaemonSet spec should match snapshot when overriding cluster ID:
           path: /var/log/journal
         name: varlogjournal
       - hostPath:
-          path: /var/lib/swo/checkpoints/6eb3475096f465fb33e3929d08ca7e1913c2896feb5e001b3600a56f3964b4d9
+          path: /var/lib/swo/checkpoints/customUid
+          type: DirectoryOrCreate
+        name: logcheckpoints
+      - configMap:
+          items:
+            - key: logs.config
+              path: relay.yaml
+          name: RELEASE-NAME-swo-k8s-collector-node-collector-config
+        name: opentelemetry-collector-configmap
+DaemonSet spec should match snapshot when setting cluster name with spaces:
+  1: |
+    affinity:
+      nodeAffinity:
+        requiredDuringSchedulingIgnoredDuringExecution:
+          nodeSelectorTerms:
+            - matchExpressions:
+                - key: eks.amazonaws.com/compute-type
+                  operator: NotIn
+                  values:
+                    - fargate
+                - key: kubernetes.io/arch
+                  operator: In
+                  values:
+                    - amd64
+                    - arm64
+                - key: kubernetes.io/os
+                  operator: In
+                  values:
+                    - linux
+    containers:
+      - command:
+          - /wrapper
+          - /swi-otelcol
+          - --config=/conf/relay.yaml
+          - --feature-gates=filelog.container.removeOriginalTimeField
+        env:
+          - name: CHECKPOINT_DIR
+            value: /var/lib/swo/checkpoints
+          - name: POD_NAME
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.name
+          - name: POD_NAMESPACE
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.namespace
+          - name: NODE_NAME
+            valueFrom:
+              fieldRef:
+                fieldPath: spec.nodeName
+          - name: SOLARWINDS_API_TOKEN
+            valueFrom:
+              secretKeyRef:
+                key: SOLARWINDS_API_TOKEN
+                name: solarwinds-api-token
+                optional: true
+          - name: GOMEMLIMIT
+            valueFrom:
+              resourceFieldRef:
+                resource: limits.memory
+        envFrom:
+          - configMapRef:
+              name: RELEASE-NAME-swo-k8s-collector-common-env
+        image: solarwinds/swi-opentelemetry-collector:1.0.0
+        imagePullPolicy: IfNotPresent
+        livenessProbe:
+          httpGet:
+            path: /
+            port: 13133
+        name: swi-opentelemetry-collector
+        ports:
+          - containerPort: 8888
+            name: http
+            protocol: TCP
+        readinessProbe:
+          httpGet:
+            path: /
+            port: 13133
+        resources:
+          limits:
+            memory: 1Gi
+          requests:
+            memory: 50Mi
+        volumeMounts:
+          - mountPath: /var/log/pods
+            name: varlogpods
+            readOnly: true
+          - mountPath: /var/log/containers
+            name: varlogcontainers
+            readOnly: true
+          - mountPath: /var/lib/docker/containers
+            name: varlibdockercontainers
+            readOnly: true
+          - mountPath: /conf
+            name: opentelemetry-collector-configmap
+            readOnly: true
+          - mountPath: /run/log/journal
+            name: runlogjournal
+            readOnly: true
+          - mountPath: /var/log/journal
+            name: varlogjournal
+            readOnly: true
+          - mountPath: /var/lib/swo/checkpoints
+            name: logcheckpoints
+    securityContext:
+      fsGroup: 0
+      runAsGroup: 0
+      runAsUser: 0
+    serviceAccountName: RELEASE-NAME-swo-k8s-collector
+    terminationGracePeriodSeconds: 600
+    tolerations:
+      - effect: NoSchedule
+        operator: Exists
+    volumes:
+      - hostPath:
+          path: /var/log/pods
+        name: varlogpods
+      - hostPath:
+          path: /var/log/containers
+        name: varlogcontainers
+      - hostPath:
+          path: /var/lib/docker/containers
+        name: varlibdockercontainers
+      - hostPath:
+          path: /run/log/journal
+        name: runlogjournal
+      - hostPath:
+          path: /var/log/journal
+        name: varlogjournal
+      - hostPath:
+          path: /var/lib/swo/checkpoints/customname
           type: DirectoryOrCreate
         name: logcheckpoints
       - configMap:
@@ -379,7 +509,7 @@ DaemonSet spec should match snapshot when using default values:
           path: /var/log/journal
         name: varlogjournal
       - hostPath:
-          path: /var/lib/swo/checkpoints/7e819eda63eb48d6b9aee7eda8e239c756bfe327e64ac579b5469466b0ca1e2d
+          path: /var/lib/swo/checkpoints/CLUSTER_NAME
           type: DirectoryOrCreate
         name: logcheckpoints
       - configMap:

--- a/deploy/helm/tests/node-collector-daemon-set_test.yaml
+++ b/deploy/helm/tests/node-collector-daemon-set_test.yaml
@@ -27,3 +27,10 @@ tests:
     asserts:
       - matchSnapshot:
           path: spec.template.spec
+  - it: DaemonSet spec should match snapshot when setting cluster name with spaces
+    template: node-collector-daemon-set.yaml
+    set:
+      cluster.name: custom &^%$ name
+    asserts:
+      - matchSnapshot:
+          path: spec.template.spec


### PR DESCRIPTION
Instead of using sha256 for hostPath it now replaces invalid characters, so for standard cluster.ids it should be unchanged during upgrade. If the result is empty it will use sha256. It should be much less breaking for the customers compared to original https://github.com/solarwinds/swi-k8s-opentelemetry-collector/pull/716 
