### PR TITLE
Remove pod status from metrics

### DIFF
--- a/deploy/helm/metrics-collector-config.yaml
+++ b/deploy/helm/metrics-collector-config.yaml
@@ -679,7 +679,6 @@ processors:
       - image
       - image_id
       - k8s.node.name
-      - sw.k8s.pod.status
       - sw.k8s.namespace.status
       - sw.k8s.node.status
       - sw.k8s.container.status
@@ -720,16 +719,6 @@ processors:
         - k8s.kube_namespace_status_phase
     actions:
       - key: sw.k8s.namespace.status
-        from_attribute: phase
-        action: insert
-
-  attributes/attributes_pod_status:
-    include:
-      match_type: regexp
-      metric_names:
-        - kube_pod_status_phase
-    actions:
-      - key: sw.k8s.pod.status
         from_attribute: phase
         action: insert
 
@@ -1188,7 +1177,6 @@ service:
         - filter/preprocessing
         - filter/remove_internal_postprocessing
         - attributes/remove_temp
-        - attributes/attributes_pod_status
         - attributes/attributes_namespace_status
         - cumulativetodelta
         - deltatorate

--- a/deploy/helm/templates/_common-config.tpl
+++ b/deploy/helm/templates/_common-config.tpl
@@ -431,7 +431,6 @@ groupbyattrs/all:
     - image
     - image_id
     - k8s.node.name
-    - sw.k8s.pod.status
     - sw.k8s.namespace.status
     - sw.k8s.node.status
     - sw.k8s.container.status

--- a/deploy/helm/tests/__snapshot__/metrics-collector-config-map-fargate_test.yaml.snap
+++ b/deploy/helm/tests/__snapshot__/metrics-collector-config-map-fargate_test.yaml.snap
@@ -34,15 +34,6 @@ Metrics config should match snapshot when using default values:
             match_type: regexp
             metric_names:
             - k8s.kube_namespace_status_phase
-        attributes/attributes_pod_status:
-          actions:
-          - action: insert
-            from_attribute: phase
-            key: sw.k8s.pod.status
-          include:
-            match_type: regexp
-            metric_names:
-            - kube_pod_status_phase
         attributes/identify_init_container:
           actions:
           - action: insert
@@ -393,7 +384,6 @@ Metrics config should match snapshot when using default values:
           - image
           - image_id
           - k8s.node.name
-          - sw.k8s.pod.status
           - sw.k8s.namespace.status
           - sw.k8s.node.status
           - sw.k8s.container.status
@@ -1824,7 +1814,6 @@ Metrics config should match snapshot when using default values:
             - filter/preprocessing
             - filter/remove_internal_postprocessing
             - attributes/remove_temp
-            - attributes/attributes_pod_status
             - attributes/attributes_namespace_status
             - cumulativetodelta
             - deltatorate

--- a/deploy/helm/tests/__snapshot__/metrics-collector-config-map_test.yaml.snap
+++ b/deploy/helm/tests/__snapshot__/metrics-collector-config-map_test.yaml.snap
@@ -34,15 +34,6 @@ Metrics config should match snapshot when fargate is enabled:
             match_type: regexp
             metric_names:
             - k8s.kube_namespace_status_phase
-        attributes/attributes_pod_status:
-          actions:
-          - action: insert
-            from_attribute: phase
-            key: sw.k8s.pod.status
-          include:
-            match_type: regexp
-            metric_names:
-            - kube_pod_status_phase
         attributes/identify_init_container:
           actions:
           - action: insert
@@ -393,7 +384,6 @@ Metrics config should match snapshot when fargate is enabled:
           - image
           - image_id
           - k8s.node.name
-          - sw.k8s.pod.status
           - sw.k8s.namespace.status
           - sw.k8s.node.status
           - sw.k8s.container.status
@@ -1824,7 +1814,6 @@ Metrics config should match snapshot when fargate is enabled:
             - filter/preprocessing
             - filter/remove_internal_postprocessing
             - attributes/remove_temp
-            - attributes/attributes_pod_status
             - attributes/attributes_namespace_status
             - cumulativetodelta
             - deltatorate
@@ -1889,15 +1878,6 @@ Metrics config should match snapshot when using Prometheus url with extra_scrape
             match_type: regexp
             metric_names:
             - k8s.kube_namespace_status_phase
-        attributes/attributes_pod_status:
-          actions:
-          - action: insert
-            from_attribute: phase
-            key: sw.k8s.pod.status
-          include:
-            match_type: regexp
-            metric_names:
-            - kube_pod_status_phase
         attributes/identify_init_container:
           actions:
           - action: insert
@@ -2251,7 +2231,6 @@ Metrics config should match snapshot when using Prometheus url with extra_scrape
           - image
           - image_id
           - k8s.node.name
-          - sw.k8s.pod.status
           - sw.k8s.namespace.status
           - sw.k8s.node.status
           - sw.k8s.container.status
@@ -3617,7 +3596,6 @@ Metrics config should match snapshot when using Prometheus url with extra_scrape
             - filter/preprocessing
             - filter/remove_internal_postprocessing
             - attributes/remove_temp
-            - attributes/attributes_pod_status
             - attributes/attributes_namespace_status
             - cumulativetodelta
             - deltatorate
@@ -3689,15 +3667,6 @@ Metrics config should match snapshot when using default values:
             match_type: regexp
             metric_names:
             - k8s.kube_namespace_status_phase
-        attributes/attributes_pod_status:
-          actions:
-          - action: insert
-            from_attribute: phase
-            key: sw.k8s.pod.status
-          include:
-            match_type: regexp
-            metric_names:
-            - kube_pod_status_phase
         attributes/identify_init_container:
           actions:
           - action: insert
@@ -4051,7 +4020,6 @@ Metrics config should match snapshot when using default values:
           - image
           - image_id
           - k8s.node.name
-          - sw.k8s.pod.status
           - sw.k8s.namespace.status
           - sw.k8s.node.status
           - sw.k8s.container.status
@@ -5402,7 +5370,6 @@ Metrics config should match snapshot when using default values:
             - filter/preprocessing
             - filter/remove_internal_postprocessing
             - attributes/remove_temp
-            - attributes/attributes_pod_status
             - attributes/attributes_namespace_status
             - cumulativetodelta
             - deltatorate

--- a/deploy/helm/tests/__snapshot__/node-collector-config-map-windows_test.yaml.snap
+++ b/deploy/helm/tests/__snapshot__/node-collector-config-map-windows_test.yaml.snap
@@ -201,7 +201,6 @@ Node collector config for windows nodes should match snapshot when using default
           - image
           - image_id
           - k8s.node.name
-          - sw.k8s.pod.status
           - sw.k8s.namespace.status
           - sw.k8s.node.status
           - sw.k8s.container.status
@@ -1355,7 +1354,6 @@ Node collector config for windows nodes should match snapshot when using legacy 
           - image
           - image_id
           - k8s.node.name
-          - sw.k8s.pod.status
           - sw.k8s.namespace.status
           - sw.k8s.node.status
           - sw.k8s.container.status

--- a/deploy/helm/tests/__snapshot__/node-collector-config-map_test.yaml.snap
+++ b/deploy/helm/tests/__snapshot__/node-collector-config-map_test.yaml.snap
@@ -205,7 +205,6 @@ Custom logs filter with new syntax:
           - image
           - image_id
           - k8s.node.name
-          - sw.k8s.pod.status
           - sw.k8s.namespace.status
           - sw.k8s.node.status
           - sw.k8s.container.status
@@ -1396,7 +1395,6 @@ Custom logs filter with old syntax:
           - image
           - image_id
           - k8s.node.name
-          - sw.k8s.pod.status
           - sw.k8s.namespace.status
           - sw.k8s.node.status
           - sw.k8s.container.status
@@ -2661,7 +2659,6 @@ Node collector config should match snapshot when autodiscovery is disabled:
           - image
           - image_id
           - k8s.node.name
-          - sw.k8s.pod.status
           - sw.k8s.namespace.status
           - sw.k8s.node.status
           - sw.k8s.container.status
@@ -3799,7 +3796,6 @@ Node collector config should match snapshot when fargate is enabled:
           - image
           - image_id
           - k8s.node.name
-          - sw.k8s.pod.status
           - sw.k8s.namespace.status
           - sw.k8s.node.status
           - sw.k8s.container.status
@@ -4913,7 +4909,6 @@ Node collector config should match snapshot when fargate is enabled and autodisc
           - image
           - image_id
           - k8s.node.name
-          - sw.k8s.pod.status
           - sw.k8s.namespace.status
           - sw.k8s.node.status
           - sw.k8s.container.status
@@ -5981,7 +5976,6 @@ Node collector config should match snapshot when using default values:
           - image
           - image_id
           - k8s.node.name
-          - sw.k8s.pod.status
           - sw.k8s.namespace.status
           - sw.k8s.node.status
           - sw.k8s.container.status


### PR DESCRIPTION
This PR removes `sw.k8s.pod.status` from `metrics-collector-config.yaml`