### PR TITLE
Fix "Source" link in Helm chart

### DIFF
--- a/deploy/helm/Chart.yaml
+++ b/deploy/helm/Chart.yaml
@@ -13,7 +13,7 @@ keywords:
 home: https://solarwinds.com/
 icon: https://helm.solarwinds.com/favicon.png
 sources:
-  - https://github.com/solarwinds/swi-k8s-opentelemetry-collector/deploy/helm/
+  - https://github.com/solarwinds/swi-k8s-opentelemetry-collector/tree/master/deploy/helm
 maintainers:
   - name: SolarWinds
     email: support@solarwinds.com


### PR DESCRIPTION
The original link goes to 404.