### PR TITLE
Removing exposed endpoints in default beyla setup

### DIFF
--- a/deploy/helm/Chart.yaml
+++ b/deploy/helm/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: swo-k8s-collector
-version: 4.6.0-alpha.6
+version: 4.6.0-alpha.7
 appVersion: 0.119.10
 description: SolarWinds Kubernetes Integration
 keywords:

--- a/deploy/helm/templates/beyla/configmap.yaml
+++ b/deploy/helm/templates/beyla/configmap.yaml
@@ -48,17 +48,6 @@ data:
       kubernetes:
         enable: true
     {{- end }}
-    {{- if not .Values.beyla.config.prometheus_export }}
-    prometheus_export:
-      port: 9090
-      path: /metrics
-    {{- end }}
-    {{- if not .Values.beyla.config.internal_metrics }}
-    internal_metrics:
-      prometheus:
-        port: 6060
-        path: /metrics
-    {{- end }}
     {{- if .Values.beyla.config }}
   {{- toYaml .Values.beyla.config | nindent 4}}
     {{- end }}


### PR DESCRIPTION
Those endpoints can be optionally added via values.yaml. Releasing as `4.6.0-alpha.7`
