### PR TITLE
Build all images under one tag

### DIFF
--- a/.github/workflows/buildAndDeploy.yml
+++ b/.github/workflows/buildAndDeploy.yml
@@ -190,20 +190,44 @@ jobs:
           docker push ${{ env.DOCKERHUB_IMAGE }}:${{ steps.vars.outputs.tag }}-nanoserver-ltsc2022
           docker push ${{ env.DOCKERHUB_IMAGE }}:${{ steps.vars.outputs.tag }}-nanoserver-ltsc2019
 
-      - name: Create multi-arch manifest
-        run: | 
-          docker manifest create ${{ env.DOCKERHUB_IMAGE }}:${{ steps.vars.outputs.tag }}-nanoserver --amend ${{ env.DOCKERHUB_IMAGE }}:${{ steps.vars.outputs.tag }}-nanoserver-ltsc2022 --amend ${{ env.DOCKERHUB_IMAGE }}:${{ steps.vars.outputs.tag }}-nanoserver-ltsc2019
-
-      - name: Push multi-arch manifest
-        run: | 
-          docker manifest push ${{ env.DOCKERHUB_IMAGE }}:${{ steps.vars.outputs.tag }}-nanoserver
-
-  create_release:
+  create_and_push_manifest:
     runs-on: ubuntu-latest
     name: Create GitHub Release
     needs:
       - deploy_dockerhub_windows
       - deploy_dockerhub
+    steps:   
+      - name: Get image tag
+        id: vars
+        run: echo ::set-output name=tag::${GITHUB_REF#refs/*/}    
+
+      - name: Docker login
+        env:
+          DOCKER_HUB_CI_PASSWORD: ${{ secrets.DOCKER_HUB_CI_PASSWORD }}
+          DOCKER_HUB_CI_USER: ${{ secrets.DOCKER_HUB_CI_USER }}
+        run: echo "$env:DOCKER_HUB_CI_PASSWORD" | docker login -u "$env:DOCKER_HUB_CI_USER" --password-stdin   
+        
+      - name: Get linux manifest
+        run: | 
+          docker manifest inspect ${{ env.DOCKERHUB_IMAGE }}:${{ steps.vars.outputs.tag }} > manifest.json
+          
+      - name: Create multi-arch manifest
+        run: | 
+          docker manifest create ${{ env.DOCKERHUB_IMAGE }}:${{ steps.vars.outputs.tag }}  \
+            --amend ${{ env.DOCKERHUB_IMAGE }}:${{ steps.vars.outputs.tag }}-nanoserver-ltsc2022 \
+            --amend ${{ env.DOCKERHUB_IMAGE }}:${{ steps.vars.outputs.tag }}-nanoserver-ltsc2019 \
+            --amend ${{ env.DOCKERHUB_IMAGE }}@$(jq -r '.manifests[] | select(.platform.os == "linux" and .platform.architecture == "amd64") | .digest' manifest.json) \
+            --amend ${{ env.DOCKERHUB_IMAGE }}@$(jq -r '.manifests[] | select(.platform.os == "linux" and .platform.architecture == "arm64") | .digest' manifest.json) 
+
+      - name: Push multi-arch manifest
+        run: | 
+          docker manifest push ${{ env.DOCKERHUB_IMAGE }}:${{ steps.vars.outputs.tag }}
+
+  create_release:
+    runs-on: ubuntu-latest
+    name: Create GitHub Release
+    needs:
+      - create_and_push_manifest
     steps:
       - name: Checkout code
         uses: actions/checkout@v4

--- a/deploy/helm/templates/node-collector-daemon-set-windows.yaml
+++ b/deploy/helm/templates/node-collector-daemon-set-windows.yaml
@@ -63,7 +63,7 @@ spec:
       {{- end }}
       containers:
         - name: swi-opentelemetry-collector
-          image: "{{ include "common.image" (tuple . .Values.otel.windows (tuple "image" "image_windows") nil (printf "%s%s" .Chart.AppVersion "-nanoserver")) }}"
+          image: "{{ include "common.image" (tuple . .Values.otel.windows (tuple "image" "image_windows") nil .Chart.AppVersion ) }}"
           imagePullPolicy: {{ .Values.otel.windows.image.pullPolicy }}
           command:
             - c:\wrapper.exe

--- a/deploy/helm/tests/__snapshot__/node-collector-daemon-set-windows_test.yaml.snap
+++ b/deploy/helm/tests/__snapshot__/node-collector-daemon-set-windows_test.yaml.snap
@@ -43,7 +43,7 @@ DaemonSet spec for windows nodes should match snapshot when overriding cluster I
         envFrom:
           - configMapRef:
               name: RELEASE-NAME-swo-k8s-collector-common-env
-        image: solarwinds/swi-opentelemetry-collector:1.0.0-nanoserver
+        image: solarwinds/swi-opentelemetry-collector:1.0.0
         imagePullPolicy: IfNotPresent
         livenessProbe:
           httpGet:
@@ -151,7 +151,7 @@ DaemonSet spec for windows nodes should match snapshot when using default values
         envFrom:
           - configMapRef:
               name: RELEASE-NAME-swo-k8s-collector-common-env
-        image: solarwinds/swi-opentelemetry-collector:1.0.0-nanoserver
+        image: solarwinds/swi-opentelemetry-collector:1.0.0
         imagePullPolicy: IfNotPresent
         livenessProbe:
           httpGet:

--- a/deploy/helm/tests/node-collector-daemon-set-windows_test.yaml
+++ b/deploy/helm/tests/node-collector-daemon-set-windows_test.yaml
@@ -17,15 +17,15 @@ tests:
     asserts:
     - equal:
           path: spec.template.spec.containers[0].image
-          value: solarwinds/swi-opentelemetry-collector:1.0.0-nanoserver
+          value: solarwinds/swi-opentelemetry-collector:1.0.0
   - it: Image should be correct when overriden tag
     template: node-collector-daemon-set-windows.yaml
     set:
-      otel.windows.image.tag: "beta1-nanoserver"
+      otel.windows.image.tag: "beta1"
     asserts:
     - equal:
           path: spec.template.spec.containers[0].image
-          value: solarwinds/swi-opentelemetry-collector:beta1-nanoserver
+          value: solarwinds/swi-opentelemetry-collector:beta1
   - it: Image should be correct when overriden by azure
     template: node-collector-daemon-set-windows.yaml
     set:


### PR DESCRIPTION
Artifact hub is complaining about using different tags for these images:

```
error scanning image solarwinds/swi-opentelemetry-collector:0.11.5-nanoserver: error running trivy on image solarwinds/swi-opentelemetry-collector:0.11.5-nanoserver: * remote error: no child with platform linux/amd64 in index solarwinds/swi-opentelemetry-collector:0.11.5-nanoserver (package swo-k8s-collector:4.1.0)

```
