### PR TITLE
Adjust batch size in k8s collector

### DIFF
--- a/deploy/helm/tests/__snapshot__/events-collector-config-map_test.yaml.snap
+++ b/deploy/helm/tests/__snapshot__/events-collector-config-map_test.yaml.snap
@@ -23,8 +23,8 @@ Custom events filter with new syntax:
           endpoint: 0.0.0.0:13133
       processors:
         batch:
-          send_batch_max_size: 512
-          send_batch_size: 512
+          send_batch_max_size: 64
+          send_batch_size: 64
           timeout: 1s
         filter:
           logs:
@@ -558,8 +558,8 @@ Custom events filter with old syntax:
           endpoint: 0.0.0.0:13133
       processors:
         batch:
-          send_batch_max_size: 512
-          send_batch_size: 512
+          send_batch_max_size: 64
+          send_batch_size: 64
           timeout: 1s
         filter:
           logs:
@@ -1096,8 +1096,8 @@ Events config should match snapshot when using default values:
           endpoint: 0.0.0.0:13133
       processors:
         batch:
-          send_batch_max_size: 512
-          send_batch_size: 512
+          send_batch_max_size: 64
+          send_batch_size: 64
           timeout: 1s
         groupbyattrs/manifest:
           keys:
@@ -1626,8 +1626,8 @@ Events config should not contain manifest collection pipeline when disabled:
           endpoint: 0.0.0.0:13133
       processors:
         batch:
-          send_batch_max_size: 512
-          send_batch_size: 512
+          send_batch_max_size: 64
+          send_batch_size: 64
           timeout: 1s
         memory_limiter:
           check_interval: 1s

--- a/deploy/helm/values.yaml
+++ b/deploy/helm/values.yaml
@@ -355,8 +355,8 @@ otel:
     # Batching configuration for events
     # see https://github.com/open-telemetry/opentelemetry-collector/tree/main/processor/batchprocessor for configuration reference
     batch:
-      send_batch_size: 512
-      send_batch_max_size: 512
+      send_batch_size: 64
+      send_batch_max_size: 64
       timeout: 1s
 
     sending_queue:


### PR DESCRIPTION
Manifests take up more space, so we can fit less records in one OTEL message