### PR TITLE
Cert-manager metrics are enabled by default

### DIFF
--- a/deploy/helm/metrics-collector-config.yaml
+++ b/deploy/helm/metrics-collector-config.yaml
@@ -1146,7 +1146,7 @@ receivers:
             enable_http2: true
           relabel_configs:
           - source_labels: [__meta_kubernetes_service_label_app_kubernetes_io_instance, __meta_kubernetes_service_label_app_kubernetes_io_name]
-            regex: cert-manager;cert-manager
+            regex: cert-manager
             action: keep
 
 service:

--- a/deploy/helm/metrics-collector-config.yaml
+++ b/deploy/helm/metrics-collector-config.yaml
@@ -163,7 +163,7 @@ processors:
   metricstransform/rename:
     transforms:
       # add `k8s.` suffix to all metrics that are clearly provided by Kubernetes
-      - include: ^(kube_|container_|kubernetes_|kubelet_|workqueue_|apiserver_|coredns_)(.*)$$
+      - include: ^(kube_|container_|kubernetes_|kubelet_|workqueue_|apiserver_|coredns_|certmanager_)(.*)$$
         match_type: regexp
         action: update
         new_name: k8s.$${1}$${2}
@@ -942,7 +942,13 @@ processors:
           name == "coredns_dns_request_duration_seconds" or
           name == "coredns_cache_entries" or
           name == "coredns_cache_hits_total" or
-          name == "coredns_cache_misses_total"
+          name == "coredns_cache_misses_total" or
+          name == "certmanager_certificate_expiration_timestamp_seconds" or
+          name == "certmanager_certificate_ready_status" or
+          name == "certmanager_certificate_renewal_timestamp_seconds" or
+          name == "certmanager_clock_time_seconds" or
+          name == "certmanager_clock_time_seconds_gauge" or
+          name == "certmanager_controller_sync_call_count"
           )
   filter/histograms:
     metrics:
@@ -1115,6 +1121,18 @@ receivers:
           - source_labels: [__address__]
             target_label: scrape_job
             replacement: "kubernetes-coredns"
+        - job_name: cert-manager
+          honor_timestamps: false
+          scrape_interval: {{ quote .Values.otel.metrics.prometheus.scrape_interval }}
+          scrape_timeout: 10s
+          kubernetes_sd_configs:
+          - role: endpoints
+            follow_redirects: true
+            enable_http2: true
+          relabel_configs:
+          - source_labels: [__meta_kubernetes_service_label_app_kubernetes_io_instance, __meta_kubernetes_service_label_app_kubernetes_io_name]
+            regex: cert-manager;cert-manager
+            action: keep
 
 service:
   extensions:

--- a/deploy/helm/tests/__snapshot__/metrics-collector-config-map-fargate_test.yaml.snap
+++ b/deploy/helm/tests/__snapshot__/metrics-collector-config-map-fargate_test.yaml.snap
@@ -2138,7 +2138,7 @@ Metrics config should match snapshot when using default values:
                 role: endpoints
               relabel_configs:
               - action: keep
-                regex: cert-manager;cert-manager
+                regex: cert-manager
                 source_labels:
                 - __meta_kubernetes_service_label_app_kubernetes_io_instance
                 - __meta_kubernetes_service_label_app_kubernetes_io_name

--- a/deploy/helm/tests/__snapshot__/metrics-collector-config-map-fargate_test.yaml.snap
+++ b/deploy/helm/tests/__snapshot__/metrics-collector-config-map-fargate_test.yaml.snap
@@ -624,7 +624,13 @@ Metrics config should match snapshot when using default values:
               name == "coredns_dns_request_duration_seconds" or
               name == "coredns_cache_entries" or
               name == "coredns_cache_hits_total" or
-              name == "coredns_cache_misses_total"
+              name == "coredns_cache_misses_total" or
+              name == "certmanager_certificate_expiration_timestamp_seconds" or
+              name == "certmanager_certificate_ready_status" or
+              name == "certmanager_certificate_renewal_timestamp_seconds" or
+              name == "certmanager_clock_time_seconds" or
+              name == "certmanager_clock_time_seconds_gauge" or
+              name == "certmanager_controller_sync_call_count"
               )
         filter/receiver:
           metrics:
@@ -1603,7 +1609,7 @@ Metrics config should match snapshot when using default values:
         metricstransform/rename:
           transforms:
           - action: update
-            include: ^(kube_|container_|kubernetes_|kubelet_|workqueue_|apiserver_|coredns_)(.*)$$
+            include: ^(kube_|container_|kubernetes_|kubelet_|workqueue_|apiserver_|coredns_|certmanager_)(.*)$$
             match_type: regexp
             new_name: k8s.$${1}$${2}
         metricstransform/rename-otel:
@@ -2122,6 +2128,20 @@ Metrics config should match snapshot when using default values:
                 source_labels:
                 - __address__
                 target_label: scrape_job
+              scrape_interval: 60s
+              scrape_timeout: 10s
+            - honor_timestamps: false
+              job_name: cert-manager
+              kubernetes_sd_configs:
+              - enable_http2: true
+                follow_redirects: true
+                role: endpoints
+              relabel_configs:
+              - action: keep
+                regex: cert-manager;cert-manager
+                source_labels:
+                - __meta_kubernetes_service_label_app_kubernetes_io_instance
+                - __meta_kubernetes_service_label_app_kubernetes_io_name
               scrape_interval: 60s
               scrape_timeout: 10s
       service:

--- a/deploy/helm/tests/__snapshot__/metrics-collector-config-map_test.yaml.snap
+++ b/deploy/helm/tests/__snapshot__/metrics-collector-config-map_test.yaml.snap
@@ -2138,7 +2138,7 @@ Metrics config should match snapshot when fargate is enabled:
                 role: endpoints
               relabel_configs:
               - action: keep
-                regex: cert-manager;cert-manager
+                regex: cert-manager
                 source_labels:
                 - __meta_kubernetes_service_label_app_kubernetes_io_instance
                 - __meta_kubernetes_service_label_app_kubernetes_io_name
@@ -4328,7 +4328,7 @@ Metrics config should match snapshot when using Prometheus url with extra_scrape
                 role: endpoints
               relabel_configs:
               - action: keep
-                regex: cert-manager;cert-manager
+                regex: cert-manager
                 source_labels:
                 - __meta_kubernetes_service_label_app_kubernetes_io_instance
                 - __meta_kubernetes_service_label_app_kubernetes_io_name
@@ -6540,7 +6540,7 @@ Metrics config should match snapshot when using default values:
                 role: endpoints
               relabel_configs:
               - action: keep
-                regex: cert-manager;cert-manager
+                regex: cert-manager
                 source_labels:
                 - __meta_kubernetes_service_label_app_kubernetes_io_instance
                 - __meta_kubernetes_service_label_app_kubernetes_io_name

--- a/deploy/helm/tests/__snapshot__/metrics-collector-config-map_test.yaml.snap
+++ b/deploy/helm/tests/__snapshot__/metrics-collector-config-map_test.yaml.snap
@@ -624,7 +624,13 @@ Metrics config should match snapshot when fargate is enabled:
               name == "coredns_dns_request_duration_seconds" or
               name == "coredns_cache_entries" or
               name == "coredns_cache_hits_total" or
-              name == "coredns_cache_misses_total"
+              name == "coredns_cache_misses_total" or
+              name == "certmanager_certificate_expiration_timestamp_seconds" or
+              name == "certmanager_certificate_ready_status" or
+              name == "certmanager_certificate_renewal_timestamp_seconds" or
+              name == "certmanager_clock_time_seconds" or
+              name == "certmanager_clock_time_seconds_gauge" or
+              name == "certmanager_controller_sync_call_count"
               )
         filter/receiver:
           metrics:
@@ -1603,7 +1609,7 @@ Metrics config should match snapshot when fargate is enabled:
         metricstransform/rename:
           transforms:
           - action: update
-            include: ^(kube_|container_|kubernetes_|kubelet_|workqueue_|apiserver_|coredns_)(.*)$$
+            include: ^(kube_|container_|kubernetes_|kubelet_|workqueue_|apiserver_|coredns_|certmanager_)(.*)$$
             match_type: regexp
             new_name: k8s.$${1}$${2}
         metricstransform/rename-otel:
@@ -2122,6 +2128,20 @@ Metrics config should match snapshot when fargate is enabled:
                 source_labels:
                 - __address__
                 target_label: scrape_job
+              scrape_interval: 60s
+              scrape_timeout: 10s
+            - honor_timestamps: false
+              job_name: cert-manager
+              kubernetes_sd_configs:
+              - enable_http2: true
+                follow_redirects: true
+                role: endpoints
+              relabel_configs:
+              - action: keep
+                regex: cert-manager;cert-manager
+                source_labels:
+                - __meta_kubernetes_service_label_app_kubernetes_io_instance
+                - __meta_kubernetes_service_label_app_kubernetes_io_name
               scrape_interval: 60s
               scrape_timeout: 10s
       service:
@@ -2874,7 +2894,13 @@ Metrics config should match snapshot when using Prometheus url with extra_scrape
               name == "coredns_dns_request_duration_seconds" or
               name == "coredns_cache_entries" or
               name == "coredns_cache_hits_total" or
-              name == "coredns_cache_misses_total"
+              name == "coredns_cache_misses_total" or
+              name == "certmanager_certificate_expiration_timestamp_seconds" or
+              name == "certmanager_certificate_ready_status" or
+              name == "certmanager_certificate_renewal_timestamp_seconds" or
+              name == "certmanager_clock_time_seconds" or
+              name == "certmanager_clock_time_seconds_gauge" or
+              name == "certmanager_controller_sync_call_count"
               )
         filter/receiver:
           metrics:
@@ -3853,7 +3879,7 @@ Metrics config should match snapshot when using Prometheus url with extra_scrape
         metricstransform/rename:
           transforms:
           - action: update
-            include: ^(kube_|container_|kubernetes_|kubelet_|workqueue_|apiserver_|coredns_)(.*)$$
+            include: ^(kube_|container_|kubernetes_|kubelet_|workqueue_|apiserver_|coredns_|certmanager_)(.*)$$
             match_type: regexp
             new_name: k8s.$${1}$${2}
         metricstransform/rename-otel:
@@ -4292,6 +4318,20 @@ Metrics config should match snapshot when using Prometheus url with extra_scrape
                 source_labels:
                 - __address__
                 target_label: scrape_job
+              scrape_interval: 60s
+              scrape_timeout: 10s
+            - honor_timestamps: false
+              job_name: cert-manager
+              kubernetes_sd_configs:
+              - enable_http2: true
+                follow_redirects: true
+                role: endpoints
+              relabel_configs:
+              - action: keep
+                regex: cert-manager;cert-manager
+                source_labels:
+                - __meta_kubernetes_service_label_app_kubernetes_io_instance
+                - __meta_kubernetes_service_label_app_kubernetes_io_name
               scrape_interval: 60s
               scrape_timeout: 10s
         prometheus/prometheus-server:
@@ -5066,7 +5106,13 @@ Metrics config should match snapshot when using default values:
               name == "coredns_dns_request_duration_seconds" or
               name == "coredns_cache_entries" or
               name == "coredns_cache_hits_total" or
-              name == "coredns_cache_misses_total"
+              name == "coredns_cache_misses_total" or
+              name == "certmanager_certificate_expiration_timestamp_seconds" or
+              name == "certmanager_certificate_ready_status" or
+              name == "certmanager_certificate_renewal_timestamp_seconds" or
+              name == "certmanager_clock_time_seconds" or
+              name == "certmanager_clock_time_seconds_gauge" or
+              name == "certmanager_controller_sync_call_count"
               )
         filter/receiver:
           metrics:
@@ -6045,7 +6091,7 @@ Metrics config should match snapshot when using default values:
         metricstransform/rename:
           transforms:
           - action: update
-            include: ^(kube_|container_|kubernetes_|kubelet_|workqueue_|apiserver_|coredns_)(.*)$$
+            include: ^(kube_|container_|kubernetes_|kubelet_|workqueue_|apiserver_|coredns_|certmanager_)(.*)$$
             match_type: regexp
             new_name: k8s.$${1}$${2}
         metricstransform/rename-otel:
@@ -6484,6 +6530,20 @@ Metrics config should match snapshot when using default values:
                 source_labels:
                 - __address__
                 target_label: scrape_job
+              scrape_interval: 60s
+              scrape_timeout: 10s
+            - honor_timestamps: false
+              job_name: cert-manager
+              kubernetes_sd_configs:
+              - enable_http2: true
+                follow_redirects: true
+                role: endpoints
+              relabel_configs:
+              - action: keep
+                regex: cert-manager;cert-manager
+                source_labels:
+                - __meta_kubernetes_service_label_app_kubernetes_io_instance
+                - __meta_kubernetes_service_label_app_kubernetes_io_name
               scrape_interval: 60s
               scrape_timeout: 10s
       service:


### PR DESCRIPTION
## Summary

This PR enables [cert-manager](https://cert-manager.io/) metrics by default.