### PR TITLE
Set SWO Agent as ephemeral

### DIFF
--- a/deploy/helm/templates/swo-agent-statefulset.yaml
+++ b/deploy/helm/templates/swo-agent-statefulset.yaml
@@ -90,6 +90,8 @@ spec:
                   name: {{ include "common.fullname" (tuple . "-common-env") }}
                   key: HTTPS_PROXY
                   optional: true
+            - name: UAMS_IS_EPHEMERAL
+              value: "true"
           volumeMounts:
             - name: uams-client-workdir
               mountPath: /uamsclient/workdir

--- a/deploy/helm/tests/swo-agent-statefulset_test.yaml
+++ b/deploy/helm/tests/swo-agent-statefulset_test.yaml
@@ -10,7 +10,7 @@ tests:
     asserts:
     - equal:
           path: spec.template.spec.containers[0].image
-          value: solarwinds/swo-agent:v2.10.136
+          value: solarwinds/swo-agent:v2.10.156
   - it: Image should be correct when overriden tag
     template: swo-agent-statefulset.yaml
     set:

--- a/deploy/helm/values.yaml
+++ b/deploy/helm/values.yaml
@@ -797,7 +797,7 @@ swoagent:
   enabled: false
   image:
     repository: solarwinds/swo-agent
-    tag: "v2.10.136"
+    tag: "v2.10.156"
     pullPolicy: IfNotPresent
   resources:
     limits:


### PR DESCRIPTION
This setting ensures, that the SWO Agent will be automatically unregistered from SWO 24 hours after the `k8s collector` that owns it is uninstalled.