### PR TITLE
NH-105498: Fixing cluster name when beyla is enabled

### DIFF
--- a/deploy/helm/Chart.yaml
+++ b/deploy/helm/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: swo-k8s-collector
-version: 4.6.0-alpha.5
+version: 4.6.0-alpha.6
 appVersion: 0.119.10
 description: SolarWinds Kubernetes Integration
 keywords:

--- a/deploy/helm/metrics-collector-config.yaml
+++ b/deploy/helm/metrics-collector-config.yaml
@@ -727,7 +727,7 @@ processors:
 
       - key: k8s.cluster.name
         value: ${CLUSTER_NAME}
-        action: insert
+        action: upsert
 
   batch:
 {{ toYaml .Values.otel.metrics.batch | indent 4 }}

--- a/deploy/helm/tests/__snapshot__/metrics-collector-config-map-fargate_test.yaml.snap
+++ b/deploy/helm/tests/__snapshot__/metrics-collector-config-map-fargate_test.yaml.snap
@@ -1445,7 +1445,7 @@ Metrics config should match snapshot when using default values:
           - action: insert
             key: sw.k8s.cluster.uid
             value: ${CLUSTER_UID}
-          - action: insert
+          - action: upsert
             key: k8s.cluster.name
             value: ${CLUSTER_NAME}
         transform:

--- a/deploy/helm/tests/__snapshot__/metrics-collector-config-map_test.yaml.snap
+++ b/deploy/helm/tests/__snapshot__/metrics-collector-config-map_test.yaml.snap
@@ -1445,7 +1445,7 @@ Metrics config should match snapshot when fargate is enabled:
           - action: insert
             key: sw.k8s.cluster.uid
             value: ${CLUSTER_UID}
-          - action: insert
+          - action: upsert
             key: k8s.cluster.name
             value: ${CLUSTER_NAME}
         transform:
@@ -3179,7 +3179,7 @@ Metrics config should match snapshot when using Prometheus url with extra_scrape
           - action: insert
             key: sw.k8s.cluster.uid
             value: ${CLUSTER_UID}
-          - action: insert
+          - action: upsert
             key: k8s.cluster.name
             value: ${CLUSTER_NAME}
         transform:
@@ -4855,7 +4855,7 @@ Metrics config should match snapshot when using default values:
           - action: insert
             key: sw.k8s.cluster.uid
             value: ${CLUSTER_UID}
-          - action: insert
+          - action: upsert
             key: k8s.cluster.name
             value: ${CLUSTER_NAME}
         transform:


### PR DESCRIPTION
on beyla application metrics (instrumented by beyla) there is empty `k8s.cluster.name` ingested. So using `upsert` in Helm to override it.