### PR TITLE
NH-103832 Upgrade to APM Python 3.5.0

### DIFF
--- a/deploy/helm/values.yaml
+++ b/deploy/helm/values.yaml
@@ -1011,7 +1011,7 @@ operator:
         tag: ""
       python:
         repository: "solarwinds/autoinstrumentation-python"
-        tag: "3.4.0"
+        tag: "3.5.0"
       dotnet:
         repository: ""
         tag: ""


### PR DESCRIPTION
Upgrades the autoinstrumentation-python image to APM Python 3.5.0, released Mar 14 2025.