### PR TITLE
Removed `name` and `version` from the scope context

### DIFF
--- a/deploy/helm/events-collector-config.yaml
+++ b/deploy/helm/events-collector-config.yaml
@@ -168,6 +168,12 @@ processors:
             # convert body to string
             - set(body, body.string)
 {{- end }}
+  transform/scope:
+    log_statements:
+      - context: scope
+        statements:
+          - set(name, "")
+          - set(version, "")
 {{- if .Values.otel.manifests.enabled }}
   groupbyattrs/manifest:
     keys:
@@ -358,6 +364,7 @@ service:
         - groupbyattrs/manifest
         - resource/manifest
         - swk8sattributes
+        - transform/scope
 {{- if not (empty .Values.otel.events.k8s_instrumentation.labels.excludePattern) }}
         - resource/swk8sattributes_labels_filter
 {{- end }}

--- a/deploy/helm/metrics-collector-config.yaml
+++ b/deploy/helm/metrics-collector-config.yaml
@@ -54,6 +54,12 @@ processors:
   {{- include "common-config.filter-remove-internal" . | nindent 2 }}
   {{- include "common-config.filter-remove-internal-post-processing" . | nindent 2 }}
 
+  transform/scope:
+    metric_statements:
+      - context: scope
+        statements:
+          - set(name, "")
+          - set(version, "")
   # unify attributes
   attributes/unify_node_attribute:
     include:
@@ -1247,6 +1253,7 @@ service:
         - otlp
       processors:
         - memory_limiter
+        - transform/scope
         - filter/histograms
         - batch
       receivers:

--- a/deploy/helm/node-collector-config.yaml
+++ b/deploy/helm/node-collector-config.yaml
@@ -314,7 +314,17 @@ processors:
     metrics:
       metric:
         - 'type == METRIC_DATA_TYPE_HISTOGRAM and not(name == "k8s.rest_client_request_duration_seconds" or name == "k8s.workqueue_queue_duration_seconds" or name == "k8s.etcd_disk_wal_fsync_duration_seconds" or name == "k8s.etcd_disk_backend_commit_duration_seconds")'
-
+  transform/scope:
+    metric_statements:
+      - context: scope
+        statements:
+          - set(name, "")
+          - set(version, "")
+    log_statements:
+      - context: scope
+        statements:
+          - set(name, "")
+          - set(version, "")
   transform/istio-metrics:
     metric_statements:
       - context: metric
@@ -884,6 +894,7 @@ service:
         - memory_limiter
         - filter/histograms
         - swk8sattributes
+        - transform/scope
 {{- if not (empty .Values.otel.metrics.k8s_instrumentation.labels.excludePattern) }}
         - resource/swk8sattributes_labels_filter
 {{- end }}

--- a/deploy/helm/tests/__snapshot__/events-collector-config-map_test.yaml.snap
+++ b/deploy/helm/tests/__snapshot__/events-collector-config-map_test.yaml.snap
@@ -349,6 +349,12 @@ Custom events filter with new syntax:
           - context: log
             statements:
             - set(attributes["sw.namespace"], "sw.events.inframon.k8s")
+        transform/scope:
+          log_statements:
+          - context: scope
+            statements:
+            - set(name, "")
+            - set(version, "")
         transform/set_labels_and_annotations_for_entities:
           error_mode: ignore
           log_statements:
@@ -542,6 +548,7 @@ Custom events filter with new syntax:
             - groupbyattrs/manifest
             - resource/manifest
             - swk8sattributes
+            - transform/scope
             - transform/cleanup_attributes_for_nonexisting_entities
             - batch
             receivers:
@@ -905,6 +912,12 @@ Custom events filter with old syntax:
           - context: log
             statements:
             - set(attributes["sw.namespace"], "sw.events.inframon.k8s")
+        transform/scope:
+          log_statements:
+          - context: scope
+            statements:
+            - set(name, "")
+            - set(version, "")
         transform/set_labels_and_annotations_for_entities:
           error_mode: ignore
           log_statements:
@@ -1098,6 +1111,7 @@ Custom events filter with old syntax:
             - groupbyattrs/manifest
             - resource/manifest
             - swk8sattributes
+            - transform/scope
             - transform/cleanup_attributes_for_nonexisting_entities
             - batch
             receivers:
@@ -1454,6 +1468,12 @@ Events config should match snapshot when using default values:
           - context: log
             statements:
             - set(attributes["sw.namespace"], "sw.events.inframon.k8s")
+        transform/scope:
+          log_statements:
+          - context: scope
+            statements:
+            - set(name, "")
+            - set(version, "")
         transform/set_labels_and_annotations_for_entities:
           error_mode: ignore
           log_statements:
@@ -1646,6 +1666,7 @@ Events config should match snapshot when using default values:
             - groupbyattrs/manifest
             - resource/manifest
             - swk8sattributes
+            - transform/scope
             - transform/cleanup_attributes_for_nonexisting_entities
             - batch
             receivers:
@@ -1902,6 +1923,12 @@ Events config should not contain manifest collection pipeline when disabled:
           - context: log
             statements:
             - set(attributes["sw.namespace"], "sw.events.inframon.k8s")
+        transform/scope:
+          log_statements:
+          - context: scope
+            statements:
+            - set(name, "")
+            - set(version, "")
         transform/severity:
           log_statements:
           - context: log

--- a/deploy/helm/tests/__snapshot__/metrics-collector-config-map-fargate_test.yaml.snap
+++ b/deploy/helm/tests/__snapshot__/metrics-collector-config-map-fargate_test.yaml.snap
@@ -1699,6 +1699,12 @@ Metrics config should match snapshot when using default values:
             - delete_key(resource.attributes, "sw.k8s.job.found")
             - delete_key(resource.attributes, "sw.k8s.cronjob.found")
             - delete_key(resource.attributes, "sw.k8s.node.found")
+        transform/scope:
+          metric_statements:
+          - context: scope
+            statements:
+            - set(name, "")
+            - set(version, "")
         transform/unify_node_attribute:
           metric_statements:
           - context: datapoint
@@ -1880,6 +1886,7 @@ Metrics config should match snapshot when using default values:
             - otlp
             processors:
             - memory_limiter
+            - transform/scope
             - filter/histograms
             - batch
             receivers:

--- a/deploy/helm/tests/__snapshot__/metrics-collector-config-map_test.yaml.snap
+++ b/deploy/helm/tests/__snapshot__/metrics-collector-config-map_test.yaml.snap
@@ -1699,6 +1699,12 @@ Metrics config should match snapshot when fargate is enabled:
             - delete_key(resource.attributes, "sw.k8s.job.found")
             - delete_key(resource.attributes, "sw.k8s.cronjob.found")
             - delete_key(resource.attributes, "sw.k8s.node.found")
+        transform/scope:
+          metric_statements:
+          - context: scope
+            statements:
+            - set(name, "")
+            - set(version, "")
         transform/unify_node_attribute:
           metric_statements:
           - context: datapoint
@@ -1880,6 +1886,7 @@ Metrics config should match snapshot when fargate is enabled:
             - otlp
             processors:
             - memory_limiter
+            - transform/scope
             - filter/histograms
             - batch
             receivers:
@@ -3658,6 +3665,12 @@ Metrics config should match snapshot when using Prometheus url with extra_scrape
             - delete_key(resource.attributes, "sw.k8s.job.found")
             - delete_key(resource.attributes, "sw.k8s.cronjob.found")
             - delete_key(resource.attributes, "sw.k8s.node.found")
+        transform/scope:
+          metric_statements:
+          - context: scope
+            statements:
+            - set(name, "")
+            - set(version, "")
         transform/unify_node_attribute:
           metric_statements:
           - context: datapoint
@@ -3774,6 +3787,7 @@ Metrics config should match snapshot when using Prometheus url with extra_scrape
             - otlp
             processors:
             - memory_limiter
+            - transform/scope
             - filter/histograms
             - batch
             receivers:
@@ -5559,6 +5573,12 @@ Metrics config should match snapshot when using default values:
             - delete_key(resource.attributes, "sw.k8s.job.found")
             - delete_key(resource.attributes, "sw.k8s.cronjob.found")
             - delete_key(resource.attributes, "sw.k8s.node.found")
+        transform/scope:
+          metric_statements:
+          - context: scope
+            statements:
+            - set(name, "")
+            - set(version, "")
         transform/unify_node_attribute:
           metric_statements:
           - context: datapoint
@@ -5660,6 +5680,7 @@ Metrics config should match snapshot when using default values:
             - otlp
             processors:
             - memory_limiter
+            - transform/scope
             - filter/histograms
             - batch
             receivers:

--- a/deploy/helm/tests/__snapshot__/node-collector-config-map-windows_test.yaml.snap
+++ b/deploy/helm/tests/__snapshot__/node-collector-config-map-windows_test.yaml.snap
@@ -920,6 +920,17 @@ Node collector config for windows nodes should match snapshot when using default
               "k8s.istio_request_duration_milliseconds_sum"
             - set(name, "k8s.istio_request_duration_milliseconds_count_temp") where name
               == "k8s.istio_request_duration_milliseconds_count"
+        transform/scope:
+          log_statements:
+          - context: scope
+            statements:
+            - set(name, "")
+            - set(version, "")
+          metric_statements:
+          - context: scope
+            statements:
+            - set(name, "")
+            - set(version, "")
         transform/syslogify:
           error_mode: ignore
           log_statements:
@@ -1117,6 +1128,7 @@ Node collector config for windows nodes should match snapshot when using default
             - memory_limiter
             - filter/histograms
             - swk8sattributes
+            - transform/scope
             - filter/remove_temporary_metrics
             - batch/metrics
             receivers:
@@ -2093,6 +2105,17 @@ Node collector config for windows nodes should match snapshot when using legacy 
               "k8s.istio_request_duration_milliseconds_sum"
             - set(name, "k8s.istio_request_duration_milliseconds_count_temp") where name
               == "k8s.istio_request_duration_milliseconds_count"
+        transform/scope:
+          log_statements:
+          - context: scope
+            statements:
+            - set(name, "")
+            - set(version, "")
+          metric_statements:
+          - context: scope
+            statements:
+            - set(name, "")
+            - set(version, "")
         transform/syslogify:
           error_mode: ignore
           log_statements:
@@ -2364,6 +2387,7 @@ Node collector config for windows nodes should match snapshot when using legacy 
             - memory_limiter
             - filter/histograms
             - swk8sattributes
+            - transform/scope
             - filter/remove_temporary_metrics
             - batch/metrics
             receivers:

--- a/deploy/helm/tests/__snapshot__/node-collector-config-map_test.yaml.snap
+++ b/deploy/helm/tests/__snapshot__/node-collector-config-map_test.yaml.snap
@@ -944,6 +944,17 @@ Custom logs filter with new syntax:
               "k8s.istio_request_duration_milliseconds_sum"
             - set(name, "k8s.istio_request_duration_milliseconds_count_temp") where name
               == "k8s.istio_request_duration_milliseconds_count"
+        transform/scope:
+          log_statements:
+          - context: scope
+            statements:
+            - set(name, "")
+            - set(version, "")
+          metric_statements:
+          - context: scope
+            statements:
+            - set(name, "")
+            - set(version, "")
         transform/syslogify:
           error_mode: ignore
           log_statements:
@@ -1150,6 +1161,7 @@ Custom logs filter with new syntax:
             - memory_limiter
             - filter/histograms
             - swk8sattributes
+            - transform/scope
             - filter/remove_temporary_metrics
             - batch/metrics
             receivers:
@@ -2146,6 +2158,17 @@ Custom logs filter with old syntax:
               "k8s.istio_request_duration_milliseconds_sum"
             - set(name, "k8s.istio_request_duration_milliseconds_count_temp") where name
               == "k8s.istio_request_duration_milliseconds_count"
+        transform/scope:
+          log_statements:
+          - context: scope
+            statements:
+            - set(name, "")
+            - set(version, "")
+          metric_statements:
+          - context: scope
+            statements:
+            - set(name, "")
+            - set(version, "")
         transform/syslogify:
           error_mode: ignore
           log_statements:
@@ -2433,6 +2456,7 @@ Custom logs filter with old syntax:
             - memory_limiter
             - filter/histograms
             - swk8sattributes
+            - transform/scope
             - filter/remove_temporary_metrics
             - batch/metrics
             receivers:
@@ -3422,6 +3446,17 @@ Node collector config should match snapshot when autodiscovery is disabled:
               "k8s.istio_request_duration_milliseconds_sum"
             - set(name, "k8s.istio_request_duration_milliseconds_count_temp") where name
               == "k8s.istio_request_duration_milliseconds_count"
+        transform/scope:
+          log_statements:
+          - context: scope
+            statements:
+            - set(name, "")
+            - set(version, "")
+          metric_statements:
+          - context: scope
+            statements:
+            - set(name, "")
+            - set(version, "")
         transform/syslogify:
           error_mode: ignore
           log_statements:
@@ -3585,6 +3620,7 @@ Node collector config should match snapshot when autodiscovery is disabled:
             - memory_limiter
             - filter/histograms
             - swk8sattributes
+            - transform/scope
             - filter/remove_temporary_metrics
             - batch/metrics
             receivers:
@@ -4571,6 +4607,17 @@ Node collector config should match snapshot when fargate is enabled:
               "k8s.istio_request_duration_milliseconds_sum"
             - set(name, "k8s.istio_request_duration_milliseconds_count_temp") where name
               == "k8s.istio_request_duration_milliseconds_count"
+        transform/scope:
+          log_statements:
+          - context: scope
+            statements:
+            - set(name, "")
+            - set(version, "")
+          metric_statements:
+          - context: scope
+            statements:
+            - set(name, "")
+            - set(version, "")
         transform/syslogify:
           error_mode: ignore
           log_statements:
@@ -4739,6 +4786,7 @@ Node collector config should match snapshot when fargate is enabled:
             - memory_limiter
             - filter/histograms
             - swk8sattributes
+            - transform/scope
             - filter/remove_temporary_metrics
             - batch/metrics
             receivers:
@@ -5696,6 +5744,17 @@ Node collector config should match snapshot when fargate is enabled and autodisc
               "k8s.istio_request_duration_milliseconds_sum"
             - set(name, "k8s.istio_request_duration_milliseconds_count_temp") where name
               == "k8s.istio_request_duration_milliseconds_count"
+        transform/scope:
+          log_statements:
+          - context: scope
+            statements:
+            - set(name, "")
+            - set(version, "")
+          metric_statements:
+          - context: scope
+            statements:
+            - set(name, "")
+            - set(version, "")
         transform/syslogify:
           error_mode: ignore
           log_statements:
@@ -6776,6 +6835,17 @@ Node collector config should match snapshot when using default values:
               "k8s.istio_request_duration_milliseconds_sum"
             - set(name, "k8s.istio_request_duration_milliseconds_count_temp") where name
               == "k8s.istio_request_duration_milliseconds_count"
+        transform/scope:
+          log_statements:
+          - context: scope
+            statements:
+            - set(name, "")
+            - set(version, "")
+          metric_statements:
+          - context: scope
+            statements:
+            - set(name, "")
+            - set(version, "")
         transform/syslogify:
           error_mode: ignore
           log_statements:
@@ -6981,6 +7051,7 @@ Node collector config should match snapshot when using default values:
             - memory_limiter
             - filter/histograms
             - swk8sattributes
+            - transform/scope
             - filter/remove_temporary_metrics
             - batch/metrics
             receivers:


### PR DESCRIPTION
## Summary

This PR removes `name` and `version` from the scope context

*Before*

```json
{
    "resourceMetrics": [
        {
            "resource":  ...
            "scopeMetrics": [
                {
                    "scope": {
                        "name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
                        "version": "0.11.4"
                    }
                }
            ]
        }
    ]
}
```

*After*

```json
{
    "resourceMetrics": [
        {
            "resource":  ...
            "scopeMetrics": [
                {
                    "scope": { }
                }
            ]
        }
    ]
}
```
