### PR TITLE
Collect CronJob info

### DIFF
--- a/deploy/helm/events-collector-config.yaml
+++ b/deploy/helm/events-collector-config.yaml
@@ -118,11 +118,24 @@ processors:
       - statements:
           # convert body to string
           - set(log.body, log.body.string)
-  transform/set_status_for_pods:
+
+  transform/extract_resource_attrs_from_manifests:
     error_mode: ignore
     log_statements:
-      - statements:
-          - set(resource.attributes["sw.k8s.pod.status"], log.body["status"]["phase"]) where log.body["kind"] == "Pod" and log.body["status"]["phase"] != nil
+      - conditions:
+          - body["kind"] == "Pod"
+        statements:
+          - set(resource.attributes["sw.k8s.pod.status"], log.body["status"]["phase"]) where log.body["status"]["phase"] != nil
+      - conditions:
+          - body["kind"] == "CronJob"
+        statements:
+          - set(resource.attributes["sw.k8s.cronjob.suspended"], log.body["spec"]["suspend"]) where log.body["spec"]["suspend"] != nil
+          - set(resource.attributes["sw.k8s.cronjob.schedule"], log.body["spec"]["schedule"]) where log.body["spec"]["schedule"] != nil
+          - set(resource.attributes["sw.k8s.cronjob.concurrencypolicy"], log.body["spec"]["concurrencyPolicy"]) where log.body["spec"]["concurrencyPolicy"] != nil
+          - set(resource.attributes["sw.k8s.cronjob.failedjobshistorylimit"], log.body["spec"]["failedJobsHistoryLimit"]) where log.body["spec"]["failedJobsHistoryLimit"] != nil
+          - set(resource.attributes["sw.k8s.cronjob.successfuljobshistorylimit"], log.body["spec"]["successfulJobsHistoryLimit"]) where log.body["spec"]["successfulJobsHistoryLimit"] != nil
+          - set(resource.attributes["sw.k8s.cronjob.active"], Len(log.body["status"]["active"])) where log.body["status"]["active"] != nil
+          - set(resource.attributes["sw.k8s.cronjob.active"], 0) where log.body["status"]["active"] == nil
 
   transform/set_labels_and_annotations_for_entities:
     error_mode: ignore
@@ -387,7 +400,7 @@ service:
         - transform/manifest
         - groupbyattrs/manifest
         - transform/set_labels_and_annotations_for_entities
-        - transform/set_status_for_pods
+        - transform/extract_resource_attrs_from_manifests
         - transform/stringify_body
         - resource/manifest
         - resourcedetection/providers

--- a/deploy/helm/metrics-collector-config.yaml
+++ b/deploy/helm/metrics-collector-config.yaml
@@ -783,6 +783,9 @@ processors:
           name == "kube_resourcequota" or
           name == "kube_node_status_allocatable" or
           name == "kube_node_spec_unschedulable" or
+          name == "kube_cronjob_info" or
+          name == "kube_cronjob_created" or
+          name == "kube_cronjob_status_last_schedule_time" or
           name == "kube_job_info" or
           name == "kube_job_owner" or
           name == "kube_job_created" or

--- a/deploy/helm/tests/__snapshot__/events-collector-config-map_test.yaml.snap
+++ b/deploy/helm/tests/__snapshot__/events-collector-config-map_test.yaml.snap
@@ -169,6 +169,31 @@ Custom events filter with new syntax:
               where log.attributes["k8s.namespace.name"] != nil
             - delete_key(log.attributes, "k8s.namespace.name") where log.attributes["k8s.namespace.name"]
               != nil
+        transform/extract_resource_attrs_from_manifests:
+          error_mode: ignore
+          log_statements:
+          - conditions:
+            - body["kind"] == "Pod"
+            statements:
+            - set(resource.attributes["sw.k8s.pod.status"], log.body["status"]["phase"])
+              where log.body["status"]["phase"] != nil
+          - conditions:
+            - body["kind"] == "CronJob"
+            statements:
+            - set(resource.attributes["sw.k8s.cronjob.suspended"], log.body["spec"]["suspend"])
+              where log.body["spec"]["suspend"] != nil
+            - set(resource.attributes["sw.k8s.cronjob.schedule"], log.body["spec"]["schedule"])
+              where log.body["spec"]["schedule"] != nil
+            - set(resource.attributes["sw.k8s.cronjob.concurrencypolicy"], log.body["spec"]["concurrencyPolicy"])
+              where log.body["spec"]["concurrencyPolicy"] != nil
+            - set(resource.attributes["sw.k8s.cronjob.failedjobshistorylimit"], log.body["spec"]["failedJobsHistoryLimit"])
+              where log.body["spec"]["failedJobsHistoryLimit"] != nil
+            - set(resource.attributes["sw.k8s.cronjob.successfuljobshistorylimit"], log.body["spec"]["successfulJobsHistoryLimit"])
+              where log.body["spec"]["successfulJobsHistoryLimit"] != nil
+            - set(resource.attributes["sw.k8s.cronjob.active"], Len(log.body["status"]["active"]))
+              where log.body["status"]["active"] != nil
+            - set(resource.attributes["sw.k8s.cronjob.active"], 0) where log.body["status"]["active"]
+              == nil
         transform/manifest:
           error_mode: ignore
           log_statements:
@@ -354,12 +379,6 @@ Custom events filter with new syntax:
               == "RoleBinding" or log.body["kind"] == "Role" or log.body["kind"] == "ServiceAccount"
               or log.body["kind"] == "Service" or log.body["kind"] == "StatefulSet") and
               log.cache["labels"] != nil
-        transform/set_status_for_pods:
-          error_mode: ignore
-          log_statements:
-          - statements:
-            - set(resource.attributes["sw.k8s.pod.status"], log.body["status"]["phase"])
-              where log.body["kind"] == "Pod" and log.body["status"]["phase"] != nil
         transform/severity:
           log_statements:
           - statements:
@@ -537,7 +556,7 @@ Custom events filter with new syntax:
             - transform/manifest
             - groupbyattrs/manifest
             - transform/set_labels_and_annotations_for_entities
-            - transform/set_status_for_pods
+            - transform/extract_resource_attrs_from_manifests
             - transform/stringify_body
             - resource/manifest
             - resourcedetection/providers
@@ -731,6 +750,31 @@ Custom events filter with old syntax:
               where log.attributes["k8s.namespace.name"] != nil
             - delete_key(log.attributes, "k8s.namespace.name") where log.attributes["k8s.namespace.name"]
               != nil
+        transform/extract_resource_attrs_from_manifests:
+          error_mode: ignore
+          log_statements:
+          - conditions:
+            - body["kind"] == "Pod"
+            statements:
+            - set(resource.attributes["sw.k8s.pod.status"], log.body["status"]["phase"])
+              where log.body["status"]["phase"] != nil
+          - conditions:
+            - body["kind"] == "CronJob"
+            statements:
+            - set(resource.attributes["sw.k8s.cronjob.suspended"], log.body["spec"]["suspend"])
+              where log.body["spec"]["suspend"] != nil
+            - set(resource.attributes["sw.k8s.cronjob.schedule"], log.body["spec"]["schedule"])
+              where log.body["spec"]["schedule"] != nil
+            - set(resource.attributes["sw.k8s.cronjob.concurrencypolicy"], log.body["spec"]["concurrencyPolicy"])
+              where log.body["spec"]["concurrencyPolicy"] != nil
+            - set(resource.attributes["sw.k8s.cronjob.failedjobshistorylimit"], log.body["spec"]["failedJobsHistoryLimit"])
+              where log.body["spec"]["failedJobsHistoryLimit"] != nil
+            - set(resource.attributes["sw.k8s.cronjob.successfuljobshistorylimit"], log.body["spec"]["successfulJobsHistoryLimit"])
+              where log.body["spec"]["successfulJobsHistoryLimit"] != nil
+            - set(resource.attributes["sw.k8s.cronjob.active"], Len(log.body["status"]["active"]))
+              where log.body["status"]["active"] != nil
+            - set(resource.attributes["sw.k8s.cronjob.active"], 0) where log.body["status"]["active"]
+              == nil
         transform/manifest:
           error_mode: ignore
           log_statements:
@@ -916,12 +960,6 @@ Custom events filter with old syntax:
               == "RoleBinding" or log.body["kind"] == "Role" or log.body["kind"] == "ServiceAccount"
               or log.body["kind"] == "Service" or log.body["kind"] == "StatefulSet") and
               log.cache["labels"] != nil
-        transform/set_status_for_pods:
-          error_mode: ignore
-          log_statements:
-          - statements:
-            - set(resource.attributes["sw.k8s.pod.status"], log.body["status"]["phase"])
-              where log.body["kind"] == "Pod" and log.body["status"]["phase"] != nil
         transform/severity:
           log_statements:
           - statements:
@@ -1099,7 +1137,7 @@ Custom events filter with old syntax:
             - transform/manifest
             - groupbyattrs/manifest
             - transform/set_labels_and_annotations_for_entities
-            - transform/set_status_for_pods
+            - transform/extract_resource_attrs_from_manifests
             - transform/stringify_body
             - resource/manifest
             - resourcedetection/providers
@@ -1286,6 +1324,31 @@ Events config should match snapshot when using default values:
               where log.attributes["k8s.namespace.name"] != nil
             - delete_key(log.attributes, "k8s.namespace.name") where log.attributes["k8s.namespace.name"]
               != nil
+        transform/extract_resource_attrs_from_manifests:
+          error_mode: ignore
+          log_statements:
+          - conditions:
+            - body["kind"] == "Pod"
+            statements:
+            - set(resource.attributes["sw.k8s.pod.status"], log.body["status"]["phase"])
+              where log.body["status"]["phase"] != nil
+          - conditions:
+            - body["kind"] == "CronJob"
+            statements:
+            - set(resource.attributes["sw.k8s.cronjob.suspended"], log.body["spec"]["suspend"])
+              where log.body["spec"]["suspend"] != nil
+            - set(resource.attributes["sw.k8s.cronjob.schedule"], log.body["spec"]["schedule"])
+              where log.body["spec"]["schedule"] != nil
+            - set(resource.attributes["sw.k8s.cronjob.concurrencypolicy"], log.body["spec"]["concurrencyPolicy"])
+              where log.body["spec"]["concurrencyPolicy"] != nil
+            - set(resource.attributes["sw.k8s.cronjob.failedjobshistorylimit"], log.body["spec"]["failedJobsHistoryLimit"])
+              where log.body["spec"]["failedJobsHistoryLimit"] != nil
+            - set(resource.attributes["sw.k8s.cronjob.successfuljobshistorylimit"], log.body["spec"]["successfulJobsHistoryLimit"])
+              where log.body["spec"]["successfulJobsHistoryLimit"] != nil
+            - set(resource.attributes["sw.k8s.cronjob.active"], Len(log.body["status"]["active"]))
+              where log.body["status"]["active"] != nil
+            - set(resource.attributes["sw.k8s.cronjob.active"], 0) where log.body["status"]["active"]
+              == nil
         transform/manifest:
           error_mode: ignore
           log_statements:
@@ -1471,12 +1534,6 @@ Events config should match snapshot when using default values:
               == "RoleBinding" or log.body["kind"] == "Role" or log.body["kind"] == "ServiceAccount"
               or log.body["kind"] == "Service" or log.body["kind"] == "StatefulSet") and
               log.cache["labels"] != nil
-        transform/set_status_for_pods:
-          error_mode: ignore
-          log_statements:
-          - statements:
-            - set(resource.attributes["sw.k8s.pod.status"], log.body["status"]["phase"])
-              where log.body["kind"] == "Pod" and log.body["status"]["phase"] != nil
         transform/severity:
           log_statements:
           - statements:
@@ -1653,7 +1710,7 @@ Events config should match snapshot when using default values:
             - transform/manifest
             - groupbyattrs/manifest
             - transform/set_labels_and_annotations_for_entities
-            - transform/set_status_for_pods
+            - transform/extract_resource_attrs_from_manifests
             - transform/stringify_body
             - resource/manifest
             - resourcedetection/providers
@@ -1840,6 +1897,31 @@ Events config should not contain manifest collection pipeline when disabled:
               where log.attributes["k8s.namespace.name"] != nil
             - delete_key(log.attributes, "k8s.namespace.name") where log.attributes["k8s.namespace.name"]
               != nil
+        transform/extract_resource_attrs_from_manifests:
+          error_mode: ignore
+          log_statements:
+          - conditions:
+            - body["kind"] == "Pod"
+            statements:
+            - set(resource.attributes["sw.k8s.pod.status"], log.body["status"]["phase"])
+              where log.body["status"]["phase"] != nil
+          - conditions:
+            - body["kind"] == "CronJob"
+            statements:
+            - set(resource.attributes["sw.k8s.cronjob.suspended"], log.body["spec"]["suspend"])
+              where log.body["spec"]["suspend"] != nil
+            - set(resource.attributes["sw.k8s.cronjob.schedule"], log.body["spec"]["schedule"])
+              where log.body["spec"]["schedule"] != nil
+            - set(resource.attributes["sw.k8s.cronjob.concurrencypolicy"], log.body["spec"]["concurrencyPolicy"])
+              where log.body["spec"]["concurrencyPolicy"] != nil
+            - set(resource.attributes["sw.k8s.cronjob.failedjobshistorylimit"], log.body["spec"]["failedJobsHistoryLimit"])
+              where log.body["spec"]["failedJobsHistoryLimit"] != nil
+            - set(resource.attributes["sw.k8s.cronjob.successfuljobshistorylimit"], log.body["spec"]["successfulJobsHistoryLimit"])
+              where log.body["spec"]["successfulJobsHistoryLimit"] != nil
+            - set(resource.attributes["sw.k8s.cronjob.active"], Len(log.body["status"]["active"]))
+              where log.body["status"]["active"] != nil
+            - set(resource.attributes["sw.k8s.cronjob.active"], 0) where log.body["status"]["active"]
+              == nil
         transform/manifest:
           error_mode: ignore
           log_statements:
@@ -2025,12 +2107,6 @@ Events config should not contain manifest collection pipeline when disabled:
               == "RoleBinding" or log.body["kind"] == "Role" or log.body["kind"] == "ServiceAccount"
               or log.body["kind"] == "Service" or log.body["kind"] == "StatefulSet") and
               log.cache["labels"] != nil
-        transform/set_status_for_pods:
-          error_mode: ignore
-          log_statements:
-          - statements:
-            - set(resource.attributes["sw.k8s.pod.status"], log.body["status"]["phase"])
-              where log.body["kind"] == "Pod" and log.body["status"]["phase"] != nil
         transform/severity:
           log_statements:
           - statements:
@@ -2117,7 +2193,7 @@ Events config should not contain manifest collection pipeline when disabled:
             - transform/manifest
             - groupbyattrs/manifest
             - transform/set_labels_and_annotations_for_entities
-            - transform/set_status_for_pods
+            - transform/extract_resource_attrs_from_manifests
             - transform/stringify_body
             - resource/manifest
             - resourcedetection/providers

--- a/deploy/helm/tests/__snapshot__/metrics-collector-config-map-fargate_test.yaml.snap
+++ b/deploy/helm/tests/__snapshot__/metrics-collector-config-map-fargate_test.yaml.snap
@@ -260,17 +260,18 @@ Metrics config should match snapshot when using default values:
               or\nname == \"kube_daemonset_status_number_available\" or\nname == \"kube_daemonset_status_number_misscheduled\"
               or\nname == \"kube_daemonset_status_number_ready\" or\nname == \"kube_daemonset_status_number_unavailable\"
               or\nname == \"kube_resourcequota\" or\nname == \"kube_node_status_allocatable\"
-              or\nname == \"kube_node_spec_unschedulable\" or\nname == \"kube_job_info\"
-              or\nname == \"kube_job_owner\" or\nname == \"kube_job_created\" or\nname ==
-              \"kube_job_complete\" or\nname == \"kube_job_failed\" or\nname == \"kube_job_status_active\"
-              or\nname == \"kube_job_status_succeeded\" or\nname == \"kube_job_status_failed\"
-              or\nname == \"kube_job_status_start_time\" or\nname == \"kube_job_status_completion_time\"
-              or\nname == \"kube_job_spec_completions\" or\nname == \"kube_job_spec_parallelism\"
-              or\nname == \"kube_persistentvolume_capacity_bytes\" or\nname == \"kube_persistentvolume_info\"
-              or\nname == \"kube_persistentvolume_status_phase\" or\nname == \"kube_persistentvolume_claim_ref\"
-              or\nname == \"kube_persistentvolume_created\" or\nname == \"kube_persistentvolumeclaim_info\"
-              or\nname == \"kube_persistentvolumeclaim_access_mode\" or\nname == \"kube_persistentvolumeclaim_status_phase\"
-              or\nname == \"kube_persistentvolumeclaim_resource_requests_storage_bytes\"
+              or\nname == \"kube_node_spec_unschedulable\" or\nname == \"kube_cronjob_info\"
+              or\nname == \"kube_cronjob_created\" or\nname == \"kube_cronjob_status_last_schedule_time\"
+              or\nname == \"kube_job_info\" or\nname == \"kube_job_owner\" or\nname == \"kube_job_created\"
+              or\nname == \"kube_job_complete\" or\nname == \"kube_job_failed\" or\nname
+              == \"kube_job_status_active\" or\nname == \"kube_job_status_succeeded\" or\nname
+              == \"kube_job_status_failed\" or\nname == \"kube_job_status_start_time\" or\nname
+              == \"kube_job_status_completion_time\" or\nname == \"kube_job_spec_completions\"
+              or\nname == \"kube_job_spec_parallelism\" or\nname == \"kube_persistentvolume_capacity_bytes\"
+              or\nname == \"kube_persistentvolume_info\" or\nname == \"kube_persistentvolume_status_phase\"
+              or\nname == \"kube_persistentvolume_claim_ref\" or\nname == \"kube_persistentvolume_created\"
+              or\nname == \"kube_persistentvolumeclaim_info\" or\nname == \"kube_persistentvolumeclaim_access_mode\"
+              or\nname == \"kube_persistentvolumeclaim_status_phase\" or\nname == \"kube_persistentvolumeclaim_resource_requests_storage_bytes\"
               or\nname == \"kube_persistentvolumeclaim_created\" or\nname == \"kube_pod_spec_volumes_persistentvolumeclaims_info\"
               or\nname == \"kube_service_info\" or\nname == \"kube_service_created\" or\nname
               == \"kube_service_spec_type\" or\nname == \"kube_service_spec_external_ip\"

--- a/deploy/helm/tests/__snapshot__/metrics-collector-config-map_test.yaml.snap
+++ b/deploy/helm/tests/__snapshot__/metrics-collector-config-map_test.yaml.snap
@@ -260,17 +260,18 @@ Metrics config should match snapshot when fargate is enabled:
               or\nname == \"kube_daemonset_status_number_available\" or\nname == \"kube_daemonset_status_number_misscheduled\"
               or\nname == \"kube_daemonset_status_number_ready\" or\nname == \"kube_daemonset_status_number_unavailable\"
               or\nname == \"kube_resourcequota\" or\nname == \"kube_node_status_allocatable\"
-              or\nname == \"kube_node_spec_unschedulable\" or\nname == \"kube_job_info\"
-              or\nname == \"kube_job_owner\" or\nname == \"kube_job_created\" or\nname ==
-              \"kube_job_complete\" or\nname == \"kube_job_failed\" or\nname == \"kube_job_status_active\"
-              or\nname == \"kube_job_status_succeeded\" or\nname == \"kube_job_status_failed\"
-              or\nname == \"kube_job_status_start_time\" or\nname == \"kube_job_status_completion_time\"
-              or\nname == \"kube_job_spec_completions\" or\nname == \"kube_job_spec_parallelism\"
-              or\nname == \"kube_persistentvolume_capacity_bytes\" or\nname == \"kube_persistentvolume_info\"
-              or\nname == \"kube_persistentvolume_status_phase\" or\nname == \"kube_persistentvolume_claim_ref\"
-              or\nname == \"kube_persistentvolume_created\" or\nname == \"kube_persistentvolumeclaim_info\"
-              or\nname == \"kube_persistentvolumeclaim_access_mode\" or\nname == \"kube_persistentvolumeclaim_status_phase\"
-              or\nname == \"kube_persistentvolumeclaim_resource_requests_storage_bytes\"
+              or\nname == \"kube_node_spec_unschedulable\" or\nname == \"kube_cronjob_info\"
+              or\nname == \"kube_cronjob_created\" or\nname == \"kube_cronjob_status_last_schedule_time\"
+              or\nname == \"kube_job_info\" or\nname == \"kube_job_owner\" or\nname == \"kube_job_created\"
+              or\nname == \"kube_job_complete\" or\nname == \"kube_job_failed\" or\nname
+              == \"kube_job_status_active\" or\nname == \"kube_job_status_succeeded\" or\nname
+              == \"kube_job_status_failed\" or\nname == \"kube_job_status_start_time\" or\nname
+              == \"kube_job_status_completion_time\" or\nname == \"kube_job_spec_completions\"
+              or\nname == \"kube_job_spec_parallelism\" or\nname == \"kube_persistentvolume_capacity_bytes\"
+              or\nname == \"kube_persistentvolume_info\" or\nname == \"kube_persistentvolume_status_phase\"
+              or\nname == \"kube_persistentvolume_claim_ref\" or\nname == \"kube_persistentvolume_created\"
+              or\nname == \"kube_persistentvolumeclaim_info\" or\nname == \"kube_persistentvolumeclaim_access_mode\"
+              or\nname == \"kube_persistentvolumeclaim_status_phase\" or\nname == \"kube_persistentvolumeclaim_resource_requests_storage_bytes\"
               or\nname == \"kube_persistentvolumeclaim_created\" or\nname == \"kube_pod_spec_volumes_persistentvolumeclaims_info\"
               or\nname == \"kube_service_info\" or\nname == \"kube_service_created\" or\nname
               == \"kube_service_spec_type\" or\nname == \"kube_service_spec_external_ip\"
@@ -1996,17 +1997,18 @@ Metrics config should match snapshot when using Prometheus url with extra_scrape
               or\nname == \"kube_daemonset_status_number_available\" or\nname == \"kube_daemonset_status_number_misscheduled\"
               or\nname == \"kube_daemonset_status_number_ready\" or\nname == \"kube_daemonset_status_number_unavailable\"
               or\nname == \"kube_resourcequota\" or\nname == \"kube_node_status_allocatable\"
-              or\nname == \"kube_node_spec_unschedulable\" or\nname == \"kube_job_info\"
-              or\nname == \"kube_job_owner\" or\nname == \"kube_job_created\" or\nname ==
-              \"kube_job_complete\" or\nname == \"kube_job_failed\" or\nname == \"kube_job_status_active\"
-              or\nname == \"kube_job_status_succeeded\" or\nname == \"kube_job_status_failed\"
-              or\nname == \"kube_job_status_start_time\" or\nname == \"kube_job_status_completion_time\"
-              or\nname == \"kube_job_spec_completions\" or\nname == \"kube_job_spec_parallelism\"
-              or\nname == \"kube_persistentvolume_capacity_bytes\" or\nname == \"kube_persistentvolume_info\"
-              or\nname == \"kube_persistentvolume_status_phase\" or\nname == \"kube_persistentvolume_claim_ref\"
-              or\nname == \"kube_persistentvolume_created\" or\nname == \"kube_persistentvolumeclaim_info\"
-              or\nname == \"kube_persistentvolumeclaim_access_mode\" or\nname == \"kube_persistentvolumeclaim_status_phase\"
-              or\nname == \"kube_persistentvolumeclaim_resource_requests_storage_bytes\"
+              or\nname == \"kube_node_spec_unschedulable\" or\nname == \"kube_cronjob_info\"
+              or\nname == \"kube_cronjob_created\" or\nname == \"kube_cronjob_status_last_schedule_time\"
+              or\nname == \"kube_job_info\" or\nname == \"kube_job_owner\" or\nname == \"kube_job_created\"
+              or\nname == \"kube_job_complete\" or\nname == \"kube_job_failed\" or\nname
+              == \"kube_job_status_active\" or\nname == \"kube_job_status_succeeded\" or\nname
+              == \"kube_job_status_failed\" or\nname == \"kube_job_status_start_time\" or\nname
+              == \"kube_job_status_completion_time\" or\nname == \"kube_job_spec_completions\"
+              or\nname == \"kube_job_spec_parallelism\" or\nname == \"kube_persistentvolume_capacity_bytes\"
+              or\nname == \"kube_persistentvolume_info\" or\nname == \"kube_persistentvolume_status_phase\"
+              or\nname == \"kube_persistentvolume_claim_ref\" or\nname == \"kube_persistentvolume_created\"
+              or\nname == \"kube_persistentvolumeclaim_info\" or\nname == \"kube_persistentvolumeclaim_access_mode\"
+              or\nname == \"kube_persistentvolumeclaim_status_phase\" or\nname == \"kube_persistentvolumeclaim_resource_requests_storage_bytes\"
               or\nname == \"kube_persistentvolumeclaim_created\" or\nname == \"kube_pod_spec_volumes_persistentvolumeclaims_info\"
               or\nname == \"kube_service_info\" or\nname == \"kube_service_created\" or\nname
               == \"kube_service_spec_type\" or\nname == \"kube_service_spec_external_ip\"
@@ -3674,17 +3676,18 @@ Metrics config should match snapshot when using default values:
               or\nname == \"kube_daemonset_status_number_available\" or\nname == \"kube_daemonset_status_number_misscheduled\"
               or\nname == \"kube_daemonset_status_number_ready\" or\nname == \"kube_daemonset_status_number_unavailable\"
               or\nname == \"kube_resourcequota\" or\nname == \"kube_node_status_allocatable\"
-              or\nname == \"kube_node_spec_unschedulable\" or\nname == \"kube_job_info\"
-              or\nname == \"kube_job_owner\" or\nname == \"kube_job_created\" or\nname ==
-              \"kube_job_complete\" or\nname == \"kube_job_failed\" or\nname == \"kube_job_status_active\"
-              or\nname == \"kube_job_status_succeeded\" or\nname == \"kube_job_status_failed\"
-              or\nname == \"kube_job_status_start_time\" or\nname == \"kube_job_status_completion_time\"
-              or\nname == \"kube_job_spec_completions\" or\nname == \"kube_job_spec_parallelism\"
-              or\nname == \"kube_persistentvolume_capacity_bytes\" or\nname == \"kube_persistentvolume_info\"
-              or\nname == \"kube_persistentvolume_status_phase\" or\nname == \"kube_persistentvolume_claim_ref\"
-              or\nname == \"kube_persistentvolume_created\" or\nname == \"kube_persistentvolumeclaim_info\"
-              or\nname == \"kube_persistentvolumeclaim_access_mode\" or\nname == \"kube_persistentvolumeclaim_status_phase\"
-              or\nname == \"kube_persistentvolumeclaim_resource_requests_storage_bytes\"
+              or\nname == \"kube_node_spec_unschedulable\" or\nname == \"kube_cronjob_info\"
+              or\nname == \"kube_cronjob_created\" or\nname == \"kube_cronjob_status_last_schedule_time\"
+              or\nname == \"kube_job_info\" or\nname == \"kube_job_owner\" or\nname == \"kube_job_created\"
+              or\nname == \"kube_job_complete\" or\nname == \"kube_job_failed\" or\nname
+              == \"kube_job_status_active\" or\nname == \"kube_job_status_succeeded\" or\nname
+              == \"kube_job_status_failed\" or\nname == \"kube_job_status_start_time\" or\nname
+              == \"kube_job_status_completion_time\" or\nname == \"kube_job_spec_completions\"
+              or\nname == \"kube_job_spec_parallelism\" or\nname == \"kube_persistentvolume_capacity_bytes\"
+              or\nname == \"kube_persistentvolume_info\" or\nname == \"kube_persistentvolume_status_phase\"
+              or\nname == \"kube_persistentvolume_claim_ref\" or\nname == \"kube_persistentvolume_created\"
+              or\nname == \"kube_persistentvolumeclaim_info\" or\nname == \"kube_persistentvolumeclaim_access_mode\"
+              or\nname == \"kube_persistentvolumeclaim_status_phase\" or\nname == \"kube_persistentvolumeclaim_resource_requests_storage_bytes\"
               or\nname == \"kube_persistentvolumeclaim_created\" or\nname == \"kube_pod_spec_volumes_persistentvolumeclaims_info\"
               or\nname == \"kube_service_info\" or\nname == \"kube_service_created\" or\nname
               == \"kube_service_spec_type\" or\nname == \"kube_service_spec_external_ip\"


### PR DESCRIPTION
Extract most of the data from the resource manifest. Additionally collect these metrics:
* kube_cronjob_info
* kube_cronjob_created
* kube_cronjob_status_last_schedule_time