### PR TITLE
Require Helm 3.9.0 or newer

### DIFF
--- a/.github/actions/deploy-kubernetes/action.yml
+++ b/.github/actions/deploy-kubernetes/action.yml
@@ -18,7 +18,7 @@ runs:
     - name: Install Helm
       uses: azure/setup-helm@v3
       with:
-        version: '3.8.2'
+        version: '3.9.0'
 
     - name: Print cluster info
       run: |

--- a/.github/workflows/buildAndTestHelm.yml
+++ b/.github/workflows/buildAndTestHelm.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Set up Helm
         uses: azure/setup-helm@v3
         with:
-          version: v3.8.2
+          version: v3.9.0
 
       - name: Add dependency chart repos
         run: |

--- a/deploy/helm/README.md
+++ b/deploy/helm/README.md
@@ -3,13 +3,21 @@
 ## Table of contents
 
 - [Installation](#installation)
+- [Requirements](#requirements)
 - [Configuration](#configuration)
-- [Limitations](#limitations)
 - [Auto Instrumentation (experimental feature)](#auto-instrumentation-experimental-feature)
 
 ## Installation
 
 Walk through `Add a Kubernetes cluster` in [SolarWinds Observability](https://documentation.solarwinds.com/en/success_center/observability/default.htm#cshid=gh-k8s-collector)
+
+## Requirements
+
+- Each Kubernetes version is supported for 15 months after its initial release. For example, version 1.27 released on April 11, 2023 is supported until July 11, 2024. For release dates for individual Kubernetes versions, see [Patch Releases](https://kubernetes.io/releases/patch-releases/#detailed-release-history-for-active-branches) in Kubernetes documentation.
+  - Local Kubernetes deployments (e.q. Minikube, Docker Desktop) are not supported (although most of the functionality may be working).
+  - Note: since Kubernetes v1.24 Docker container runtime will not be reporting pod level network metrics (`kubenet` and other network plumbing was removed from upstream as part of the dockershim removal/deprecation)
+- Supported architectures: Linux x86-64 (`amd64`), Linux ARM (`arm64`), Windows x86-64 (`amd64`).
+- Helm 3.9.0 or newer.
 
 ## Configuration
 
@@ -115,7 +123,6 @@ otel:
         - attributes["k8s.object.kind"] == "ConfigMap" and resource.attributes["k8s.namespace.name"] != "kube-system"
 ```
 
-
 ## Receive 3rd party metrics
 
 SWO K8s Collector has an OTEL service endpoint which is able to forward metrics and logs into SolarWinds Observability. All incoming data is properly associated with current cluster. Additionally, metrics are decorated with prefix `k8s.`.
@@ -149,13 +156,6 @@ config:
     - opentelemetry:
         service_address: <chart-name>-metrics-collector.<namespace>.svc.cluster.local:4317
 ```
-
-## Limitations
-
-- Each Kubernetes version is supported for 15 months after its initial release. For example, version 1.27 released on April 11, 2023 is supported until July 11, 2024. For release dates for individual Kubernetes versions, see [Patch Releases](https://kubernetes.io/releases/patch-releases/#detailed-release-history-for-active-branches) in Kubernetes documentation.
-  - Local Kubernetes deployments (e.q. Minikube, Docker Desktop) are not supported (although most of the functionality may be working).
-  - Note: since Kubernetes v1.24 Docker container runtime will not be reporting pod level network metrics (`kubenet` and other network plumbing was removed from upstream as part of the dockershim removal/deprecation)
-- Supported architectures: Linux x86-64 (`amd64`), Linux ARM (`arm64`), Windows x86-64 (`amd64`).
 
 ## Auto Instrumentation (experimental feature)
 

--- a/deploy/helm/templates/asserts.yaml
+++ b/deploy/helm/templates/asserts.yaml
@@ -9,3 +9,11 @@
 {{- if mustRegexMatch "^[\\s]+$" .Values.cluster.uid -}}
 {{ fail "If specified, the custom cluster UID should be a valid string." }}
 {{- end -}}
+
+{{- if empty .Capabilities.HelmVersion.Version -}}
+{{ fail "This version of Helm is not supported. Please use 3.9.0 or newer." }}
+{{- end -}}
+
+{{- if eq ((semver "3.9.0").Compare (semver .Capabilities.HelmVersion.Version)) 1 -}}
+{{ fail "This version of Helm is not supported. Please use 3.9.0 or newer." }}
+{{- end -}}


### PR DESCRIPTION
* Increase required Helm version from 3.8 to 3.9.
* Explicitly mention it in the documentation.
* Check for the version during chart installation.

Note: Helm 3.9.0 is the first version where the `.Capabilities.HelmVersion.Version` actually works.