### PR TITLE
ENOPS-5919 - Update buildAndDeploy.yml - use OAT instead of PAT

### DIFF
--- a/.github/workflows/buildAndDeploy.yml
+++ b/.github/workflows/buildAndDeploy.yml
@@ -141,8 +141,8 @@ jobs:
       - name: Login to Docker Hub
         uses: docker/login-action@v3
         with:
-          username: ${{ secrets.OPENTELEMETRY_DOCKER_HUB_CI_USER }}
-          password: ${{ secrets.OPENTELEMETRY_DOCKER_HUB_CI_PASSWORD }}
+          username: ${{ vars.DOCKER_SOLARWINDS_ORG_LOGIN }}
+          password: ${{ secrets.ENOPS5919_OPENTELEMETRYCOLLECTOR_DOCKER_HUB_CI_OAT }}
       - name: Build and push
         uses: docker/build-push-action@v6
         with:
@@ -183,9 +183,9 @@ jobs:
 
       - name: Docker login
         env:
-          OPENTELEMETRY_DOCKER_HUB_CI_PASSWORD: ${{ secrets.OPENTELEMETRY_DOCKER_HUB_CI_PASSWORD }}
-          OPENTELEMETRY_DOCKER_HUB_CI_USER: ${{ secrets.OPENTELEMETRY_DOCKER_HUB_CI_USER }}
-        run: echo "$env:OPENTELEMETRY_DOCKER_HUB_CI_PASSWORD" | docker login -u "$env:OPENTELEMETRY_DOCKER_HUB_CI_USER" --password-stdin
+          ENOPS5919_OPENTELEMETRYCOLLECTOR_DOCKER_HUB_CI_OAT: ${{ secrets.ENOPS5919_OPENTELEMETRYCOLLECTOR_DOCKER_HUB_CI_OAT }}
+          DOCKER_SOLARWINDS_ORG_LOGIN: ${{ vars.DOCKER_SOLARWINDS_ORG_LOGIN }}
+        run: echo "$env:ENOPS5919_OPENTELEMETRYCOLLECTOR_DOCKER_HUB_CI_OAT" | docker login -u "$env:DOCKER_SOLARWINDS_ORG_LOGIN" --password-stdin
 
       - name: Push as specific
         run: | 
@@ -209,8 +209,8 @@ jobs:
       - name: Login to Docker Hub
         uses: docker/login-action@v3
         with:
-          username: ${{ secrets.OPENTELEMETRY_DOCKER_HUB_CI_USER }}
-          password: ${{ secrets.OPENTELEMETRY_DOCKER_HUB_CI_PASSWORD }}
+          username: ${{ vars.DOCKER_SOLARWINDS_ORG_LOGIN }}
+          password: ${{ secrets.ENOPS5919_OPENTELEMETRYCOLLECTOR_DOCKER_HUB_CI_OAT }}
         
       - name: Get linux manifest
         run: | 


### PR DESCRIPTION
Migrate from PAT tokens to OAT tokens.

Ticket: https://swicloud.atlassian.net/browse/ENOPS-5919