### PR TITLE
Send cluster UID as an annotation

### DIFF
--- a/deploy/helm/templates/_helpers.tpl
+++ b/deploy/helm/templates/_helpers.tpl
@@ -67,7 +67,6 @@ Common labels
 app.kubernetes.io/part-of: swo-k8s-collector
 app.kubernetes.io/instance: {{ template "common.fullname" . }}
 app.kubernetes.io/managed-by: {{ .Release.Name }}
-swo.cloud.solarwinds.com/cluster-uid: {{ (include "common.cluster-uid" .) }}
 {{- if .Chart.AppVersion }}
 helm.sh/chart: {{ include "common.chart" . }}
 app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
@@ -77,6 +76,12 @@ app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
 {{- end }}
 {{- end -}}
 
+{{/*
+Common annotations
+*/}}
+{{- define "common.annotations" -}}
+swo.cloud.solarwinds.com/cluster-uid: {{ (include "common.cluster-uid" .) }}
+{{- end -}}
 
 {{/*
 Event which are considered as error

--- a/deploy/helm/templates/autoupdate/autoupdate-cronjob.yaml
+++ b/deploy/helm/templates/autoupdate/autoupdate-cronjob.yaml
@@ -6,6 +6,8 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
 {{ include "common.labels" . | indent 4 }}
+  annotations:
+{{ include "common.annotations" . | indent 4 }}
 spec:
   schedule: {{ quote .Values.autoupdate.schedule }}
   jobTemplate:

--- a/deploy/helm/templates/autoupdate/clusterrole.yaml
+++ b/deploy/helm/templates/autoupdate/clusterrole.yaml
@@ -5,6 +5,8 @@ metadata:
   name: {{ include "common.fullname" (tuple . "-autoupdate-clusterrole") }}
   labels:
 {{ include "common.labels" . | indent 4 }}
+  annotations:
+{{ include "common.annotations" . | indent 4 }}
 rules:
   - apiGroups:
       - rbac.authorization.k8s.io

--- a/deploy/helm/templates/autoupdate/clusterrolebinding.yaml
+++ b/deploy/helm/templates/autoupdate/clusterrolebinding.yaml
@@ -5,6 +5,8 @@ metadata:
   name: {{ include "common.fullname" (tuple . "-autoupdate-clusterrole-binding") }}
   labels:
 {{ include "common.labels" . | indent 4 }}
+  annotations:
+{{ include "common.annotations" . | indent 4 }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole

--- a/deploy/helm/templates/autoupdate/helm-update-config-map.yaml
+++ b/deploy/helm/templates/autoupdate/helm-update-config-map.yaml
@@ -6,6 +6,8 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
 {{ include "common.labels" . | indent 4 }}
+  annotations:
+{{ include "common.annotations" . | indent 4 }}
 data:
   helm-upgrade.sh: |
     #!/bin/bash

--- a/deploy/helm/templates/autoupdate/role.yaml
+++ b/deploy/helm/templates/autoupdate/role.yaml
@@ -6,6 +6,8 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
 {{ include "common.labels" . | indent 4 }}
+  annotations:
+{{ include "common.annotations" . | indent 4 }}
 rules:
   - apiGroups:
     - '*'

--- a/deploy/helm/templates/autoupdate/service-account.yaml
+++ b/deploy/helm/templates/autoupdate/service-account.yaml
@@ -6,4 +6,6 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
 {{ include "common.labels" . | indent 4 }}
+  annotations:
+{{ include "common.annotations" . | indent 4 }}
 {{- end }}

--- a/deploy/helm/templates/cluster-role-binding.yaml
+++ b/deploy/helm/templates/cluster-role-binding.yaml
@@ -4,6 +4,8 @@ metadata:
   name: {{ include "common.fullname" (tuple . "-role-binding") }}
   labels:
 {{ include "common.labels" . | indent 4 }}
+  annotations:
+{{ include "common.annotations" . | indent 4 }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole

--- a/deploy/helm/templates/cluster-role.yaml
+++ b/deploy/helm/templates/cluster-role.yaml
@@ -4,6 +4,8 @@ metadata:
   name: {{ include "common.fullname" (tuple . "-role") }}
   labels:
 {{ include "common.labels" . | indent 4 }}
+  annotations:
+{{ include "common.annotations" . | indent 4 }}
 rules:
   - apiGroups:
       - ""

--- a/deploy/helm/templates/collector-service.yaml
+++ b/deploy/helm/templates/collector-service.yaml
@@ -5,6 +5,8 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
 {{ include "common.labels" . | indent 4 }}
+  annotations:
+{{ include "common.annotations" . | indent 4 }}
 spec:
   type: ClusterIP
   ports:

--- a/deploy/helm/templates/common-env-config-map.yaml
+++ b/deploy/helm/templates/common-env-config-map.yaml
@@ -5,6 +5,8 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
 {{ include "common.labels" . | indent 4 }}
+  annotations:
+{{ include "common.annotations" . | indent 4 }}
 data:
   CLUSTER_NAME: {{ quote .Values.cluster.name }}
   CLUSTER_UID: {{ quote (include "common.cluster-uid" .) }}

--- a/deploy/helm/templates/events-collector-config-map.yaml
+++ b/deploy/helm/templates/events-collector-config-map.yaml
@@ -5,6 +5,8 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
 {{ include "common.labels" . | indent 4 }}
+  annotations:
+{{ include "common.annotations" . | indent 4 }}
 data:
   events.config: |
 {{ tpl (.Files.Get "events-collector-config.yaml") . | fromYaml | toYaml | indent 8 }}

--- a/deploy/helm/templates/events-collector-deployment.yaml
+++ b/deploy/helm/templates/events-collector-deployment.yaml
@@ -6,6 +6,8 @@ metadata:
   labels:
     app.kubernetes.io/name: swo-k8s-collector
 {{ include "common.labels" . | indent 4 }}
+  annotations:
+{{ include "common.annotations" . | indent 4 }}
 spec:
   replicas: 1
   selector:
@@ -17,6 +19,7 @@ spec:
         checksum/config: {{ include (print $.Template.BasePath "/events-collector-config-map.yaml") . | sha256sum }}
         checksum/config_common_env: {{ include (print $.Template.BasePath "/common-env-config-map.yaml") . | sha256sum }}
         checksum/values: {{ toJson .Values | sha256sum }}
+{{ include "common.annotations" . | indent 8 }}
 {{- if .Values.otel.events.telemetry.metrics.enabled }}
         prometheus.io/scrape: "true"
         prometheus.io/port: {{ (split ":" .Values.otel.events.telemetry.metrics.address)._1 | quote }}

--- a/deploy/helm/templates/events-pod-monitor.yaml
+++ b/deploy/helm/templates/events-pod-monitor.yaml
@@ -13,6 +13,8 @@ metadata:
     {{- if .Values.otel.events.telemetry.metrics.podMonitor.additionalLabels }}
     {{- toYaml .Values.otel.events.telemetry.metrics.podMonitor.additionalLabels | nindent 4 }}
     {{- end }}
+  annotations:
+{{ include "common.annotations" . | indent 4 }}
 spec:
   selector:
     matchLabels:

--- a/deploy/helm/templates/logs-fargate-config-map.yaml
+++ b/deploy/helm/templates/logs-fargate-config-map.yaml
@@ -12,6 +12,8 @@ metadata:
   namespace: aws-observability
   labels:
 {{ include "common.labels" . | indent 4 }}
+  annotations:
+{{ include "common.annotations" . | indent 4 }}
 data:
   flb_log_cw: "false"  # Set to true to ship Fluent Bit process logs to CloudWatch.
   filters.conf: |

--- a/deploy/helm/templates/logs-fargate-namespace.yaml
+++ b/deploy/helm/templates/logs-fargate-namespace.yaml
@@ -6,4 +6,6 @@ metadata:
   labels:
     aws-observability: enabled
 {{ include "common.labels" . | indent 4 }}
+  annotations:
+{{ include "common.annotations" . | indent 4 }}
 {{- end }}

--- a/deploy/helm/templates/metrics-collector-config-map.yaml
+++ b/deploy/helm/templates/metrics-collector-config-map.yaml
@@ -6,6 +6,8 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
 {{ include "common.labels" . | indent 4 }}
+  annotations:
+{{ include "common.annotations" . | indent 4 }}
 data:
   metrics.config: |
 {{ tpl (.Files.Get "metrics-collector-config.yaml") . | fromYaml | toYaml | indent 8 }}

--- a/deploy/helm/templates/metrics-collector-env-config-map.yaml
+++ b/deploy/helm/templates/metrics-collector-env-config-map.yaml
@@ -6,6 +6,8 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
 {{ include "common.labels" . | indent 4 }}
+  annotations:
+{{ include "common.annotations" . | indent 4 }}
 data:
 {{- if .Values.otel.metrics.prometheus.url }}
   PROMETHEUS_URL: {{ quote .Values.otel.metrics.prometheus.url }}

--- a/deploy/helm/templates/metrics-deployment.yaml
+++ b/deploy/helm/templates/metrics-deployment.yaml
@@ -7,6 +7,8 @@ metadata:
   labels:
     app.kubernetes.io/name: swo-k8s-collector
 {{ include "common.labels" . | indent 4 }}
+  annotations:
+{{ include "common.annotations" . | indent 4 }}
 spec:
   replicas: 1
   selector:
@@ -19,6 +21,7 @@ spec:
         checksum/config_common_env: {{ include (print $.Template.BasePath "/common-env-config-map.yaml") . | sha256sum }}
         checksum/config_env: {{ include (print $.Template.BasePath "/metrics-collector-env-config-map.yaml") . | sha256sum }}
         checksum/values: {{ toJson .Values | sha256sum }}
+{{ include "common.annotations" . | indent 8 }}
 {{- if .Values.otel.metrics.telemetry.metrics.enabled }}
         prometheus.io/scrape: "true"
         prometheus.io/port: {{ (split ":" .Values.otel.metrics.telemetry.metrics.address)._1 | quote }}

--- a/deploy/helm/templates/metrics-discovery-config-map.yaml
+++ b/deploy/helm/templates/metrics-discovery-config-map.yaml
@@ -6,6 +6,8 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
 {{ include "common.labels" . | indent 4 }}
+  annotations:
+{{ include "common.annotations" . | indent 4 }}
 data:
   metrics-discovery.config: |
 {{ tpl (.Files.Get "metrics-discovery-config.yaml") . | fromYaml | toYaml | indent 8 }}

--- a/deploy/helm/templates/metrics-discovery-deployment.yaml
+++ b/deploy/helm/templates/metrics-discovery-deployment.yaml
@@ -7,6 +7,8 @@ metadata:
   labels:
     app.kubernetes.io/name: swo-k8s-collector
 {{ include "common.labels" . | indent 4 }}
+  annotations:
+{{ include "common.annotations" . | indent 4 }}
 spec:
   replicas: 1
   selector:
@@ -18,6 +20,7 @@ spec:
         checksum/config: {{ include (print $.Template.BasePath "/metrics-discovery-config-map.yaml") . | sha256sum }}
         checksum/config_common_env: {{ include (print $.Template.BasePath "/common-env-config-map.yaml") . | sha256sum }}
         checksum/values: {{ toJson .Values | sha256sum }}
+{{ include "common.annotations" . | indent 8 }}
 {{- if .Values.aws_fargate.metrics.autodiscovery.telemetry.metrics.enabled }}
         prometheus.io/scrape: "true"
         prometheus.io/port: {{ (split ":" .Values.aws_fargate.metrics.autodiscovery.telemetry.metrics.address)._1 | quote }}

--- a/deploy/helm/templates/metrics-pod-monitor.yaml
+++ b/deploy/helm/templates/metrics-pod-monitor.yaml
@@ -13,6 +13,8 @@ metadata:
     {{- if .Values.otel.metrics.telemetry.metrics.podMonitor.additionalLabels }}
     {{- toYaml .Values.otel.metrics.telemetry.metrics.podMonitor.additionalLabels | nindent 4 }}
     {{- end }}
+  annotations:
+{{ include "common.annotations" . | indent 4 }}
 spec:
   selector:
     matchLabels:

--- a/deploy/helm/templates/network/k8s-collector-clusterrole.yaml
+++ b/deploy/helm/templates/network/k8s-collector-clusterrole.yaml
@@ -5,6 +5,8 @@ metadata:
   name: {{ include "common.fullname" (tuple . "-network-k8s-collector-role") }}
   labels:
 {{ include "common.labels" . | indent 4 }}
+  annotations:
+{{ include "common.annotations" . | indent 4 }}
 rules:
 - apiGroups:
   - ""

--- a/deploy/helm/templates/network/k8s-collector-clusterrolebinding.yaml
+++ b/deploy/helm/templates/network/k8s-collector-clusterrolebinding.yaml
@@ -5,6 +5,8 @@ metadata:
   name: {{ include "common.fullname" (tuple . "-network-k8s-collector-role-binding") }}
   labels:
 {{ include "common.labels" . | indent 4 }}
+  annotations:
+{{ include "common.annotations" . | indent 4 }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole

--- a/deploy/helm/templates/network/k8s-collector-deployment.yaml
+++ b/deploy/helm/templates/network/k8s-collector-deployment.yaml
@@ -5,6 +5,8 @@ metadata:
   name: {{ include "common.fullname" (tuple . "-network-k8s-collector") }}
   labels:
 {{ include "common.labels" . | indent 4 }}
+  annotations:
+{{ include "common.annotations" . | indent 4 }}
 spec:
   progressDeadlineSeconds: 600
   replicas: 1
@@ -23,6 +25,7 @@ spec:
       annotations:
         checksum/config: {{ include (print $.Template.BasePath "/network/configmap.yaml") . | sha256sum }}
         checksum/values: {{ toJson .Values | sha256sum }}
+{{ include "common.annotations" . | indent 8 }}
     spec:
       nodeSelector:
         kubernetes.io/os: linux

--- a/deploy/helm/templates/network/kernel-collector-daemonset.yaml
+++ b/deploy/helm/templates/network/kernel-collector-daemonset.yaml
@@ -5,7 +5,9 @@ metadata:
   name: {{ include "common.fullname" (tuple . "-kernel-collector") }}
   namespace: {{ .Release.Namespace }}
   labels:
-{{ include "common.labels" . | nindent 4 }}
+{{ include "common.labels" . | indent 4 }}
+  annotations:
+{{ include "common.annotations" . | indent 4 }}
 spec:
   selector:
     matchLabels:
@@ -18,6 +20,7 @@ spec:
 {{ include "common.pod-labels" . | indent 8 }}
       annotations:
         checksum/config: {{ include (print $.Template.BasePath "/network/configmap.yaml") . | sha256sum }}
+{{ include "common.annotations" . | indent 8 }}
     spec:
       terminationGracePeriodSeconds: 30
       securityContext:

--- a/deploy/helm/templates/network/reducer-deployment.yaml
+++ b/deploy/helm/templates/network/reducer-deployment.yaml
@@ -5,6 +5,8 @@ metadata:
   name: {{ include "common.fullname" (tuple . "-network-k8s-reducer") }}
   labels:
 {{ include "common.labels" . | indent 4 }}
+  annotations:
+{{ include "common.annotations" . | indent 4 }}
 spec:
   replicas: 1
   strategy:
@@ -20,6 +22,7 @@ spec:
 {{ include "common.pod-labels" . | indent 8 }}
       annotations:
         checksum/values: {{ toJson .Values | sha256sum }}
+{{ include "common.annotations" . | indent 8 }}
     spec:
       nodeSelector:
         kubernetes.io/os: linux

--- a/deploy/helm/templates/network/reducer-service.yaml
+++ b/deploy/helm/templates/network/reducer-service.yaml
@@ -5,6 +5,8 @@ metadata:
   name: {{ include "common.fullname" (tuple . "-network-k8s-reducer") }}
   labels:
 {{ include "common.labels" . | indent 4 }}
+  annotations:
+{{ include "common.annotations" . | indent 4 }}
 spec:
   type: ClusterIP
   selector:

--- a/deploy/helm/templates/node-collector-config-map-windows.yaml
+++ b/deploy/helm/templates/node-collector-config-map-windows.yaml
@@ -6,6 +6,9 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
 {{ include "common.labels" . | indent 4 }}
+  annotations:
+{{ include "common.annotations" . | indent 4 }}
+
 data:
   logs.config: |
 {{ tpl (.Files.Get "node-collector-config.yaml") (merge . (dict "isWindows" 1)) | fromYaml | toYaml | indent 8 }}

--- a/deploy/helm/templates/node-collector-config-map.yaml
+++ b/deploy/helm/templates/node-collector-config-map.yaml
@@ -6,6 +6,8 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
 {{ include "common.labels" . | indent 4 }}
+  annotations:
+{{ include "common.annotations" . | indent 4 }}
 data:
   logs.config: |
 {{ tpl (.Files.Get "node-collector-config.yaml") . | fromYaml | toYaml | indent 8 }}

--- a/deploy/helm/templates/node-collector-daemon-set-windows.yaml
+++ b/deploy/helm/templates/node-collector-daemon-set-windows.yaml
@@ -7,6 +7,8 @@ metadata:
   labels:
     app.kubernetes.io/name: swo-k8s-collector
 {{ include "common.labels" . | indent 4 }}
+  annotations:
+{{ include "common.annotations" . | indent 4 }}
 spec:
   selector:
     matchLabels:
@@ -22,6 +24,7 @@ spec:
         checksum/config: {{ tpl (.Files.Get "node-collector-config-map-windows.yaml") . | sha256sum }}
         checksum/config_common_env: {{ include (print $.Template.BasePath "/common-env-config-map.yaml") . | sha256sum }}
         checksum/values: {{ toJson .Values | sha256sum }}
+{{ include "common.annotations" . | indent 8 }}
 {{- if .Values.otel.logs.telemetry.metrics.enabled }}
         prometheus.io/scrape: "true"
         prometheus.io/port: {{ (split ":" .Values.otel.logs.telemetry.metrics.address)._1 | quote }}

--- a/deploy/helm/templates/node-collector-daemon-set.yaml
+++ b/deploy/helm/templates/node-collector-daemon-set.yaml
@@ -7,6 +7,8 @@ metadata:
   labels:
     app.kubernetes.io/name: swo-k8s-collector
 {{ include "common.labels" . | indent 4 }}
+  annotations:
+{{ include "common.annotations" . | indent 4 }}
 spec:
   selector:
     matchLabels:
@@ -22,6 +24,7 @@ spec:
         checksum/config: {{ include (print $.Template.BasePath "/node-collector-config-map.yaml") . | sha256sum }}
         checksum/config_common_env: {{ include (print $.Template.BasePath "/common-env-config-map.yaml") . | sha256sum }}
         checksum/values: {{ toJson .Values | sha256sum }}
+{{ include "common.annotations" . | indent 8 }}
 {{- if .Values.otel.logs.telemetry.metrics.enabled }}
         prometheus.io/scrape: "true"
         prometheus.io/port: {{ (split ":" .Values.otel.logs.telemetry.metrics.address)._1 | quote }}

--- a/deploy/helm/templates/node-collector-pod-monitor.yaml
+++ b/deploy/helm/templates/node-collector-pod-monitor.yaml
@@ -13,6 +13,8 @@ metadata:
     {{- if .Values.otel.logs.telemetry.metrics.podMonitor.additionalLabels }}
     {{- toYaml .Values.otel.logs.telemetry.metrics.podMonitor.additionalLabels | nindent 4 }}
     {{- end }}
+  annotations:
+{{ include "common.annotations" . | indent 4 }}
 spec:
   selector:
     matchLabels:

--- a/deploy/helm/templates/openshift/openshift-role-binding.yaml
+++ b/deploy/helm/templates/openshift/openshift-role-binding.yaml
@@ -6,6 +6,8 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
 {{ include "common.labels" . | indent 4 }}
+  annotations:
+{{ include "common.annotations" . | indent 4 }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role

--- a/deploy/helm/templates/openshift/openshift-role.yaml
+++ b/deploy/helm/templates/openshift/openshift-role.yaml
@@ -6,6 +6,8 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
 {{ include "common.labels" . | indent 4 }}
+  annotations:
+{{ include "common.annotations" . | indent 4 }}
 rules:
 - apiGroups:
   - security.openshift.io

--- a/deploy/helm/templates/secret.yaml
+++ b/deploy/helm/templates/secret.yaml
@@ -6,6 +6,8 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
 {{ include "common.labels" . | indent 4 }}
+  annotations:
+{{ include "common.annotations" . | indent 4 }}
 type: Opaque
 data:
   SOLARWINDS_API_TOKEN: {{ .Values.otel.api_token | b64enc }}

--- a/deploy/helm/templates/service-account.yaml
+++ b/deploy/helm/templates/service-account.yaml
@@ -5,3 +5,5 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
 {{ include "common.labels" . | indent 4 }}
+  annotations:
+{{ include "common.annotations" . | indent 4 }}

--- a/deploy/helm/templates/swo-agent-pvc.yaml
+++ b/deploy/helm/templates/swo-agent-pvc.yaml
@@ -11,6 +11,8 @@ metadata:
   labels:
     app.kubernetes.io/name: swo-agent
 {{ include "common.labels" . | indent 4 }}
+  annotations:
+{{ include "common.annotations" . | indent 4 }}
 spec:
   accessModes:
     - ReadWriteOnce

--- a/deploy/helm/templates/swo-agent-statefulset.yaml
+++ b/deploy/helm/templates/swo-agent-statefulset.yaml
@@ -12,6 +12,8 @@ metadata:
     solarwinds/swo-agent: "true"
     app.kubernetes.io/name: swo-agent
 {{ include "common.labels" . | indent 4 }}
+  annotations:
+{{ include "common.annotations" . | indent 4 }}
 spec:
   serviceName: {{ include "common.fullname" (tuple . "-swo-agent") }}
   replicas: 1
@@ -22,6 +24,7 @@ spec:
     metadata:
       annotations:
         checksum/values: {{ toJson .Values | sha256sum }}
+{{ include "common.annotations" . | indent 8 }}
       labels:
 {{ include "common.labels" . | indent 8 }}
         app: {{ include "common.fullname" (tuple . "-swo-agent") }}

--- a/deploy/helm/templates/values-config-map.yaml
+++ b/deploy/helm/templates/values-config-map.yaml
@@ -6,6 +6,8 @@ metadata:
   labels:
 {{ include "common.labels" . | indent 4 }}
     swo.cloud.solarwinds.com/config-type: values-config-map
+  annotations:
+{{ include "common.annotations" . | indent 4 }}
 data:
   VALUES_YAML: |-
     {{- $filteredValues := .Values | deepCopy }}


### PR DESCRIPTION
Kubernetes Cluster UID is now filled with the name of the cluster. AKS extension (soon to be released in Azure) creates name that is long and uses forbidden characters for K8S workflow label. That's why we are switching to annotation (annotation can handle longer strings with special characters).

