### PR TITLE
Update kube-state-metrics

### DIFF
--- a/deploy/helm/Chart.lock
+++ b/deploy/helm/Chart.lock
@@ -1,12 +1,12 @@
 dependencies:
 - name: kube-state-metrics
   repository: https://prometheus-community.github.io/helm-charts
-  version: 5.28.1
+  version: 5.31.0
 - name: opentelemetry-operator
   repository: https://open-telemetry.github.io/opentelemetry-helm-charts
   version: 0.78.2
 - name: cert-manager
   repository: https://charts.jetstack.io
   version: v1.16.1
-digest: sha256:276ab1fcf94c85a18d6d5162c0d764bcb2dc05efa44cd3581b2e575c0577e168
-generated: "2025-02-26T00:55:27.536158+01:00"
+digest: sha256:f8e345b829722421d89d5cf1fc46f88e8715ed75a2a6c3548442690fd9285298
+generated: "2025-03-25T15:11:42.3291808+01:00"

--- a/deploy/helm/Chart.yaml
+++ b/deploy/helm/Chart.yaml
@@ -20,7 +20,7 @@ maintainers:
 dependencies:
   - name: kube-state-metrics
     repository: https://prometheus-community.github.io/helm-charts
-    version: "~> 5.28.0"
+    version: 5.31.0
     condition: kube-state-metrics.enabled
   - name: opentelemetry-operator
     repository: https://open-telemetry.github.io/opentelemetry-helm-charts


### PR DESCRIPTION
There should be no visible changes for us. The main reason for the update is that the new image contains some security fixes. Also, changed the `kube-state-metrics`'s Helm version to be fixed instead of allowing for silent updates.