### PR TITLE
Add a separate testing endpoint for manifests

### DIFF
--- a/doc/development.md
+++ b/doc/development.md
@@ -6,10 +6,11 @@
 - [Prerequisites](#prerequisites)
 - [Deployment](#deployment)
 - [Develop against remote prometheus](#develop-against-remote-prometheus)
+- [Helm Unit tests](#helm-unit-tests)
 - [Integration tests](#integration-tests)
 - [Updating Chart dependencies](#updating-chart-dependencies)
 - [Updating Chart configuration](#updating-chart-configuration)
-- [Publishing](#publishing)
+- [Release](#release)
 
 ## Contribution Guidelines
 
@@ -91,16 +92,25 @@ Possible issues:
   ```shell
   helm repo add "stable" "https://charts.helm.sh/stable" --force-update
   ```
+
 ### How can you analyze exported telemetry
+
 #### Metrics
-* You can look at `http://localhost:8088/metrics.json` (each line is JSON as bulk sent by OTEL collector)
-* You can also look at local Prometheus which collects all the outputs with metric names prefixed with `output_` at `http://localhost:8080`
+
+- You can look at `http://localhost:8088/metrics.json` (each line is JSON as bulk sent by OTEL collector)
+- You can also look at local Prometheus which collects all the outputs with metric names prefixed with `output_` at `http://localhost:8080`
 
 #### Logs
+
 You can look at `http://localhost:8088/logs.json` (each line is JSON as bulk sent by OTEL collector)
 
 #### Events
+
 You can look at `http://localhost:8088/events.json` (each line is JSON as bulk sent by OTEL collector)
+
+#### Manifests
+
+You can look at `http://localhost:8088/manifests.json` (each line is JSON as bulk sent by OTEL collector)
 
 ## Develop against remote cluster
 * Make sure that you have working kubeContext, set this to `test-cluster` profile section in `skaffold.yaml`:
@@ -218,10 +228,12 @@ The Helm chart is bundled also in AKS/EKS addons. Make sure that any changes are
 ### Docker image
 
 1. Create tag you want to release and push it to origin
-    ```
+
+    ```shell
     git tag 0.11.5
     git push origin 0.11.5
     ```
+
 1. GitHub Action will be triggered, building the release and awaiting manual approval for publishing.
 1. Once approved, it will be published to Docker Hub repository: [solarwinds/swi-opentelemetry-collector](https://hub.docker.com/repository/docker/solarwinds/swi-opentelemetry-collector).
 

--- a/tests/deploy/base/mocks.yaml
+++ b/tests/deploy/base/mocks.yaml
@@ -21,6 +21,10 @@ data:
         path: /data/events.json
         # empty rotation - workaround for https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/18251
         rotation:
+      file/manifests:
+        path: /data/manifests.json
+        # empty rotation - workaround for https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/18251
+        rotation:
       prometheus:
         endpoint: "0.0.0.0:8080"
         namespace: output
@@ -30,24 +34,34 @@ data:
         resource_to_telemetry_conversion:
           enabled: true
     extensions:
-      health_check: {}
+      health_check:
+        endpoint: 0.0.0.0:13133
       memory_ballast:
-        size_mib: "204"
+        size_mib: 204
     processors:
-      filter/events_in:
+      filter/events:
         logs: 
           include:
             match_type: strict
             resource_attributes:
               - key: sw.k8s.log.type
                 value: event
-      filter/events_out:
+      filter/manifests:
+        logs: 
+          include:
+            match_type: strict
+            resource_attributes:
+              - key: sw.k8s.log.type
+                value: manifest
+      filter/logs:
         logs: 
           exclude:
             match_type: strict
             resource_attributes:
               - key: sw.k8s.log.type
                 value: event
+              - key: sw.k8s.log.type
+                value: manifest
     receivers:
       otlp:
         protocols:
@@ -69,14 +83,21 @@ data:
           exporters:
           - file/logs
           processors:
-          - filter/events_out
+          - filter/logs
           receivers:
           - otlp
         logs/events:
           exporters:
           - file/events
           processors:
-          - filter/events_in
+          - filter/events
+          receivers:
+          - otlp
+        logs/manifests:
+          exporters:
+          - file/manifests
+          processors:
+          - filter/manifests
           receivers:
           - otlp
 ---
@@ -127,7 +148,7 @@ spec:
             - --config=/conf/relay.yaml
           securityContext:
             runAsUser: 0
-          image: "otel/opentelemetry-collector-contrib:0.98.0"
+          image: "otel/opentelemetry-collector-contrib:0.107.0"
           imagePullPolicy: IfNotPresent
           ports:
             - name: otlp
@@ -148,7 +169,7 @@ spec:
               mountPath: /data
         - name: file-provider
           image: nginx:alpine
-          command: ['sh', '-c', 'touch /usr/share/nginx/html/events.json && touch /usr/share/nginx/html/metrics.json && touch /usr/share/nginx/html/logs.json && chmod -R 777 /usr/share/nginx/html && nginx -g "daemon off;"']
+          command: ['sh', '-c', 'touch /usr/share/nginx/html/events.json && touch /usr/share/nginx/html/metrics.json && touch /usr/share/nginx/html/logs.json && touch /usr/share/nginx/html/manifests.json && chmod -R 777 /usr/share/nginx/html && nginx -g "daemon off;"']
           securityContext:
             runAsUser: 0
           volumeMounts:


### PR DESCRIPTION
Add a separate `http://localhost:8088/manifests.json` testing endpoint.
Update `timeseries-mock-service` to use a newer OTEL collector version.