### PR TITLE
Bump Helm chart version to 4.7.0-alpha.2

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,81 @@
+# Project snapshot
+*Name*: SWO K8s Collector
+*Domain*: Kubernetes monitoring and observability  
+*Key technologies*: OpenTelemetry, Helm, Kubernetes, Python, Prometheus, eBPF
+
+# Directory layout
+- **deploy/helm/** – Helm chart for deploying the collector
+  - **templates/metrics-deployment.yaml** – MetricsCollector deployment definition
+  - **templates/metrics-discovery-deployment.yaml** – MetricsDiscovery deployment definition
+  - **templates/events-collector-statefulset.yaml** – EventsCollector statefulset definition
+  - **templates/node-collector-daemon-set.yaml** – NodeCollector daemonset definition
+  - **templates/node-collector-daemon-set-windows.yaml** – NodeCollector Windows daemonset definition
+  - **templates/gateway/** – Gateway collector components
+  - **templates/network/** – eBPF network monitoring components
+  - **templates/beyla/** – Beyla eBPF-based auto-instrumentation
+  - **templates/operator/** – OpenTelemetry operator integration
+  - **templates/autoupdate/** – Components for auto-updating configurations
+  - **templates/openshift/** – OpenShift-specific components
+  - **metrics-collector-config.yaml** – MetricsCollector pipeline configuration
+  - **metrics-discovery-config.yaml** – MetricsDiscovery pipeline configuration for discovered metrics
+  - **events-collector-config.yaml** – EventsCollector pipeline configuration
+  - **gateway-collector-config.yaml** – Gateway collector pipeline configuration
+  - **node-collector-config.yaml** – NodeCollector pipeline configuration
+  - **values.yaml** – Helm chart default values
+  - **values.schema.json** – JSON schema for validating Helm values
+- **doc/** – Documentation including development and metrics info
+  - **collectorPipeline.md** – Description of data flow between components
+  - **development.md** – Development guide
+  - **exported_metrics.md** – List of metrics exported by the collector
+- **tests/integration/** – Integration tests for verifying telemetry collection  
+- **operator/** – OpenTelemetry operator customization
+- **utils/** – Utility scripts for development and testing  
+
+# OTEL Collector Pipelines
+The SWO K8s Collector consists of five main components, each with specific pipelines:
+
+## MetricsCollector Deployment
+- **metrics pipeline**: Main pipeline that exports metrics via OTLP
+- **metrics/kubestatemetrics pipeline**: Collects metrics from the Kube State Metrics service
+- **metrics/otlp pipeline**: Receives metrics via OTLP protocol and forwards them to the main metrics pipeline
+- **metrics/prometheus pipeline**: Processes Prometheus-formatted metrics and forwards them to the main metrics pipeline
+- **metrics/prometheus-node-metrics pipeline**: Collects node-level metrics in Prometheus format
+- **metrics/prometheus-server pipeline**: Collects metrics from the Prometheus server
+
+## MetricsDiscovery Deployment
+- **metrics/discovery pipeline**: Discovers and collects metrics from annotated pods (especially in AWS Fargate) using the receiver_creator and k8s_observer
+- **metrics pipeline**: Processes discovered metrics and exports them via OTLP
+
+## EventsCollector Deployment
+- **logs pipeline**: Collects Kubernetes events (pod creations, deletions, etc.) via the k8s_events receiver
+- **logs/manifests pipeline**: Collects Kubernetes object manifests via the k8sobjects receiver
+
+## NodeCollector DaemonSet
+- **logs pipeline**: Main pipeline for logs that exports them via OTLP
+- **logs/container pipeline**: Collects container logs from files using the filelog receiver
+- **logs/journal pipeline**: Collects system logs from journald
+- **metrics pipeline**: Main pipeline for node-level metrics that exports them via OTLP
+- **metrics/discovery pipeline**: Uses receiver_creator to discover and collect metrics from discoverable endpoints
+- **metrics/node pipeline**: Collects metrics specific to the node using receiver_creator
+
+## Gateway Collector Deployment
+- **traces pipeline**: Receives traces via OTLP protocol and exports them
+- **metrics pipeline**: Receives metrics via OTLP protocol and exports them
+- **logs pipeline**: Receives logs via OTLP protocol and exports them
+
+# Component configuration
+- OTEL uses SolarWinds built OTEL Collector
+- Use `github` MCP server to access GitHub related content
+- You will find all the components available in this file https://github.com/solarwinds/solarwinds-otel-collector-releases/blob/main/distributions/k8s/manifest.yaml
+    - Location of component configuration can be infered from the `gomod` line
+    - For example if you find `  - gomod: github.com/solarwinds/solarwinds-otel-collector-contrib/connector/solarwindsentityconnector v0.123.7` you will look for configuration settings into `https://github.com/solarwinds/solarwinds-otel-collector-contrib/tree/main/connector/solarwindsentityconnector`. 
+    - You look first into README.md, if that does not contain configuration sample or example you have to look at the code of the component. 
+- Generally the component is referenced in the configuration typically without receiver/exporter/processor/connector suffux (e.g. in configuration use `solarwindsentity` key instead of `solarwindsentityconnector`)
+
+# Coding conventions 
+1. Maintain backward compatibility when updating chart configurations.  
+2. Follow JSON schema validation for Helm values through `values.schema.json`.  
+
+# Testing rules
+- Use Helm unit tests for verifying chart rendering.  
+- Update snapshot tests with `helm unittest -u deploy/helm`.

--- a/.github/prompts/bump-version.prompt.md
+++ b/.github/prompts/bump-version.prompt.md
@@ -1,0 +1,9 @@
+---
+mode: 'agent'
+description: 'Bump version and create new PR'
+---
+
+# Task
+Bump the version of the Helm chart in the `deploy/helm` directory in #file deploy/helm/Chart.yaml and create a new PR with the changes (create new branch for it if master is checked out). The version should be incremented according to semantic versioning rules.
+
+

--- a/.github/prompts/update-collector-pipelines.prompt.md
+++ b/.github/prompts/update-collector-pipelines.prompt.md
@@ -1,0 +1,9 @@
+---
+mode: 'agent'
+description: 'Updates collector pipelines'
+---
+
+# Task
+Update #file doc/collectorPipeline.md with the latest information from the repository, especially mermaid diagram. 
+Compare information in mermaid diagram with current state of the repository and make updates if needed. 
+

--- a/.github/prompts/update-configuration.prompt.md
+++ b/.github/prompts/update-configuration.prompt.md
@@ -1,0 +1,22 @@
+---
+mode: 'agent'
+description: 'Update Helm chart configuration'
+---
+
+# Task
+Read the Jira issue ${input:jira} description and if needed related Jira issues, comments or confluence documents.
+
+# Context
+- Relevant files: 
+    - #file deploy/helm/events-collector-config.yaml
+    - #file deploy/helm/gateway-collector-config.yaml
+    - #file deploy/helm/metrics-collector-config.yaml
+    - #file deploy/helm/node-collector-config.yaml
+    - #file deploy/helm/templates/_common-config.tpl
+    - #file deploy/helm/templates/_helpers.tpl
+    - #file deploy/helm/values.yaml
+    - #file deploy/helm/values.schema.json
+
+# Definition of Done
+- Helm unit tests are passing.
+

--- a/.github/prompts/update-copilot-instructions.prompt.md
+++ b/.github/prompts/update-copilot-instructions.prompt.md
@@ -1,0 +1,10 @@
+---
+mode: 'agent'
+description: 'Updates copilot instructions'
+---
+
+# Task
+Update #file .github/copilot-instructions.md with the latest information from the repository, that includes:
+* `Directory layout` section - compare information with current state of the repository and make updates if needed.
+* `OTEL Collector Pipelines` section - compare information with current state of the repository (#file doc/collectorPipeline.md and actual configurations) and make updates if needed.
+

--- a/deploy/helm/CHANGELOG.md
+++ b/deploy/helm/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## [4.7.0-alpha.2] - 2025-05-26
+
+### Changed
+
+- Bumped chart version according to semantic versioning
+
 ## [4.3.0-alpha.1] - 2024-11-11
 
 ### Added 

--- a/deploy/helm/Chart.yaml
+++ b/deploy/helm/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: swo-k8s-collector
-version: 4.7.0-alpha.1
+version: 4.7.0-alpha.2
 appVersion: 0.123.7
 description: SolarWinds Kubernetes Integration
 keywords:


### PR DESCRIPTION
This PR bumps the version of the Helm chart in `deploy/helm/Chart.yaml` from `4.7.0-alpha.1` to `4.7.0-alpha.2` following semantic versioning principles.

## Changes
- Updated version in Chart.yaml from 4.7.0-alpha.1 to 4.7.0-alpha.2
- Added entry to CHANGELOG.md for the new version