### PR TITLE
Move annotations to Chart.yaml

### DIFF
--- a/.github/add_annotation.sh
+++ b/.github/add_annotation.sh
@@ -1,15 +1,13 @@
 #!/bin/bash
 
 # Check if the correct number of arguments are provided
-if [ $# -ne 3 ]; then
-  echo "Usage: $0 <yaml-file> <values-yaml-file> <release>"
+if [ $# -ne 2 ]; then
+  echo "Usage: $0 <yaml-file> <release-type>"
   exit 1
 fi
 
 YAML_FILE=$1
-VALUES_YAML_FILE=$2
-RELEASE=$3
-
+RELEASE_TYPE=$2
 
 # Check if the YAML file exists
 if [ ! -f "$YAML_FILE" ]; then
@@ -17,38 +15,20 @@ if [ ! -f "$YAML_FILE" ]; then
   exit 1
 fi
 
-# Check if the YAML file exists
-if [ ! -f "$VALUES_YAML_FILE" ]; then
-  echo "Error: File '$VALUES_YAML_FILE' not found!"
-  exit 1
-fi
-
-
-
 # Check if yq is installed
 if ! command -v yq &> /dev/null; then
   echo "yq is required but it's not installed. Please install it first."
   exit 1
 fi
 
-KERNEL_COLLECTOR=$(yq eval '.ebpfNetworkMonitoring.kernelCollector.image.repository + ":" + .ebpfNetworkMonitoring.kernelCollector.image.tag' $VALUES_YAML_FILE)
-K8S_COLLECTOR_WATCHER=$(yq eval '.ebpfNetworkMonitoring.k8sCollector.watcher.image.repository + ":" + .ebpfNetworkMonitoring.k8sCollector.watcher.image.tag' $VALUES_YAML_FILE)
-K8S_COLLECTOR_RELAY=$(yq eval '.ebpfNetworkMonitoring.k8sCollector.relay.image.repository + ":" + .ebpfNetworkMonitoring.k8sCollector.relay.image.tag' $VALUES_YAML_FILE)
-REDUCER=$(yq eval '.ebpfNetworkMonitoring.reducer.image.repository + ":" + .ebpfNetworkMonitoring.reducer.image.tag' $VALUES_YAML_FILE)
 
-echo "Found images:"
-echo $KERNEL_COLLECTOR
-echo $K8S_COLLECTOR_WATCHER
-echo $K8S_COLLECTOR_RELAY
-echo $REDUCER
+if [ "$RELEASE_TYPE" = "" ]; then
+  # Production release
+  yq eval ".annotations.\"artifacthub.io/prerelease\" = \"false\"" deploy/helm/Chart.yaml -i
 
+else
+  yq eval ".annotations.\"artifacthub.io/prerelease\" = \"true\"" deploy/helm/Chart.yaml -i
 
-yq eval "(.entries.\"swo-k8s-collector\"[] | select(.version == \"$RELEASE\").annotations.\"artifacthub.io/images\") = 
-\"- name: ebpf-kernelCollector\n  image: $KERNEL_COLLECTOR\n  whitelisted: true
-- name: ebpf-k8sCollectorWatcher\n  image: $K8S_COLLECTOR_WATCHER\n  whitelisted: true
-- name: ebpf-k8sCollectorRelay\n  image: $K8S_COLLECTOR_RELAY\n  whitelisted: true
-- name: ebpf-reducer\n  image: $REDUCER\n  whitelisted: true\"" -i "$YAML_FILE"
+fi
 
-
-echo "Annotation added to release $RELEASE in $YAML_FILE."
 

--- a/.github/cr.sh
+++ b/.github/cr.sh
@@ -24,6 +24,8 @@ main() {
         PREVIOUS_TAG=$(git tag --sort=version:refname | grep -v alpha | grep -B1 "^swo-k8s-collector" | tail -n 1)
         PRE_RELEASE=""
     fi
+    
+    .github/add_annotation.sh deploy/helm/Chart.yaml $PRE_RELEASE
 
     echo "Packaging chart ..."
     cr package "deploy/helm"
@@ -54,7 +56,6 @@ main() {
     echo 'Updating chart repo index...'
     cr index
 
-    .github/add_annotation.sh .cr-index/index.yaml deploy/helm/values.yaml $(yq -e '.version' deploy/helm/Chart.yaml)
 
     echo 'Pushing update...'
     push_files "$RELEASE_NAME"

--- a/deploy/helm/Chart.yaml
+++ b/deploy/helm/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: swo-k8s-collector
-version: 4.2.0-alpha.5
+version: 4.2.0-alpha.6
 appVersion: 0.11.7
 description: SolarWinds Kubernetes Integration
 keywords:
@@ -22,3 +22,19 @@ dependencies:
     repository: https://prometheus-community.github.io/helm-charts
     version: "~> 5.25.1"
     condition: kube-state-metrics.enabled
+annotations:
+  artifacthub.io/prerelease: "false"
+  artifacthub.io/license: Apache-2.0
+  artifacthub.io/images: |
+    - name: ebpf-kernelCollector
+      image: solarwinds/opentelemetry-ebpf-kernel-collector:v0.10.2
+      whitelisted: true
+    - name: ebpf-k8sCollectorWatcher
+      image: solarwinds/opentelemetry-ebpf-k8s-watcher:v0.10.2
+      whitelisted: true
+    - name: ebpf-k8sCollectorRelay
+      image: solarwinds/opentelemetry-ebpf-k8s-relay:v0.10.2
+      whitelisted: true
+    - name: ebpf-reducer
+      image: solarwinds/opentelemetry-ebpf-reducer:v0.10.2
+      whitelisted: true


### PR DESCRIPTION
We need to add annotation to Chart.yaml instead of index.yaml of helm repo.  Adding also prerelease tag and license to improve artifacthub visualization. We can still automate versions of network collector to be pulled automatically from values.yaml.