### PR TITLE
Update kube-state-metrics sub-chart to 5.28.0

### DIFF
--- a/deploy/helm/Chart.lock
+++ b/deploy/helm/Chart.lock
@@ -1,12 +1,12 @@
 dependencies:
 - name: kube-state-metrics
   repository: https://prometheus-community.github.io/helm-charts
-  version: 5.26.0
+  version: 5.28.0
 - name: opentelemetry-operator
   repository: https://open-telemetry.github.io/opentelemetry-helm-charts
   version: 0.68.3
 - name: cert-manager
   repository: https://charts.jetstack.io
   version: v1.16.1
-digest: sha256:531536930d6703d7eac1fef0edc60b586790199100d10af78f82a58ba839694b
-generated: "2024-11-11T10:34:43.72979+01:00"
+digest: sha256:38d69a6382829ee33fd382ba95f1b7b5c7751f0d011e4c0881c4e28321713334
+generated: "2025-01-06T09:28:44.7431325+01:00"

--- a/deploy/helm/Chart.yaml
+++ b/deploy/helm/Chart.yaml
@@ -20,7 +20,7 @@ maintainers:
 dependencies:
   - name: kube-state-metrics
     repository: https://prometheus-community.github.io/helm-charts
-    version: "~> 5.26.0"
+    version: "~> 5.28.0"
     condition: kube-state-metrics.enabled
   - name: opentelemetry-operator
     repository: https://open-telemetry.github.io/opentelemetry-helm-charts

--- a/deploy/helm/metrics-collector-config.yaml
+++ b/deploy/helm/metrics-collector-config.yaml
@@ -862,8 +862,6 @@ processors:
           name == "kube_service_spec_type" or
           name == "kube_service_spec_external_ip" or
           name == "kube_service_status_load_balancer_ingress" or
-          name == "kube_endpoint_address_not_ready" or
-          name == "kube_endpoint_address_available" or
           name == "kube_endpoint_info" or
           name == "kube_endpoint_created" or
           name == "kube_endpoint_ports" or

--- a/deploy/helm/tests/__snapshot__/metrics-collector-config-map-fargate_test.yaml.snap
+++ b/deploy/helm/tests/__snapshot__/metrics-collector-config-map-fargate_test.yaml.snap
@@ -273,8 +273,7 @@ Metrics config should match snapshot when using default values:
               or\nname == \"kube_persistentvolumeclaim_created\" or\nname == \"kube_pod_spec_volumes_persistentvolumeclaims_info\"
               or\nname == \"kube_service_info\" or\nname == \"kube_service_created\" or\nname
               == \"kube_service_spec_type\" or\nname == \"kube_service_spec_external_ip\"
-              or\nname == \"kube_service_status_load_balancer_ingress\" or\nname == \"kube_endpoint_address_not_ready\"
-              or\nname == \"kube_endpoint_address_available\" or\nname == \"kube_endpoint_info\"
+              or\nname == \"kube_service_status_load_balancer_ingress\" or\nname == \"kube_endpoint_info\"
               or\nname == \"kube_endpoint_created\" or\nname == \"kube_endpoint_ports\"
               or\nname == \"kube_endpoint_address\"\n)\n"
         filter/preprocessing:

--- a/deploy/helm/tests/__snapshot__/metrics-collector-config-map_test.yaml.snap
+++ b/deploy/helm/tests/__snapshot__/metrics-collector-config-map_test.yaml.snap
@@ -273,8 +273,7 @@ Metrics config should match snapshot when fargate is enabled:
               or\nname == \"kube_persistentvolumeclaim_created\" or\nname == \"kube_pod_spec_volumes_persistentvolumeclaims_info\"
               or\nname == \"kube_service_info\" or\nname == \"kube_service_created\" or\nname
               == \"kube_service_spec_type\" or\nname == \"kube_service_spec_external_ip\"
-              or\nname == \"kube_service_status_load_balancer_ingress\" or\nname == \"kube_endpoint_address_not_ready\"
-              or\nname == \"kube_endpoint_address_available\" or\nname == \"kube_endpoint_info\"
+              or\nname == \"kube_service_status_load_balancer_ingress\" or\nname == \"kube_endpoint_info\"
               or\nname == \"kube_endpoint_created\" or\nname == \"kube_endpoint_ports\"
               or\nname == \"kube_endpoint_address\"\n)\n"
         filter/preprocessing:
@@ -2129,8 +2128,7 @@ Metrics config should match snapshot when using Prometheus url with extra_scrape
               or\nname == \"kube_persistentvolumeclaim_created\" or\nname == \"kube_pod_spec_volumes_persistentvolumeclaims_info\"
               or\nname == \"kube_service_info\" or\nname == \"kube_service_created\" or\nname
               == \"kube_service_spec_type\" or\nname == \"kube_service_spec_external_ip\"
-              or\nname == \"kube_service_status_load_balancer_ingress\" or\nname == \"kube_endpoint_address_not_ready\"
-              or\nname == \"kube_endpoint_address_available\" or\nname == \"kube_endpoint_info\"
+              or\nname == \"kube_service_status_load_balancer_ingress\" or\nname == \"kube_endpoint_info\"
               or\nname == \"kube_endpoint_created\" or\nname == \"kube_endpoint_ports\"
               or\nname == \"kube_endpoint_address\"\n)\n"
         filter/preprocessing:
@@ -3927,8 +3925,7 @@ Metrics config should match snapshot when using default values:
               or\nname == \"kube_persistentvolumeclaim_created\" or\nname == \"kube_pod_spec_volumes_persistentvolumeclaims_info\"
               or\nname == \"kube_service_info\" or\nname == \"kube_service_created\" or\nname
               == \"kube_service_spec_type\" or\nname == \"kube_service_spec_external_ip\"
-              or\nname == \"kube_service_status_load_balancer_ingress\" or\nname == \"kube_endpoint_address_not_ready\"
-              or\nname == \"kube_endpoint_address_available\" or\nname == \"kube_endpoint_info\"
+              or\nname == \"kube_service_status_load_balancer_ingress\" or\nname == \"kube_endpoint_info\"
               or\nname == \"kube_endpoint_created\" or\nname == \"kube_endpoint_ports\"
               or\nname == \"kube_endpoint_address\"\n)\n"
         filter/preprocessing:

--- a/doc/exported_metrics.md
+++ b/doc/exported_metrics.md
@@ -271,8 +271,6 @@ The following tables contain the list of all metrics exported by the swi-k8s-ope
 | Metric | Type | Unit | Description | native/custom |
 | ---    | ---  | ---  | ---         | ---           |
 | k8s.kube_endpoint_annotations| Gauge |  | Kubernetes annotations converted to Prometheus labels | native |
-| k8s.kube_endpoint_address_not_ready| Gauge |  |  | native |
-| k8s.kube_endpoint_address_available| Gauge |  |  | native |
 | k8s.kube_endpoint_info| Gauge |  | Information about Endpoint | native |
 | k8s.kube_endpoint_labels| Gauge |  | Kubernetes labels converted to Prometheus labels | native |
 | k8s.kube_endpoint_created| Gauge |  | Unix creation timestamp | native |

--- a/tests/deploy/tests/test_metric_manifest.yaml
+++ b/tests/deploy/tests/test_metric_manifest.yaml
@@ -69,6 +69,9 @@ spec:
       - name: test-container
         image: busybox
         command: ["sh", "-c", "sleep infinity"]
+        ports:
+        - containerPort: 80
+          name: http-web-svc
 ---
 apiVersion: apps/v1
 kind: ReplicaSet
@@ -197,7 +200,7 @@ metadata:
     example.com/annotation: "example-annotation"
 spec:
   selector:
-    app: test-pod
+    app: test-statefulset
   ports:
   - name: test-service-port
     protocol: TCP

--- a/tests/integration/expected_metric_names.txt
+++ b/tests/integration/expected_metric_names.txt
@@ -53,8 +53,7 @@ k8s.kube_deployment_status_replicas_available
 k8s.kube_deployment_status_replicas_ready
 k8s.kube_deployment_status_replicas_unavailable
 k8s.kube_deployment_status_replicas_updated
-k8s.kube_endpoint_address_available
-k8s.kube_endpoint_address_not_ready
+k8s.kube_endpoint_address
 k8s.kube_endpoint_created
 k8s.kube_endpoint_info
 k8s.kube_endpoint_ports

--- a/tests/integration/expected_telemetry/service.json
+++ b/tests/integration/expected_telemetry/service.json
@@ -1,7 +1,6 @@
 {
     "metrics": [
-        { "name": "k8s.kube_endpoint_address_available" },
-        { "name": "k8s.kube_endpoint_address_not_ready" },
+        { "name": "k8s.kube_endpoint_address" },
         { "name": "k8s.kube_endpoint_created" },
         { "name": "k8s.kube_endpoint_info" },
         { "name": "k8s.kube_service_created" },


### PR DESCRIPTION
The new version removes two deprecated metrics `kube_endpoint_address_not_ready` and `kube_endpoint_address_available`.