### PR TITLE
Removed name and version from scope context of all messages

### DIFF
--- a/deploy/helm/events-collector-config.yaml
+++ b/deploy/helm/events-collector-config.yaml
@@ -356,6 +356,7 @@ service:
 {{- if and .Values.otel.events.filter (eq (include "isDeprecatedFilterSyntax" .Values.otel.events.filter) "false") }}
         - filter
 {{- end }}
+        - transform/scope
         - batch
       receivers:
         - k8s_events
@@ -371,7 +372,6 @@ service:
         - groupbyattrs/manifest
         - resource/manifest
         - swk8sattributes
-        - transform/scope
 {{- if not (empty .Values.otel.events.k8s_instrumentation.labels.excludePattern) }}
         - resource/swk8sattributes_labels_filter
 {{- end }}
@@ -382,6 +382,7 @@ service:
 {{- if .Values.otel.manifests.filter }}
         - filter/manifests
 {{- end }}
+        - transform/scope
         - batch
       receivers:
         - k8sobjects

--- a/deploy/helm/metrics-collector-config.yaml
+++ b/deploy/helm/metrics-collector-config.yaml
@@ -1253,8 +1253,8 @@ service:
         - otlp
       processors:
         - memory_limiter
-        - transform/scope
         - filter/histograms
+        - transform/scope
         - batch
       receivers:
         - forward/metric-exporter

--- a/deploy/helm/node-collector-config.yaml
+++ b/deploy/helm/node-collector-config.yaml
@@ -827,6 +827,7 @@ service:
         - otlp
       processors:
         - memory_limiter
+        - transform/scope
         - batch/logs
       receivers:
         - forward/logs-exporter
@@ -894,7 +895,6 @@ service:
         - memory_limiter
         - filter/histograms
         - swk8sattributes
-        - transform/scope
 {{- if not (empty .Values.otel.metrics.k8s_instrumentation.labels.excludePattern) }}
         - resource/swk8sattributes_labels_filter
 {{- end }}
@@ -905,6 +905,7 @@ service:
         - filter/metrics
 {{- end }}
         - filter/remove_temporary_metrics
+        - transform/scope
         - batch/metrics
       receivers:
         - forward/metric-exporter

--- a/deploy/helm/tests/__snapshot__/events-collector-config-map_test.yaml.snap
+++ b/deploy/helm/tests/__snapshot__/events-collector-config-map_test.yaml.snap
@@ -549,6 +549,7 @@ Custom events filter with new syntax:
             - swk8sattributes
             - transform/cleanup_attributes_for_nonexisting_entities
             - filter
+            - transform/scope
             - batch
             receivers:
             - k8s_events
@@ -562,8 +563,8 @@ Custom events filter with new syntax:
             - groupbyattrs/manifest
             - resource/manifest
             - swk8sattributes
-            - transform/scope
             - transform/cleanup_attributes_for_nonexisting_entities
+            - transform/scope
             - batch
             receivers:
             - k8sobjects
@@ -1126,6 +1127,7 @@ Custom events filter with old syntax:
             - resource/events
             - swk8sattributes
             - transform/cleanup_attributes_for_nonexisting_entities
+            - transform/scope
             - batch
             receivers:
             - k8s_events
@@ -1139,8 +1141,8 @@ Custom events filter with old syntax:
             - groupbyattrs/manifest
             - resource/manifest
             - swk8sattributes
-            - transform/scope
             - transform/cleanup_attributes_for_nonexisting_entities
+            - transform/scope
             - batch
             receivers:
             - k8sobjects
@@ -1695,6 +1697,7 @@ Events config should match snapshot when using default values:
             - resource/events
             - swk8sattributes
             - transform/cleanup_attributes_for_nonexisting_entities
+            - transform/scope
             - batch
             receivers:
             - k8s_events
@@ -1708,8 +1711,8 @@ Events config should match snapshot when using default values:
             - groupbyattrs/manifest
             - resource/manifest
             - swk8sattributes
-            - transform/scope
             - transform/cleanup_attributes_for_nonexisting_entities
+            - transform/scope
             - batch
             receivers:
             - k8sobjects
@@ -2034,6 +2037,7 @@ Events config should not contain manifest collection pipeline when disabled:
             - resource/events
             - swk8sattributes
             - transform/cleanup_attributes_for_nonexisting_entities
+            - transform/scope
             - batch
             receivers:
             - k8s_events

--- a/deploy/helm/tests/__snapshot__/metrics-collector-config-map-fargate_test.yaml.snap
+++ b/deploy/helm/tests/__snapshot__/metrics-collector-config-map-fargate_test.yaml.snap
@@ -1886,8 +1886,8 @@ Metrics config should match snapshot when using default values:
             - otlp
             processors:
             - memory_limiter
-            - transform/scope
             - filter/histograms
+            - transform/scope
             - batch
             receivers:
             - forward/metric-exporter

--- a/deploy/helm/tests/__snapshot__/metrics-collector-config-map_test.yaml.snap
+++ b/deploy/helm/tests/__snapshot__/metrics-collector-config-map_test.yaml.snap
@@ -1886,8 +1886,8 @@ Metrics config should match snapshot when fargate is enabled:
             - otlp
             processors:
             - memory_limiter
-            - transform/scope
             - filter/histograms
+            - transform/scope
             - batch
             receivers:
             - forward/metric-exporter
@@ -3787,8 +3787,8 @@ Metrics config should match snapshot when using Prometheus url with extra_scrape
             - otlp
             processors:
             - memory_limiter
-            - transform/scope
             - filter/histograms
+            - transform/scope
             - batch
             receivers:
             - forward/metric-exporter
@@ -5680,8 +5680,8 @@ Metrics config should match snapshot when using default values:
             - otlp
             processors:
             - memory_limiter
-            - transform/scope
             - filter/histograms
+            - transform/scope
             - batch
             receivers:
             - forward/metric-exporter

--- a/deploy/helm/tests/__snapshot__/node-collector-config-map-windows_test.yaml.snap
+++ b/deploy/helm/tests/__snapshot__/node-collector-config-map-windows_test.yaml.snap
@@ -1105,6 +1105,7 @@ Node collector config for windows nodes should match snapshot when using default
             - otlp
             processors:
             - memory_limiter
+            - transform/scope
             - batch/logs
             receivers:
             - forward/logs-exporter
@@ -1128,8 +1129,8 @@ Node collector config for windows nodes should match snapshot when using default
             - memory_limiter
             - filter/histograms
             - swk8sattributes
-            - transform/scope
             - filter/remove_temporary_metrics
+            - transform/scope
             - batch/metrics
             receivers:
             - forward/metric-exporter
@@ -2363,6 +2364,7 @@ Node collector config for windows nodes should match snapshot when using legacy 
             - otlp
             processors:
             - memory_limiter
+            - transform/scope
             - batch/logs
             receivers:
             - forward/logs-exporter
@@ -2387,8 +2389,8 @@ Node collector config for windows nodes should match snapshot when using legacy 
             - memory_limiter
             - filter/histograms
             - swk8sattributes
-            - transform/scope
             - filter/remove_temporary_metrics
+            - transform/scope
             - batch/metrics
             receivers:
             - forward/metric-exporter

--- a/deploy/helm/tests/__snapshot__/node-collector-config-map_test.yaml.snap
+++ b/deploy/helm/tests/__snapshot__/node-collector-config-map_test.yaml.snap
@@ -1128,6 +1128,7 @@ Custom logs filter with new syntax:
             - otlp
             processors:
             - memory_limiter
+            - transform/scope
             - batch/logs
             receivers:
             - forward/logs-exporter
@@ -1161,8 +1162,8 @@ Custom logs filter with new syntax:
             - memory_limiter
             - filter/histograms
             - swk8sattributes
-            - transform/scope
             - filter/remove_temporary_metrics
+            - transform/scope
             - batch/metrics
             receivers:
             - forward/metric-exporter
@@ -2423,6 +2424,7 @@ Custom logs filter with old syntax:
             - otlp
             processors:
             - memory_limiter
+            - transform/scope
             - batch/logs
             receivers:
             - forward/logs-exporter
@@ -2456,8 +2458,8 @@ Custom logs filter with old syntax:
             - memory_limiter
             - filter/histograms
             - swk8sattributes
-            - transform/scope
             - filter/remove_temporary_metrics
+            - transform/scope
             - batch/metrics
             receivers:
             - forward/metric-exporter
@@ -3588,6 +3590,7 @@ Node collector config should match snapshot when autodiscovery is disabled:
             - otlp
             processors:
             - memory_limiter
+            - transform/scope
             - batch/logs
             receivers:
             - forward/logs-exporter
@@ -3620,8 +3623,8 @@ Node collector config should match snapshot when autodiscovery is disabled:
             - memory_limiter
             - filter/histograms
             - swk8sattributes
-            - transform/scope
             - filter/remove_temporary_metrics
+            - transform/scope
             - batch/metrics
             receivers:
             - forward/metric-exporter
@@ -4754,6 +4757,7 @@ Node collector config should match snapshot when fargate is enabled:
             - otlp
             processors:
             - memory_limiter
+            - transform/scope
             - batch/logs
             receivers:
             - forward/logs-exporter
@@ -4786,8 +4790,8 @@ Node collector config should match snapshot when fargate is enabled:
             - memory_limiter
             - filter/histograms
             - swk8sattributes
-            - transform/scope
             - filter/remove_temporary_metrics
+            - transform/scope
             - batch/metrics
             receivers:
             - forward/metric-exporter
@@ -5848,6 +5852,7 @@ Node collector config should match snapshot when fargate is enabled and autodisc
             - otlp
             processors:
             - memory_limiter
+            - transform/scope
             - batch/logs
             receivers:
             - forward/logs-exporter
@@ -7019,6 +7024,7 @@ Node collector config should match snapshot when using default values:
             - otlp
             processors:
             - memory_limiter
+            - transform/scope
             - batch/logs
             receivers:
             - forward/logs-exporter
@@ -7051,8 +7057,8 @@ Node collector config should match snapshot when using default values:
             - memory_limiter
             - filter/histograms
             - swk8sattributes
-            - transform/scope
             - filter/remove_temporary_metrics
+            - transform/scope
             - batch/metrics
             receivers:
             - forward/metric-exporter


### PR DESCRIPTION
A follow-up to https://github.com/solarwinds/swi-k8s-opentelemetry-collector/pull/797.

The actual behavior does not change, this is only about unification. The instrumentation scope for logs is already always empty, at least in the current version of OTEL Collector. So we don't actually need to make it empty explicitly. But ...

This PR clears the instrumentation scope for all OTEL messages from the `k8s collector` and does it at the same places in the respective pipelines.