### PR TITLE
Update autoupdate test

### DIFF
--- a/.github/actions/deploy-kubernetes/action.yml
+++ b/.github/actions/deploy-kubernetes/action.yml
@@ -1,5 +1,5 @@
 name: 'Deploy kubernetes locally'
-description: 'Deployes k3s and all kubernetes tools'
+description: 'Deploys k3s and all kubernetes tools'
 inputs:
   ssh-key:
     description: 'ssh key'
@@ -8,9 +8,9 @@ runs:
   using: 'composite'
   steps:
     - name: Start k8s locally
-      uses: jupyterhub/action-k3s-helm@v1
+      uses: jupyterhub/action-k3s-helm@v4
       with:
-        k3s-channel: v1.23
+        k3s-channel: v1.31
         traefik-enabled: false
         docker-enabled: true
         metrics-enabled: true


### PR DESCRIPTION
The used `k3s` stopped working, likely because the build machine switched to a newer Ubuntu release. Switching to `kind`, which we use in other places, did not work for some reason. So this PR just updates the version of the cluster and of the build action.