### PR TITLE
feature: Adding keep alive events that should make sure that SWO entities are updated

### DIFF
--- a/deploy/helm/Chart.yaml
+++ b/deploy/helm/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: swo-k8s-collector
-version: 4.6.0-alpha.12
-appVersion: 0.123.2
+version: 4.6.0-alpha.13
+appVersion: 0.123.7
 description: SolarWinds Kubernetes Integration
 keywords:
   - monitoring

--- a/deploy/helm/events-collector-config.yaml
+++ b/deploy/helm/events-collector-config.yaml
@@ -55,6 +55,87 @@ extensions:
   health_check:
     endpoint: 0.0.0.0:13133
 
+connectors:
+{{- if and .Values.otel.manifests.enabled .Values.otel.manifests.keepalive_events.enabled }}
+  solarwindsentity/keepalive:
+    schema:
+      entities:
+        - entity: KubernetesConfigMap
+          id:
+            - sw.k8s.cluster.uid
+            - k8s.namespace.name
+            - k8s.configmap.name
+        - entity: KubernetesContainer
+          id:
+            - sw.k8s.cluster.uid
+            - k8s.namespace.name
+            - k8s.pod.name
+            - k8s.container.name
+        - entity: KubernetesCronJob
+          id:
+            - sw.k8s.cluster.uid
+            - k8s.namespace.name
+            - k8s.cronjob.name
+        - entity: KubernetesCronJob
+          id:
+            - sw.k8s.cluster.uid
+            - k8s.namespace.name
+            - k8s.cronjob.name
+        - entity: KubernetesDaemonSet
+          id:
+            - sw.k8s.cluster.uid
+            - k8s.namespace.name
+            - k8s.daemonset.name
+        - entity: KubernetesDeployment
+          id:
+            - sw.k8s.cluster.uid
+            - k8s.namespace.name
+            - k8s.deployment.name
+        - entity: KubernetesIngress
+          id:
+            - sw.k8s.cluster.uid
+            - k8s.namespace.name
+            - k8s.ingress.name
+        - entity: KubernetesJob
+          id:
+            - sw.k8s.cluster.uid
+            - k8s.namespace.name
+            - k8s.job.name
+        - entity: KubernetesNode
+          id:
+            - sw.k8s.cluster.uid
+            - k8s.node.name
+        - entity: KubernetesPersistentVolume
+          id:
+            - sw.k8s.cluster.uid
+            - k8s.persistentvolume.name
+        - entity: KubernetesPersistentVolumeClaim
+          id:
+            - sw.k8s.cluster.uid
+            - k8s.namespace.name
+            - k8s.persistentvolumeclaim.name
+        - entity: KubernetesPod
+          id:
+            - sw.k8s.cluster.uid
+            - k8s.namespace.name
+            - k8s.pod.name
+        - entity: KubernetesReplicaSet
+          id:
+            - sw.k8s.cluster.uid
+            - k8s.namespace.name
+            - k8s.replicaset.name
+        - entity: KubernetesService
+          id:
+            - sw.k8s.cluster.uid
+            - k8s.namespace.name
+            - k8s.service.name
+        - entity: KubernetesStatefulSet 
+          id:
+            - sw.k8s.cluster.uid
+            - k8s.namespace.name
+            - k8s.statefulset.name
+{{- end }}
+
 processors:
   k8seventgeneration:
   memory_limiter:
@@ -331,7 +412,9 @@ processors:
 
 receivers:
   k8s_events:
-  swok8sobjects:
+{{- $root := . }}
+{{- if and .Values.otel.manifests.enabled .Values.otel.manifests.keepalive_events.enabled }}
+  swok8sobjects/keepalive:
     auth_type: serviceAccount
 {{- if and .Values.otel.manifests.enabled .Values.otel.manifests.persistent_storage.enabled }}
     storage: file_storage/manifests
@@ -341,7 +424,25 @@ receivers:
 {{- if or (.Capabilities.APIVersions.Has "networking.istio.io/v1alpha3") (.Capabilities.APIVersions.Has "networking.istio.io/v1beta1") (.Capabilities.APIVersions.Has "networking.istio.io/v1") -}}
 {{- $arrayOfWatchedResources = append $arrayOfWatchedResources "virtualservices" }}
 {{- end }}
-{{- $root := . }}
+{{- range $index, $resource := $arrayOfWatchedResources }}
+      - name: {{ $resource }}
+        mode: pull
+        interval: {{ quote $root.Values.otel.manifests.keepalive_events.pull_every }}
+{{- end }}
+{{- else }}
+      - name: "configmaps"
+        mode: pull
+        interval: {{ quote .Values.otel.manifests.keepalive_events.pull_every }}
+{{- end }}
+{{- end}}
+
+  swok8sobjects:
+    auth_type: serviceAccount
+    objects:
+{{- if and .Values.otel.events.enabled .Values.otel.manifests.enabled }}
+{{- if or (.Capabilities.APIVersions.Has "networking.istio.io/v1alpha3") (.Capabilities.APIVersions.Has "networking.istio.io/v1beta1") (.Capabilities.APIVersions.Has "networking.istio.io/v1") -}}
+{{- $arrayOfWatchedResources = append $arrayOfWatchedResources "virtualservices" }}
+{{- end }}
 {{- range $index, $resource := $arrayOfWatchedResources }}
       - name: {{ $resource }}
         mode: pull
@@ -419,6 +520,41 @@ service:
         - batch
       receivers:
         - swok8sobjects
+    
+{{- if and .Values.otel.manifests.enabled .Values.otel.manifests.keepalive_events.enabled }}
+    logs/manifests-keepalive:
+      exporters:
+        - solarwindsentity/keepalive
+      processors:
+        - memory_limiter
+        - transform/manifest
+        - groupbyattrs/manifest
+        - resource/manifest
+        - k8sattributes
+        - k8seventgeneration
+{{- if not (and .Values.otel.events.enabled .Values.otel.manifests.enabled) }}
+        - filter/k8s_collector_config_include
+{{- end }}
+{{- if eq (include "isNamespacesFilterEnabled" .) "true" }}
+        - filter/namespaces
+{{- end }}  
+{{- if .Values.otel.manifests.filter }}
+        - filter/manifests
+{{- end }}
+      receivers:
+        - swok8sobjects/keepalive
+
+    logs/stateevents:
+      exporters:
+        - otlp
+      processors:
+        - memory_limiter
+        - transform/scope
+        - batch
+      receivers:
+        - solarwindsentity/keepalive
+{{- end }}
+        
   telemetry:
 {{- if .Values.otel.events.telemetry.logs.enabled }}
     logs:

--- a/deploy/helm/events-collector-config.yaml
+++ b/deploy/helm/events-collector-config.yaml
@@ -76,11 +76,6 @@ connectors:
             - sw.k8s.cluster.uid
             - k8s.namespace.name
             - k8s.cronjob.name
-        - entity: KubernetesCronJob
-          id:
-            - sw.k8s.cluster.uid
-            - k8s.namespace.name
-            - k8s.cronjob.name
         - entity: KubernetesDaemonSet
           id:
             - sw.k8s.cluster.uid

--- a/deploy/helm/tests/__snapshot__/events-collector-config-map_test.yaml.snap
+++ b/deploy/helm/tests/__snapshot__/events-collector-config-map_test.yaml.snap
@@ -1,6 +1,84 @@
 Custom events filter with new syntax:
   1: |
     events.config: |-
+      connectors:
+        solarwindsentity/keepalive:
+          schema:
+            entities:
+            - entity: KubernetesConfigMap
+              id:
+              - sw.k8s.cluster.uid
+              - k8s.namespace.name
+              - k8s.configmap.name
+            - entity: KubernetesContainer
+              id:
+              - sw.k8s.cluster.uid
+              - k8s.namespace.name
+              - k8s.pod.name
+              - k8s.container.name
+            - entity: KubernetesCronJob
+              id:
+              - sw.k8s.cluster.uid
+              - k8s.namespace.name
+              - k8s.cronjob.name
+            - entity: KubernetesCronJob
+              id:
+              - sw.k8s.cluster.uid
+              - k8s.namespace.name
+              - k8s.cronjob.name
+            - entity: KubernetesDaemonSet
+              id:
+              - sw.k8s.cluster.uid
+              - k8s.namespace.name
+              - k8s.daemonset.name
+            - entity: KubernetesDeployment
+              id:
+              - sw.k8s.cluster.uid
+              - k8s.namespace.name
+              - k8s.deployment.name
+            - entity: KubernetesIngress
+              id:
+              - sw.k8s.cluster.uid
+              - k8s.namespace.name
+              - k8s.ingress.name
+            - entity: KubernetesJob
+              id:
+              - sw.k8s.cluster.uid
+              - k8s.namespace.name
+              - k8s.job.name
+            - entity: KubernetesNode
+              id:
+              - sw.k8s.cluster.uid
+              - k8s.node.name
+            - entity: KubernetesPersistentVolume
+              id:
+              - sw.k8s.cluster.uid
+              - k8s.persistentvolume.name
+            - entity: KubernetesPersistentVolumeClaim
+              id:
+              - sw.k8s.cluster.uid
+              - k8s.namespace.name
+              - k8s.persistentvolumeclaim.name
+            - entity: KubernetesPod
+              id:
+              - sw.k8s.cluster.uid
+              - k8s.namespace.name
+              - k8s.pod.name
+            - entity: KubernetesReplicaSet
+              id:
+              - sw.k8s.cluster.uid
+              - k8s.namespace.name
+              - k8s.replicaset.name
+            - entity: KubernetesService
+              id:
+              - sw.k8s.cluster.uid
+              - k8s.namespace.name
+              - k8s.service.name
+            - entity: KubernetesStatefulSet
+              id:
+              - sw.k8s.cluster.uid
+              - k8s.namespace.name
+              - k8s.statefulset.name
       exporters:
         otlp:
           endpoint: ${OTEL_ENVOY_ADDRESS}
@@ -529,6 +607,66 @@ Custom events filter with new syntax:
             name: statefulsets
           - mode: watch
             name: statefulsets
+        swok8sobjects/keepalive:
+          auth_type: serviceAccount
+          objects:
+          - interval: 20m
+            mode: pull
+            name: clusterrolebindings
+          - interval: 20m
+            mode: pull
+            name: clusterroles
+          - interval: 20m
+            mode: pull
+            name: configmaps
+          - interval: 20m
+            mode: pull
+            name: cronjobs
+          - interval: 20m
+            mode: pull
+            name: daemonsets
+          - interval: 20m
+            mode: pull
+            name: deployments
+          - interval: 20m
+            mode: pull
+            name: ingresses
+          - interval: 20m
+            mode: pull
+            name: jobs
+          - interval: 20m
+            mode: pull
+            name: namespaces
+          - interval: 20m
+            mode: pull
+            name: nodes
+          - interval: 20m
+            mode: pull
+            name: persistentvolumeclaims
+          - interval: 20m
+            mode: pull
+            name: persistentvolumes
+          - interval: 20m
+            mode: pull
+            name: pods
+          - interval: 20m
+            mode: pull
+            name: replicasets
+          - interval: 20m
+            mode: pull
+            name: rolebindings
+          - interval: 20m
+            mode: pull
+            name: roles
+          - interval: 20m
+            mode: pull
+            name: serviceaccounts
+          - interval: 20m
+            mode: pull
+            name: services
+          - interval: 20m
+            mode: pull
+            name: statefulsets
       service:
         extensions:
         - health_check
@@ -566,6 +704,27 @@ Custom events filter with new syntax:
             - batch
             receivers:
             - swok8sobjects
+          logs/manifests-keepalive:
+            exporters:
+            - solarwindsentity/keepalive
+            processors:
+            - memory_limiter
+            - transform/manifest
+            - groupbyattrs/manifest
+            - resource/manifest
+            - k8sattributes
+            - k8seventgeneration
+            receivers:
+            - swok8sobjects/keepalive
+          logs/stateevents:
+            exporters:
+            - otlp
+            processors:
+            - memory_limiter
+            - transform/scope
+            - batch
+            receivers:
+            - solarwindsentity/keepalive
         telemetry:
           logs:
             level: info
@@ -579,6 +738,84 @@ Custom events filter with new syntax:
 Custom events filter with old syntax:
   1: |
     events.config: |-
+      connectors:
+        solarwindsentity/keepalive:
+          schema:
+            entities:
+            - entity: KubernetesConfigMap
+              id:
+              - sw.k8s.cluster.uid
+              - k8s.namespace.name
+              - k8s.configmap.name
+            - entity: KubernetesContainer
+              id:
+              - sw.k8s.cluster.uid
+              - k8s.namespace.name
+              - k8s.pod.name
+              - k8s.container.name
+            - entity: KubernetesCronJob
+              id:
+              - sw.k8s.cluster.uid
+              - k8s.namespace.name
+              - k8s.cronjob.name
+            - entity: KubernetesCronJob
+              id:
+              - sw.k8s.cluster.uid
+              - k8s.namespace.name
+              - k8s.cronjob.name
+            - entity: KubernetesDaemonSet
+              id:
+              - sw.k8s.cluster.uid
+              - k8s.namespace.name
+              - k8s.daemonset.name
+            - entity: KubernetesDeployment
+              id:
+              - sw.k8s.cluster.uid
+              - k8s.namespace.name
+              - k8s.deployment.name
+            - entity: KubernetesIngress
+              id:
+              - sw.k8s.cluster.uid
+              - k8s.namespace.name
+              - k8s.ingress.name
+            - entity: KubernetesJob
+              id:
+              - sw.k8s.cluster.uid
+              - k8s.namespace.name
+              - k8s.job.name
+            - entity: KubernetesNode
+              id:
+              - sw.k8s.cluster.uid
+              - k8s.node.name
+            - entity: KubernetesPersistentVolume
+              id:
+              - sw.k8s.cluster.uid
+              - k8s.persistentvolume.name
+            - entity: KubernetesPersistentVolumeClaim
+              id:
+              - sw.k8s.cluster.uid
+              - k8s.namespace.name
+              - k8s.persistentvolumeclaim.name
+            - entity: KubernetesPod
+              id:
+              - sw.k8s.cluster.uid
+              - k8s.namespace.name
+              - k8s.pod.name
+            - entity: KubernetesReplicaSet
+              id:
+              - sw.k8s.cluster.uid
+              - k8s.namespace.name
+              - k8s.replicaset.name
+            - entity: KubernetesService
+              id:
+              - sw.k8s.cluster.uid
+              - k8s.namespace.name
+              - k8s.service.name
+            - entity: KubernetesStatefulSet
+              id:
+              - sw.k8s.cluster.uid
+              - k8s.namespace.name
+              - k8s.statefulset.name
       exporters:
         otlp:
           endpoint: ${OTEL_ENVOY_ADDRESS}
@@ -1110,6 +1347,66 @@ Custom events filter with old syntax:
             name: statefulsets
           - mode: watch
             name: statefulsets
+        swok8sobjects/keepalive:
+          auth_type: serviceAccount
+          objects:
+          - interval: 20m
+            mode: pull
+            name: clusterrolebindings
+          - interval: 20m
+            mode: pull
+            name: clusterroles
+          - interval: 20m
+            mode: pull
+            name: configmaps
+          - interval: 20m
+            mode: pull
+            name: cronjobs
+          - interval: 20m
+            mode: pull
+            name: daemonsets
+          - interval: 20m
+            mode: pull
+            name: deployments
+          - interval: 20m
+            mode: pull
+            name: ingresses
+          - interval: 20m
+            mode: pull
+            name: jobs
+          - interval: 20m
+            mode: pull
+            name: namespaces
+          - interval: 20m
+            mode: pull
+            name: nodes
+          - interval: 20m
+            mode: pull
+            name: persistentvolumeclaims
+          - interval: 20m
+            mode: pull
+            name: persistentvolumes
+          - interval: 20m
+            mode: pull
+            name: pods
+          - interval: 20m
+            mode: pull
+            name: replicasets
+          - interval: 20m
+            mode: pull
+            name: rolebindings
+          - interval: 20m
+            mode: pull
+            name: roles
+          - interval: 20m
+            mode: pull
+            name: serviceaccounts
+          - interval: 20m
+            mode: pull
+            name: services
+          - interval: 20m
+            mode: pull
+            name: statefulsets
       service:
         extensions:
         - health_check
@@ -1147,6 +1444,27 @@ Custom events filter with old syntax:
             - batch
             receivers:
             - swok8sobjects
+          logs/manifests-keepalive:
+            exporters:
+            - solarwindsentity/keepalive
+            processors:
+            - memory_limiter
+            - transform/manifest
+            - groupbyattrs/manifest
+            - resource/manifest
+            - k8sattributes
+            - k8seventgeneration
+            receivers:
+            - swok8sobjects/keepalive
+          logs/stateevents:
+            exporters:
+            - otlp
+            processors:
+            - memory_limiter
+            - transform/scope
+            - batch
+            receivers:
+            - solarwindsentity/keepalive
         telemetry:
           logs:
             level: info
@@ -1160,6 +1478,84 @@ Custom events filter with old syntax:
 Events config should match snapshot when using default values:
   1: |
     events.config: |-
+      connectors:
+        solarwindsentity/keepalive:
+          schema:
+            entities:
+            - entity: KubernetesConfigMap
+              id:
+              - sw.k8s.cluster.uid
+              - k8s.namespace.name
+              - k8s.configmap.name
+            - entity: KubernetesContainer
+              id:
+              - sw.k8s.cluster.uid
+              - k8s.namespace.name
+              - k8s.pod.name
+              - k8s.container.name
+            - entity: KubernetesCronJob
+              id:
+              - sw.k8s.cluster.uid
+              - k8s.namespace.name
+              - k8s.cronjob.name
+            - entity: KubernetesCronJob
+              id:
+              - sw.k8s.cluster.uid
+              - k8s.namespace.name
+              - k8s.cronjob.name
+            - entity: KubernetesDaemonSet
+              id:
+              - sw.k8s.cluster.uid
+              - k8s.namespace.name
+              - k8s.daemonset.name
+            - entity: KubernetesDeployment
+              id:
+              - sw.k8s.cluster.uid
+              - k8s.namespace.name
+              - k8s.deployment.name
+            - entity: KubernetesIngress
+              id:
+              - sw.k8s.cluster.uid
+              - k8s.namespace.name
+              - k8s.ingress.name
+            - entity: KubernetesJob
+              id:
+              - sw.k8s.cluster.uid
+              - k8s.namespace.name
+              - k8s.job.name
+            - entity: KubernetesNode
+              id:
+              - sw.k8s.cluster.uid
+              - k8s.node.name
+            - entity: KubernetesPersistentVolume
+              id:
+              - sw.k8s.cluster.uid
+              - k8s.persistentvolume.name
+            - entity: KubernetesPersistentVolumeClaim
+              id:
+              - sw.k8s.cluster.uid
+              - k8s.namespace.name
+              - k8s.persistentvolumeclaim.name
+            - entity: KubernetesPod
+              id:
+              - sw.k8s.cluster.uid
+              - k8s.namespace.name
+              - k8s.pod.name
+            - entity: KubernetesReplicaSet
+              id:
+              - sw.k8s.cluster.uid
+              - k8s.namespace.name
+              - k8s.replicaset.name
+            - entity: KubernetesService
+              id:
+              - sw.k8s.cluster.uid
+              - k8s.namespace.name
+              - k8s.service.name
+            - entity: KubernetesStatefulSet
+              id:
+              - sw.k8s.cluster.uid
+              - k8s.namespace.name
+              - k8s.statefulset.name
       exporters:
         otlp:
           endpoint: ${OTEL_ENVOY_ADDRESS}
@@ -1684,6 +2080,66 @@ Events config should match snapshot when using default values:
             name: statefulsets
           - mode: watch
             name: statefulsets
+        swok8sobjects/keepalive:
+          auth_type: serviceAccount
+          objects:
+          - interval: 20m
+            mode: pull
+            name: clusterrolebindings
+          - interval: 20m
+            mode: pull
+            name: clusterroles
+          - interval: 20m
+            mode: pull
+            name: configmaps
+          - interval: 20m
+            mode: pull
+            name: cronjobs
+          - interval: 20m
+            mode: pull
+            name: daemonsets
+          - interval: 20m
+            mode: pull
+            name: deployments
+          - interval: 20m
+            mode: pull
+            name: ingresses
+          - interval: 20m
+            mode: pull
+            name: jobs
+          - interval: 20m
+            mode: pull
+            name: namespaces
+          - interval: 20m
+            mode: pull
+            name: nodes
+          - interval: 20m
+            mode: pull
+            name: persistentvolumeclaims
+          - interval: 20m
+            mode: pull
+            name: persistentvolumes
+          - interval: 20m
+            mode: pull
+            name: pods
+          - interval: 20m
+            mode: pull
+            name: replicasets
+          - interval: 20m
+            mode: pull
+            name: rolebindings
+          - interval: 20m
+            mode: pull
+            name: roles
+          - interval: 20m
+            mode: pull
+            name: serviceaccounts
+          - interval: 20m
+            mode: pull
+            name: services
+          - interval: 20m
+            mode: pull
+            name: statefulsets
       service:
         extensions:
         - health_check
@@ -1720,6 +2176,27 @@ Events config should match snapshot when using default values:
             - batch
             receivers:
             - swok8sobjects
+          logs/manifests-keepalive:
+            exporters:
+            - solarwindsentity/keepalive
+            processors:
+            - memory_limiter
+            - transform/manifest
+            - groupbyattrs/manifest
+            - resource/manifest
+            - k8sattributes
+            - k8seventgeneration
+            receivers:
+            - swok8sobjects/keepalive
+          logs/stateevents:
+            exporters:
+            - otlp
+            processors:
+            - memory_limiter
+            - transform/scope
+            - batch
+            receivers:
+            - solarwindsentity/keepalive
         telemetry:
           logs:
             level: info
@@ -1733,6 +2210,7 @@ Events config should match snapshot when using default values:
 Events config should not contain manifest collection pipeline when disabled:
   1: |
     events.config: |-
+      connectors: null
       exporters:
         otlp:
           endpoint: ${OTEL_ENVOY_ADDRESS}

--- a/deploy/helm/tests/__snapshot__/events-collector-config-map_test.yaml.snap
+++ b/deploy/helm/tests/__snapshot__/events-collector-config-map_test.yaml.snap
@@ -21,11 +21,6 @@ Custom events filter with new syntax:
               - sw.k8s.cluster.uid
               - k8s.namespace.name
               - k8s.cronjob.name
-            - entity: KubernetesCronJob
-              id:
-              - sw.k8s.cluster.uid
-              - k8s.namespace.name
-              - k8s.cronjob.name
             - entity: KubernetesDaemonSet
               id:
               - sw.k8s.cluster.uid
@@ -753,11 +748,6 @@ Custom events filter with old syntax:
               - k8s.namespace.name
               - k8s.pod.name
               - k8s.container.name
-            - entity: KubernetesCronJob
-              id:
-              - sw.k8s.cluster.uid
-              - k8s.namespace.name
-              - k8s.cronjob.name
             - entity: KubernetesCronJob
               id:
               - sw.k8s.cluster.uid
@@ -1493,11 +1483,6 @@ Events config should match snapshot when using default values:
               - k8s.namespace.name
               - k8s.pod.name
               - k8s.container.name
-            - entity: KubernetesCronJob
-              id:
-              - sw.k8s.cluster.uid
-              - k8s.namespace.name
-              - k8s.cronjob.name
             - entity: KubernetesCronJob
               id:
               - sw.k8s.cluster.uid

--- a/deploy/helm/values.schema.json
+++ b/deploy/helm/values.schema.json
@@ -920,6 +920,18 @@
                         },
                         "filter": {
                             "type": "object"
+                        },
+                        "keepalive_events": {
+                            "type": "object",
+                            "properties": {
+                                "enabled": {
+                                    "type": "boolean"
+                                },
+                                "pull_every": {
+                                    "type": "string"
+                                }
+                            },
+                            "additionalProperties": false
                         }
                     },
                     "additionalProperties": false

--- a/deploy/helm/values.yaml
+++ b/deploy/helm/values.yaml
@@ -736,6 +736,14 @@ otel:
     # https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/processor/filterprocessor for configuration reference
     filter: {}
 
+    # In order to keep `lastSeen` timestamp in entities of SWO, the collector needs to send keepalive events
+    # Those events are lightweight, includes only keys identifying the entity
+    keepalive_events:
+      enabled: true
+
+      # How often the keepalive events are sent
+      pull_every: 20m
+
   # Check if SWI OTEL endpoint is reachable
   swi_endpoint_check:
     enabled: true

--- a/skaffold.yaml
+++ b/skaffold.yaml
@@ -64,6 +64,8 @@ deploy:
               pull_every: 1m
               persistent_storage:
                 enabled: false
+              keepalive_events:
+                pull_every: 10s
             logs:
               # journal on Docker Desktop is not supported
               journal: false


### PR DESCRIPTION
* This rely on deployment of https://github.com/solarwinds/solarwinds-otel-collector-releases/pull/163 as `0.123.7` (not yet released) which will include `solarwindsentityconnector` in K8s distribution.
* Configured `solarwindsentityconnector` with keys for all existing Kubernetes entities except `KubernetesCluster`.
* Those events are ingested once per 20 minutes for each entity
* Bumping version to `4.6.0-alpha.13`


Dependencies:
- [x] Wait for `0.123.7` to be released