### PR TITLE
Adding more configuration options to beyla

### DIFF
--- a/deploy/helm/metrics-collector-config.yaml
+++ b/deploy/helm/metrics-collector-config.yaml
@@ -703,6 +703,12 @@ processors:
 
   {{- include "common-config.attributes-remove-prometheus-attributes" . | nindent 2 }}
 
+  # Those attributes are defined by SWO K8s Collector even if they are send as attributes in OTLP message
+  attributes/clean-attributes-otlp-metrics:
+    actions:
+      - key: k8s.cluster.name
+        action: delete
+
   resource/otlp-metrics:
     attributes:
       # Collector and Manifest version
@@ -1097,6 +1103,7 @@ service:
         - filter/ebpf
 {{- end }}
         - metricstransform/rename-otel
+        - attributes/clean-attributes-otlp-metrics
         - resource/otlp-metrics
       receivers:
         - otlp

--- a/deploy/helm/metrics-collector-config.yaml
+++ b/deploy/helm/metrics-collector-config.yaml
@@ -865,7 +865,27 @@ processors:
   filter/histograms:
     metrics:
       metric:
-        - 'type == METRIC_DATA_TYPE_HISTOGRAM and not(name == "k8s.apiserver_request_duration_seconds" or name == "k8s.workqueue_queue_duration_seconds" or name == "k8s.coredns_dns_request_duration_seconds" or name == "k8s.coredns_dns_request_size_bytes" or name == "k8s.coredns_dns_response_size_bytes")'
+        # Exclude all histograms except the ones listed below
+        # excluded histograms are:
+        # - all histograms required for system dashboards (apiserver, coredns, controller_manager)
+        # - all histograms from beyla
+        - 'type == METRIC_DATA_TYPE_HISTOGRAM and not(
+            name == "k8s.apiserver_request_duration_seconds" or 
+            name == "k8s.workqueue_queue_duration_seconds" or 
+            name == "k8s.coredns_dns_request_duration_seconds" or 
+            name == "k8s.coredns_dns_request_size_bytes" or 
+            name == "k8s.coredns_dns_response_size_bytes" or 
+            name == "k8s.http.client.request.duration" or
+            name == "k8s.http.client.request.body.size" or
+            name == "k8s.http.server.request.duration" or 
+            name == "k8s.http.server.request.body.size" or
+            name == "k8s.rpc.client.duration" or
+            name == "k8s.rpc.server.duration" or
+            name == "k8s.sql.client.duration" or
+            name == "k8s.redis.client.duration" or
+            name == "k8s.messaging.publish.duration" or
+            name == "k8s.messaging.process.duration"
+          )'
 
 connectors:
   forward/prometheus:

--- a/deploy/helm/templates/beyla/configmap.yaml
+++ b/deploy/helm/templates/beyla/configmap.yaml
@@ -11,32 +11,55 @@ metadata:
 {{ include "common.annotations" . | indent 4 }}
 data:
   beyla-config.yml: |
+    {{- if not .Values.beyla.config.otel_metrics_export }}
     otel_metrics_export:
       endpoint: http://{{ include "common.fullname" (tuple . "-metrics-collector") }}:{{ .Values.otel.metrics.otlp_endpoint.port }}
       protocol: grpc
       interval: {{ quote .Values.otel.metrics.prometheus.scrape_interval }}
       features: ["application", "application_process", "application_service_graph", "network"]
+    {{- end }}
+    {{- if not .Values.beyla.config.ebpf }}
     ebpf:
       enable_context_propagation: true
+    {{- end }}
+    {{- if not .Values.beyla.config.process }}
     process:
       enabled: true
+    {{- end }}
+    {{- if not .Values.beyla.config.network }}
     network:
       enable: true
+    {{- end }}
+    {{- if not .Values.beyla.config.discovery }}
     discovery:
       services:
         - k8s_namespace: .*
       exclude_services:
         - exe_path: ".*otelcol.*|.*beyla.*"
-    log_level: {{ .Values.beyla.telemetry.logs.level }}
+    {{- end }}
+    {{- if not .Values.beyla.config.log_level }}
+    log_level: info
+    {{- end }}
+    {{- if not .Values.beyla.config.open_port }}
     open_port: 80,443,8000-8999
+    {{- end }}
+    {{- if not .Values.beyla.config.attributes }}
     attributes:
       kubernetes:
         enable: true
+    {{- end }}
+    {{- if not .Values.beyla.config.prometheus_export }}
     prometheus_export:
       port: 9090
       path: /metrics
+    {{- end }}
+    {{- if not .Values.beyla.config.internal_metrics }}
     internal_metrics:
       prometheus:
         port: 6060
         path: /metrics
+    {{- end }}
+    {{- if .Values.beyla.config }}
+  {{- toYaml .Values.beyla.config | nindent 4}}
+    {{- end }}
 {{- end }}

--- a/deploy/helm/templates/beyla/daemon-set.yaml
+++ b/deploy/helm/templates/beyla/daemon-set.yaml
@@ -42,17 +42,23 @@ spec:
                 - CHECKPOINT_RESTORE
                 - DAC_READ_SEARCH
                 - PERFMON
-                - SYS_ADMIN
                 - NET_ADMIN
+              {{- with .Values.beyla.extraCapabilities }}
+                {{- toYaml . | nindent 16 }}
+              {{- end }}
               drop:
                 - ALL
           ports:
+          {{- if .Values.beyla.config.prometheus_export }}
           - name: metrics
-            containerPort: 9090
+            containerPort: {{ .Values.beyla.config.prometheus_export.port }}
             protocol: TCP
+          {{- end }}
+          {{- if .Values.beyla.config.internal_metrics }}
           - name: int-metrics
-            containerPort: 6060
+            containerPort: {{ .Values.beyla.config.internal_metrics.prometheus.port }}
             protocol: TCP
+          {{- end }}
           {{- with .Values.beyla.resources }}
           resources:
             {{- toYaml . | nindent 12 }}

--- a/deploy/helm/tests/__snapshot__/metrics-collector-config-map-fargate_test.yaml.snap
+++ b/deploy/helm/tests/__snapshot__/metrics-collector-config-map-fargate_test.yaml.snap
@@ -34,6 +34,10 @@ Metrics config should match snapshot when using default values:
             match_type: regexp
             metric_names:
             - k8s.kube_namespace_status_phase
+        attributes/clean-attributes-otlp-metrics:
+          actions:
+          - action: delete
+            key: k8s.cluster.name
         attributes/identify_init_container:
           actions:
           - action: insert
@@ -1659,6 +1663,7 @@ Metrics config should match snapshot when using default values:
             - memory_limiter
             - filter/ebpf
             - metricstransform/rename-otel
+            - attributes/clean-attributes-otlp-metrics
             - resource/otlp-metrics
             receivers:
             - otlp

--- a/deploy/helm/tests/__snapshot__/metrics-collector-config-map-fargate_test.yaml.snap
+++ b/deploy/helm/tests/__snapshot__/metrics-collector-config-map-fargate_test.yaml.snap
@@ -221,9 +221,15 @@ Metrics config should match snapshot when using default values:
         filter/histograms:
           metrics:
             metric:
-            - type == METRIC_DATA_TYPE_HISTOGRAM and not(name == "k8s.apiserver_request_duration_seconds"
+            - type == METRIC_DATA_TYPE_HISTOGRAM and not( name == "k8s.apiserver_request_duration_seconds"
               or name == "k8s.workqueue_queue_duration_seconds" or name == "k8s.coredns_dns_request_duration_seconds"
-              or name == "k8s.coredns_dns_request_size_bytes" or name == "k8s.coredns_dns_response_size_bytes")
+              or name == "k8s.coredns_dns_request_size_bytes" or name == "k8s.coredns_dns_response_size_bytes"
+              or name == "k8s.http.client.request.duration" or name == "k8s.http.client.request.body.size"
+              or name == "k8s.http.server.request.duration" or name == "k8s.http.server.request.body.size"
+              or name == "k8s.rpc.client.duration" or name == "k8s.rpc.server.duration"
+              or name == "k8s.sql.client.duration" or name == "k8s.redis.client.duration"
+              or name == "k8s.messaging.publish.duration" or name == "k8s.messaging.process.duration"
+              )
         filter/kube-state-metrics:
           metrics:
             metric:

--- a/deploy/helm/tests/__snapshot__/metrics-collector-config-map_test.yaml.snap
+++ b/deploy/helm/tests/__snapshot__/metrics-collector-config-map_test.yaml.snap
@@ -221,9 +221,15 @@ Metrics config should match snapshot when fargate is enabled:
         filter/histograms:
           metrics:
             metric:
-            - type == METRIC_DATA_TYPE_HISTOGRAM and not(name == "k8s.apiserver_request_duration_seconds"
+            - type == METRIC_DATA_TYPE_HISTOGRAM and not( name == "k8s.apiserver_request_duration_seconds"
               or name == "k8s.workqueue_queue_duration_seconds" or name == "k8s.coredns_dns_request_duration_seconds"
-              or name == "k8s.coredns_dns_request_size_bytes" or name == "k8s.coredns_dns_response_size_bytes")
+              or name == "k8s.coredns_dns_request_size_bytes" or name == "k8s.coredns_dns_response_size_bytes"
+              or name == "k8s.http.client.request.duration" or name == "k8s.http.client.request.body.size"
+              or name == "k8s.http.server.request.duration" or name == "k8s.http.server.request.body.size"
+              or name == "k8s.rpc.client.duration" or name == "k8s.rpc.server.duration"
+              or name == "k8s.sql.client.duration" or name == "k8s.redis.client.duration"
+              or name == "k8s.messaging.publish.duration" or name == "k8s.messaging.process.duration"
+              )
         filter/kube-state-metrics:
           metrics:
             metric:
@@ -1938,9 +1944,15 @@ Metrics config should match snapshot when using Prometheus url with extra_scrape
         filter/histograms:
           metrics:
             metric:
-            - type == METRIC_DATA_TYPE_HISTOGRAM and not(name == "k8s.apiserver_request_duration_seconds"
+            - type == METRIC_DATA_TYPE_HISTOGRAM and not( name == "k8s.apiserver_request_duration_seconds"
               or name == "k8s.workqueue_queue_duration_seconds" or name == "k8s.coredns_dns_request_duration_seconds"
-              or name == "k8s.coredns_dns_request_size_bytes" or name == "k8s.coredns_dns_response_size_bytes")
+              or name == "k8s.coredns_dns_request_size_bytes" or name == "k8s.coredns_dns_response_size_bytes"
+              or name == "k8s.http.client.request.duration" or name == "k8s.http.client.request.body.size"
+              or name == "k8s.http.server.request.duration" or name == "k8s.http.server.request.body.size"
+              or name == "k8s.rpc.client.duration" or name == "k8s.rpc.server.duration"
+              or name == "k8s.sql.client.duration" or name == "k8s.redis.client.duration"
+              or name == "k8s.messaging.publish.duration" or name == "k8s.messaging.process.duration"
+              )
         filter/kube-state-metrics:
           metrics:
             metric:
@@ -3597,9 +3609,15 @@ Metrics config should match snapshot when using default values:
         filter/histograms:
           metrics:
             metric:
-            - type == METRIC_DATA_TYPE_HISTOGRAM and not(name == "k8s.apiserver_request_duration_seconds"
+            - type == METRIC_DATA_TYPE_HISTOGRAM and not( name == "k8s.apiserver_request_duration_seconds"
               or name == "k8s.workqueue_queue_duration_seconds" or name == "k8s.coredns_dns_request_duration_seconds"
-              or name == "k8s.coredns_dns_request_size_bytes" or name == "k8s.coredns_dns_response_size_bytes")
+              or name == "k8s.coredns_dns_request_size_bytes" or name == "k8s.coredns_dns_response_size_bytes"
+              or name == "k8s.http.client.request.duration" or name == "k8s.http.client.request.body.size"
+              or name == "k8s.http.server.request.duration" or name == "k8s.http.server.request.body.size"
+              or name == "k8s.rpc.client.duration" or name == "k8s.rpc.server.duration"
+              or name == "k8s.sql.client.duration" or name == "k8s.redis.client.duration"
+              or name == "k8s.messaging.publish.duration" or name == "k8s.messaging.process.duration"
+              )
         filter/kube-state-metrics:
           metrics:
             metric:

--- a/deploy/helm/tests/__snapshot__/metrics-collector-config-map_test.yaml.snap
+++ b/deploy/helm/tests/__snapshot__/metrics-collector-config-map_test.yaml.snap
@@ -34,6 +34,10 @@ Metrics config should match snapshot when fargate is enabled:
             match_type: regexp
             metric_names:
             - k8s.kube_namespace_status_phase
+        attributes/clean-attributes-otlp-metrics:
+          actions:
+          - action: delete
+            key: k8s.cluster.name
         attributes/identify_init_container:
           actions:
           - action: insert
@@ -1659,6 +1663,7 @@ Metrics config should match snapshot when fargate is enabled:
             - memory_limiter
             - filter/ebpf
             - metricstransform/rename-otel
+            - attributes/clean-attributes-otlp-metrics
             - resource/otlp-metrics
             receivers:
             - otlp
@@ -1754,6 +1759,10 @@ Metrics config should match snapshot when using Prometheus url with extra_scrape
             match_type: regexp
             metric_names:
             - k8s.kube_namespace_status_phase
+        attributes/clean-attributes-otlp-metrics:
+          actions:
+          - action: delete
+            key: k8s.cluster.name
         attributes/identify_init_container:
           actions:
           - action: insert
@@ -3317,6 +3326,7 @@ Metrics config should match snapshot when using Prometheus url with extra_scrape
             - memory_limiter
             - filter/ebpf
             - metricstransform/rename-otel
+            - attributes/clean-attributes-otlp-metrics
             - resource/otlp-metrics
             receivers:
             - otlp
@@ -3419,6 +3429,10 @@ Metrics config should match snapshot when using default values:
             match_type: regexp
             metric_names:
             - k8s.kube_namespace_status_phase
+        attributes/clean-attributes-otlp-metrics:
+          actions:
+          - action: delete
+            key: k8s.cluster.name
         attributes/identify_init_container:
           actions:
           - action: insert
@@ -4967,6 +4981,7 @@ Metrics config should match snapshot when using default values:
             - memory_limiter
             - filter/ebpf
             - metricstransform/rename-otel
+            - attributes/clean-attributes-otlp-metrics
             - resource/otlp-metrics
             receivers:
             - otlp

--- a/deploy/helm/values.schema.json
+++ b/deploy/helm/values.schema.json
@@ -1541,9 +1541,6 @@
                 "resources": {
                     "$ref": "#/definitions/k8sResourceRequirements"
                 },
-                "telemetry": {
-                    "$ref": "#/definitions/ebpfTelemetry"
-                },
                 "tolerations": {
                     "$ref": "#/definitions/k8sTolerations"
                 },

--- a/deploy/helm/values.yaml
+++ b/deploy/helm/values.yaml
@@ -1062,17 +1062,13 @@ beyla:
     tag: "2.0.3"
     pullPolicy: IfNotPresent
 
-  telemetry:
-    logs:
-      level: "info"
-
   resources:
     requests:
       cpu: 100m
       memory: 128Mi
     limits:
       cpu: 500m
-      memory: 512Mi
+      memory: 768Mi
 
   # Scheduling configurations
   nodeSelector: {}
@@ -1082,4 +1078,15 @@ beyla:
 
   # See https://kubernetes.io/docs/tasks/configure-pod-container/assign-pods-nodes-using-node-affinity/
   affinity: {}
+
+  # Overrides in beyla configuration
+  # see https://grafana.com/docs/beyla/latest/configure/ for all the options
+  config: {}
+
+  # -- Extra capabilities for unprivileged / less privileged setup.
+  extraCapabilities: []
+  # - SYS_RESOURCE       # <-- pre 5.11 only. Allows Beyla to increase the amount of locked memory.
+  # - SYS_ADMIN          # <-- Required for Go application trace context propagation, or if kernel.perf_event_paranoid >= 3 on Debian distributions.
+
+
 

--- a/skaffold.yaml
+++ b/skaffold.yaml
@@ -134,6 +134,8 @@ deploy:
             enabled: true
           prometheusCRDs:
             install: true
+          beyla:
+            enabled: true
         upgradeOnChange: true
       # Deploy prometheus for development purposes. Metrics prefixed with `output_` contains metrics produced by the agent
       - name: timeseries-mock-service-custom-resources

--- a/tests/integration/expected_telemetry/beyla.json
+++ b/tests/integration/expected_telemetry/beyla.json
@@ -1,0 +1,44 @@
+{
+    "metrics": [
+        { 
+            "name": "k8s.beyla.network.flow.bytes",
+            "attributes": [
+                "direction",
+                "k8s.dst.namespace",
+                "k8s.dst.owner.name",
+                "k8s.dst.owner.type",
+                "k8s.src.namespace",
+                "k8s.src.owner.name",
+                "k8s.src.owner.type"
+            ] 
+        },
+        { 
+            "name": "k8s.http.server.request.duration",
+            "attributes": [
+                "http.request.method",
+                "http.response.status_code",
+                "http.route",
+                "server.address",
+                "server.port",
+                "service.name",
+                "service.namespace"
+            ] 
+        },
+        { 
+            "name": "k8s.http.server.request.body.size",
+            "attributes": [
+                "http.request.method",
+                "http.response.status_code",
+                "http.route",
+                "server.address",
+                "server.port",
+                "service.name",
+                "service.namespace"
+            ] 
+        }
+    ],
+    "resource_attributes": [
+        "sw.k8s.cluster.uid",
+        { "key":"k8s.cluster.name", "value": "cluster name" }
+    ]
+}

--- a/tests/integration/expected_telemetry/beyla.json
+++ b/tests/integration/expected_telemetry/beyla.json
@@ -11,30 +11,6 @@
                 "k8s.src.owner.name",
                 "k8s.src.owner.type"
             ] 
-        },
-        { 
-            "name": "k8s.http.server.request.duration",
-            "attributes": [
-                "http.request.method",
-                "http.response.status_code",
-                "http.route",
-                "server.address",
-                "server.port",
-                "service.name",
-                "service.namespace"
-            ] 
-        },
-        { 
-            "name": "k8s.http.server.request.body.size",
-            "attributes": [
-                "http.request.method",
-                "http.response.status_code",
-                "http.route",
-                "server.address",
-                "server.port",
-                "service.name",
-                "service.namespace"
-            ] 
         }
     ],
     "resource_attributes": [


### PR DESCRIPTION
* Removing SYS_ADMIN capability by default, making it possible to add that
* Stoped reusing eBPFNetwork structure of telemetry.log.level
* Disabling prometheus endpoints by default, making it possible to enable
* Making it possible to override any beyla's configuration
* Enabling beyla in development environment by default
* Adding expected metrics to integration test suite, to make sure beyla is producing both network and instrumented metrics
* Cleaning up `k8s.cluster.name` from incomming attributes, because beyla send it as empty and it would cause duplicate information as we already send it as resource attribute.
