### PR TITLE
NH-94277: fixing scrape of etcd and controller manager with autodiscovery disabled

### DIFF
--- a/deploy/helm/Chart.yaml
+++ b/deploy/helm/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: swo-k8s-collector
-version: 4.2.0-alpha.8
+version: 4.2.0-alpha.9
 appVersion: 0.11.7
 description: SolarWinds Kubernetes Integration
 keywords:

--- a/deploy/helm/node-collector-config.yaml
+++ b/deploy/helm/node-collector-config.yaml
@@ -665,7 +665,7 @@ receivers:
       {{- end }}
       {{- end }}
     {{- end }}
-    
+
       {{- if .Values.otel.metrics.control_plane.controller_manager.enabled }}
       prometheus/controller-manager:
         rule: type == "pod" && labels[{{ quote $.Values.otel.metrics.control_plane.controller_manager.label_selector.key }}] == {{ quote $.Values.otel.metrics.control_plane.controller_manager.label_selector.value }}
@@ -678,6 +678,7 @@ receivers:
                 metrics_path: {{ quote .Values.otel.metrics.control_plane.controller_manager.metrics_path }}
                 honor_timestamps: false
                 honor_labels: true
+                {{- if eq .Values.otel.metrics.control_plane.controller_manager.scheme "https" }}
                 authorization:
                   type: Bearer
                   credentials_file: /var/run/secrets/kubernetes.io/serviceaccount/token
@@ -686,6 +687,7 @@ receivers:
                   insecure_skip_verify: true
                 follow_redirects: true
                 enable_http2: true
+                {{- end }}
                 static_configs:
                   - targets:
                       - '`endpoint`:{{ .Values.otel.metrics.control_plane.controller_manager.port }}'
@@ -703,6 +705,7 @@ receivers:
                 metrics_path: {{ quote .Values.otel.metrics.control_plane.etcd.metrics_path }}
                 honor_timestamps: false
                 honor_labels: true
+                {{- if eq .Values.otel.metrics.control_plane.etcd.scheme "https" }}
                 authorization:
                   type: Bearer
                   credentials_file: /var/run/secrets/kubernetes.io/serviceaccount/token
@@ -711,6 +714,7 @@ receivers:
                   insecure_skip_verify: true
                 follow_redirects: true
                 enable_http2: true
+                {{- end }}
                 static_configs:
                   - targets:
                       - '`endpoint`:{{ .Values.otel.metrics.control_plane.etcd.port }}'

--- a/deploy/helm/node-collector-config.yaml
+++ b/deploy/helm/node-collector-config.yaml
@@ -664,7 +664,8 @@ receivers:
       {{- end }}
       {{- end }}
       {{- end }}
-
+    {{- end }}
+    
       {{- if .Values.otel.metrics.control_plane.controller_manager.enabled }}
       prometheus/controller-manager:
         rule: type == "pod" && labels[{{ quote $.Values.otel.metrics.control_plane.controller_manager.label_selector.key }}] == {{ quote $.Values.otel.metrics.control_plane.controller_manager.label_selector.value }}
@@ -714,8 +715,6 @@ receivers:
                   - targets:
                       - '`endpoint`:{{ .Values.otel.metrics.control_plane.etcd.port }}'
       {{- end }}
-
-    {{- end }}
 {{- end }}
 
 {{- if and .Values.otel.metrics.enabled (not .Values.aws_fargate.enabled) }}

--- a/deploy/helm/tests/__snapshot__/node-collector-config-map-windows_test.yaml.snap
+++ b/deploy/helm/tests/__snapshot__/node-collector-config-map-windows_test.yaml.snap
@@ -1035,12 +1035,7 @@ Node collector config for windows nodes should match snapshot when using default
               config:
                 config:
                   scrape_configs:
-                  - authorization:
-                      credentials_file: /var/run/secrets/kubernetes.io/serviceaccount/token
-                      type: Bearer
-                    enable_http2: true
-                    follow_redirects: true
-                    honor_labels: true
+                  - honor_labels: true
                     honor_timestamps: false
                     job_name: kubernetes-etcd
                     metrics_path: /metrics
@@ -1049,9 +1044,6 @@ Node collector config for windows nodes should match snapshot when using default
                     static_configs:
                     - targets:
                       - '`endpoint`:2379'
-                    tls_config:
-                      ca_file: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
-                      insecure_skip_verify: true
               rule: type == "pod" && labels["component"] == "etcd"
           watch_observers:
           - k8s_observer
@@ -2293,12 +2285,7 @@ Node collector config for windows nodes should match snapshot when using legacy 
               config:
                 config:
                   scrape_configs:
-                  - authorization:
-                      credentials_file: /var/run/secrets/kubernetes.io/serviceaccount/token
-                      type: Bearer
-                    enable_http2: true
-                    follow_redirects: true
-                    honor_labels: true
+                  - honor_labels: true
                     honor_timestamps: false
                     job_name: kubernetes-etcd
                     metrics_path: /metrics
@@ -2307,9 +2294,6 @@ Node collector config for windows nodes should match snapshot when using legacy 
                     static_configs:
                     - targets:
                       - '`endpoint`:2379'
-                    tls_config:
-                      ca_file: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
-                      insecure_skip_verify: true
               rule: type == "pod" && labels["component"] == "etcd"
           watch_observers:
           - k8s_observer

--- a/deploy/helm/tests/__snapshot__/node-collector-config-map_test.yaml.snap
+++ b/deploy/helm/tests/__snapshot__/node-collector-config-map_test.yaml.snap
@@ -3491,7 +3491,51 @@ Node collector config should match snapshot when autodiscovery is disabled:
           - docker
           - containerd
         receiver_creator/discovery:
-          receivers: null
+          receivers:
+            prometheus/controller-manager:
+              config:
+                config:
+                  scrape_configs:
+                  - authorization:
+                      credentials_file: /var/run/secrets/kubernetes.io/serviceaccount/token
+                      type: Bearer
+                    enable_http2: true
+                    follow_redirects: true
+                    honor_labels: true
+                    honor_timestamps: false
+                    job_name: kubernetes-controller-manager
+                    metrics_path: /metrics
+                    scheme: https
+                    scrape_interval: 60s
+                    static_configs:
+                    - targets:
+                      - '`endpoint`:10257'
+                    tls_config:
+                      ca_file: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+                      insecure_skip_verify: true
+              rule: type == "pod" && labels["component"] == "kube-controller-manager"
+            prometheus/etcd:
+              config:
+                config:
+                  scrape_configs:
+                  - authorization:
+                      credentials_file: /var/run/secrets/kubernetes.io/serviceaccount/token
+                      type: Bearer
+                    enable_http2: true
+                    follow_redirects: true
+                    honor_labels: true
+                    honor_timestamps: false
+                    job_name: kubernetes-etcd
+                    metrics_path: /metrics
+                    scheme: http
+                    scrape_interval: 60s
+                    static_configs:
+                    - targets:
+                      - '`endpoint`:2379'
+                    tls_config:
+                      ca_file: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+                      insecure_skip_verify: true
+              rule: type == "pod" && labels["component"] == "etcd"
           watch_observers:
           - k8s_observer
         receiver_creator/node:
@@ -5730,7 +5774,51 @@ Node collector config should match snapshot when fargate is enabled and autodisc
           - docker
           - containerd
         receiver_creator/discovery:
-          receivers: null
+          receivers:
+            prometheus/controller-manager:
+              config:
+                config:
+                  scrape_configs:
+                  - authorization:
+                      credentials_file: /var/run/secrets/kubernetes.io/serviceaccount/token
+                      type: Bearer
+                    enable_http2: true
+                    follow_redirects: true
+                    honor_labels: true
+                    honor_timestamps: false
+                    job_name: kubernetes-controller-manager
+                    metrics_path: /metrics
+                    scheme: https
+                    scrape_interval: 60s
+                    static_configs:
+                    - targets:
+                      - '`endpoint`:10257'
+                    tls_config:
+                      ca_file: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+                      insecure_skip_verify: true
+              rule: type == "pod" && labels["component"] == "kube-controller-manager"
+            prometheus/etcd:
+              config:
+                config:
+                  scrape_configs:
+                  - authorization:
+                      credentials_file: /var/run/secrets/kubernetes.io/serviceaccount/token
+                      type: Bearer
+                    enable_http2: true
+                    follow_redirects: true
+                    honor_labels: true
+                    honor_timestamps: false
+                    job_name: kubernetes-etcd
+                    metrics_path: /metrics
+                    scheme: http
+                    scrape_interval: 60s
+                    static_configs:
+                    - targets:
+                      - '`endpoint`:2379'
+                    tls_config:
+                      ca_file: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+                      insecure_skip_verify: true
+              rule: type == "pod" && labels["component"] == "etcd"
           watch_observers:
           - k8s_observer
       service:

--- a/deploy/helm/tests/__snapshot__/node-collector-config-map_test.yaml.snap
+++ b/deploy/helm/tests/__snapshot__/node-collector-config-map_test.yaml.snap
@@ -1058,12 +1058,7 @@ Custom logs filter with new syntax:
               config:
                 config:
                   scrape_configs:
-                  - authorization:
-                      credentials_file: /var/run/secrets/kubernetes.io/serviceaccount/token
-                      type: Bearer
-                    enable_http2: true
-                    follow_redirects: true
-                    honor_labels: true
+                  - honor_labels: true
                     honor_timestamps: false
                     job_name: kubernetes-etcd
                     metrics_path: /metrics
@@ -1072,9 +1067,6 @@ Custom logs filter with new syntax:
                     static_configs:
                     - targets:
                       - '`endpoint`:2379'
-                    tls_config:
-                      ca_file: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
-                      insecure_skip_verify: true
               rule: type == "pod" && labels["component"] == "etcd"
           watch_observers:
           - k8s_observer
@@ -2353,12 +2345,7 @@ Custom logs filter with old syntax:
               config:
                 config:
                   scrape_configs:
-                  - authorization:
-                      credentials_file: /var/run/secrets/kubernetes.io/serviceaccount/token
-                      type: Bearer
-                    enable_http2: true
-                    follow_redirects: true
-                    honor_labels: true
+                  - honor_labels: true
                     honor_timestamps: false
                     job_name: kubernetes-etcd
                     metrics_path: /metrics
@@ -2367,9 +2354,6 @@ Custom logs filter with old syntax:
                     static_configs:
                     - targets:
                       - '`endpoint`:2379'
-                    tls_config:
-                      ca_file: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
-                      insecure_skip_verify: true
               rule: type == "pod" && labels["component"] == "etcd"
           watch_observers:
           - k8s_observer
@@ -3518,12 +3502,7 @@ Node collector config should match snapshot when autodiscovery is disabled:
               config:
                 config:
                   scrape_configs:
-                  - authorization:
-                      credentials_file: /var/run/secrets/kubernetes.io/serviceaccount/token
-                      type: Bearer
-                    enable_http2: true
-                    follow_redirects: true
-                    honor_labels: true
+                  - honor_labels: true
                     honor_timestamps: false
                     job_name: kubernetes-etcd
                     metrics_path: /metrics
@@ -3532,9 +3511,6 @@ Node collector config should match snapshot when autodiscovery is disabled:
                     static_configs:
                     - targets:
                       - '`endpoint`:2379'
-                    tls_config:
-                      ca_file: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
-                      insecure_skip_verify: true
               rule: type == "pod" && labels["component"] == "etcd"
           watch_observers:
           - k8s_observer
@@ -4706,12 +4682,7 @@ Node collector config should match snapshot when fargate is enabled:
               config:
                 config:
                   scrape_configs:
-                  - authorization:
-                      credentials_file: /var/run/secrets/kubernetes.io/serviceaccount/token
-                      type: Bearer
-                    enable_http2: true
-                    follow_redirects: true
-                    honor_labels: true
+                  - honor_labels: true
                     honor_timestamps: false
                     job_name: kubernetes-etcd
                     metrics_path: /metrics
@@ -4720,9 +4691,6 @@ Node collector config should match snapshot when fargate is enabled:
                     static_configs:
                     - targets:
                       - '`endpoint`:2379'
-                    tls_config:
-                      ca_file: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
-                      insecure_skip_verify: true
               rule: type == "pod" && labels["component"] == "etcd"
           watch_observers:
           - k8s_observer
@@ -5801,12 +5769,7 @@ Node collector config should match snapshot when fargate is enabled and autodisc
               config:
                 config:
                   scrape_configs:
-                  - authorization:
-                      credentials_file: /var/run/secrets/kubernetes.io/serviceaccount/token
-                      type: Bearer
-                    enable_http2: true
-                    follow_redirects: true
-                    honor_labels: true
+                  - honor_labels: true
                     honor_timestamps: false
                     job_name: kubernetes-etcd
                     metrics_path: /metrics
@@ -5815,9 +5778,6 @@ Node collector config should match snapshot when fargate is enabled and autodisc
                     static_configs:
                     - targets:
                       - '`endpoint`:2379'
-                    tls_config:
-                      ca_file: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
-                      insecure_skip_verify: true
               rule: type == "pod" && labels["component"] == "etcd"
           watch_observers:
           - k8s_observer
@@ -6920,12 +6880,7 @@ Node collector config should match snapshot when using default values:
               config:
                 config:
                   scrape_configs:
-                  - authorization:
-                      credentials_file: /var/run/secrets/kubernetes.io/serviceaccount/token
-                      type: Bearer
-                    enable_http2: true
-                    follow_redirects: true
-                    honor_labels: true
+                  - honor_labels: true
                     honor_timestamps: false
                     job_name: kubernetes-etcd
                     metrics_path: /metrics
@@ -6934,9 +6889,6 @@ Node collector config should match snapshot when using default values:
                     static_configs:
                     - targets:
                       - '`endpoint`:2379'
-                    tls_config:
-                      ca_file: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
-                      insecure_skip_verify: true
               rule: type == "pod" && labels["component"] == "etcd"
           watch_observers:
           - k8s_observer


### PR DESCRIPTION
`{{- if .Values.otel.metrics.autodiscovery.prometheusEndpoints.enabled}}` should end before etc/controller manager