### PR TITLE
Fixing `skaffold dev` cleanup - CRD's shouldn't be deleted by the chart

### DIFF
--- a/deploy/helm/templates/crds/crd-podmonitors.yaml
+++ b/deploy/helm/templates/crds/crd-podmonitors.yaml
@@ -7,6 +7,7 @@ metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.17.1
     operator.prometheus.io/version: 0.80.0
+    helm.sh/resource-policy: keep
   name: podmonitors.monitoring.coreos.com
 spec:
   group: monitoring.coreos.com

--- a/deploy/helm/templates/crds/crd-probes.yaml
+++ b/deploy/helm/templates/crds/crd-probes.yaml
@@ -7,6 +7,7 @@ metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.17.1
     operator.prometheus.io/version: 0.80.0
+    helm.sh/resource-policy: keep
   name: probes.monitoring.coreos.com
 spec:
   group: monitoring.coreos.com

--- a/deploy/helm/templates/crds/crd-scrapeconfigs.yaml
+++ b/deploy/helm/templates/crds/crd-scrapeconfigs.yaml
@@ -7,6 +7,7 @@ metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.17.1
     operator.prometheus.io/version: 0.80.0
+    helm.sh/resource-policy: keep
   name: scrapeconfigs.monitoring.coreos.com
 spec:
   group: monitoring.coreos.com

--- a/deploy/helm/templates/crds/crd-servicemonitors.yaml
+++ b/deploy/helm/templates/crds/crd-servicemonitors.yaml
@@ -7,6 +7,7 @@ metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.17.1
     operator.prometheus.io/version: 0.80.0
+    helm.sh/resource-policy: keep
   name: servicemonitors.monitoring.coreos.com
 spec:
   group: monitoring.coreos.com


### PR DESCRIPTION
CRDs when they are in `crds` folder are not deleted by the Helm. Our CRDs are in `templates` folder so they are deleted, so I added `helm.sh/resource-policy: keep` annotation on them, to make sure that they are not deleted by the chart when the chart is uninstalled (they need to be always uninstalled manually as usual CRDs)

This also fix the `skaffold dev` cleanup, because what happened is that it uninstalled `sut` chart with CRDs and other Helm charts that deployed custom resources that were based on those CRDs were in corrupted state not being able to uninstall.  