### PR TITLE
Remove metric k8s.container.status

### DIFF
--- a/deploy/helm/metrics-collector-config.yaml
+++ b/deploy/helm/metrics-collector-config.yaml
@@ -278,48 +278,6 @@ processors:
         experimental_match_labels: { "resource": "memory" }
         new_name: k8s.initcontainer.spec.memory.limit_temp
 
-      - include: k8s.kube_pod_container_status_waiting
-        action: insert
-        new_name: k8s.kube_pod_container_status_waiting_only_temp
-      - include: k8s.kube_pod_container_status_running
-        action: insert
-        new_name: k8s.kube_pod_container_status_running_only_temp
-      - include: k8s.kube_pod_container_status_terminated
-        action: insert
-        new_name: k8s.kube_pod_container_status_terminated_only_temp
-      - include: ^k8s.kube_pod_container_status_(?P<status>[^_]*)_only_temp$
-        match_type: regexp
-        action: combine
-        new_name: k8s.container.status_temp
-        submatch_case: lower
-        operations:
-          - action: update_label
-            label: status
-            new_label: sw.k8s.container.status
-      - include: k8s.kube_pod_init_container_status_waiting
-        action: insert
-        new_name: k8s.kube_pod_init_container_status_waiting_only_temp
-      - include: k8s.kube_pod_init_container_status_running
-        action: insert
-        new_name: k8s.kube_pod_init_container_status_running_only_temp
-      - include: k8s.kube_pod_init_container_status_terminated
-        action: insert
-        new_name: k8s.kube_pod_init_container_status_terminated_only_temp
-      - include: ^k8s.kube_pod_init_container_status_(?P<status>[^_]*)_only_temp$
-        match_type: regexp
-        action: combine
-        new_name: k8s.initcontainer.status_temp
-        submatch_case: lower
-        operations:
-          - action: update_label
-            label: status
-            new_label: sw.k8s.container.status
-      - include: (k8s.initcontainer.status_temp|k8s.container.status_temp)
-        match_type: regexp
-        action: combine
-        submatch_case: lower
-        new_name: k8s.container.status
-
       # Pod resource metrics
       - include: k8s.container.spec.cpu.limit_temp
         action: insert
@@ -608,7 +566,6 @@ processors:
         - 'metric.name == "k8s.kube_job_created" and value_double == 0'
         - 'metric.name == "k8s.kube_job_status_completion_time" and value_double == 0'
         - 'metric.name == "k8s.kube_job_status_start_time" and value_double == 0'
-        - 'metric.name == "k8s.container.status" and value_double != 1'
 
   cumulativetodelta:
     include:
@@ -682,7 +639,6 @@ processors:
       - k8s.node.name
       - sw.k8s.namespace.status
       - sw.k8s.node.status
-      - sw.k8s.container.status
       - sw.k8s.container.init
       - daemonset
       - statefulset

--- a/deploy/helm/templates/_common-config.tpl
+++ b/deploy/helm/templates/_common-config.tpl
@@ -433,7 +433,6 @@ groupbyattrs/all:
     - k8s.node.name
     - sw.k8s.namespace.status
     - sw.k8s.node.status
-    - sw.k8s.container.status
     - sw.k8s.container.init
     - daemonset
     - statefulset

--- a/deploy/helm/tests/__snapshot__/metrics-collector-config-map-fargate_test.yaml.snap
+++ b/deploy/helm/tests/__snapshot__/metrics-collector-config-map-fargate_test.yaml.snap
@@ -294,7 +294,6 @@ Metrics config should match snapshot when using default values:
             - metric.name == "k8s.kube_job_created" and value_double == 0
             - metric.name == "k8s.kube_job_status_completion_time" and value_double == 0
             - metric.name == "k8s.kube_job_status_start_time" and value_double == 0
-            - metric.name == "k8s.container.status" and value_double != 1
         filter/prometheus-node-metrics:
           metrics:
             metric:
@@ -386,7 +385,6 @@ Metrics config should match snapshot when using default values:
           - k8s.node.name
           - sw.k8s.namespace.status
           - sw.k8s.node.status
-          - sw.k8s.container.status
           - sw.k8s.container.init
           - daemonset
           - statefulset
@@ -1001,47 +999,6 @@ Metrics config should match snapshot when using default values:
             include: k8s.kube_pod_init_container_resource_limits
             match_type: regexp
             new_name: k8s.initcontainer.spec.memory.limit_temp
-          - action: insert
-            include: k8s.kube_pod_container_status_waiting
-            new_name: k8s.kube_pod_container_status_waiting_only_temp
-          - action: insert
-            include: k8s.kube_pod_container_status_running
-            new_name: k8s.kube_pod_container_status_running_only_temp
-          - action: insert
-            include: k8s.kube_pod_container_status_terminated
-            new_name: k8s.kube_pod_container_status_terminated_only_temp
-          - action: combine
-            include: ^k8s.kube_pod_container_status_(?P<status>[^_]*)_only_temp$
-            match_type: regexp
-            new_name: k8s.container.status_temp
-            operations:
-            - action: update_label
-              label: status
-              new_label: sw.k8s.container.status
-            submatch_case: lower
-          - action: insert
-            include: k8s.kube_pod_init_container_status_waiting
-            new_name: k8s.kube_pod_init_container_status_waiting_only_temp
-          - action: insert
-            include: k8s.kube_pod_init_container_status_running
-            new_name: k8s.kube_pod_init_container_status_running_only_temp
-          - action: insert
-            include: k8s.kube_pod_init_container_status_terminated
-            new_name: k8s.kube_pod_init_container_status_terminated_only_temp
-          - action: combine
-            include: ^k8s.kube_pod_init_container_status_(?P<status>[^_]*)_only_temp$
-            match_type: regexp
-            new_name: k8s.initcontainer.status_temp
-            operations:
-            - action: update_label
-              label: status
-              new_label: sw.k8s.container.status
-            submatch_case: lower
-          - action: combine
-            include: (k8s.initcontainer.status_temp|k8s.container.status_temp)
-            match_type: regexp
-            new_name: k8s.container.status
-            submatch_case: lower
           - action: insert
             include: k8s.container.spec.cpu.limit_temp
             new_name: k8s.pod.spec.cpu.limit

--- a/deploy/helm/tests/__snapshot__/metrics-collector-config-map_test.yaml.snap
+++ b/deploy/helm/tests/__snapshot__/metrics-collector-config-map_test.yaml.snap
@@ -294,7 +294,6 @@ Metrics config should match snapshot when fargate is enabled:
             - metric.name == "k8s.kube_job_created" and value_double == 0
             - metric.name == "k8s.kube_job_status_completion_time" and value_double == 0
             - metric.name == "k8s.kube_job_status_start_time" and value_double == 0
-            - metric.name == "k8s.container.status" and value_double != 1
         filter/prometheus-node-metrics:
           metrics:
             metric:
@@ -386,7 +385,6 @@ Metrics config should match snapshot when fargate is enabled:
           - k8s.node.name
           - sw.k8s.namespace.status
           - sw.k8s.node.status
-          - sw.k8s.container.status
           - sw.k8s.container.init
           - daemonset
           - statefulset
@@ -1001,47 +999,6 @@ Metrics config should match snapshot when fargate is enabled:
             include: k8s.kube_pod_init_container_resource_limits
             match_type: regexp
             new_name: k8s.initcontainer.spec.memory.limit_temp
-          - action: insert
-            include: k8s.kube_pod_container_status_waiting
-            new_name: k8s.kube_pod_container_status_waiting_only_temp
-          - action: insert
-            include: k8s.kube_pod_container_status_running
-            new_name: k8s.kube_pod_container_status_running_only_temp
-          - action: insert
-            include: k8s.kube_pod_container_status_terminated
-            new_name: k8s.kube_pod_container_status_terminated_only_temp
-          - action: combine
-            include: ^k8s.kube_pod_container_status_(?P<status>[^_]*)_only_temp$
-            match_type: regexp
-            new_name: k8s.container.status_temp
-            operations:
-            - action: update_label
-              label: status
-              new_label: sw.k8s.container.status
-            submatch_case: lower
-          - action: insert
-            include: k8s.kube_pod_init_container_status_waiting
-            new_name: k8s.kube_pod_init_container_status_waiting_only_temp
-          - action: insert
-            include: k8s.kube_pod_init_container_status_running
-            new_name: k8s.kube_pod_init_container_status_running_only_temp
-          - action: insert
-            include: k8s.kube_pod_init_container_status_terminated
-            new_name: k8s.kube_pod_init_container_status_terminated_only_temp
-          - action: combine
-            include: ^k8s.kube_pod_init_container_status_(?P<status>[^_]*)_only_temp$
-            match_type: regexp
-            new_name: k8s.initcontainer.status_temp
-            operations:
-            - action: update_label
-              label: status
-              new_label: sw.k8s.container.status
-            submatch_case: lower
-          - action: combine
-            include: (k8s.initcontainer.status_temp|k8s.container.status_temp)
-            match_type: regexp
-            new_name: k8s.container.status
-            submatch_case: lower
           - action: insert
             include: k8s.container.spec.cpu.limit_temp
             new_name: k8s.pod.spec.cpu.limit
@@ -2053,7 +2010,6 @@ Metrics config should match snapshot when using Prometheus url with extra_scrape
             - metric.name == "k8s.kube_job_created" and value_double == 0
             - metric.name == "k8s.kube_job_status_completion_time" and value_double == 0
             - metric.name == "k8s.kube_job_status_start_time" and value_double == 0
-            - metric.name == "k8s.container.status" and value_double != 1
         filter/prometheus-node-metrics:
           metrics:
             metric:
@@ -2145,7 +2101,6 @@ Metrics config should match snapshot when using Prometheus url with extra_scrape
           - k8s.node.name
           - sw.k8s.namespace.status
           - sw.k8s.node.status
-          - sw.k8s.container.status
           - sw.k8s.container.init
           - daemonset
           - statefulset
@@ -2760,47 +2715,6 @@ Metrics config should match snapshot when using Prometheus url with extra_scrape
             include: k8s.kube_pod_init_container_resource_limits
             match_type: regexp
             new_name: k8s.initcontainer.spec.memory.limit_temp
-          - action: insert
-            include: k8s.kube_pod_container_status_waiting
-            new_name: k8s.kube_pod_container_status_waiting_only_temp
-          - action: insert
-            include: k8s.kube_pod_container_status_running
-            new_name: k8s.kube_pod_container_status_running_only_temp
-          - action: insert
-            include: k8s.kube_pod_container_status_terminated
-            new_name: k8s.kube_pod_container_status_terminated_only_temp
-          - action: combine
-            include: ^k8s.kube_pod_container_status_(?P<status>[^_]*)_only_temp$
-            match_type: regexp
-            new_name: k8s.container.status_temp
-            operations:
-            - action: update_label
-              label: status
-              new_label: sw.k8s.container.status
-            submatch_case: lower
-          - action: insert
-            include: k8s.kube_pod_init_container_status_waiting
-            new_name: k8s.kube_pod_init_container_status_waiting_only_temp
-          - action: insert
-            include: k8s.kube_pod_init_container_status_running
-            new_name: k8s.kube_pod_init_container_status_running_only_temp
-          - action: insert
-            include: k8s.kube_pod_init_container_status_terminated
-            new_name: k8s.kube_pod_init_container_status_terminated_only_temp
-          - action: combine
-            include: ^k8s.kube_pod_init_container_status_(?P<status>[^_]*)_only_temp$
-            match_type: regexp
-            new_name: k8s.initcontainer.status_temp
-            operations:
-            - action: update_label
-              label: status
-              new_label: sw.k8s.container.status
-            submatch_case: lower
-          - action: combine
-            include: (k8s.initcontainer.status_temp|k8s.container.status_temp)
-            match_type: regexp
-            new_name: k8s.container.status
-            submatch_case: lower
           - action: insert
             include: k8s.container.spec.cpu.limit_temp
             new_name: k8s.pod.spec.cpu.limit
@@ -3754,7 +3668,6 @@ Metrics config should match snapshot when using default values:
             - metric.name == "k8s.kube_job_created" and value_double == 0
             - metric.name == "k8s.kube_job_status_completion_time" and value_double == 0
             - metric.name == "k8s.kube_job_status_start_time" and value_double == 0
-            - metric.name == "k8s.container.status" and value_double != 1
         filter/prometheus-node-metrics:
           metrics:
             metric:
@@ -3846,7 +3759,6 @@ Metrics config should match snapshot when using default values:
           - k8s.node.name
           - sw.k8s.namespace.status
           - sw.k8s.node.status
-          - sw.k8s.container.status
           - sw.k8s.container.init
           - daemonset
           - statefulset
@@ -4461,47 +4373,6 @@ Metrics config should match snapshot when using default values:
             include: k8s.kube_pod_init_container_resource_limits
             match_type: regexp
             new_name: k8s.initcontainer.spec.memory.limit_temp
-          - action: insert
-            include: k8s.kube_pod_container_status_waiting
-            new_name: k8s.kube_pod_container_status_waiting_only_temp
-          - action: insert
-            include: k8s.kube_pod_container_status_running
-            new_name: k8s.kube_pod_container_status_running_only_temp
-          - action: insert
-            include: k8s.kube_pod_container_status_terminated
-            new_name: k8s.kube_pod_container_status_terminated_only_temp
-          - action: combine
-            include: ^k8s.kube_pod_container_status_(?P<status>[^_]*)_only_temp$
-            match_type: regexp
-            new_name: k8s.container.status_temp
-            operations:
-            - action: update_label
-              label: status
-              new_label: sw.k8s.container.status
-            submatch_case: lower
-          - action: insert
-            include: k8s.kube_pod_init_container_status_waiting
-            new_name: k8s.kube_pod_init_container_status_waiting_only_temp
-          - action: insert
-            include: k8s.kube_pod_init_container_status_running
-            new_name: k8s.kube_pod_init_container_status_running_only_temp
-          - action: insert
-            include: k8s.kube_pod_init_container_status_terminated
-            new_name: k8s.kube_pod_init_container_status_terminated_only_temp
-          - action: combine
-            include: ^k8s.kube_pod_init_container_status_(?P<status>[^_]*)_only_temp$
-            match_type: regexp
-            new_name: k8s.initcontainer.status_temp
-            operations:
-            - action: update_label
-              label: status
-              new_label: sw.k8s.container.status
-            submatch_case: lower
-          - action: combine
-            include: (k8s.initcontainer.status_temp|k8s.container.status_temp)
-            match_type: regexp
-            new_name: k8s.container.status
-            submatch_case: lower
           - action: insert
             include: k8s.container.spec.cpu.limit_temp
             new_name: k8s.pod.spec.cpu.limit

--- a/deploy/helm/tests/__snapshot__/node-collector-config-map-windows_test.yaml.snap
+++ b/deploy/helm/tests/__snapshot__/node-collector-config-map-windows_test.yaml.snap
@@ -204,7 +204,6 @@ Node collector config for windows nodes should match snapshot when using default
           - k8s.node.name
           - sw.k8s.namespace.status
           - sw.k8s.node.status
-          - sw.k8s.container.status
           - sw.k8s.container.init
           - daemonset
           - statefulset
@@ -1358,7 +1357,6 @@ Node collector config for windows nodes should match snapshot when using legacy 
           - k8s.node.name
           - sw.k8s.namespace.status
           - sw.k8s.node.status
-          - sw.k8s.container.status
           - sw.k8s.container.init
           - daemonset
           - statefulset

--- a/deploy/helm/tests/__snapshot__/node-collector-config-map_test.yaml.snap
+++ b/deploy/helm/tests/__snapshot__/node-collector-config-map_test.yaml.snap
@@ -208,7 +208,6 @@ Custom logs filter with new syntax:
           - k8s.node.name
           - sw.k8s.namespace.status
           - sw.k8s.node.status
-          - sw.k8s.container.status
           - sw.k8s.container.init
           - daemonset
           - statefulset
@@ -1399,7 +1398,6 @@ Custom logs filter with old syntax:
           - k8s.node.name
           - sw.k8s.namespace.status
           - sw.k8s.node.status
-          - sw.k8s.container.status
           - sw.k8s.container.init
           - daemonset
           - statefulset
@@ -2664,7 +2662,6 @@ Node collector config should match snapshot when autodiscovery is disabled:
           - k8s.node.name
           - sw.k8s.namespace.status
           - sw.k8s.node.status
-          - sw.k8s.container.status
           - sw.k8s.container.init
           - daemonset
           - statefulset
@@ -3802,7 +3799,6 @@ Node collector config should match snapshot when fargate is enabled:
           - k8s.node.name
           - sw.k8s.namespace.status
           - sw.k8s.node.status
-          - sw.k8s.container.status
           - sw.k8s.container.init
           - daemonset
           - statefulset
@@ -4916,7 +4912,6 @@ Node collector config should match snapshot when fargate is enabled and autodisc
           - k8s.node.name
           - sw.k8s.namespace.status
           - sw.k8s.node.status
-          - sw.k8s.container.status
           - sw.k8s.container.init
           - daemonset
           - statefulset
@@ -5984,7 +5979,6 @@ Node collector config should match snapshot when using default values:
           - k8s.node.name
           - sw.k8s.namespace.status
           - sw.k8s.node.status
-          - sw.k8s.container.status
           - sw.k8s.container.init
           - daemonset
           - statefulset

--- a/doc/exported_metrics.md
+++ b/doc/exported_metrics.md
@@ -117,7 +117,6 @@ The following tables contain the list of all metrics exported by the swi-k8s-ope
 | k8s.container.spec.cpu.limit | Gauge | cores | CPU quota of container in given CPU period | custom |
 | k8s.container.cpu.usage.seconds.rate | Gauge | cores | The rate of pod cumulative CPU time consumed | custom |
 | k8s.container.spec.memory.requests | Gauge | bytes | The number of requested memory by a container | custom |
-| k8s.container.status | Gauge |  | Describes the status of the container (waiting/running/terminated) | custom |
 | k8s.container.fs.iops | Gauge |  | Rate of reads and writes on container | custom |
 | k8s.container.fs.throughput | Gauge |  | Rate of bytes read and written on container | custom |
 | k8s.container.network.bytes_received | Gauge |  | Rate of bytes received on container | custom |

--- a/tests/integration/expected_metric_names.txt
+++ b/tests/integration/expected_metric_names.txt
@@ -16,7 +16,6 @@ k8s.container.network.bytes_transmitted
 k8s.container.spec.cpu.requests
 k8s.container.spec.memory.limit
 k8s.container.spec.memory.requests
-k8s.container.status
 k8s.container_cpu_usage_seconds_total
 k8s.container_fs_reads_total
 k8s.container_fs_usage_bytes

--- a/tests/integration/expected_telemetry/container.json
+++ b/tests/integration/expected_telemetry/container.json
@@ -1,6 +1,5 @@
 {
     "metrics": [
-        { "name": "k8s.container.status" },
         { "name": "k8s.kube_pod_container_info" },
         { "name": "k8s.kube_pod_container_state_started" },
         { "name": "k8s.kube_pod_container_status_ready" },

--- a/tests/integration/expected_telemetry/pod.json
+++ b/tests/integration/expected_telemetry/pod.json
@@ -1,7 +1,6 @@
 {
     "metrics": [
         { "name": "k8s.container.cpu.usage.seconds.rate" },
-        { "name": "k8s.container.status" },
         { "name": "k8s.container_cpu_usage_seconds_total" },
         { "name": "k8s.container_memory_working_set_bytes" },
         { "name": "k8s.container_spec_cpu_period" },


### PR DESCRIPTION
Container status is computed by processor and update is sent as event. We don't need anymore duplicate logic in metric