### PR TITLE
Release k8s collector 4.3.0-alpha.4

### DIFF
--- a/deploy/helm/Chart.yaml
+++ b/deploy/helm/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: swo-k8s-collector
-version: 4.3.0-alpha.3
+version: 4.3.0-alpha.4
 appVersion: 0.12.0
 description: SolarWinds Kubernetes Integration
 keywords:


### PR DESCRIPTION
Removed name and version from scope context of all messages
Updated OTEL Collector to v0.113.0
Updated base images
Fixed collecting logs on Windows