### PR TITLE
Update Go to 1.23

### DIFF
--- a/build/docker/Dockerfile.Windows-2022
+++ b/build/docker/Dockerfile.Windows-2022
@@ -1,4 +1,4 @@
-FROM docker.io/library/golang:1.23.3-nanoserver-ltsc2022@sha256:eaa046b39f5184d7339c2f596af16e16e7b4d2fe8460c790e845b45d34fa4793 AS base
+FROM docker.io/library/golang:1.23.3-nanoserver-ltsc2022@sha256:cc07a6756869a7f5b585fb37f423da6d0821897ceae1bae4212d019ef6f09065 AS base
 WORKDIR /src
 COPY ["./src/", "./src/"]
 

--- a/src/cmd/go.mod
+++ b/src/cmd/go.mod
@@ -14,9 +14,7 @@
 
 module github.com/solarwinds/swi-k8s-opentelemetry-collector
 
-go 1.22.0
-
-toolchain go1.23.0
+go 1.23.0
 
 require (
 	github.com/open-telemetry/opentelemetry-collector-contrib/extension/healthcheckextension v0.113.0

--- a/src/internal/coreinternal/go.mod
+++ b/src/internal/coreinternal/go.mod
@@ -1,7 +1,5 @@
 module github.com/solarwinds/swi-k8s-opentelemetry-collector/internal/coreinternal
 
-go 1.22.0
-
-toolchain go1.22.2
+go 1.23.0
 
 require go.opentelemetry.io/collector/client v1.19.0

--- a/src/internal/k8sconfig/go.mod
+++ b/src/internal/k8sconfig/go.mod
@@ -1,8 +1,6 @@
 module github.com/solarwinds/swi-k8s-opentelemetry-collector/internal/k8sconfig
 
-go 1.22.0
-
-toolchain go1.22.2
+go 1.23.0
 
 require (
 	github.com/openshift/client-go v0.0.0-20210521082421-73d9475a9142

--- a/src/processor/k8sattributesprocessor/go.mod
+++ b/src/processor/k8sattributesprocessor/go.mod
@@ -1,8 +1,6 @@
 module github.com/solarwinds/swi-k8s-opentelemetry-collector/processor/swk8sattributesprocessor
 
-go 1.22.0
-
-toolchain go1.22.2
+go 1.23.0
 
 require (
 	github.com/distribution/reference v0.6.0

--- a/src/wrapper/go.mod
+++ b/src/wrapper/go.mod
@@ -1,3 +1,3 @@
 module wrapper
 
-go 1.22
+go 1.23.0


### PR DESCRIPTION
Update Go toolchain to 1.23. Also, use `go 1.23.0` instead of `go 1.23` in `go.mod` files, because some tooling, like our CodeQL checks, has trouble with parsing the former format.