### PR TITLE
Fix collecting logs on Windows

### DIFF
--- a/deploy/helm/templates/node-collector-daemon-set-windows.yaml
+++ b/deploy/helm/templates/node-collector-daemon-set-windows.yaml
@@ -65,6 +65,9 @@ spec:
         - name: swi-opentelemetry-collector
           image: "{{ include "common.image" (tuple . .Values.otel.windows (tuple "image" "image_windows") nil .Chart.AppVersion ) }}"
           imagePullPolicy: {{ .Values.otel.windows.image.pullPolicy }}
+          securityContext:
+            windowsOptions:
+              runAsUserName: ContainerAdministrator
           command:
             - c:\wrapper.exe
             - c:\swi-otelcol.exe

--- a/deploy/helm/tests/__snapshot__/node-collector-daemon-set-windows_test.yaml.snap
+++ b/deploy/helm/tests/__snapshot__/node-collector-daemon-set-windows_test.yaml.snap
@@ -63,6 +63,9 @@ DaemonSet spec for windows nodes should match snapshot when overriding cluster I
             memory: 1Gi
           requests:
             memory: 50Mi
+        securityContext:
+          windowsOptions:
+            runAsUserName: ContainerAdministrator
         volumeMounts:
           - mountPath: c:\var\log\pods
             name: varlogpods
@@ -171,6 +174,9 @@ DaemonSet spec for windows nodes should match snapshot when using default values
             memory: 1Gi
           requests:
             memory: 50Mi
+        securityContext:
+          windowsOptions:
+            runAsUserName: ContainerAdministrator
         volumeMounts:
           - mountPath: c:\var\log\pods
             name: varlogpods


### PR DESCRIPTION
New EKS Windows AMI templates enforce permission checks when accessing Pod logs. Unlike the Linux version of the node collector, the Windows one did not use elevated user to access them. This PR changes that.