### PR TITLE
chore: Fixing pre-deploy hook

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .env
+.tmp
 .DS_Store
 skaffold.env
 deploy/helm/charts/*.tgz

--- a/utils/pre-deploy.bat
+++ b/utils/pre-deploy.bat
@@ -1,23 +1,41 @@
 @echo off
 
-:: Get the current Kubernetes context
-for /f "tokens=*" %%i in ('kubectl config current-context') do set current_context=%%i
+REM Ensure the .tmp directory exists
+if not exist .tmp mkdir .tmp
 
-:: Check if the current context is 'docker-desktop' or 'default'
-if "%current_context%" neq "docker-desktop" if "%current_context%" neq "default" (
+REM File to store the last Skaffold run ID
+set "LAST_RUN_ID_FILE=.tmp\last_run_id"
+
+REM Check if the current Skaffold run ID matches the last run ID
+if exist "%LAST_RUN_ID_FILE%" (
+    for /f "tokens=*" %%i in (%LAST_RUN_ID_FILE%) do set "LAST_RUN_ID=%%i"
+    if "%LAST_RUN_ID%" == "%SKAFFOLD_RUN_ID%" (
+        echo Skaffold run ID matches the last run ID. Skipping cleanup.
+        exit /b 0
+    )
+)
+
+REM Save the current Skaffold run ID
+echo %SKAFFOLD_RUN_ID% > "%LAST_RUN_ID_FILE%"
+
+REM Get the current Kubernetes context
+for /f "tokens=*" %%i in ('kubectl config current-context') do set "current_context=%%i"
+
+REM Check if the current context is 'docker-desktop' or 'default'
+if not "%current_context%" == "docker-desktop" if not "%current_context%" == "default" (
     echo This script can only be run in the 'docker-desktop' or 'default' context. Current context is '%current_context%'. Exiting gracefully.
     exit /b 0
 )
 
-:: Patch the CRD to remove finalizers
+REM Patch the CRD to remove finalizers
 echo Patching the CRD to remove finalizers
 kubectl patch crd/opentelemetrycollectors.opentelemetry.io -p "{\"metadata\":{\"finalizers\":[]}}" --type=merge
 
-:: Delete all resources in the test-namespace
+REM Delete all resources in the test-namespace
 echo Deleting all resources in the test-namespace
 kubectl delete all --all -n test-namespace
 
-:: Those resources are not deleted by the previous command
+REM Those resources are not deleted by the previous command
 kubectl delete secrets --all -n test-namespace
 kubectl delete configmaps --all -n test-namespace
 kubectl delete persistentvolumeclaims --all -n test-namespace
@@ -26,14 +44,14 @@ kubectl delete roles --all -n test-namespace
 kubectl delete rolebindings --all -n test-namespace
 kubectl delete networkpolicies --all -n test-namespace
 
-:: Delete all CRDs from monitoring.coreos.com group
+REM Delete all CRDs from monitoring.coreos.com group
 echo Deleting all CRDs from monitoring.coreos.com group
 for /f "tokens=*" %%i in ('kubectl get crd -o jsonpath="{range .items[?(@.spec.group=='monitoring.coreos.com')]}{.metadata.name}{'\n'}{end}"') do kubectl delete crd %%i
 
-:: Delete all CRDs from cert-manager.io group
+REM Delete all CRDs from cert-manager.io group
 echo Deleting all CRDs from cert-manager.io group
 for /f "tokens=*" %%i in ('kubectl get crd -o jsonpath="{range .items[?(@.spec.group=='cert-manager.io')]}{.metadata.name}{'\n'}{end}"') do kubectl delete crd %%i
 
-:: Delete all CRDs from acme.cert-manager.io group
+REM Delete all CRDs from acme.cert-manager.io group
 echo Deleting all CRDs from acme.cert-manager.io group
 for /f "tokens=*" %%i in ('kubectl get crd -o jsonpath="{range .items[?(@.spec.group=='acme.cert-manager.io')]}{.metadata.name}{'\n'}{end}"') do kubectl delete crd %%i

--- a/utils/pre-deploy.sh
+++ b/utils/pre-deploy.sh
@@ -1,5 +1,20 @@
 #!/bin/bash
 
+# Ensure the .tmp directory exists
+mkdir -p .tmp
+
+# File to store the last Skaffold run ID
+LAST_RUN_ID_FILE=".tmp/last_run_id"
+
+# Check if the current Skaffold run ID matches the last run ID
+if [ -f "$LAST_RUN_ID_FILE" ] && [ "$(cat $LAST_RUN_ID_FILE)" == "$SKAFFOLD_RUN_ID" ]; then
+    echo "Skaffold run ID matches the last run ID. Skipping cleanup."
+    exit 0
+fi
+
+# Save the current Skaffold run ID
+echo "$SKAFFOLD_RUN_ID" > "$LAST_RUN_ID_FILE"
+
 # Get the current Kubernetes context
 current_context=$(kubectl config current-context)
 


### PR DESCRIPTION
Currently when there were some manifest modified during the existing deployment, it cleanup whole environment instead of just deploying updated manifest. Now it use `$SKAFFOLD_RUN_ID` environment variable which is filled by skaffold to indicate if the deployment is initial, or continuous deployment caused by some changes.
