### PR TITLE
Remove workaround that is no longer necessary after updating OTEL Collector to v0.113.0

### DIFF
--- a/deploy/helm/node-collector-config.yaml
+++ b/deploy/helm/node-collector-config.yaml
@@ -556,17 +556,6 @@ receivers:
         to: body
 {{- else }}
     operators:
-# The 'container' operator has hardcoded that 'log.file.path' must use '/' as a separator, whic is not true on Windows
-{{- if (.isWindows) }}
-      - type: add
-        field: attributes["log.file.path.windows"]
-        value: 'EXPR(replace(attributes["log.file.path"], "\\", "/"))'
-      - type: remove
-        field: attributes["log.file.path"]
-      - type: move
-        from: attributes["log.file.path.windows"]
-        to: attributes["log.file.path"]
-{{- end }}
       - id: container-parser
         type: container
       - type: remove

--- a/deploy/helm/tests/__snapshot__/node-collector-config-map-windows_test.yaml.snap
+++ b/deploy/helm/tests/__snapshot__/node-collector-config-map-windows_test.yaml.snap
@@ -950,14 +950,6 @@ Node collector config for windows nodes should match snapshot when using default
           max_concurrent_files: 10
           max_log_size: 1MiB
           operators:
-          - field: attributes["log.file.path.windows"]
-            type: add
-            value: EXPR(replace(attributes["log.file.path"], "\\", "/"))
-          - field: attributes["log.file.path"]
-            type: remove
-          - from: attributes["log.file.path.windows"]
-            to: attributes["log.file.path"]
-            type: move
           - id: container-parser
             type: container
           - field: resource["k8s.container.restart_count"]


### PR DESCRIPTION
The `container` operator now supports Windows log paths natively.