### PR TITLE
NH-94277: Fixing scraping of etcd and controller-manager when autodiscovery is disabled

### DIFF
--- a/deploy/helm/Chart.yaml
+++ b/deploy/helm/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: swo-k8s-collector
-version: 4.2.0-alpha.10
+version: 4.2.0-alpha.11
 appVersion: 0.11.8
 description: SolarWinds Kubernetes Integration
 keywords:

--- a/deploy/helm/node-collector-config.yaml
+++ b/deploy/helm/node-collector-config.yaml
@@ -822,7 +822,7 @@ service:
         - forward/logs-exporter
 {{- end }}
 
-{{- if and .Values.otel.metrics.enabled .Values.otel.metrics.autodiscovery.prometheusEndpoints.enabled }}
+{{- if .Values.otel.metrics.enabled }}
     metrics/discovery:
       exporters:
         - forward/metric-exporter

--- a/deploy/helm/tests/__snapshot__/node-collector-config-map_test.yaml.snap
+++ b/deploy/helm/tests/__snapshot__/node-collector-config-map_test.yaml.snap
@@ -3589,6 +3589,21 @@ Node collector config should match snapshot when autodiscovery is disabled:
             - batch/metrics
             receivers:
             - forward/metric-exporter
+          metrics/discovery:
+            exporters:
+            - forward/metric-exporter
+            processors:
+            - memory_limiter
+            - metricstransform/rename/discovery
+            - transform/istio-metrics
+            - metricstransform/istio-metrics
+            - cumulativetodelta/istio-metrics
+            - deltatorate/istio-metrics
+            - experimental_metricsgeneration/istio-metrics
+            - groupbyattrs/common-all
+            - resource/all
+            receivers:
+            - receiver_creator/discovery
           metrics/node:
             exporters:
             - forward/metric-exporter
@@ -5799,6 +5814,21 @@ Node collector config should match snapshot when fargate is enabled and autodisc
             - resource/journal
             receivers:
             - journald
+          metrics/discovery:
+            exporters:
+            - forward/metric-exporter
+            processors:
+            - memory_limiter
+            - metricstransform/rename/discovery
+            - transform/istio-metrics
+            - metricstransform/istio-metrics
+            - cumulativetodelta/istio-metrics
+            - deltatorate/istio-metrics
+            - experimental_metricsgeneration/istio-metrics
+            - groupbyattrs/common-all
+            - resource/all
+            receivers:
+            - receiver_creator/discovery
         telemetry:
           logs:
             level: info


### PR DESCRIPTION
Fixing this as 4.2.0-alpha.11