### PR TITLE
NH-67059 add etcd metrics

### DIFF
--- a/deploy/helm/CHANGELOG.md
+++ b/deploy/helm/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## [4.2.0-alpha.5] - 2024-10-23
+
+### Added
+
+- Added metrics for Etcd
+
+
 ## [4.1.0] - 2024-09-30
 
 ### Added

--- a/deploy/helm/Chart.yaml
+++ b/deploy/helm/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: swo-k8s-collector
-version: 4.2.0-alpha.4
+version: 4.2.0-alpha.5
 appVersion: 0.11.7
 description: SolarWinds Kubernetes Integration
 keywords:

--- a/deploy/helm/node-collector-config.yaml
+++ b/deploy/helm/node-collector-config.yaml
@@ -305,7 +305,7 @@ processors:
   filter/histograms:
     metrics:
       metric:
-        - 'type == METRIC_DATA_TYPE_HISTOGRAM'
+        - 'type == METRIC_DATA_TYPE_HISTOGRAM and not(name == "k8s.etcd_disk_wal_fsync_duration_seconds" or name == "k8s.etcd_disk_backend_commit_duration_seconds")'
 
   transform/istio-metrics:
     metric_statements:

--- a/deploy/helm/tests/__snapshot__/node-collector-config-map-windows_test.yaml.snap
+++ b/deploy/helm/tests/__snapshot__/node-collector-config-map-windows_test.yaml.snap
@@ -165,7 +165,7 @@ Node collector config for windows nodes should match snapshot when using default
           metrics:
             metric:
             - type == METRIC_DATA_TYPE_HISTOGRAM and not(name == "k8s.rest_client_request_duration_seconds"
-              or name == "k8s.workqueue_queue_duration_seconds or name == "k8s.etcd_disk_wal_fsync_duration_seconds"
+              or name == "k8s.workqueue_queue_duration_seconds" or name == "k8s.etcd_disk_wal_fsync_duration_seconds"
               or name == "k8s.etcd_disk_backend_commit_duration_seconds")
         filter/receiver:
           metrics:
@@ -1283,7 +1283,7 @@ Node collector config for windows nodes should match snapshot when using legacy 
           metrics:
             metric:
             - type == METRIC_DATA_TYPE_HISTOGRAM and not(name == "k8s.rest_client_request_duration_seconds"
-              or name == "k8s.workqueue_queue_duration_seconds or name == "k8s.etcd_disk_wal_fsync_duration_seconds"
+              or name == "k8s.workqueue_queue_duration_seconds" or name == "k8s.etcd_disk_wal_fsync_duration_seconds"
               or name == "k8s.etcd_disk_backend_commit_duration_seconds")
         filter/logs:
           logs:

--- a/deploy/helm/tests/__snapshot__/node-collector-config-map-windows_test.yaml.snap
+++ b/deploy/helm/tests/__snapshot__/node-collector-config-map-windows_test.yaml.snap
@@ -165,7 +165,7 @@ Node collector config for windows nodes should match snapshot when using default
           metrics:
             metric:
             - type == METRIC_DATA_TYPE_HISTOGRAM and not(name == "k8s.etcd_disk_wal_fsync_duration_seconds"
-				      or name == "k8s.etcd_disk_backend_commit_duration_seconds")
+              or name == "k8s.etcd_disk_backend_commit_duration_seconds")
         filter/receiver:
           metrics:
             metric:
@@ -1256,7 +1256,7 @@ Node collector config for windows nodes should match snapshot when using legacy 
           metrics:
             metric:
             - type == METRIC_DATA_TYPE_HISTOGRAM and not(name == "k8s.etcd_disk_wal_fsync_duration_seconds"
-				      or name == "k8s.etcd_disk_backend_commit_duration_seconds")
+              or name == "k8s.etcd_disk_backend_commit_duration_seconds")
         filter/logs:
           logs:
             include:

--- a/deploy/helm/tests/__snapshot__/node-collector-config-map-windows_test.yaml.snap
+++ b/deploy/helm/tests/__snapshot__/node-collector-config-map-windows_test.yaml.snap
@@ -164,7 +164,8 @@ Node collector config for windows nodes should match snapshot when using default
         filter/histograms:
           metrics:
             metric:
-            - type == METRIC_DATA_TYPE_HISTOGRAM and not(name == "k8s.etcd_disk_wal_fsync_duration_seconds" or name == "k8s.etcd_disk_backend_commit_duration_seconds")
+            - type == METRIC_DATA_TYPE_HISTOGRAM and not(name == "k8s.etcd_disk_wal_fsync_duration_seconds"
+				      or name == "k8s.etcd_disk_backend_commit_duration_seconds")
         filter/receiver:
           metrics:
             metric:
@@ -1254,7 +1255,8 @@ Node collector config for windows nodes should match snapshot when using legacy 
         filter/histograms:
           metrics:
             metric:
-            - type == METRIC_DATA_TYPE_HISTOGRAM and not(name == "k8s.etcd_disk_wal_fsync_duration_seconds" or name == "k8s.etcd_disk_backend_commit_duration_seconds")
+            - type == METRIC_DATA_TYPE_HISTOGRAM and not(name == "k8s.etcd_disk_wal_fsync_duration_seconds"
+				      or name == "k8s.etcd_disk_backend_commit_duration_seconds")
         filter/logs:
           logs:
             include:

--- a/deploy/helm/tests/__snapshot__/node-collector-config-map-windows_test.yaml.snap
+++ b/deploy/helm/tests/__snapshot__/node-collector-config-map-windows_test.yaml.snap
@@ -164,7 +164,7 @@ Node collector config for windows nodes should match snapshot when using default
         filter/histograms:
           metrics:
             metric:
-            - type == METRIC_DATA_TYPE_HISTOGRAM
+            - type == METRIC_DATA_TYPE_HISTOGRAM and not(name == "k8s.etcd_disk_wal_fsync_duration_seconds" or name == "k8s.etcd_disk_backend_commit_duration_seconds")
         filter/receiver:
           metrics:
             metric:
@@ -1254,7 +1254,7 @@ Node collector config for windows nodes should match snapshot when using legacy 
         filter/histograms:
           metrics:
             metric:
-            - type == METRIC_DATA_TYPE_HISTOGRAM
+            - type == METRIC_DATA_TYPE_HISTOGRAM and not(name == "k8s.etcd_disk_wal_fsync_duration_seconds" or name == "k8s.etcd_disk_backend_commit_duration_seconds")
         filter/logs:
           logs:
             include:

--- a/deploy/helm/tests/__snapshot__/node-collector-config-map_test.yaml.snap
+++ b/deploy/helm/tests/__snapshot__/node-collector-config-map_test.yaml.snap
@@ -164,7 +164,8 @@ Custom logs filter with new syntax:
         filter/histograms:
           metrics:
             metric:
-            - type == METRIC_DATA_TYPE_HISTOGRAM and not(name == "k8s.etcd_disk_wal_fsync_duration_seconds" or name == "k8s.etcd_disk_backend_commit_duration_seconds")
+            - type == METRIC_DATA_TYPE_HISTOGRAM and not(name == "k8s.etcd_disk_wal_fsync_duration_seconds"
+				      or name == "k8s.etcd_disk_backend_commit_duration_seconds")
         filter/logs:
           logs:
             log_record:
@@ -1287,7 +1288,8 @@ Custom logs filter with old syntax:
         filter/histograms:
           metrics:
             metric:
-            - type == METRIC_DATA_TYPE_HISTOGRAM and not(name == "k8s.etcd_disk_wal_fsync_duration_seconds" or name == "k8s.etcd_disk_backend_commit_duration_seconds")
+            - type == METRIC_DATA_TYPE_HISTOGRAM and not(name == "k8s.etcd_disk_wal_fsync_duration_seconds"
+				      or name == "k8s.etcd_disk_backend_commit_duration_seconds")
         filter/logs:
           logs:
             include:
@@ -2494,7 +2496,8 @@ Node collector config should match snapshot when autodiscovery is disabled:
         filter/histograms:
           metrics:
             metric:
-            - type == METRIC_DATA_TYPE_HISTOGRAM and not(name == "k8s.etcd_disk_wal_fsync_duration_seconds" or name == "k8s.etcd_disk_backend_commit_duration_seconds")
+            - type == METRIC_DATA_TYPE_HISTOGRAM and not(name == "k8s.etcd_disk_wal_fsync_duration_seconds"
+				      or name == "k8s.etcd_disk_backend_commit_duration_seconds")
         filter/receiver:
           metrics:
             metric:
@@ -3574,7 +3577,8 @@ Node collector config should match snapshot when fargate is enabled:
         filter/histograms:
           metrics:
             metric:
-            - type == METRIC_DATA_TYPE_HISTOGRAM and not(name == "k8s.etcd_disk_wal_fsync_duration_seconds" or name == "k8s.etcd_disk_backend_commit_duration_seconds")
+            - type == METRIC_DATA_TYPE_HISTOGRAM and not(name == "k8s.etcd_disk_wal_fsync_duration_seconds"
+				      or name == "k8s.etcd_disk_backend_commit_duration_seconds")
         filter/receiver:
           metrics:
             metric:
@@ -4623,7 +4627,8 @@ Node collector config should match snapshot when fargate is enabled and autodisc
         filter/histograms:
           metrics:
             metric:
-            - type == METRIC_DATA_TYPE_HISTOGRAM and not(name == "k8s.etcd_disk_wal_fsync_duration_seconds" or name == "k8s.etcd_disk_backend_commit_duration_seconds")
+            - type == METRIC_DATA_TYPE_HISTOGRAM and not(name == "k8s.etcd_disk_wal_fsync_duration_seconds"
+				      or name == "k8s.etcd_disk_backend_commit_duration_seconds")
         filter/receiver:
           metrics:
             metric:
@@ -5634,7 +5639,8 @@ Node collector config should match snapshot when using default values:
         filter/histograms:
           metrics:
             metric:
-            - type == METRIC_DATA_TYPE_HISTOGRAM and not(name == "k8s.etcd_disk_wal_fsync_duration_seconds" or name == "k8s.etcd_disk_backend_commit_duration_seconds")
+            - type == METRIC_DATA_TYPE_HISTOGRAM and not(name == "k8s.etcd_disk_wal_fsync_duration_seconds"
+				      or name == "k8s.etcd_disk_backend_commit_duration_seconds")
         filter/receiver:
           metrics:
             metric:

--- a/deploy/helm/tests/__snapshot__/node-collector-config-map_test.yaml.snap
+++ b/deploy/helm/tests/__snapshot__/node-collector-config-map_test.yaml.snap
@@ -165,7 +165,7 @@ Custom logs filter with new syntax:
           metrics:
             metric:
             - type == METRIC_DATA_TYPE_HISTOGRAM and not(name == "k8s.rest_client_request_duration_seconds"
-              or name == "k8s.workqueue_queue_duration_seconds or name == "k8s.etcd_disk_wal_fsync_duration_seconds"
+              or name == "k8s.workqueue_queue_duration_seconds" or name == "k8s.etcd_disk_wal_fsync_duration_seconds"
               or name == "k8s.etcd_disk_backend_commit_duration_seconds")
         filter/logs:
           logs:
@@ -1316,7 +1316,7 @@ Custom logs filter with old syntax:
           metrics:
             metric:
             - type == METRIC_DATA_TYPE_HISTOGRAM and not(name == "k8s.rest_client_request_duration_seconds"
-              or name == "k8s.workqueue_queue_duration_seconds or name == "k8s.etcd_disk_wal_fsync_duration_seconds"
+              or name == "k8s.workqueue_queue_duration_seconds" or name == "k8s.etcd_disk_wal_fsync_duration_seconds"
               or name == "k8s.etcd_disk_backend_commit_duration_seconds")
         filter/logs:
           logs:
@@ -2551,7 +2551,7 @@ Node collector config should match snapshot when autodiscovery is disabled:
           metrics:
             metric:
             - type == METRIC_DATA_TYPE_HISTOGRAM and not(name == "k8s.rest_client_request_duration_seconds"
-              or name == "k8s.workqueue_queue_duration_seconds or name == "k8s.etcd_disk_wal_fsync_duration_seconds"
+              or name == "k8s.workqueue_queue_duration_seconds" or name == "k8s.etcd_disk_wal_fsync_duration_seconds"
               or name == "k8s.etcd_disk_backend_commit_duration_seconds")
         filter/receiver:
           metrics:
@@ -3633,7 +3633,7 @@ Node collector config should match snapshot when fargate is enabled:
           metrics:
             metric:
             - type == METRIC_DATA_TYPE_HISTOGRAM and not(name == "k8s.rest_client_request_duration_seconds"
-              or name == "k8s.workqueue_queue_duration_seconds or name == "k8s.etcd_disk_wal_fsync_duration_seconds"
+              or name == "k8s.workqueue_queue_duration_seconds" or name == "k8s.etcd_disk_wal_fsync_duration_seconds"
               or name == "k8s.etcd_disk_backend_commit_duration_seconds")
         filter/receiver:
           metrics:
@@ -4710,7 +4710,7 @@ Node collector config should match snapshot when fargate is enabled and autodisc
           metrics:
             metric:
             - type == METRIC_DATA_TYPE_HISTOGRAM and not(name == "k8s.rest_client_request_duration_seconds"
-              or name == "k8s.workqueue_queue_duration_seconds or name == "k8s.etcd_disk_wal_fsync_duration_seconds"
+              or name == "k8s.workqueue_queue_duration_seconds" or name == "k8s.etcd_disk_wal_fsync_duration_seconds"
               or name == "k8s.etcd_disk_backend_commit_duration_seconds")
         filter/receiver:
           metrics:
@@ -5723,7 +5723,7 @@ Node collector config should match snapshot when using default values:
           metrics:
             metric:
             - type == METRIC_DATA_TYPE_HISTOGRAM and not(name == "k8s.rest_client_request_duration_seconds"
-              or name == "k8s.workqueue_queue_duration_seconds or name == "k8s.etcd_disk_wal_fsync_duration_seconds"
+              or name == "k8s.workqueue_queue_duration_seconds" or name == "k8s.etcd_disk_wal_fsync_duration_seconds"
               or name == "k8s.etcd_disk_backend_commit_duration_seconds")
         filter/receiver:
           metrics:

--- a/deploy/helm/tests/__snapshot__/node-collector-config-map_test.yaml.snap
+++ b/deploy/helm/tests/__snapshot__/node-collector-config-map_test.yaml.snap
@@ -165,7 +165,7 @@ Custom logs filter with new syntax:
           metrics:
             metric:
             - type == METRIC_DATA_TYPE_HISTOGRAM and not(name == "k8s.etcd_disk_wal_fsync_duration_seconds"
-				      or name == "k8s.etcd_disk_backend_commit_duration_seconds")
+              or name == "k8s.etcd_disk_backend_commit_duration_seconds")
         filter/logs:
           logs:
             log_record:
@@ -1289,7 +1289,7 @@ Custom logs filter with old syntax:
           metrics:
             metric:
             - type == METRIC_DATA_TYPE_HISTOGRAM and not(name == "k8s.etcd_disk_wal_fsync_duration_seconds"
-				      or name == "k8s.etcd_disk_backend_commit_duration_seconds")
+              or name == "k8s.etcd_disk_backend_commit_duration_seconds")
         filter/logs:
           logs:
             include:
@@ -2497,7 +2497,7 @@ Node collector config should match snapshot when autodiscovery is disabled:
           metrics:
             metric:
             - type == METRIC_DATA_TYPE_HISTOGRAM and not(name == "k8s.etcd_disk_wal_fsync_duration_seconds"
-				      or name == "k8s.etcd_disk_backend_commit_duration_seconds")
+              or name == "k8s.etcd_disk_backend_commit_duration_seconds")
         filter/receiver:
           metrics:
             metric:
@@ -3578,7 +3578,7 @@ Node collector config should match snapshot when fargate is enabled:
           metrics:
             metric:
             - type == METRIC_DATA_TYPE_HISTOGRAM and not(name == "k8s.etcd_disk_wal_fsync_duration_seconds"
-				      or name == "k8s.etcd_disk_backend_commit_duration_seconds")
+              or name == "k8s.etcd_disk_backend_commit_duration_seconds")
         filter/receiver:
           metrics:
             metric:
@@ -4628,7 +4628,7 @@ Node collector config should match snapshot when fargate is enabled and autodisc
           metrics:
             metric:
             - type == METRIC_DATA_TYPE_HISTOGRAM and not(name == "k8s.etcd_disk_wal_fsync_duration_seconds"
-				      or name == "k8s.etcd_disk_backend_commit_duration_seconds")
+              or name == "k8s.etcd_disk_backend_commit_duration_seconds")
         filter/receiver:
           metrics:
             metric:
@@ -5640,7 +5640,7 @@ Node collector config should match snapshot when using default values:
           metrics:
             metric:
             - type == METRIC_DATA_TYPE_HISTOGRAM and not(name == "k8s.etcd_disk_wal_fsync_duration_seconds"
-				      or name == "k8s.etcd_disk_backend_commit_duration_seconds")
+              or name == "k8s.etcd_disk_backend_commit_duration_seconds")
         filter/receiver:
           metrics:
             metric:

--- a/deploy/helm/tests/__snapshot__/node-collector-config-map_test.yaml.snap
+++ b/deploy/helm/tests/__snapshot__/node-collector-config-map_test.yaml.snap
@@ -164,7 +164,7 @@ Custom logs filter with new syntax:
         filter/histograms:
           metrics:
             metric:
-            - type == METRIC_DATA_TYPE_HISTOGRAM
+            - type == METRIC_DATA_TYPE_HISTOGRAM and not(name == "k8s.etcd_disk_wal_fsync_duration_seconds" or name == "k8s.etcd_disk_backend_commit_duration_seconds")
         filter/logs:
           logs:
             log_record:
@@ -1287,7 +1287,7 @@ Custom logs filter with old syntax:
         filter/histograms:
           metrics:
             metric:
-            - type == METRIC_DATA_TYPE_HISTOGRAM
+            - type == METRIC_DATA_TYPE_HISTOGRAM and not(name == "k8s.etcd_disk_wal_fsync_duration_seconds" or name == "k8s.etcd_disk_backend_commit_duration_seconds")
         filter/logs:
           logs:
             include:
@@ -2494,7 +2494,7 @@ Node collector config should match snapshot when autodiscovery is disabled:
         filter/histograms:
           metrics:
             metric:
-            - type == METRIC_DATA_TYPE_HISTOGRAM
+            - type == METRIC_DATA_TYPE_HISTOGRAM and not(name == "k8s.etcd_disk_wal_fsync_duration_seconds" or name == "k8s.etcd_disk_backend_commit_duration_seconds")
         filter/receiver:
           metrics:
             metric:
@@ -3574,7 +3574,7 @@ Node collector config should match snapshot when fargate is enabled:
         filter/histograms:
           metrics:
             metric:
-            - type == METRIC_DATA_TYPE_HISTOGRAM
+            - type == METRIC_DATA_TYPE_HISTOGRAM and not(name == "k8s.etcd_disk_wal_fsync_duration_seconds" or name == "k8s.etcd_disk_backend_commit_duration_seconds")
         filter/receiver:
           metrics:
             metric:
@@ -4623,7 +4623,7 @@ Node collector config should match snapshot when fargate is enabled and autodisc
         filter/histograms:
           metrics:
             metric:
-            - type == METRIC_DATA_TYPE_HISTOGRAM
+            - type == METRIC_DATA_TYPE_HISTOGRAM and not(name == "k8s.etcd_disk_wal_fsync_duration_seconds" or name == "k8s.etcd_disk_backend_commit_duration_seconds")
         filter/receiver:
           metrics:
             metric:
@@ -5634,7 +5634,7 @@ Node collector config should match snapshot when using default values:
         filter/histograms:
           metrics:
             metric:
-            - type == METRIC_DATA_TYPE_HISTOGRAM
+            - type == METRIC_DATA_TYPE_HISTOGRAM and not(name == "k8s.etcd_disk_wal_fsync_duration_seconds" or name == "k8s.etcd_disk_backend_commit_duration_seconds")
         filter/receiver:
           metrics:
             metric:


### PR DESCRIPTION
Enable histogram metrics `k8s.etcd_disk_wal_fsync_duration_seconds` and `k8s.etcd_disk_backend_commit_duration_seconds` on node collector - discovery.