### PR TITLE
Adding support to discover and scrape `https` prometheus endpoints

### DIFF
--- a/deploy/helm/node-collector-config.yaml
+++ b/deploy/helm/node-collector-config.yaml
@@ -543,11 +543,11 @@ receivers:
     watch_observers:
       - k8s_observer
     receivers:
-      prometheus/discovery:
+      prometheus/discovery/http:
         {{- if .Values.otel.metrics.autodiscovery.prometheusEndpoints.additionalRules }}
-        rule: type == "pod" && annotations["prometheus.io/scrape"] == "true" && {{ .Values.otel.metrics.autodiscovery.prometheusEndpoints.additionalRules }}
+        rule: type == "pod" && annotations["prometheus.io/scrape"] == "true" && annotations["prometheus.io/scheme"] != "https" && {{ .Values.otel.metrics.autodiscovery.prometheusEndpoints.additionalRules }}
         {{- else }}
-        rule: type == "pod" && annotations["prometheus.io/scrape"] == "true"
+        rule: type == "pod" && annotations["prometheus.io/scrape"] == "true" && annotations["prometheus.io/scheme"] != "https"
         {{- end }}
         config:
           config:
@@ -561,6 +561,34 @@ receivers:
                 static_configs:
                   - targets:
                       - '`endpoint`:`"prometheus.io/port" in annotations ? annotations["prometheus.io/port"] : 9090`'
+
+      prometheus/discovery/https:
+        {{- if .Values.otel.metrics.autodiscovery.prometheusEndpoints.additionalRules }}
+        rule: type == "pod" && annotations["prometheus.io/scrape"] == "true" && annotations["prometheus.io/scheme"] == "https" && {{ .Values.otel.metrics.autodiscovery.prometheusEndpoints.additionalRules }}
+        {{- else }}
+        rule: type == "pod" && annotations["prometheus.io/scrape"] == "true" && annotations["prometheus.io/scheme"] == "https"
+        {{- end }}
+        config:
+          config:
+            scrape_configs:
+              - job_name: pod
+                scheme: "https"
+                scrape_interval: {{ quote .Values.otel.metrics.prometheus.scrape_interval }}
+                metrics_path: '`"prometheus.io/path" in annotations ? annotations["prometheus.io/path"] : "/metrics"`'
+                honor_timestamps: false
+                honor_labels: true
+                authorization:
+                  type: Bearer
+                  credentials_file: /var/run/secrets/kubernetes.io/serviceaccount/token
+                tls_config:
+                  ca_file: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+                  insecure_skip_verify: true
+                follow_redirects: true
+                enable_http2: true
+                static_configs:
+                  - targets:
+                      - '`endpoint`:`"prometheus.io/port" in annotations ? annotations["prometheus.io/port"] : 9090`'
+
 
       {{- if .Values.otel.metrics.autodiscovery.prometheusEndpoints.podMonitors }}
       {{- range $key, $rule :=.Values.otel.metrics.autodiscovery.prometheusEndpoints.podMonitors.rules }}

--- a/deploy/helm/node-collector-config.yaml
+++ b/deploy/helm/node-collector-config.yaml
@@ -305,7 +305,7 @@ processors:
   filter/histograms:
     metrics:
       metric:
-        - 'type == METRIC_DATA_TYPE_HISTOGRAM'
+        - 'type == METRIC_DATA_TYPE_HISTOGRAM and not(name == "k8s.rest_client_request_duration_seconds" or name == "k8s.workqueue_queue_duration_seconds")'
 
   transform/istio-metrics:
     metric_statements:

--- a/deploy/helm/tests/__snapshot__/node-collector-config-map-windows_test.yaml.snap
+++ b/deploy/helm/tests/__snapshot__/node-collector-config-map-windows_test.yaml.snap
@@ -164,7 +164,8 @@ Node collector config for windows nodes should match snapshot when using default
         filter/histograms:
           metrics:
             metric:
-            - type == METRIC_DATA_TYPE_HISTOGRAM
+            - type == METRIC_DATA_TYPE_HISTOGRAM and not(name == "k8s.rest_client_request_duration_seconds"
+              or name == "k8s.workqueue_queue_duration_seconds")
         filter/receiver:
           metrics:
             metric:
@@ -1280,7 +1281,8 @@ Node collector config for windows nodes should match snapshot when using legacy 
         filter/histograms:
           metrics:
             metric:
-            - type == METRIC_DATA_TYPE_HISTOGRAM
+            - type == METRIC_DATA_TYPE_HISTOGRAM and not(name == "k8s.rest_client_request_duration_seconds"
+              or name == "k8s.workqueue_queue_duration_seconds")
         filter/logs:
           logs:
             include:

--- a/deploy/helm/tests/__snapshot__/node-collector-config-map-windows_test.yaml.snap
+++ b/deploy/helm/tests/__snapshot__/node-collector-config-map-windows_test.yaml.snap
@@ -949,7 +949,7 @@ Node collector config for windows nodes should match snapshot when using default
           storage: file_storage/checkpoints
         receiver_creator/discovery:
           receivers:
-            prometheus/discovery:
+            prometheus/discovery/http:
               config:
                 config:
                   scrape_configs:
@@ -964,7 +964,33 @@ Node collector config for windows nodes should match snapshot when using default
                     - targets:
                       - '`endpoint`:`"prometheus.io/port" in annotations ? annotations["prometheus.io/port"]
                         : 9090`'
-              rule: type == "pod" && annotations["prometheus.io/scrape"] == "true"
+              rule: type == "pod" && annotations["prometheus.io/scrape"] == "true" && annotations["prometheus.io/scheme"]
+                != "https"
+            prometheus/discovery/https:
+              config:
+                config:
+                  scrape_configs:
+                  - authorization:
+                      credentials_file: /var/run/secrets/kubernetes.io/serviceaccount/token
+                      type: Bearer
+                    enable_http2: true
+                    follow_redirects: true
+                    honor_labels: true
+                    honor_timestamps: false
+                    job_name: pod
+                    metrics_path: '`"prometheus.io/path" in annotations ? annotations["prometheus.io/path"]
+                      : "/metrics"`'
+                    scheme: https
+                    scrape_interval: 60s
+                    static_configs:
+                    - targets:
+                      - '`endpoint`:`"prometheus.io/port" in annotations ? annotations["prometheus.io/port"]
+                        : 9090`'
+                    tls_config:
+                      ca_file: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+                      insecure_skip_verify: true
+              rule: type == "pod" && annotations["prometheus.io/scrape"] == "true" && annotations["prometheus.io/scheme"]
+                == "https"
           watch_observers:
           - k8s_observer
         receiver_creator/node:
@@ -2119,7 +2145,7 @@ Node collector config for windows nodes should match snapshot when using legacy 
           storage: file_storage/checkpoints
         receiver_creator/discovery:
           receivers:
-            prometheus/discovery:
+            prometheus/discovery/http:
               config:
                 config:
                   scrape_configs:
@@ -2134,7 +2160,33 @@ Node collector config for windows nodes should match snapshot when using legacy 
                     - targets:
                       - '`endpoint`:`"prometheus.io/port" in annotations ? annotations["prometheus.io/port"]
                         : 9090`'
-              rule: type == "pod" && annotations["prometheus.io/scrape"] == "true"
+              rule: type == "pod" && annotations["prometheus.io/scrape"] == "true" && annotations["prometheus.io/scheme"]
+                != "https"
+            prometheus/discovery/https:
+              config:
+                config:
+                  scrape_configs:
+                  - authorization:
+                      credentials_file: /var/run/secrets/kubernetes.io/serviceaccount/token
+                      type: Bearer
+                    enable_http2: true
+                    follow_redirects: true
+                    honor_labels: true
+                    honor_timestamps: false
+                    job_name: pod
+                    metrics_path: '`"prometheus.io/path" in annotations ? annotations["prometheus.io/path"]
+                      : "/metrics"`'
+                    scheme: https
+                    scrape_interval: 60s
+                    static_configs:
+                    - targets:
+                      - '`endpoint`:`"prometheus.io/port" in annotations ? annotations["prometheus.io/port"]
+                        : 9090`'
+                    tls_config:
+                      ca_file: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+                      insecure_skip_verify: true
+              rule: type == "pod" && annotations["prometheus.io/scrape"] == "true" && annotations["prometheus.io/scheme"]
+                == "https"
           watch_observers:
           - k8s_observer
         receiver_creator/node:

--- a/deploy/helm/tests/__snapshot__/node-collector-config-map_test.yaml.snap
+++ b/deploy/helm/tests/__snapshot__/node-collector-config-map_test.yaml.snap
@@ -164,7 +164,8 @@ Custom logs filter with new syntax:
         filter/histograms:
           metrics:
             metric:
-            - type == METRIC_DATA_TYPE_HISTOGRAM
+            - type == METRIC_DATA_TYPE_HISTOGRAM and not(name == "k8s.rest_client_request_duration_seconds"
+              or name == "k8s.workqueue_queue_duration_seconds")
         filter/logs:
           logs:
             log_record:
@@ -1313,7 +1314,8 @@ Custom logs filter with old syntax:
         filter/histograms:
           metrics:
             metric:
-            - type == METRIC_DATA_TYPE_HISTOGRAM
+            - type == METRIC_DATA_TYPE_HISTOGRAM and not(name == "k8s.rest_client_request_duration_seconds"
+              or name == "k8s.workqueue_queue_duration_seconds")
         filter/logs:
           logs:
             include:
@@ -2546,7 +2548,8 @@ Node collector config should match snapshot when autodiscovery is disabled:
         filter/histograms:
           metrics:
             metric:
-            - type == METRIC_DATA_TYPE_HISTOGRAM
+            - type == METRIC_DATA_TYPE_HISTOGRAM and not(name == "k8s.rest_client_request_duration_seconds"
+              or name == "k8s.workqueue_queue_duration_seconds")
         filter/receiver:
           metrics:
             metric:
@@ -3626,7 +3629,8 @@ Node collector config should match snapshot when fargate is enabled:
         filter/histograms:
           metrics:
             metric:
-            - type == METRIC_DATA_TYPE_HISTOGRAM
+            - type == METRIC_DATA_TYPE_HISTOGRAM and not(name == "k8s.rest_client_request_duration_seconds"
+              or name == "k8s.workqueue_queue_duration_seconds")
         filter/receiver:
           metrics:
             metric:
@@ -4701,7 +4705,8 @@ Node collector config should match snapshot when fargate is enabled and autodisc
         filter/histograms:
           metrics:
             metric:
-            - type == METRIC_DATA_TYPE_HISTOGRAM
+            - type == METRIC_DATA_TYPE_HISTOGRAM and not(name == "k8s.rest_client_request_duration_seconds"
+              or name == "k8s.workqueue_queue_duration_seconds")
         filter/receiver:
           metrics:
             metric:
@@ -5712,7 +5717,8 @@ Node collector config should match snapshot when using default values:
         filter/histograms:
           metrics:
             metric:
-            - type == METRIC_DATA_TYPE_HISTOGRAM
+            - type == METRIC_DATA_TYPE_HISTOGRAM and not(name == "k8s.rest_client_request_duration_seconds"
+              or name == "k8s.workqueue_queue_duration_seconds")
         filter/receiver:
           metrics:
             metric:

--- a/deploy/helm/tests/__snapshot__/node-collector-config-map_test.yaml.snap
+++ b/deploy/helm/tests/__snapshot__/node-collector-config-map_test.yaml.snap
@@ -972,7 +972,7 @@ Custom logs filter with new syntax:
           - containerd
         receiver_creator/discovery:
           receivers:
-            prometheus/discovery:
+            prometheus/discovery/http:
               config:
                 config:
                   scrape_configs:
@@ -987,7 +987,33 @@ Custom logs filter with new syntax:
                     - targets:
                       - '`endpoint`:`"prometheus.io/port" in annotations ? annotations["prometheus.io/port"]
                         : 9090`'
-              rule: type == "pod" && annotations["prometheus.io/scrape"] == "true"
+              rule: type == "pod" && annotations["prometheus.io/scrape"] == "true" && annotations["prometheus.io/scheme"]
+                != "https"
+            prometheus/discovery/https:
+              config:
+                config:
+                  scrape_configs:
+                  - authorization:
+                      credentials_file: /var/run/secrets/kubernetes.io/serviceaccount/token
+                      type: Bearer
+                    enable_http2: true
+                    follow_redirects: true
+                    honor_labels: true
+                    honor_timestamps: false
+                    job_name: pod
+                    metrics_path: '`"prometheus.io/path" in annotations ? annotations["prometheus.io/path"]
+                      : "/metrics"`'
+                    scheme: https
+                    scrape_interval: 60s
+                    static_configs:
+                    - targets:
+                      - '`endpoint`:`"prometheus.io/port" in annotations ? annotations["prometheus.io/port"]
+                        : 9090`'
+                    tls_config:
+                      ca_file: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+                      insecure_skip_verify: true
+              rule: type == "pod" && annotations["prometheus.io/scrape"] == "true" && annotations["prometheus.io/scheme"]
+                == "https"
           watch_observers:
           - k8s_observer
         receiver_creator/node:
@@ -2179,7 +2205,7 @@ Custom logs filter with old syntax:
           - containerd
         receiver_creator/discovery:
           receivers:
-            prometheus/discovery:
+            prometheus/discovery/http:
               config:
                 config:
                   scrape_configs:
@@ -2194,7 +2220,33 @@ Custom logs filter with old syntax:
                     - targets:
                       - '`endpoint`:`"prometheus.io/port" in annotations ? annotations["prometheus.io/port"]
                         : 9090`'
-              rule: type == "pod" && annotations["prometheus.io/scrape"] == "true"
+              rule: type == "pod" && annotations["prometheus.io/scrape"] == "true" && annotations["prometheus.io/scheme"]
+                != "https"
+            prometheus/discovery/https:
+              config:
+                config:
+                  scrape_configs:
+                  - authorization:
+                      credentials_file: /var/run/secrets/kubernetes.io/serviceaccount/token
+                      type: Bearer
+                    enable_http2: true
+                    follow_redirects: true
+                    honor_labels: true
+                    honor_timestamps: false
+                    job_name: pod
+                    metrics_path: '`"prometheus.io/path" in annotations ? annotations["prometheus.io/path"]
+                      : "/metrics"`'
+                    scheme: https
+                    scrape_interval: 60s
+                    static_configs:
+                    - targets:
+                      - '`endpoint`:`"prometheus.io/port" in annotations ? annotations["prometheus.io/port"]
+                        : 9090`'
+                    tls_config:
+                      ca_file: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+                      insecure_skip_verify: true
+              rule: type == "pod" && annotations["prometheus.io/scrape"] == "true" && annotations["prometheus.io/scheme"]
+                == "https"
           watch_observers:
           - k8s_observer
         receiver_creator/node:
@@ -4378,7 +4430,7 @@ Node collector config should match snapshot when fargate is enabled:
           - containerd
         receiver_creator/discovery:
           receivers:
-            prometheus/discovery:
+            prometheus/discovery/http:
               config:
                 config:
                   scrape_configs:
@@ -4393,7 +4445,33 @@ Node collector config should match snapshot when fargate is enabled:
                     - targets:
                       - '`endpoint`:`"prometheus.io/port" in annotations ? annotations["prometheus.io/port"]
                         : 9090`'
-              rule: type == "pod" && annotations["prometheus.io/scrape"] == "true"
+              rule: type == "pod" && annotations["prometheus.io/scrape"] == "true" && annotations["prometheus.io/scheme"]
+                != "https"
+            prometheus/discovery/https:
+              config:
+                config:
+                  scrape_configs:
+                  - authorization:
+                      credentials_file: /var/run/secrets/kubernetes.io/serviceaccount/token
+                      type: Bearer
+                    enable_http2: true
+                    follow_redirects: true
+                    honor_labels: true
+                    honor_timestamps: false
+                    job_name: pod
+                    metrics_path: '`"prometheus.io/path" in annotations ? annotations["prometheus.io/path"]
+                      : "/metrics"`'
+                    scheme: https
+                    scrape_interval: 60s
+                    static_configs:
+                    - targets:
+                      - '`endpoint`:`"prometheus.io/port" in annotations ? annotations["prometheus.io/port"]
+                        : 9090`'
+                    tls_config:
+                      ca_file: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+                      insecure_skip_verify: true
+              rule: type == "pod" && annotations["prometheus.io/scrape"] == "true" && annotations["prometheus.io/scheme"]
+                == "https"
           watch_observers:
           - k8s_observer
       service:
@@ -6438,7 +6516,7 @@ Node collector config should match snapshot when using default values:
           - containerd
         receiver_creator/discovery:
           receivers:
-            prometheus/discovery:
+            prometheus/discovery/http:
               config:
                 config:
                   scrape_configs:
@@ -6453,7 +6531,33 @@ Node collector config should match snapshot when using default values:
                     - targets:
                       - '`endpoint`:`"prometheus.io/port" in annotations ? annotations["prometheus.io/port"]
                         : 9090`'
-              rule: type == "pod" && annotations["prometheus.io/scrape"] == "true"
+              rule: type == "pod" && annotations["prometheus.io/scrape"] == "true" && annotations["prometheus.io/scheme"]
+                != "https"
+            prometheus/discovery/https:
+              config:
+                config:
+                  scrape_configs:
+                  - authorization:
+                      credentials_file: /var/run/secrets/kubernetes.io/serviceaccount/token
+                      type: Bearer
+                    enable_http2: true
+                    follow_redirects: true
+                    honor_labels: true
+                    honor_timestamps: false
+                    job_name: pod
+                    metrics_path: '`"prometheus.io/path" in annotations ? annotations["prometheus.io/path"]
+                      : "/metrics"`'
+                    scheme: https
+                    scrape_interval: 60s
+                    static_configs:
+                    - targets:
+                      - '`endpoint`:`"prometheus.io/port" in annotations ? annotations["prometheus.io/port"]
+                        : 9090`'
+                    tls_config:
+                      ca_file: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+                      insecure_skip_verify: true
+              rule: type == "pod" && annotations["prometheus.io/scrape"] == "true" && annotations["prometheus.io/scheme"]
+                == "https"
           watch_observers:
           - k8s_observer
         receiver_creator/node:


### PR DESCRIPTION
This is needed for scraping kube-controller-manager