### PR TITLE
Make it possible to customise prefix of discovered metrics

### DIFF
--- a/deploy/helm/CHANGELOG.md
+++ b/deploy/helm/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Added
+
+- It is now possible to customize prefix of discovered metrics using `otel.metrics.autodiscovery.prefix` (default `k8s.`)
+
 ## [4.2.0-alpha.5] - 2024-10-23
 
 ### Added

--- a/deploy/helm/metrics-collector-config.yaml
+++ b/deploy/helm/metrics-collector-config.yaml
@@ -163,7 +163,7 @@ processors:
   metricstransform/rename:
     transforms:
       # add `k8s.` suffix to all metrics that are clearly provided by Kubernetes
-      - include: ^(kube_|container_|kubernetes_|kubelet_|workqueue_|apiserver_|coredns_)(.*)$$
+      - include: ^(kube_|container_|kubernetes_|kubelet_|workqueue_|apiserver_|coredns_|etcd_)(.*)$$
         match_type: regexp
         action: update
         new_name: k8s.$${1}$${2}
@@ -1099,6 +1099,7 @@ receivers:
             kubeconfig_file: ""
             follow_redirects: true
             enable_http2: true
+        {{- if .Values.otel.metrics.control_plane.coredns.enabled }}
         - job_name: kubernetes-coredns
           honor_timestamps: false
           scrape_interval: {{ quote .Values.otel.metrics.prometheus.scrape_interval }}
@@ -1115,6 +1116,20 @@ receivers:
           - source_labels: [__address__]
             target_label: scrape_job
             replacement: "kubernetes-coredns"
+        {{- end }}
+        {{- if and .Values.otel.metrics.control_plane.etcd.enabled (eq .Values.otel.metrics.control_plane.etcd.scrape_kind "static") }}
+        - job_name: kubernetes-etcd
+          scheme: {{ quote .Values.otel.metrics.control_plane.etcd.scheme }}
+          scrape_interval: {{ quote .Values.otel.metrics.prometheus.scrape_interval }}
+          metrics_path: {{ quote .Values.otel.metrics.control_plane.etcd.metrics_path }}
+          honor_timestamps: false
+          honor_labels: true
+          static_configs:
+            - targets:
+                {{- range $endpoint := .Values.otel.metrics.control_plane.etcd.static_endpoints }}
+                - {{ $endpoint}}
+                {{- end }}
+        {{- end }}
 
 service:
   extensions:

--- a/deploy/helm/node-collector-config.yaml
+++ b/deploy/helm/node-collector-config.yaml
@@ -281,6 +281,14 @@ processors:
         action: update
         new_name: k8s.$${1}
 
+  metricstransform/rename/discovery:
+    transforms:
+      # add `k8s.` prefix to all metrics
+      - include: ^(.*)$$
+        match_type: regexp
+        action: update
+        new_name: {{ .Values.otel.metrics.autodiscovery.prefix }}$${1}
+
 {{- if .Values.otel.metrics.autodiscovery.prometheusEndpoints.customTransformations.counterToRate }}
   cumulativetodelta/discovery:
     include:
@@ -311,18 +319,28 @@ processors:
     metric_statements:
       - context: metric
         statements:
-          - extract_sum_metric(true) where (name == "k8s.istio_request_bytes" or name == "k8s.istio_response_bytes" or name == "k8s.istio_request_duration_milliseconds")
-          - extract_count_metric(true) where (name == "k8s.istio_request_duration_milliseconds")
-          - set(name, "k8s.istio_request_bytes.rate") where name == "k8s.istio_request_bytes_sum"
-          - set(name, "k8s.istio_response_bytes.rate") where name == "k8s.istio_response_bytes_sum"
-          - set(name, "k8s.istio_requests.rate") where name == "k8s.istio_requests_total"
-          - set(name, "k8s.istio_tcp_sent_bytes.rate") where name == "k8s.istio_tcp_sent_bytes_total"
-          - set(name, "k8s.istio_tcp_received_bytes.rate") where name == "k8s.istio_tcp_received_bytes_total"
-          - set(name, "k8s.istio_request_duration_milliseconds_sum_temp") where name == "k8s.istio_request_duration_milliseconds_sum"
-          - set(name, "k8s.istio_request_duration_milliseconds_count_temp") where name == "k8s.istio_request_duration_milliseconds_count"
+          - extract_sum_metric(true) where (name == "{{ .Values.otel.metrics.autodiscovery.prefix }}istio_request_bytes" or name == "{{ .Values.otel.metrics.autodiscovery.prefix }}istio_response_bytes" or name == "{{ .Values.otel.metrics.autodiscovery.prefix }}istio_request_duration_milliseconds")
+          - extract_count_metric(true) where (name == "{{ .Values.otel.metrics.autodiscovery.prefix }}istio_request_duration_milliseconds")
+          - set(name, "k8s.istio_request_duration_milliseconds_sum_temp") where name == "{{ .Values.otel.metrics.autodiscovery.prefix }}istio_request_duration_milliseconds_sum"
+          - set(name, "k8s.istio_request_duration_milliseconds_count_temp") where name == "{{ .Values.otel.metrics.autodiscovery.prefix }}istio_request_duration_milliseconds_count"
   
   metricstransform/istio-metrics:
     transforms:
+      - include: {{ .Values.otel.metrics.autodiscovery.prefix }}istio_request_bytes_sum
+        action: insert
+        new_name: k8s.istio_request_bytes.rate
+      - include: {{ .Values.otel.metrics.autodiscovery.prefix }}istio_response_bytes_sum
+        action: insert
+        new_name: k8s.istio_response_bytes.rate
+      - include: {{ .Values.otel.metrics.autodiscovery.prefix }}istio_requests_total
+        action: insert
+        new_name: k8s.istio_requests.rate
+      - include: {{ .Values.otel.metrics.autodiscovery.prefix }}istio_tcp_sent_bytes_total
+        action: insert
+        new_name: k8s.istio_tcp_sent_bytes.rate
+      - include: {{ .Values.otel.metrics.autodiscovery.prefix }}istio_tcp_received_bytes_total
+        action: insert
+        new_name: k8s.istio_tcp_received_bytes.rate
       - include: k8s.istio_request_bytes.rate
         action: insert
         new_name: k8s.istio_request_bytes.delta
@@ -722,7 +740,9 @@ service:
 {{- if .Values.otel.metrics.autodiscovery.prometheusEndpoints.filter }}
         - filter/metrics-discovery
 {{- end }}
-        - metricstransform/rename
+{{- if .Values.otel.metrics.autodiscovery.prefix }}
+        - metricstransform/rename/discovery
+{{- end }}
         - transform/istio-metrics
         - metricstransform/istio-metrics
         - cumulativetodelta/istio-metrics

--- a/deploy/helm/node-collector-config.yaml
+++ b/deploy/helm/node-collector-config.yaml
@@ -324,6 +324,41 @@ processors:
           - set(name, "k8s.istio_request_duration_milliseconds_sum_temp") where name == "{{ .Values.otel.metrics.autodiscovery.prefix }}istio_request_duration_milliseconds_sum"
           - set(name, "k8s.istio_request_duration_milliseconds_count_temp") where name == "{{ .Values.otel.metrics.autodiscovery.prefix }}istio_request_duration_milliseconds_count"
   
+{{- if ne .Values.otel.metrics.autodiscovery.prefix "k8s." }}
+  # in case the prefix differs from "k8s." we need to copy the required metrics
+  # so that SWO built-in dashboards works correctly
+{{- $arrayOfRequiredMetrics := list 
+  "etcd_disk_backend_commit_duration_seconds"
+  "etcd_disk_wal_fsync_duration_seconds" 
+  "etcd_network_client_grpc_received_bytes_total" 
+  "etcd_network_client_grpc_sent_bytes_total" 
+  "etcd_network_peer_received_bytes_total" 
+  "etcd_network_peer_sent_bytes_total" 
+  "etcd_server_leader_changes_seen_total" 
+  "etcd_server_proposals_applied_total" 
+  "etcd_server_proposals_committed_total"
+  "etcd_server_proposals_failed_total"
+  "etcd_server_proposals_pending"
+  "etcd_server_has_leader"
+  "etcd_mvcc_db_total_size_in_bytes"
+  "process_resident_memory_bytes"
+  "grpc_server_started_total"
+  "grpc_server_handled_total"
+  "rest_client_request_duration_seconds"
+  "rest_client_requests_total"
+  "workqueue_adds_total"
+  "workqueue_depth"
+  "workqueue_queue_duration_seconds"
+}}
+  metricstransform/copy-required-metrics:
+    transforms:
+    {{- $root := . }}
+    {{- range $index, $metric := $arrayOfRequiredMetrics }}
+      - include: {{ $root.Values.otel.metrics.autodiscovery.prefix }}{{ $metric }}
+        action: insert
+        new_name: k8s.{{ $metric }}
+    {{- end }}
+{{- end }}
   metricstransform/istio-metrics:
     transforms:
       - include: {{ .Values.otel.metrics.autodiscovery.prefix }}istio_request_bytes_sum
@@ -556,11 +591,12 @@ receivers:
         field: attributes["log.file.path"]
 {{- end }}
 
-{{- if and .Values.otel.metrics.enabled .Values.otel.metrics.autodiscovery.prometheusEndpoints.enabled }}
+{{- if .Values.otel.metrics.enabled }}
   receiver_creator/discovery:
     watch_observers:
       - k8s_observer
     receivers:
+    {{- if .Values.otel.metrics.autodiscovery.prometheusEndpoints.enabled}}
       prometheus/discovery/http:
         {{- if .Values.otel.metrics.autodiscovery.prometheusEndpoints.additionalRules }}
         rule: type == "pod" && annotations["prometheus.io/scrape"] == "true" && annotations["prometheus.io/scheme"] != "https" && {{ .Values.otel.metrics.autodiscovery.prometheusEndpoints.additionalRules }}
@@ -628,6 +664,58 @@ receivers:
       {{- end }}
       {{- end }}
       {{- end }}
+
+      {{- if .Values.otel.metrics.control_plane.controller_manager.enabled }}
+      prometheus/controller-manager:
+        rule: type == "pod" && labels[{{ quote $.Values.otel.metrics.control_plane.controller_manager.label_selector.key }}] == {{ quote $.Values.otel.metrics.control_plane.controller_manager.label_selector.value }}
+        config:
+          config:
+            scrape_configs:
+              - job_name: kubernetes-controller-manager
+                scheme: {{ quote .Values.otel.metrics.control_plane.controller_manager.scheme }}
+                scrape_interval: {{ quote .Values.otel.metrics.prometheus.scrape_interval }}
+                metrics_path: {{ quote .Values.otel.metrics.control_plane.controller_manager.metrics_path }}
+                honor_timestamps: false
+                honor_labels: true
+                authorization:
+                  type: Bearer
+                  credentials_file: /var/run/secrets/kubernetes.io/serviceaccount/token
+                tls_config:
+                  ca_file: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+                  insecure_skip_verify: true
+                follow_redirects: true
+                enable_http2: true
+                static_configs:
+                  - targets:
+                      - '`endpoint`:{{ .Values.otel.metrics.control_plane.controller_manager.port }}'
+      {{- end }}
+
+      {{- if and .Values.otel.metrics.control_plane.etcd.enabled (eq .Values.otel.metrics.control_plane.etcd.scrape_kind "pod") }}
+      prometheus/etcd:
+        rule: type == "pod" && labels[{{ quote .Values.otel.metrics.control_plane.etcd.label_selector.key }}] == {{ quote .Values.otel.metrics.control_plane.etcd.label_selector.value }}
+        config:
+          config:
+            scrape_configs:
+              - job_name: kubernetes-etcd
+                scheme: {{ quote .Values.otel.metrics.control_plane.etcd.scheme }}
+                scrape_interval: {{ quote .Values.otel.metrics.prometheus.scrape_interval }}
+                metrics_path: {{ quote .Values.otel.metrics.control_plane.etcd.metrics_path }}
+                honor_timestamps: false
+                honor_labels: true
+                authorization:
+                  type: Bearer
+                  credentials_file: /var/run/secrets/kubernetes.io/serviceaccount/token
+                tls_config:
+                  ca_file: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+                  insecure_skip_verify: true
+                follow_redirects: true
+                enable_http2: true
+                static_configs:
+                  - targets:
+                      - '`endpoint`:{{ .Values.otel.metrics.control_plane.etcd.port }}'
+      {{- end }}
+
+    {{- end }}
 {{- end }}
 
 {{- if and .Values.otel.metrics.enabled (not .Values.aws_fargate.enabled) }}
@@ -742,6 +830,9 @@ service:
 {{- end }}
 {{- if .Values.otel.metrics.autodiscovery.prefix }}
         - metricstransform/rename/discovery
+{{- end }}
+{{- if ne .Values.otel.metrics.autodiscovery.prefix "k8s." }}
+        - metricstransform/copy-required-metrics
 {{- end }}
         - transform/istio-metrics
         - metricstransform/istio-metrics

--- a/deploy/helm/tests/__snapshot__/metrics-collector-config-map-fargate_test.yaml.snap
+++ b/deploy/helm/tests/__snapshot__/metrics-collector-config-map-fargate_test.yaml.snap
@@ -1603,7 +1603,7 @@ Metrics config should match snapshot when using default values:
         metricstransform/rename:
           transforms:
           - action: update
-            include: ^(kube_|container_|kubernetes_|kubelet_|workqueue_|apiserver_|coredns_)(.*)$$
+            include: ^(kube_|container_|kubernetes_|kubelet_|workqueue_|apiserver_|coredns_|etcd_)(.*)$$
             match_type: regexp
             new_name: k8s.$${1}$${2}
         metricstransform/rename-otel:

--- a/deploy/helm/tests/__snapshot__/metrics-collector-config-map_test.yaml.snap
+++ b/deploy/helm/tests/__snapshot__/metrics-collector-config-map_test.yaml.snap
@@ -1603,7 +1603,7 @@ Metrics config should match snapshot when fargate is enabled:
         metricstransform/rename:
           transforms:
           - action: update
-            include: ^(kube_|container_|kubernetes_|kubelet_|workqueue_|apiserver_|coredns_)(.*)$$
+            include: ^(kube_|container_|kubernetes_|kubelet_|workqueue_|apiserver_|coredns_|etcd_)(.*)$$
             match_type: regexp
             new_name: k8s.$${1}$${2}
         metricstransform/rename-otel:
@@ -3853,7 +3853,7 @@ Metrics config should match snapshot when using Prometheus url with extra_scrape
         metricstransform/rename:
           transforms:
           - action: update
-            include: ^(kube_|container_|kubernetes_|kubelet_|workqueue_|apiserver_|coredns_)(.*)$$
+            include: ^(kube_|container_|kubernetes_|kubelet_|workqueue_|apiserver_|coredns_|etcd_)(.*)$$
             match_type: regexp
             new_name: k8s.$${1}$${2}
         metricstransform/rename-otel:
@@ -6045,7 +6045,7 @@ Metrics config should match snapshot when using default values:
         metricstransform/rename:
           transforms:
           - action: update
-            include: ^(kube_|container_|kubernetes_|kubelet_|workqueue_|apiserver_|coredns_)(.*)$$
+            include: ^(kube_|container_|kubernetes_|kubelet_|workqueue_|apiserver_|coredns_|etcd_)(.*)$$
             match_type: regexp
             new_name: k8s.$${1}$${2}
         metricstransform/rename-otel:

--- a/deploy/helm/tests/__snapshot__/node-collector-config-map-windows_test.yaml.snap
+++ b/deploy/helm/tests/__snapshot__/node-collector-config-map-windows_test.yaml.snap
@@ -255,6 +255,21 @@ Node collector config for windows nodes should match snapshot when using default
         metricstransform/istio-metrics:
           transforms:
           - action: insert
+            include: k8s.istio_request_bytes_sum
+            new_name: k8s.istio_request_bytes.rate
+          - action: insert
+            include: k8s.istio_response_bytes_sum
+            new_name: k8s.istio_response_bytes.rate
+          - action: insert
+            include: k8s.istio_requests_total
+            new_name: k8s.istio_requests.rate
+          - action: insert
+            include: k8s.istio_tcp_sent_bytes_total
+            new_name: k8s.istio_tcp_sent_bytes.rate
+          - action: insert
+            include: k8s.istio_tcp_received_bytes_total
+            new_name: k8s.istio_tcp_received_bytes.rate
+          - action: insert
             include: k8s.istio_request_bytes.rate
             new_name: k8s.istio_request_bytes.delta
           - action: insert
@@ -703,6 +718,12 @@ Node collector config for windows nodes should match snapshot when using default
             include: ^(.*)$$
             match_type: regexp
             new_name: k8s.$${1}
+        metricstransform/rename/discovery:
+          transforms:
+          - action: update
+            include: ^(.*)$$
+            match_type: regexp
+            new_name: k8s.$${1}
         resource/all:
           attributes:
           - action: insert
@@ -896,11 +917,6 @@ Node collector config for windows nodes should match snapshot when using default
             - extract_sum_metric(true) where (name == "k8s.istio_request_bytes" or name
               == "k8s.istio_response_bytes" or name == "k8s.istio_request_duration_milliseconds")
             - extract_count_metric(true) where (name == "k8s.istio_request_duration_milliseconds")
-            - set(name, "k8s.istio_request_bytes.rate") where name == "k8s.istio_request_bytes_sum"
-            - set(name, "k8s.istio_response_bytes.rate") where name == "k8s.istio_response_bytes_sum"
-            - set(name, "k8s.istio_requests.rate") where name == "k8s.istio_requests_total"
-            - set(name, "k8s.istio_tcp_sent_bytes.rate") where name == "k8s.istio_tcp_sent_bytes_total"
-            - set(name, "k8s.istio_tcp_received_bytes.rate") where name == "k8s.istio_tcp_received_bytes_total"
             - set(name, "k8s.istio_request_duration_milliseconds_sum_temp") where name ==
               "k8s.istio_request_duration_milliseconds_sum"
             - set(name, "k8s.istio_request_duration_milliseconds_count_temp") where name
@@ -1075,7 +1091,7 @@ Node collector config for windows nodes should match snapshot when using default
             - forward/metric-exporter
             processors:
             - memory_limiter
-            - metricstransform/rename
+            - metricstransform/rename/discovery
             - transform/istio-metrics
             - metricstransform/istio-metrics
             - cumulativetodelta/istio-metrics
@@ -1380,6 +1396,21 @@ Node collector config for windows nodes should match snapshot when using legacy 
         metricstransform/istio-metrics:
           transforms:
           - action: insert
+            include: k8s.istio_request_bytes_sum
+            new_name: k8s.istio_request_bytes.rate
+          - action: insert
+            include: k8s.istio_response_bytes_sum
+            new_name: k8s.istio_response_bytes.rate
+          - action: insert
+            include: k8s.istio_requests_total
+            new_name: k8s.istio_requests.rate
+          - action: insert
+            include: k8s.istio_tcp_sent_bytes_total
+            new_name: k8s.istio_tcp_sent_bytes.rate
+          - action: insert
+            include: k8s.istio_tcp_received_bytes_total
+            new_name: k8s.istio_tcp_received_bytes.rate
+          - action: insert
             include: k8s.istio_request_bytes.rate
             new_name: k8s.istio_request_bytes.delta
           - action: insert
@@ -1828,6 +1859,12 @@ Node collector config for windows nodes should match snapshot when using legacy 
             include: ^(.*)$$
             match_type: regexp
             new_name: k8s.$${1}
+        metricstransform/rename/discovery:
+          transforms:
+          - action: update
+            include: ^(.*)$$
+            match_type: regexp
+            new_name: k8s.$${1}
         resource/all:
           attributes:
           - action: insert
@@ -2021,11 +2058,6 @@ Node collector config for windows nodes should match snapshot when using legacy 
             - extract_sum_metric(true) where (name == "k8s.istio_request_bytes" or name
               == "k8s.istio_response_bytes" or name == "k8s.istio_request_duration_milliseconds")
             - extract_count_metric(true) where (name == "k8s.istio_request_duration_milliseconds")
-            - set(name, "k8s.istio_request_bytes.rate") where name == "k8s.istio_request_bytes_sum"
-            - set(name, "k8s.istio_response_bytes.rate") where name == "k8s.istio_response_bytes_sum"
-            - set(name, "k8s.istio_requests.rate") where name == "k8s.istio_requests_total"
-            - set(name, "k8s.istio_tcp_sent_bytes.rate") where name == "k8s.istio_tcp_sent_bytes_total"
-            - set(name, "k8s.istio_tcp_received_bytes.rate") where name == "k8s.istio_tcp_received_bytes_total"
             - set(name, "k8s.istio_request_duration_milliseconds_sum_temp") where name ==
               "k8s.istio_request_duration_milliseconds_sum"
             - set(name, "k8s.istio_request_duration_milliseconds_count_temp") where name
@@ -2274,7 +2306,7 @@ Node collector config for windows nodes should match snapshot when using legacy 
             - forward/metric-exporter
             processors:
             - memory_limiter
-            - metricstransform/rename
+            - metricstransform/rename/discovery
             - transform/istio-metrics
             - metricstransform/istio-metrics
             - cumulativetodelta/istio-metrics

--- a/deploy/helm/tests/__snapshot__/node-collector-config-map-windows_test.yaml.snap
+++ b/deploy/helm/tests/__snapshot__/node-collector-config-map-windows_test.yaml.snap
@@ -967,6 +967,28 @@ Node collector config for windows nodes should match snapshot when using default
           storage: file_storage/checkpoints
         receiver_creator/discovery:
           receivers:
+            prometheus/controller-manager:
+              config:
+                config:
+                  scrape_configs:
+                  - authorization:
+                      credentials_file: /var/run/secrets/kubernetes.io/serviceaccount/token
+                      type: Bearer
+                    enable_http2: true
+                    follow_redirects: true
+                    honor_labels: true
+                    honor_timestamps: false
+                    job_name: kubernetes-controller-manager
+                    metrics_path: /metrics
+                    scheme: https
+                    scrape_interval: 60s
+                    static_configs:
+                    - targets:
+                      - '`endpoint`:10257'
+                    tls_config:
+                      ca_file: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+                      insecure_skip_verify: true
+              rule: type == "pod" && labels["component"] == "kube-controller-manager"
             prometheus/discovery/http:
               config:
                 config:
@@ -1009,6 +1031,28 @@ Node collector config for windows nodes should match snapshot when using default
                       insecure_skip_verify: true
               rule: type == "pod" && annotations["prometheus.io/scrape"] == "true" && annotations["prometheus.io/scheme"]
                 == "https"
+            prometheus/etcd:
+              config:
+                config:
+                  scrape_configs:
+                  - authorization:
+                      credentials_file: /var/run/secrets/kubernetes.io/serviceaccount/token
+                      type: Bearer
+                    enable_http2: true
+                    follow_redirects: true
+                    honor_labels: true
+                    honor_timestamps: false
+                    job_name: kubernetes-etcd
+                    metrics_path: /metrics
+                    scheme: http
+                    scrape_interval: 60s
+                    static_configs:
+                    - targets:
+                      - '`endpoint`:2379'
+                    tls_config:
+                      ca_file: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+                      insecure_skip_verify: true
+              rule: type == "pod" && labels["component"] == "etcd"
           watch_observers:
           - k8s_observer
         receiver_creator/node:
@@ -2181,6 +2225,28 @@ Node collector config for windows nodes should match snapshot when using legacy 
           storage: file_storage/checkpoints
         receiver_creator/discovery:
           receivers:
+            prometheus/controller-manager:
+              config:
+                config:
+                  scrape_configs:
+                  - authorization:
+                      credentials_file: /var/run/secrets/kubernetes.io/serviceaccount/token
+                      type: Bearer
+                    enable_http2: true
+                    follow_redirects: true
+                    honor_labels: true
+                    honor_timestamps: false
+                    job_name: kubernetes-controller-manager
+                    metrics_path: /metrics
+                    scheme: https
+                    scrape_interval: 60s
+                    static_configs:
+                    - targets:
+                      - '`endpoint`:10257'
+                    tls_config:
+                      ca_file: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+                      insecure_skip_verify: true
+              rule: type == "pod" && labels["component"] == "kube-controller-manager"
             prometheus/discovery/http:
               config:
                 config:
@@ -2223,6 +2289,28 @@ Node collector config for windows nodes should match snapshot when using legacy 
                       insecure_skip_verify: true
               rule: type == "pod" && annotations["prometheus.io/scrape"] == "true" && annotations["prometheus.io/scheme"]
                 == "https"
+            prometheus/etcd:
+              config:
+                config:
+                  scrape_configs:
+                  - authorization:
+                      credentials_file: /var/run/secrets/kubernetes.io/serviceaccount/token
+                      type: Bearer
+                    enable_http2: true
+                    follow_redirects: true
+                    honor_labels: true
+                    honor_timestamps: false
+                    job_name: kubernetes-etcd
+                    metrics_path: /metrics
+                    scheme: http
+                    scrape_interval: 60s
+                    static_configs:
+                    - targets:
+                      - '`endpoint`:2379'
+                    tls_config:
+                      ca_file: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+                      insecure_skip_verify: true
+              rule: type == "pod" && labels["component"] == "etcd"
           watch_observers:
           - k8s_observer
         receiver_creator/node:

--- a/deploy/helm/tests/__snapshot__/node-collector-config-map_test.yaml.snap
+++ b/deploy/helm/tests/__snapshot__/node-collector-config-map_test.yaml.snap
@@ -990,6 +990,28 @@ Custom logs filter with new syntax:
           - containerd
         receiver_creator/discovery:
           receivers:
+            prometheus/controller-manager:
+              config:
+                config:
+                  scrape_configs:
+                  - authorization:
+                      credentials_file: /var/run/secrets/kubernetes.io/serviceaccount/token
+                      type: Bearer
+                    enable_http2: true
+                    follow_redirects: true
+                    honor_labels: true
+                    honor_timestamps: false
+                    job_name: kubernetes-controller-manager
+                    metrics_path: /metrics
+                    scheme: https
+                    scrape_interval: 60s
+                    static_configs:
+                    - targets:
+                      - '`endpoint`:10257'
+                    tls_config:
+                      ca_file: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+                      insecure_skip_verify: true
+              rule: type == "pod" && labels["component"] == "kube-controller-manager"
             prometheus/discovery/http:
               config:
                 config:
@@ -1032,6 +1054,28 @@ Custom logs filter with new syntax:
                       insecure_skip_verify: true
               rule: type == "pod" && annotations["prometheus.io/scrape"] == "true" && annotations["prometheus.io/scheme"]
                 == "https"
+            prometheus/etcd:
+              config:
+                config:
+                  scrape_configs:
+                  - authorization:
+                      credentials_file: /var/run/secrets/kubernetes.io/serviceaccount/token
+                      type: Bearer
+                    enable_http2: true
+                    follow_redirects: true
+                    honor_labels: true
+                    honor_timestamps: false
+                    job_name: kubernetes-etcd
+                    metrics_path: /metrics
+                    scheme: http
+                    scrape_interval: 60s
+                    static_configs:
+                    - targets:
+                      - '`endpoint`:2379'
+                    tls_config:
+                      ca_file: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+                      insecure_skip_verify: true
+              rule: type == "pod" && labels["component"] == "etcd"
           watch_observers:
           - k8s_observer
         receiver_creator/node:
@@ -2241,6 +2285,28 @@ Custom logs filter with old syntax:
           - containerd
         receiver_creator/discovery:
           receivers:
+            prometheus/controller-manager:
+              config:
+                config:
+                  scrape_configs:
+                  - authorization:
+                      credentials_file: /var/run/secrets/kubernetes.io/serviceaccount/token
+                      type: Bearer
+                    enable_http2: true
+                    follow_redirects: true
+                    honor_labels: true
+                    honor_timestamps: false
+                    job_name: kubernetes-controller-manager
+                    metrics_path: /metrics
+                    scheme: https
+                    scrape_interval: 60s
+                    static_configs:
+                    - targets:
+                      - '`endpoint`:10257'
+                    tls_config:
+                      ca_file: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+                      insecure_skip_verify: true
+              rule: type == "pod" && labels["component"] == "kube-controller-manager"
             prometheus/discovery/http:
               config:
                 config:
@@ -2283,6 +2349,28 @@ Custom logs filter with old syntax:
                       insecure_skip_verify: true
               rule: type == "pod" && annotations["prometheus.io/scrape"] == "true" && annotations["prometheus.io/scheme"]
                 == "https"
+            prometheus/etcd:
+              config:
+                config:
+                  scrape_configs:
+                  - authorization:
+                      credentials_file: /var/run/secrets/kubernetes.io/serviceaccount/token
+                      type: Bearer
+                    enable_http2: true
+                    follow_redirects: true
+                    honor_labels: true
+                    honor_timestamps: false
+                    job_name: kubernetes-etcd
+                    metrics_path: /metrics
+                    scheme: http
+                    scrape_interval: 60s
+                    static_configs:
+                    - targets:
+                      - '`endpoint`:2379'
+                    tls_config:
+                      ca_file: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+                      insecure_skip_verify: true
+              rule: type == "pod" && labels["component"] == "etcd"
           watch_observers:
           - k8s_observer
         receiver_creator/node:
@@ -3402,6 +3490,10 @@ Node collector config should match snapshot when autodiscovery is disabled:
           - kubelet
           - docker
           - containerd
+        receiver_creator/discovery:
+          receivers: null
+          watch_observers:
+          - k8s_observer
         receiver_creator/node:
           receivers:
             prometheus/node:
@@ -4502,6 +4594,28 @@ Node collector config should match snapshot when fargate is enabled:
           - containerd
         receiver_creator/discovery:
           receivers:
+            prometheus/controller-manager:
+              config:
+                config:
+                  scrape_configs:
+                  - authorization:
+                      credentials_file: /var/run/secrets/kubernetes.io/serviceaccount/token
+                      type: Bearer
+                    enable_http2: true
+                    follow_redirects: true
+                    honor_labels: true
+                    honor_timestamps: false
+                    job_name: kubernetes-controller-manager
+                    metrics_path: /metrics
+                    scheme: https
+                    scrape_interval: 60s
+                    static_configs:
+                    - targets:
+                      - '`endpoint`:10257'
+                    tls_config:
+                      ca_file: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+                      insecure_skip_verify: true
+              rule: type == "pod" && labels["component"] == "kube-controller-manager"
             prometheus/discovery/http:
               config:
                 config:
@@ -4544,6 +4658,28 @@ Node collector config should match snapshot when fargate is enabled:
                       insecure_skip_verify: true
               rule: type == "pod" && annotations["prometheus.io/scrape"] == "true" && annotations["prometheus.io/scheme"]
                 == "https"
+            prometheus/etcd:
+              config:
+                config:
+                  scrape_configs:
+                  - authorization:
+                      credentials_file: /var/run/secrets/kubernetes.io/serviceaccount/token
+                      type: Bearer
+                    enable_http2: true
+                    follow_redirects: true
+                    honor_labels: true
+                    honor_timestamps: false
+                    job_name: kubernetes-etcd
+                    metrics_path: /metrics
+                    scheme: http
+                    scrape_interval: 60s
+                    static_configs:
+                    - targets:
+                      - '`endpoint`:2379'
+                    tls_config:
+                      ca_file: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+                      insecure_skip_verify: true
+              rule: type == "pod" && labels["component"] == "etcd"
           watch_observers:
           - k8s_observer
       service:
@@ -5593,6 +5729,10 @@ Node collector config should match snapshot when fargate is enabled and autodisc
           - kubelet
           - docker
           - containerd
+        receiver_creator/discovery:
+          receivers: null
+          watch_observers:
+          - k8s_observer
       service:
         extensions:
         - file_storage/checkpoints
@@ -6624,6 +6764,28 @@ Node collector config should match snapshot when using default values:
           - containerd
         receiver_creator/discovery:
           receivers:
+            prometheus/controller-manager:
+              config:
+                config:
+                  scrape_configs:
+                  - authorization:
+                      credentials_file: /var/run/secrets/kubernetes.io/serviceaccount/token
+                      type: Bearer
+                    enable_http2: true
+                    follow_redirects: true
+                    honor_labels: true
+                    honor_timestamps: false
+                    job_name: kubernetes-controller-manager
+                    metrics_path: /metrics
+                    scheme: https
+                    scrape_interval: 60s
+                    static_configs:
+                    - targets:
+                      - '`endpoint`:10257'
+                    tls_config:
+                      ca_file: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+                      insecure_skip_verify: true
+              rule: type == "pod" && labels["component"] == "kube-controller-manager"
             prometheus/discovery/http:
               config:
                 config:
@@ -6666,6 +6828,28 @@ Node collector config should match snapshot when using default values:
                       insecure_skip_verify: true
               rule: type == "pod" && annotations["prometheus.io/scrape"] == "true" && annotations["prometheus.io/scheme"]
                 == "https"
+            prometheus/etcd:
+              config:
+                config:
+                  scrape_configs:
+                  - authorization:
+                      credentials_file: /var/run/secrets/kubernetes.io/serviceaccount/token
+                      type: Bearer
+                    enable_http2: true
+                    follow_redirects: true
+                    honor_labels: true
+                    honor_timestamps: false
+                    job_name: kubernetes-etcd
+                    metrics_path: /metrics
+                    scheme: http
+                    scrape_interval: 60s
+                    static_configs:
+                    - targets:
+                      - '`endpoint`:2379'
+                    tls_config:
+                      ca_file: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+                      insecure_skip_verify: true
+              rule: type == "pod" && labels["component"] == "etcd"
           watch_observers:
           - k8s_observer
         receiver_creator/node:

--- a/deploy/helm/tests/__snapshot__/node-collector-config-map_test.yaml.snap
+++ b/deploy/helm/tests/__snapshot__/node-collector-config-map_test.yaml.snap
@@ -259,6 +259,21 @@ Custom logs filter with new syntax:
         metricstransform/istio-metrics:
           transforms:
           - action: insert
+            include: k8s.istio_request_bytes_sum
+            new_name: k8s.istio_request_bytes.rate
+          - action: insert
+            include: k8s.istio_response_bytes_sum
+            new_name: k8s.istio_response_bytes.rate
+          - action: insert
+            include: k8s.istio_requests_total
+            new_name: k8s.istio_requests.rate
+          - action: insert
+            include: k8s.istio_tcp_sent_bytes_total
+            new_name: k8s.istio_tcp_sent_bytes.rate
+          - action: insert
+            include: k8s.istio_tcp_received_bytes_total
+            new_name: k8s.istio_tcp_received_bytes.rate
+          - action: insert
             include: k8s.istio_request_bytes.rate
             new_name: k8s.istio_request_bytes.delta
           - action: insert
@@ -707,6 +722,12 @@ Custom logs filter with new syntax:
             include: ^(.*)$$
             match_type: regexp
             new_name: k8s.$${1}
+        metricstransform/rename/discovery:
+          transforms:
+          - action: update
+            include: ^(.*)$$
+            match_type: regexp
+            new_name: k8s.$${1}
         resource/all:
           attributes:
           - action: insert
@@ -920,11 +941,6 @@ Custom logs filter with new syntax:
             - extract_sum_metric(true) where (name == "k8s.istio_request_bytes" or name
               == "k8s.istio_response_bytes" or name == "k8s.istio_request_duration_milliseconds")
             - extract_count_metric(true) where (name == "k8s.istio_request_duration_milliseconds")
-            - set(name, "k8s.istio_request_bytes.rate") where name == "k8s.istio_request_bytes_sum"
-            - set(name, "k8s.istio_response_bytes.rate") where name == "k8s.istio_response_bytes_sum"
-            - set(name, "k8s.istio_requests.rate") where name == "k8s.istio_requests_total"
-            - set(name, "k8s.istio_tcp_sent_bytes.rate") where name == "k8s.istio_tcp_sent_bytes_total"
-            - set(name, "k8s.istio_tcp_received_bytes.rate") where name == "k8s.istio_tcp_received_bytes_total"
             - set(name, "k8s.istio_request_duration_milliseconds_sum_temp") where name ==
               "k8s.istio_request_duration_milliseconds_sum"
             - set(name, "k8s.istio_request_duration_milliseconds_count_temp") where name
@@ -1108,7 +1124,7 @@ Custom logs filter with new syntax:
             - forward/metric-exporter
             processors:
             - memory_limiter
-            - metricstransform/rename
+            - metricstransform/rename/discovery
             - transform/istio-metrics
             - metricstransform/istio-metrics
             - cumulativetodelta/istio-metrics
@@ -1413,6 +1429,21 @@ Custom logs filter with old syntax:
         metricstransform/istio-metrics:
           transforms:
           - action: insert
+            include: k8s.istio_request_bytes_sum
+            new_name: k8s.istio_request_bytes.rate
+          - action: insert
+            include: k8s.istio_response_bytes_sum
+            new_name: k8s.istio_response_bytes.rate
+          - action: insert
+            include: k8s.istio_requests_total
+            new_name: k8s.istio_requests.rate
+          - action: insert
+            include: k8s.istio_tcp_sent_bytes_total
+            new_name: k8s.istio_tcp_sent_bytes.rate
+          - action: insert
+            include: k8s.istio_tcp_received_bytes_total
+            new_name: k8s.istio_tcp_received_bytes.rate
+          - action: insert
             include: k8s.istio_request_bytes.rate
             new_name: k8s.istio_request_bytes.delta
           - action: insert
@@ -1861,6 +1892,12 @@ Custom logs filter with old syntax:
             include: ^(.*)$$
             match_type: regexp
             new_name: k8s.$${1}
+        metricstransform/rename/discovery:
+          transforms:
+          - action: update
+            include: ^(.*)$$
+            match_type: regexp
+            new_name: k8s.$${1}
         resource/all:
           attributes:
           - action: insert
@@ -2074,11 +2111,6 @@ Custom logs filter with old syntax:
             - extract_sum_metric(true) where (name == "k8s.istio_request_bytes" or name
               == "k8s.istio_response_bytes" or name == "k8s.istio_request_duration_milliseconds")
             - extract_count_metric(true) where (name == "k8s.istio_request_duration_milliseconds")
-            - set(name, "k8s.istio_request_bytes.rate") where name == "k8s.istio_request_bytes_sum"
-            - set(name, "k8s.istio_response_bytes.rate") where name == "k8s.istio_response_bytes_sum"
-            - set(name, "k8s.istio_requests.rate") where name == "k8s.istio_requests_total"
-            - set(name, "k8s.istio_tcp_sent_bytes.rate") where name == "k8s.istio_tcp_sent_bytes_total"
-            - set(name, "k8s.istio_tcp_received_bytes.rate") where name == "k8s.istio_tcp_received_bytes_total"
             - set(name, "k8s.istio_request_duration_milliseconds_sum_temp") where name ==
               "k8s.istio_request_duration_milliseconds_sum"
             - set(name, "k8s.istio_request_duration_milliseconds_count_temp") where name
@@ -2343,7 +2375,7 @@ Custom logs filter with old syntax:
             - forward/metric-exporter
             processors:
             - memory_limiter
-            - metricstransform/rename
+            - metricstransform/rename/discovery
             - transform/istio-metrics
             - metricstransform/istio-metrics
             - cumulativetodelta/istio-metrics
@@ -2641,6 +2673,21 @@ Node collector config should match snapshot when autodiscovery is disabled:
         metricstransform/istio-metrics:
           transforms:
           - action: insert
+            include: k8s.istio_request_bytes_sum
+            new_name: k8s.istio_request_bytes.rate
+          - action: insert
+            include: k8s.istio_response_bytes_sum
+            new_name: k8s.istio_response_bytes.rate
+          - action: insert
+            include: k8s.istio_requests_total
+            new_name: k8s.istio_requests.rate
+          - action: insert
+            include: k8s.istio_tcp_sent_bytes_total
+            new_name: k8s.istio_tcp_sent_bytes.rate
+          - action: insert
+            include: k8s.istio_tcp_received_bytes_total
+            new_name: k8s.istio_tcp_received_bytes.rate
+          - action: insert
             include: k8s.istio_request_bytes.rate
             new_name: k8s.istio_request_bytes.delta
           - action: insert
@@ -3089,6 +3136,12 @@ Node collector config should match snapshot when autodiscovery is disabled:
             include: ^(.*)$$
             match_type: regexp
             new_name: k8s.$${1}
+        metricstransform/rename/discovery:
+          transforms:
+          - action: update
+            include: ^(.*)$$
+            match_type: regexp
+            new_name: k8s.$${1}
         resource/all:
           attributes:
           - action: insert
@@ -3302,11 +3355,6 @@ Node collector config should match snapshot when autodiscovery is disabled:
             - extract_sum_metric(true) where (name == "k8s.istio_request_bytes" or name
               == "k8s.istio_response_bytes" or name == "k8s.istio_request_duration_milliseconds")
             - extract_count_metric(true) where (name == "k8s.istio_request_duration_milliseconds")
-            - set(name, "k8s.istio_request_bytes.rate") where name == "k8s.istio_request_bytes_sum"
-            - set(name, "k8s.istio_response_bytes.rate") where name == "k8s.istio_response_bytes_sum"
-            - set(name, "k8s.istio_requests.rate") where name == "k8s.istio_requests_total"
-            - set(name, "k8s.istio_tcp_sent_bytes.rate") where name == "k8s.istio_tcp_sent_bytes_total"
-            - set(name, "k8s.istio_tcp_received_bytes.rate") where name == "k8s.istio_tcp_received_bytes_total"
             - set(name, "k8s.istio_request_duration_milliseconds_sum_temp") where name ==
               "k8s.istio_request_duration_milliseconds_sum"
             - set(name, "k8s.istio_request_duration_milliseconds_count_temp") where name
@@ -3723,6 +3771,21 @@ Node collector config should match snapshot when fargate is enabled:
         metricstransform/istio-metrics:
           transforms:
           - action: insert
+            include: k8s.istio_request_bytes_sum
+            new_name: k8s.istio_request_bytes.rate
+          - action: insert
+            include: k8s.istio_response_bytes_sum
+            new_name: k8s.istio_response_bytes.rate
+          - action: insert
+            include: k8s.istio_requests_total
+            new_name: k8s.istio_requests.rate
+          - action: insert
+            include: k8s.istio_tcp_sent_bytes_total
+            new_name: k8s.istio_tcp_sent_bytes.rate
+          - action: insert
+            include: k8s.istio_tcp_received_bytes_total
+            new_name: k8s.istio_tcp_received_bytes.rate
+          - action: insert
             include: k8s.istio_request_bytes.rate
             new_name: k8s.istio_request_bytes.delta
           - action: insert
@@ -4171,6 +4234,12 @@ Node collector config should match snapshot when fargate is enabled:
             include: ^(.*)$$
             match_type: regexp
             new_name: k8s.$${1}
+        metricstransform/rename/discovery:
+          transforms:
+          - action: update
+            include: ^(.*)$$
+            match_type: regexp
+            new_name: k8s.$${1}
         resource/all:
           attributes:
           - action: insert
@@ -4384,11 +4453,6 @@ Node collector config should match snapshot when fargate is enabled:
             - extract_sum_metric(true) where (name == "k8s.istio_request_bytes" or name
               == "k8s.istio_response_bytes" or name == "k8s.istio_request_duration_milliseconds")
             - extract_count_metric(true) where (name == "k8s.istio_request_duration_milliseconds")
-            - set(name, "k8s.istio_request_bytes.rate") where name == "k8s.istio_request_bytes_sum"
-            - set(name, "k8s.istio_response_bytes.rate") where name == "k8s.istio_response_bytes_sum"
-            - set(name, "k8s.istio_requests.rate") where name == "k8s.istio_requests_total"
-            - set(name, "k8s.istio_tcp_sent_bytes.rate") where name == "k8s.istio_tcp_sent_bytes_total"
-            - set(name, "k8s.istio_tcp_received_bytes.rate") where name == "k8s.istio_tcp_received_bytes_total"
             - set(name, "k8s.istio_request_duration_milliseconds_sum_temp") where name ==
               "k8s.istio_request_duration_milliseconds_sum"
             - set(name, "k8s.istio_request_duration_milliseconds_count_temp") where name
@@ -4534,7 +4598,7 @@ Node collector config should match snapshot when fargate is enabled:
             - forward/metric-exporter
             processors:
             - memory_limiter
-            - metricstransform/rename
+            - metricstransform/rename/discovery
             - transform/istio-metrics
             - metricstransform/istio-metrics
             - cumulativetodelta/istio-metrics
@@ -4800,6 +4864,21 @@ Node collector config should match snapshot when fargate is enabled and autodisc
         metricstransform/istio-metrics:
           transforms:
           - action: insert
+            include: k8s.istio_request_bytes_sum
+            new_name: k8s.istio_request_bytes.rate
+          - action: insert
+            include: k8s.istio_response_bytes_sum
+            new_name: k8s.istio_response_bytes.rate
+          - action: insert
+            include: k8s.istio_requests_total
+            new_name: k8s.istio_requests.rate
+          - action: insert
+            include: k8s.istio_tcp_sent_bytes_total
+            new_name: k8s.istio_tcp_sent_bytes.rate
+          - action: insert
+            include: k8s.istio_tcp_received_bytes_total
+            new_name: k8s.istio_tcp_received_bytes.rate
+          - action: insert
             include: k8s.istio_request_bytes.rate
             new_name: k8s.istio_request_bytes.delta
           - action: insert
@@ -5248,6 +5327,12 @@ Node collector config should match snapshot when fargate is enabled and autodisc
             include: ^(.*)$$
             match_type: regexp
             new_name: k8s.$${1}
+        metricstransform/rename/discovery:
+          transforms:
+          - action: update
+            include: ^(.*)$$
+            match_type: regexp
+            new_name: k8s.$${1}
         resource/all:
           attributes:
           - action: insert
@@ -5461,11 +5546,6 @@ Node collector config should match snapshot when fargate is enabled and autodisc
             - extract_sum_metric(true) where (name == "k8s.istio_request_bytes" or name
               == "k8s.istio_response_bytes" or name == "k8s.istio_request_duration_milliseconds")
             - extract_count_metric(true) where (name == "k8s.istio_request_duration_milliseconds")
-            - set(name, "k8s.istio_request_bytes.rate") where name == "k8s.istio_request_bytes_sum"
-            - set(name, "k8s.istio_response_bytes.rate") where name == "k8s.istio_response_bytes_sum"
-            - set(name, "k8s.istio_requests.rate") where name == "k8s.istio_requests_total"
-            - set(name, "k8s.istio_tcp_sent_bytes.rate") where name == "k8s.istio_tcp_sent_bytes_total"
-            - set(name, "k8s.istio_tcp_received_bytes.rate") where name == "k8s.istio_tcp_received_bytes_total"
             - set(name, "k8s.istio_request_duration_milliseconds_sum_temp") where name ==
               "k8s.istio_request_duration_milliseconds_sum"
             - set(name, "k8s.istio_request_duration_milliseconds_count_temp") where name
@@ -5813,6 +5893,21 @@ Node collector config should match snapshot when using default values:
         metricstransform/istio-metrics:
           transforms:
           - action: insert
+            include: k8s.istio_request_bytes_sum
+            new_name: k8s.istio_request_bytes.rate
+          - action: insert
+            include: k8s.istio_response_bytes_sum
+            new_name: k8s.istio_response_bytes.rate
+          - action: insert
+            include: k8s.istio_requests_total
+            new_name: k8s.istio_requests.rate
+          - action: insert
+            include: k8s.istio_tcp_sent_bytes_total
+            new_name: k8s.istio_tcp_sent_bytes.rate
+          - action: insert
+            include: k8s.istio_tcp_received_bytes_total
+            new_name: k8s.istio_tcp_received_bytes.rate
+          - action: insert
             include: k8s.istio_request_bytes.rate
             new_name: k8s.istio_request_bytes.delta
           - action: insert
@@ -6261,6 +6356,12 @@ Node collector config should match snapshot when using default values:
             include: ^(.*)$$
             match_type: regexp
             new_name: k8s.$${1}
+        metricstransform/rename/discovery:
+          transforms:
+          - action: update
+            include: ^(.*)$$
+            match_type: regexp
+            new_name: k8s.$${1}
         resource/all:
           attributes:
           - action: insert
@@ -6474,11 +6575,6 @@ Node collector config should match snapshot when using default values:
             - extract_sum_metric(true) where (name == "k8s.istio_request_bytes" or name
               == "k8s.istio_response_bytes" or name == "k8s.istio_request_duration_milliseconds")
             - extract_count_metric(true) where (name == "k8s.istio_request_duration_milliseconds")
-            - set(name, "k8s.istio_request_bytes.rate") where name == "k8s.istio_request_bytes_sum"
-            - set(name, "k8s.istio_response_bytes.rate") where name == "k8s.istio_response_bytes_sum"
-            - set(name, "k8s.istio_requests.rate") where name == "k8s.istio_requests_total"
-            - set(name, "k8s.istio_tcp_sent_bytes.rate") where name == "k8s.istio_tcp_sent_bytes_total"
-            - set(name, "k8s.istio_tcp_received_bytes.rate") where name == "k8s.istio_tcp_received_bytes_total"
             - set(name, "k8s.istio_request_duration_milliseconds_sum_temp") where name ==
               "k8s.istio_request_duration_milliseconds_sum"
             - set(name, "k8s.istio_request_duration_milliseconds_count_temp") where name
@@ -6661,7 +6757,7 @@ Node collector config should match snapshot when using default values:
             - forward/metric-exporter
             processors:
             - memory_limiter
-            - metricstransform/rename
+            - metricstransform/rename/discovery
             - transform/istio-metrics
             - metricstransform/istio-metrics
             - cumulativetodelta/istio-metrics

--- a/deploy/helm/values.schema.json
+++ b/deploy/helm/values.schema.json
@@ -889,6 +889,113 @@
                             },
                             "additionalProperties": false
                         },
+                        "control_plane": {
+                            "description": "Configuration for scraping control plane components' metrics.",
+                            "type": "object",
+                            "properties": {
+                            "coredns": {
+                                "type": "object",
+                                "description": "Configuration for scraping CoreDNS metrics.",
+                                "properties": {
+                                "enabled": {
+                                    "type": "boolean",
+                                    "description": "Enable or disable scraping of CoreDNS metrics."
+                                }
+                                },
+                                "additionalProperties": false
+                            },
+                            "controller_manager": {
+                                "type": "object",
+                                "description": "Configuration for scraping metrics from the controller manager.",
+                                "properties": {
+                                "enabled": {
+                                    "type": "boolean",
+                                    "description": "Enable or disable scraping of controller manager metrics."
+                                },
+                                "label_selector": {
+                                    "type": "object",
+                                    "description": "Label selector for identifying the controller manager pod.",
+                                    "properties": {
+                                    "key": {
+                                        "type": "string",
+                                        "description": "Key of the label used for selecting the pod."
+                                    },
+                                    "value": {
+                                        "type": "string",
+                                        "description": "Value of the label used for selecting the pod."
+                                    }
+                                    },
+                                    "additionalProperties": false
+                                },
+                                "scheme": {
+                                    "type": "string",
+                                    "description": "Scheme to access metrics (http or https)."
+                                },
+                                "metrics_path": {
+                                    "type": "string",
+                                    "description": "Path to metrics endpoint."
+                                },
+                                "port": {
+                                    "type": "integer",
+                                    "description": "Port for accessing controller manager metrics."
+                                }
+                                },
+                                "additionalProperties": false
+                            },
+                            "etcd": {
+                                "type": "object",
+                                "description": "Configuration for scraping etcd metrics.",
+                                "properties": {
+                                "enabled": {
+                                    "type": "boolean",
+                                    "description": "Enable or disable scraping of etcd metrics."
+                                },
+                                "scheme": {
+                                    "type": "string",
+                                    "description": "Scheme to access etcd metrics (http or https)."
+                                },
+                                "metrics_path": {
+                                    "type": "string",
+                                    "description": "Path to metrics endpoint."
+                                },
+                                "port": {
+                                    "type": "integer",
+                                    "description": "Port for accessing etcd metrics."
+                                },
+                                "scrape_kind": {
+                                    "type": "string",
+                                    "enum": ["static", "pod"],
+                                    "description": "Scrape kind for etcd: 'static' for static endpoints, 'pod' to scrape etcd pods in the cluster."
+                                },
+                                "label_selector": {
+                                    "type": "object",
+                                    "description": "Label selector for identifying etcd pods when using scrape_kind 'pod'.",
+                                    "properties": {
+                                    "key": {
+                                        "type": "string",
+                                        "description": "Key of the label used for selecting etcd pods."
+                                    },
+                                    "value": {
+                                        "type": "string",
+                                        "description": "Value of the label used for selecting etcd pods."
+                                    }
+                                    },
+                                    "additionalProperties": false
+                                },
+                                "static_endpoints": {
+                                    "type": "array",
+                                    "description": "List of static IP endpoints for scraping etcd metrics.",
+                                    "items": {
+                                    "type": "string",
+                                    "description": "Static IP endpoint (e.g., '10.240.0.32:2379')."
+                                    }
+                                }
+                                },
+                                "additionalProperties": false
+                            }
+                            },
+                            "additionalProperties": false
+                        },
                         "livenessProbe": {
                             "type": "object",
                             "properties": {

--- a/deploy/helm/values.schema.json
+++ b/deploy/helm/values.schema.json
@@ -846,6 +846,9 @@
                                         }
                                     },
                                     "additionalProperties": false
+                                },
+                                "prefix": {
+                                    "type": "string"
                                 }
                             },
                             "additionalProperties": false

--- a/deploy/helm/values.yaml
+++ b/deploy/helm/values.yaml
@@ -186,6 +186,46 @@ otel:
       # How often the metrics are scraped from Prometheus
       scrape_interval: 60s
 
+    control_plane:
+      coredns:
+        enabled: true
+
+      controller_manager:
+        enabled: true
+
+        label_selector:
+          key: "component"
+          value: "kube-controller-manager"
+        scheme: "https"
+        metrics_path: "/metrics"
+        port: 10257
+      etcd:
+        enabled: true
+
+        scheme: "http"
+        metrics_path: "/metrics"
+        port: 2379
+
+        # scrape kind can be either "static" or "pod"
+        # static - scrape etcd from static endpoints defined in static-endpoints
+        # pod - scrape etcd from etcd pods in the cluster (see label-selector configuration)
+        scrape_kind: "pod"
+
+        # label_selector is used to find etcd pods in the cluster
+        label_selector:
+          key: "component"
+          value: "etcd"
+
+        # If scrape_kind is set to "static" and endpoints are set etcd will be scraped from those ips
+        # this covers scenario where etcd is not running in k8s cluster
+        # example: 
+        # static_endpoints:
+        #   - 10.240.0.32:2379
+        #   - 10.240.0.33:2379
+        #   - 10.240.0.34:2379
+        static_endpoints: []
+      
+
     # This filter is applied after metric processing, it is the place where metrics could be filtered out
     # https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/processor/filterprocessor for configuration reference
     # With filter conditions we build a global blacklist. So if we exclude data, let's say by specific namespace,

--- a/deploy/helm/values.yaml
+++ b/deploy/helm/values.yaml
@@ -122,6 +122,9 @@ otel:
         # https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/processor/filterprocessor for configuration reference
         filter: {}
 
+      # Prefix that will be added to all metrics
+      prefix: "k8s."
+
     # Check if SWI OTEL endpoint is reachable
     swi_endpoint_check: true
 

--- a/skaffold.yaml
+++ b/skaffold.yaml
@@ -57,6 +57,11 @@ deploy:
                 scrape_interval: "15s"
               kube-state-metrics:
                 scrape_interval: "15s"
+              control_plane:
+                controller_manager:
+                  enabled: false
+                etcd:
+                  enabled: false
               k8s_instrumentation:
                 annotations:
                   # excluded annotations:

--- a/skaffold.yaml
+++ b/skaffold.yaml
@@ -83,6 +83,7 @@ deploy:
                       - rule: labels["app"] == "test-deployment"
                         metrics_path: "/custom_metrics"
                         endpoint_port: 8081
+                prefix: ""
             events:
               enabled: true
               sending_queue:

--- a/tests/integration/expected_telemetry/deployment_with_metric.json
+++ b/tests/integration/expected_telemetry/deployment_with_metric.json
@@ -1,6 +1,6 @@
 {
     "metrics": [
-        { "name": "k8s.test_metric_from_deployment" }
+        { "name": "test_metric_from_deployment" }
 ],
     "resource_attributes": [
         "sw.k8s.cluster.uid",

--- a/tests/integration/expected_telemetry/pod.json
+++ b/tests/integration/expected_telemetry/pod.json
@@ -21,7 +21,7 @@
         { "name": "k8s.kube_pod_status_ready" },
         { "name": "k8s.pod.containers" },
         { "name": "k8s.pod.containers.running" },
-        { "name": "k8s.test_metric_from_pod" }
+        { "name": "test_metric_from_pod" }
     ],
     "resource_attributes": [
         "sw.k8s.cluster.uid",


### PR DESCRIPTION
using `otel.metrics.autodiscovery.prefix` (default `k8s.`)

* Istio metrics that are created from original ones keep `k8s.` as those metrics are required for topology view
* etcd and kube-controller-manager metrics are scraped independently on autodiscovery. 
* There is list of required metrics, that will always have `k8s.` prefix. If autodiscovery prefix differs from `k8s.` those metrics are copied.
