### PR TITLE
Adjust memory limits in the events collector

### DIFF
--- a/deploy/helm/tests/__snapshot__/events-collector-config-map_test.yaml.snap
+++ b/deploy/helm/tests/__snapshot__/events-collector-config-map_test.yaml.snap
@@ -49,8 +49,8 @@ Custom events filter with new syntax:
           - k8s.configmap.name
         memory_limiter:
           check_interval: 1s
-          limit_mib: 512
-          spike_limit_mib: 128
+          limit_mib: 800
+          spike_limit_mib: 300
         resource/events:
           attributes:
           - action: insert
@@ -587,8 +587,8 @@ Custom events filter with old syntax:
           - k8s.configmap.name
         memory_limiter:
           check_interval: 1s
-          limit_mib: 512
-          spike_limit_mib: 128
+          limit_mib: 800
+          spike_limit_mib: 300
         resource/events:
           attributes:
           - action: insert
@@ -1118,8 +1118,8 @@ Events config should match snapshot when using default values:
           - k8s.configmap.name
         memory_limiter:
           check_interval: 1s
-          limit_mib: 512
-          spike_limit_mib: 128
+          limit_mib: 800
+          spike_limit_mib: 300
         resource/events:
           attributes:
           - action: insert
@@ -1631,8 +1631,8 @@ Events config should not contain manifest collection pipeline when disabled:
           timeout: 1s
         memory_limiter:
           check_interval: 1s
-          limit_mib: 512
-          spike_limit_mib: 128
+          limit_mib: 800
+          spike_limit_mib: 300
         resource/events:
           attributes:
           - action: insert

--- a/deploy/helm/values.yaml
+++ b/deploy/helm/values.yaml
@@ -394,8 +394,8 @@ otel:
     # See https://github.com/open-telemetry/opentelemetry-collector/tree/main/processor/memorylimiterprocessor for configuration reference
     memory_limiter:
       check_interval: 1s
-      limit_mib: 512
-      spike_limit_mib: 128
+      limit_mib: 800
+      spike_limit_mib: 300
 
     # DEPRECATED: Memory Ballast enables applications to configure memory ballast for the process.
     # See https://github.com/open-telemetry/opentelemetry-collector/tree/main/extension/ballastextension for configuration reference
@@ -602,7 +602,7 @@ otel:
     # By default: affinity is set to run the DaemonSet on linux amd64.
     affinity: {}
 
-    # Properties that can be configured on filelog reciever. For full description of properties
+    # Properties that can be configured on filelog receiver. For full description of properties
     # see https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/filelogreceiver
     receiver:
       start_at: end


### PR DESCRIPTION
The limits were set unnecessarily low, make them the same as for logs. The actual container requests/limits are unchanged.