### PR TITLE
NH-108817: Creating relationship state events from Istio metrics

### DIFF
--- a/deploy/helm/metrics-discovery-config.yaml
+++ b/deploy/helm/metrics-discovery-config.yaml
@@ -42,15 +42,6 @@ processors:
       - statements:
         - set(scope.name, "")
         - set(scope.version, "")
-
-  metricstransform/rename/discovery:
-    transforms:
-      # add `k8s.` prefix to all metrics
-      - include: ^(.*)$$
-        match_type: regexp
-        action: update
-        new_name: {{ .Values.otel.metrics.autodiscovery.prefix }}$${1}
-
  
   groupbyattrs/common-all:
     keys:
@@ -98,7 +89,7 @@ processors:
 
   batch/metrics:
 {{ toYaml .Values.aws_fargate.metrics.autodiscovery.batch | indent 4 }}
-  
+
 {{- include "common-config.filter-remove-temporary-metrics" . | nindent 2 }}
 
   filter/histograms:
@@ -106,65 +97,12 @@ processors:
       metric:
         - 'type == METRIC_DATA_TYPE_HISTOGRAM and not(name == "k8s.rest_client_request_duration_seconds" or name == "k8s.workqueue_queue_duration_seconds")'
 
-{{- if .Values.otel.metrics.autodiscovery.prometheusEndpoints.filter }}
-  filter/metrics-discovery:
-    metrics:
-{{ toYaml .Values.otel.metrics.autodiscovery.prometheusEndpoints.filter | indent 6 }}
-{{- end }}
-
-{{- if .Values.otel.metrics.autodiscovery.prometheusEndpoints.customTransformations.counterToRate }}
-  cumulativetodelta/discovery:
-    include:
-      metrics:
-{{- range .Values.otel.metrics.autodiscovery.prometheusEndpoints.customTransformations.counterToRate }}
-        - {{ . }}
-{{- end }}
-      match_type: strict
-  deltatorate/discovery:
-    metrics:
-{{- range .Values.otel.metrics.autodiscovery.prometheusEndpoints.customTransformations.counterToRate }}
-      - {{ . }}
-{{- end }}
-{{- end }}
-
-{{- if ne .Values.otel.metrics.autodiscovery.prefix "k8s." }}
-  # in case the prefix differs from "k8s." we need to copy the required metrics
-  # so that SWO built-in dashboards works correctly
-{{- $arrayOfRequiredMetrics := list 
-  "etcd_disk_backend_commit_duration_seconds"
-  "etcd_disk_wal_fsync_duration_seconds" 
-  "etcd_network_client_grpc_received_bytes_total" 
-  "etcd_network_client_grpc_sent_bytes_total" 
-  "etcd_network_peer_received_bytes_total" 
-  "etcd_network_peer_sent_bytes_total" 
-  "etcd_server_leader_changes_seen_total" 
-  "etcd_server_proposals_applied_total" 
-  "etcd_server_proposals_committed_total"
-  "etcd_server_proposals_failed_total"
-  "etcd_server_proposals_pending"
-  "etcd_server_has_leader"
-  "etcd_mvcc_db_total_size_in_bytes"
-  "process_resident_memory_bytes"
-  "grpc_server_started_total"
-  "grpc_server_handled_total"
-  "rest_client_request_duration_seconds"
-  "rest_client_requests_total"
-  "workqueue_adds_total"
-  "workqueue_depth"
-  "workqueue_queue_duration_seconds"
-}}
-  metricstransform/copy-required-metrics:
-    transforms:
-    {{- $root := . }}
-    {{- range $index, $metric := $arrayOfRequiredMetrics }}
-      - include: {{ $root.Values.otel.metrics.autodiscovery.prefix }}{{ $metric }}
-        action: insert
-        new_name: k8s.{{ $metric }}
-    {{- end }}
-{{- end }}
+{{ include "common-discovery-config.processors" . | indent 2 }}
 
 connectors:
   forward/metric-exporter:
+
+{{ include "common-discovery-config.connectors" . | indent 2 }}
 
 receivers:
   receiver_creator/discovery:
@@ -225,29 +163,9 @@ service:
     - health_check
     - k8s_observer
   pipelines:
-    metrics/discovery:
-      exporters:
-        - forward/metric-exporter
-      processors:
-        - memory_limiter
-{{- if .Values.otel.metrics.autodiscovery.prometheusEndpoints.filter }}
-        - filter/metrics-discovery
-{{- end }}        
-{{- if .Values.otel.metrics.autodiscovery.prefix }}
-        - metricstransform/rename/discovery
-{{- end }}
-{{- if ne .Values.otel.metrics.autodiscovery.prefix "k8s." }}
-        - metricstransform/copy-required-metrics
-{{- end }}
-{{- if .Values.otel.metrics.autodiscovery.prometheusEndpoints.customTransformations.counterToRate }}
-        - cumulativetodelta/discovery
-        - deltatorate/discovery
-{{- end }}
-        - groupbyattrs/common-all
-        - resource/all
-      receivers:
-        - receiver_creator/discovery
-    
+
+{{ include "common-discovery-config.pipelines" (tuple . "receiver_creator/discovery" "forward/metric-exporter") | indent 4 }}
+
     metrics:
       exporters:
         - otlp

--- a/deploy/helm/node-collector-config.yaml
+++ b/deploy/helm/node-collector-config.yaml
@@ -1,4 +1,9 @@
 exporters:
+  debug:
+    verbosity: detailed
+    sampling_initial: 5
+    sampling_thereafter: 200
+
   otlp:
     endpoint: ${OTEL_ENVOY_ADDRESS}
     tls:
@@ -253,35 +258,6 @@ processors:
         action: update
         new_name: k8s.$${1}
 
-  metricstransform/rename/discovery:
-    transforms:
-      # add `k8s.` prefix to all metrics
-      - include: ^(.*)$$
-        match_type: regexp
-        action: update
-        new_name: {{ .Values.otel.metrics.autodiscovery.prefix }}$${1}
-
-{{- if .Values.otel.metrics.autodiscovery.prometheusEndpoints.customTransformations.counterToRate }}
-  cumulativetodelta/discovery:
-    include:
-      metrics:
-{{- range .Values.otel.metrics.autodiscovery.prometheusEndpoints.customTransformations.counterToRate }}
-        - {{ . }}
-{{- end }}
-      match_type: strict
-  deltatorate/discovery:
-    metrics:
-{{- range .Values.otel.metrics.autodiscovery.prometheusEndpoints.customTransformations.counterToRate }}
-      - {{ . }}
-{{- end }}
-{{- end }}
-
-{{- if .Values.otel.metrics.autodiscovery.prometheusEndpoints.filter }}
-  filter/metrics-discovery:
-    metrics:
-{{ toYaml .Values.otel.metrics.autodiscovery.prometheusEndpoints.filter | indent 6 }}
-{{- end }}
-
   filter/histograms:
     metrics:
       metric:
@@ -295,117 +271,8 @@ processors:
       - statements:
         - set(scope.name, "")
         - set(scope.version, "")
-  transform/istio-metrics:
-    metric_statements:
-      - statements:
-          - extract_sum_metric(true) where (metric.name == "{{ .Values.otel.metrics.autodiscovery.prefix }}istio_request_bytes" or metric.name == "{{ .Values.otel.metrics.autodiscovery.prefix }}istio_response_bytes" or metric.name == "{{ .Values.otel.metrics.autodiscovery.prefix }}istio_request_duration_milliseconds")
-          - extract_count_metric(true) where (metric.name == "{{ .Values.otel.metrics.autodiscovery.prefix }}istio_request_duration_milliseconds")
-          - set(metric.name, "k8s.istio_request_duration_milliseconds_sum_temp") where metric.name == "{{ .Values.otel.metrics.autodiscovery.prefix }}istio_request_duration_milliseconds_sum"
-          - set(metric.name, "k8s.istio_request_duration_milliseconds_count_temp") where metric.name == "{{ .Values.otel.metrics.autodiscovery.prefix }}istio_request_duration_milliseconds_count"
-  
-{{- if ne .Values.otel.metrics.autodiscovery.prefix "k8s." }}
-  # in case the prefix differs from "k8s." we need to copy the required metrics
-  # so that SWO built-in dashboards works correctly
-{{- $arrayOfRequiredMetrics := list 
-  "etcd_disk_backend_commit_duration_seconds"
-  "etcd_disk_wal_fsync_duration_seconds" 
-  "etcd_network_client_grpc_received_bytes_total" 
-  "etcd_network_client_grpc_sent_bytes_total" 
-  "etcd_network_peer_received_bytes_total" 
-  "etcd_network_peer_sent_bytes_total" 
-  "etcd_server_leader_changes_seen_total" 
-  "etcd_server_proposals_applied_total" 
-  "etcd_server_proposals_committed_total"
-  "etcd_server_proposals_failed_total"
-  "etcd_server_proposals_pending"
-  "etcd_server_has_leader"
-  "etcd_mvcc_db_total_size_in_bytes"
-  "process_resident_memory_bytes"
-  "grpc_server_started_total"
-  "grpc_server_handled_total"
-  "rest_client_request_duration_seconds"
-  "rest_client_requests_total"
-  "workqueue_adds_total"
-  "workqueue_depth"
-  "workqueue_queue_duration_seconds"
-}}
-  metricstransform/copy-required-metrics:
-    transforms:
-    {{- $root := . }}
-    {{- range $index, $metric := $arrayOfRequiredMetrics }}
-      - include: {{ $root.Values.otel.metrics.autodiscovery.prefix }}{{ $metric }}
-        action: insert
-        new_name: k8s.{{ $metric }}
-    {{- end }}
-{{- end }}
-  metricstransform/istio-metrics:
-    transforms:
-      - include: {{ .Values.otel.metrics.autodiscovery.prefix }}istio_request_bytes_sum
-        action: insert
-        new_name: k8s.istio_request_bytes.rate
-      - include: {{ .Values.otel.metrics.autodiscovery.prefix }}istio_response_bytes_sum
-        action: insert
-        new_name: k8s.istio_response_bytes.rate
-      - include: {{ .Values.otel.metrics.autodiscovery.prefix }}istio_requests_total
-        action: insert
-        new_name: k8s.istio_requests.rate
-      - include: {{ .Values.otel.metrics.autodiscovery.prefix }}istio_tcp_sent_bytes_total
-        action: insert
-        new_name: k8s.istio_tcp_sent_bytes.rate
-      - include: {{ .Values.otel.metrics.autodiscovery.prefix }}istio_tcp_received_bytes_total
-        action: insert
-        new_name: k8s.istio_tcp_received_bytes.rate
-      - include: k8s.istio_request_bytes.rate
-        action: insert
-        new_name: k8s.istio_request_bytes.delta
-      - include: k8s.istio_response_bytes.rate
-        action: insert
-        new_name: k8s.istio_response_bytes.delta
-      - include: k8s.istio_requests.rate
-        action: insert
-        new_name: k8s.istio_requests.delta
-      - include: k8s.istio_tcp_sent_bytes.rate
-        action: insert
-        new_name: k8s.istio_tcp_sent_bytes.delta
-      - include: k8s.istio_tcp_received_bytes.rate
-        action: insert
-        new_name: k8s.istio_tcp_received_bytes.delta
 
-  cumulativetodelta/istio-metrics:
-    include:
-      metrics:
-        - k8s.istio_request_bytes.rate
-        - k8s.istio_response_bytes.rate
-        - k8s.istio_request_duration_milliseconds_sum_temp
-        - k8s.istio_request_duration_milliseconds_count_temp
-        - k8s.istio_requests.rate
-        - k8s.istio_tcp_sent_bytes.rate
-        - k8s.istio_tcp_received_bytes.rate
-        - k8s.istio_request_bytes.delta
-        - k8s.istio_response_bytes.delta
-        - k8s.istio_requests.delta
-        - k8s.istio_tcp_sent_bytes.delta
-        - k8s.istio_tcp_received_bytes.delta
-      match_type: strict
-
-  deltatorate/istio-metrics:
-    metrics:
-      - k8s.istio_request_bytes.rate
-      - k8s.istio_response_bytes.rate
-      - k8s.istio_request_duration_milliseconds_sum_temp
-      - k8s.istio_request_duration_milliseconds_count_temp
-      - k8s.istio_requests.rate
-      - k8s.istio_tcp_sent_bytes.rate
-      - k8s.istio_tcp_received_bytes.rate
-
-  metricsgeneration/istio-metrics:
-    rules:
-      - name: k8s.istio_request_duration_milliseconds.rate
-        type: calculate
-        metric1: k8s.istio_request_duration_milliseconds_sum_temp
-        metric2: k8s.istio_request_duration_milliseconds_count_temp
-        operation: divide
-
+{{ include "common-discovery-config.processors" . | indent 2 }}
 
 connectors:
 {{- if and .Values.otel.metrics.enabled (or (not .Values.aws_fargate.enabled) .Values.otel.metrics.autodiscovery.prometheusEndpoints.enabled) }}
@@ -414,6 +281,8 @@ connectors:
 {{- if and .Values.otel.logs.enabled (or .Values.otel.logs.container (and (not .isWindows) .Values.otel.logs.journal))}}
   forward/logs-exporter:
 {{- end }}
+
+{{ include "common-discovery-config.connectors" . | indent 2 }}
 
 receivers:
 {{- if and (not .isWindows) .Values.otel.logs.journal }}
@@ -789,33 +658,8 @@ service:
 {{- end }}
 
 {{- if .Values.otel.metrics.enabled }}
-    metrics/discovery:
-      exporters:
-        - forward/metric-exporter
-      processors:
-        - memory_limiter
-{{- if .Values.otel.metrics.autodiscovery.prometheusEndpoints.filter }}
-        - filter/metrics-discovery
-{{- end }}
-{{- if .Values.otel.metrics.autodiscovery.prefix }}
-        - metricstransform/rename/discovery
-{{- end }}
-{{- if ne .Values.otel.metrics.autodiscovery.prefix "k8s." }}
-        - metricstransform/copy-required-metrics
-{{- end }}
-        - transform/istio-metrics
-        - metricstransform/istio-metrics
-        - cumulativetodelta/istio-metrics
-        - deltatorate/istio-metrics
-        - metricsgeneration/istio-metrics
-{{- if .Values.otel.metrics.autodiscovery.prometheusEndpoints.customTransformations.counterToRate }}
-        - cumulativetodelta/discovery
-        - deltatorate/discovery
-{{- end }}
-        - groupbyattrs/common-all
-        - resource/all
-      receivers:
-        - receiver_creator/discovery
+{{ include "common-discovery-config.pipelines" (tuple . "receiver_creator/discovery" "forward/metric-exporter") | indent 4 }}
+
 {{- end }}
 {{- if and .Values.otel.metrics.enabled (not .Values.aws_fargate.enabled) }}
     metrics/node:

--- a/deploy/helm/node-collector-config.yaml
+++ b/deploy/helm/node-collector-config.yaml
@@ -1,9 +1,4 @@
 exporters:
-  debug:
-    verbosity: detailed
-    sampling_initial: 5
-    sampling_thereafter: 200
-
   otlp:
     endpoint: ${OTEL_ENVOY_ADDRESS}
     tls:

--- a/deploy/helm/templates/_common-discovery-config.tpl
+++ b/deploy/helm/templates/_common-discovery-config.tpl
@@ -149,9 +149,6 @@ swok8sworkloadtype/istio:
         - deployments
         - daemonsets
         - statefulsets
-        - jobs
-        - cronjobs
-        - pods
     - name_attr: destination_workload
       namespace_attr: destination_workload_namespace
       workload_type_attr: destination_workload_type
@@ -159,9 +156,6 @@ swok8sworkloadtype/istio:
         - deployments
         - daemonsets
         - statefulsets
-        - jobs
-        - cronjobs
-        - pods
     - name_attr: destination_service_name
       namespace_attr: destination_service_namespace
       workload_type_attr: destination_service_type
@@ -174,14 +168,10 @@ groupbyattrs/istio-relationships:
     - source.k8s.deployment.name
     - source.k8s.statefulset.name
     - source.k8s.daemonset.name
-    - source.k8s.job.name
-    - source.k8s.cronjob.name
     - source.k8s.namespace.name
     - dest.k8s.deployment.name
     - dest.k8s.statefulset.name
     - dest.k8s.daemonset.name
-    - dest.k8s.job.name
-    - dest.k8s.cronjob.name
     - dest.k8s.namespace.name
     - dest.k8s.service.name
 
@@ -207,14 +197,10 @@ transform/istio-workload-workload:
     - set(datapoint.attributes["source.k8s.deployment.name"], datapoint.attributes["source_workload"]) where datapoint.attributes["source_workload_type"] == "Deployment"
     - set(datapoint.attributes["source.k8s.statefulset.name"], datapoint.attributes["source_workload"]) where datapoint.attributes["source_workload_type"] == "StatefulSet"
     - set(datapoint.attributes["source.k8s.daemonset.name"], datapoint.attributes["source_workload"]) where datapoint.attributes["source_workload_type"] == "DaemonSet"
-    - set(datapoint.attributes["source.k8s.job.name"], datapoint.attributes["source_workload"]) where datapoint.attributes["source_workload_type"] == "Job"
-    - set(datapoint.attributes["source.k8s.cronjob.name"], datapoint.attributes["source_workload"]) where datapoint.attributes["source_workload_type"] == "CronJob"
     - set(datapoint.attributes["source.k8s.namespace.name"], datapoint.attributes["source_workload_namespace"])
     - set(datapoint.attributes["dest.k8s.deployment.name"], datapoint.attributes["destination_workload"]) where datapoint.attributes["destination_workload_type"] == "Deployment"
     - set(datapoint.attributes["dest.k8s.statefulset.name"], datapoint.attributes["destination_workload"]) where datapoint.attributes["destination_workload_type"] == "StatefulSet"
     - set(datapoint.attributes["dest.k8s.daemonset.name"], datapoint.attributes["destination_workload"]) where datapoint.attributes["destination_workload_type"] == "DaemonSet"
-    - set(datapoint.attributes["dest.k8s.job.name"], datapoint.attributes["destination_workload"]) where datapoint.attributes["destination_workload_type"] == "Job"
-    - set(datapoint.attributes["dest.k8s.cronjob.name"], datapoint.attributes["destination_workload"]) where datapoint.attributes["destination_workload_type"] == "CronJob"
     - set(datapoint.attributes["dest.k8s.namespace.name"], datapoint.attributes["destination_workload_namespace"])
 
 transform/istio-workload-service:
@@ -223,8 +209,6 @@ transform/istio-workload-service:
     - set(datapoint.attributes["source.k8s.deployment.name"], datapoint.attributes["source_workload"]) where datapoint.attributes["source_workload_type"] == "Deployment"
     - set(datapoint.attributes["source.k8s.statefulset.name"], datapoint.attributes["source_workload"]) where datapoint.attributes["source_workload_type"] == "StatefulSet"
     - set(datapoint.attributes["source.k8s.daemonset.name"], datapoint.attributes["source_workload"]) where datapoint.attributes["source_workload_type"] == "DaemonSet"
-    - set(datapoint.attributes["source.k8s.job.name"], datapoint.attributes["source_workload"]) where datapoint.attributes["source_workload_type"] == "Job"
-    - set(datapoint.attributes["source.k8s.cronjob.name"], datapoint.attributes["source_workload"]) where datapoint.attributes["source_workload_type"] == "CronJob"
     - set(datapoint.attributes["source.k8s.namespace.name"], datapoint.attributes["source_workload_namespace"])
     - set(datapoint.attributes["dest.k8s.service.name"], datapoint.attributes["destination_service_name"]) where datapoint.attributes["destination_service_type"] == "Service"
     - set(datapoint.attributes["dest.k8s.namespace.name"], datapoint.attributes["destination_service_namespace"])
@@ -271,16 +255,6 @@ solarwindsentity/istio-workload-workload:
           - sw.k8s.cluster.uid
           - k8s.namespace.name
           - k8s.daemonset.name
-      - entity: KubernetesJob
-        id:
-          - sw.k8s.cluster.uid
-          - k8s.namespace.name
-          - k8s.job.name
-      - entity: KubernetesCronJob
-        id:
-          - sw.k8s.cluster.uid
-          - k8s.namespace.name
-          - k8s.cronjob.name
 
     events:
       relationships:
@@ -321,32 +295,6 @@ solarwindsentity/istio-workload-workload:
           attributes:
         - type: KubernetesCommunicatesWith
           source_entity: KubernetesDaemonSet
-          destination_entity: KubernetesDaemonSet
-          attributes:
-        # source KubernetesJob
-        - type: KubernetesCommunicatesWith
-          source_entity: KubernetesJob
-          destination_entity: KubernetesDeployment
-          attributes:
-        - type: KubernetesCommunicatesWith
-          source_entity: KubernetesJob
-          destination_entity: KubernetesStatefulSet
-          attributes:
-        - type: KubernetesCommunicatesWith
-          source_entity: KubernetesJob
-          destination_entity: KubernetesDaemonSet
-          attributes:
-        # source KubernetesCronJob
-        - type: KubernetesCommunicatesWith
-          source_entity: KubernetesCronJob
-          destination_entity: KubernetesDeployment
-          attributes:
-        - type: KubernetesCommunicatesWith
-          source_entity: KubernetesCronJob
-          destination_entity: KubernetesStatefulSet
-          attributes:
-        - type: KubernetesCommunicatesWith
-          source_entity: KubernetesCronJob
           destination_entity: KubernetesDaemonSet
           attributes:
 
@@ -401,16 +349,6 @@ solarwindsentity/istio-workload-service:
         # source KubernetesDaemonSet
         - type: KubernetesCommunicatesWith
           source_entity: KubernetesDaemonSet
-          destination_entity: KubernetesService
-          attributes:
-        # source KubernetesJob
-        - type: KubernetesCommunicatesWith
-          source_entity: KubernetesJob
-          destination_entity: KubernetesService
-          attributes:
-        # source KubernetesCronJob
-        - type: KubernetesCommunicatesWith
-          source_entity: KubernetesCronJob
           destination_entity: KubernetesService
           attributes:
 {{- end }}

--- a/deploy/helm/templates/_common-discovery-config.tpl
+++ b/deploy/helm/templates/_common-discovery-config.tpl
@@ -1,0 +1,505 @@
+{{- define "common-discovery-config.processors" -}}
+{{- if .Values.otel.metrics.autodiscovery.prometheusEndpoints.filter }}
+filter/metrics-discovery:
+  metrics:
+{{ toYaml .Values.otel.metrics.autodiscovery.prometheusEndpoints.filter | indent 4 }}
+{{- end }}
+
+metricstransform/rename/discovery:
+  transforms:
+    # add `k8s.` prefix to all metrics
+    - include: ^(.*)$$
+      match_type: regexp
+      action: update
+      new_name: {{ .Values.otel.metrics.autodiscovery.prefix }}$${1}
+
+{{- if ne .Values.otel.metrics.autodiscovery.prefix "k8s." }}
+  # in case the prefix differs from "k8s." we need to copy the required metrics
+  # so that SWO built-in dashboards works correctly
+{{- $arrayOfRequiredMetrics := list 
+  "etcd_disk_backend_commit_duration_seconds"
+  "etcd_disk_wal_fsync_duration_seconds" 
+  "etcd_network_client_grpc_received_bytes_total" 
+  "etcd_network_client_grpc_sent_bytes_total" 
+  "etcd_network_peer_received_bytes_total" 
+  "etcd_network_peer_sent_bytes_total" 
+  "etcd_server_leader_changes_seen_total" 
+  "etcd_server_proposals_applied_total" 
+  "etcd_server_proposals_committed_total"
+  "etcd_server_proposals_failed_total"
+  "etcd_server_proposals_pending"
+  "etcd_server_has_leader"
+  "etcd_mvcc_db_total_size_in_bytes"
+  "process_resident_memory_bytes"
+  "grpc_server_started_total"
+  "grpc_server_handled_total"
+  "rest_client_request_duration_seconds"
+  "rest_client_requests_total"
+  "workqueue_adds_total"
+  "workqueue_depth"
+  "workqueue_queue_duration_seconds"
+}}
+metricstransform/copy-required-metrics:
+  transforms:
+  {{- $root := . }}
+  {{- range $index, $metric := $arrayOfRequiredMetrics }}
+    - include: {{ $root.Values.otel.metrics.autodiscovery.prefix }}{{ $metric }}
+      action: insert
+      new_name: k8s.{{ $metric }}
+  {{- end }}
+{{- end }}
+
+{{- if .Values.otel.metrics.autodiscovery.prometheusEndpoints.customTransformations.counterToRate }}
+cumulativetodelta/discovery:
+  include:
+    metrics:
+{{- range .Values.otel.metrics.autodiscovery.prometheusEndpoints.customTransformations.counterToRate }}
+      - {{ . }}
+{{- end }}
+    match_type: strict
+deltatorate/discovery:
+  metrics:
+{{- range .Values.otel.metrics.autodiscovery.prometheusEndpoints.customTransformations.counterToRate }}
+    - {{ . }}
+{{- end }}
+{{- end }}
+
+metricstransform/istio-metrics:
+  transforms:
+    - include: {{ .Values.otel.metrics.autodiscovery.prefix }}istio_request_bytes_sum
+      action: insert
+      new_name: k8s.istio_request_bytes.rate
+    - include: {{ .Values.otel.metrics.autodiscovery.prefix }}istio_response_bytes_sum
+      action: insert
+      new_name: k8s.istio_response_bytes.rate
+    - include: {{ .Values.otel.metrics.autodiscovery.prefix }}istio_requests_total
+      action: insert
+      new_name: k8s.istio_requests.rate
+    - include: {{ .Values.otel.metrics.autodiscovery.prefix }}istio_tcp_sent_bytes_total
+      action: insert
+      new_name: k8s.istio_tcp_sent_bytes.rate
+    - include: {{ .Values.otel.metrics.autodiscovery.prefix }}istio_tcp_received_bytes_total
+      action: insert
+      new_name: k8s.istio_tcp_received_bytes.rate
+    - include: k8s.istio_request_bytes.rate
+      action: insert
+      new_name: k8s.istio_request_bytes.delta
+    - include: k8s.istio_response_bytes.rate
+      action: insert
+      new_name: k8s.istio_response_bytes.delta
+    - include: k8s.istio_requests.rate
+      action: insert
+      new_name: k8s.istio_requests.delta
+    - include: k8s.istio_tcp_sent_bytes.rate
+      action: insert
+      new_name: k8s.istio_tcp_sent_bytes.delta
+    - include: k8s.istio_tcp_received_bytes.rate
+      action: insert
+      new_name: k8s.istio_tcp_received_bytes.delta
+
+cumulativetodelta/istio-metrics:
+  include:
+    metrics:
+      - k8s.istio_request_bytes.rate
+      - k8s.istio_response_bytes.rate
+      - k8s.istio_request_duration_milliseconds_sum_temp
+      - k8s.istio_request_duration_milliseconds_count_temp
+      - k8s.istio_requests.rate
+      - k8s.istio_tcp_sent_bytes.rate
+      - k8s.istio_tcp_received_bytes.rate
+      - k8s.istio_request_bytes.delta
+      - k8s.istio_response_bytes.delta
+      - k8s.istio_requests.delta
+      - k8s.istio_tcp_sent_bytes.delta
+      - k8s.istio_tcp_received_bytes.delta
+    match_type: strict
+
+deltatorate/istio-metrics:
+  metrics:
+    - k8s.istio_request_bytes.rate
+    - k8s.istio_response_bytes.rate
+    - k8s.istio_request_duration_milliseconds_sum_temp
+    - k8s.istio_request_duration_milliseconds_count_temp
+    - k8s.istio_requests.rate
+    - k8s.istio_tcp_sent_bytes.rate
+    - k8s.istio_tcp_received_bytes.rate
+
+metricsgeneration/istio-metrics:
+  rules:
+    - name: k8s.istio_request_duration_milliseconds.rate
+      type: calculate
+      metric1: k8s.istio_request_duration_milliseconds_sum_temp
+      metric2: k8s.istio_request_duration_milliseconds_count_temp
+      operation: divide
+
+transform/istio-metrics:
+  metric_statements:
+    - statements:
+        - extract_sum_metric(true) where (metric.name == "{{ .Values.otel.metrics.autodiscovery.prefix }}istio_request_bytes" or metric.name == "{{ .Values.otel.metrics.autodiscovery.prefix }}istio_response_bytes" or metric.name == "{{ .Values.otel.metrics.autodiscovery.prefix }}istio_request_duration_milliseconds")
+        - extract_count_metric(true) where (metric.name == "{{ .Values.otel.metrics.autodiscovery.prefix }}istio_request_duration_milliseconds")
+        - set(metric.name, "k8s.istio_request_duration_milliseconds_sum_temp") where metric.name == "{{ .Values.otel.metrics.autodiscovery.prefix }}istio_request_duration_milliseconds_sum"
+        - set(metric.name, "k8s.istio_request_duration_milliseconds_count_temp") where metric.name == "{{ .Values.otel.metrics.autodiscovery.prefix }}istio_request_duration_milliseconds_count"
+
+swok8sworkloadtype/istio:
+  workload_mappings:
+    - name_attr: source_workload
+      namespace_attr: source_workload_namespace
+      workload_type_attr: source_workload_type
+      expected_types:
+        - deployments
+        - daemonsets
+        - statefulsets
+        - jobs
+        - cronjobs
+        - pods
+    - name_attr: destination_workload
+      namespace_attr: destination_workload_namespace
+      workload_type_attr: destination_workload_type
+      expected_types:
+        - deployments
+        - daemonsets
+        - statefulsets
+        - jobs
+        - cronjobs
+        - pods
+    - name_attr: destination_service_name
+      namespace_attr: destination_service_namespace
+      workload_type_attr: destination_service_type
+      expected_types:
+        - services
+
+groupbyattrs/istio-relationships:
+  keys:
+    - sw.k8s.cluster.uid
+    - source.k8s.deployment.name
+    - source.k8s.statefulset.name
+    - source.k8s.daemonset.name
+    - source.k8s.job.name
+    - source.k8s.cronjob.name
+    - source.k8s.namespace.name
+    - dest.k8s.deployment.name
+    - dest.k8s.statefulset.name
+    - dest.k8s.daemonset.name
+    - dest.k8s.job.name
+    - dest.k8s.cronjob.name
+    - dest.k8s.namespace.name
+    - dest.k8s.service.name
+
+filter/keep-workload-workload-relationships:
+  error_mode: ignore
+  metrics:
+    metric:
+      - name != "{{ .Values.otel.metrics.autodiscovery.prefix }}istio_request_bytes_sum"
+    datapoint:
+      - datapoint.attributes["source_workload_type"] == nil or datapoint.attributes["destination_workload_type"] == nil or datapoint.attributes["source_workload_type"] == "" or datapoint.attributes["destination_workload_type"] == ""
+
+filter/keep-workload-service-relationships:
+  error_mode: ignore
+  metrics:
+    metric:
+      - name != "{{ .Values.otel.metrics.autodiscovery.prefix }}istio_request_bytes_sum"
+    datapoint:
+      - datapoint.attributes["source_workload_type"] == nil or datapoint.attributes["destination_service_type"] == nil or datapoint.attributes["source_workload_type"] == "" or datapoint.attributes["destination_service_type"] == ""
+
+transform/istio-workload-workload:
+  metric_statements:
+    - keep_keys(datapoint.attributes, ["source_workload", "source_workload_namespace", "destination_workload", "destination_workload_namespace", "source_workload_type", "destination_workload_type"])
+    - set(datapoint.attributes["source.k8s.deployment.name"], datapoint.attributes["source_workload"]) where datapoint.attributes["source_workload_type"] == "Deployment"
+    - set(datapoint.attributes["source.k8s.statefulset.name"], datapoint.attributes["source_workload"]) where datapoint.attributes["source_workload_type"] == "StatefulSet"
+    - set(datapoint.attributes["source.k8s.daemonset.name"], datapoint.attributes["source_workload"]) where datapoint.attributes["source_workload_type"] == "DaemonSet"
+    - set(datapoint.attributes["source.k8s.job.name"], datapoint.attributes["source_workload"]) where datapoint.attributes["source_workload_type"] == "Job"
+    - set(datapoint.attributes["source.k8s.cronjob.name"], datapoint.attributes["source_workload"]) where datapoint.attributes["source_workload_type"] == "CronJob"
+    - set(datapoint.attributes["source.k8s.namespace.name"], datapoint.attributes["source_workload_namespace"])
+    - set(datapoint.attributes["dest.k8s.deployment.name"], datapoint.attributes["destination_workload"]) where datapoint.attributes["destination_workload_type"] == "Deployment"
+    - set(datapoint.attributes["dest.k8s.statefulset.name"], datapoint.attributes["destination_workload"]) where datapoint.attributes["destination_workload_type"] == "StatefulSet"
+    - set(datapoint.attributes["dest.k8s.daemonset.name"], datapoint.attributes["destination_workload"]) where datapoint.attributes["destination_workload_type"] == "DaemonSet"
+    - set(datapoint.attributes["dest.k8s.job.name"], datapoint.attributes["destination_workload"]) where datapoint.attributes["destination_workload_type"] == "Job"
+    - set(datapoint.attributes["dest.k8s.cronjob.name"], datapoint.attributes["destination_workload"]) where datapoint.attributes["destination_workload_type"] == "CronJob"
+    - set(datapoint.attributes["dest.k8s.namespace.name"], datapoint.attributes["destination_workload_namespace"])
+
+transform/istio-workload-service:
+  metric_statements:
+    - keep_keys(datapoint.attributes, ["source_workload", "source_workload_namespace", "destination_service_name", "destination_service_namespace", "source_workload_type", "destination_service_type"])
+    - set(datapoint.attributes["source.k8s.deployment.name"], datapoint.attributes["source_workload"]) where datapoint.attributes["source_workload_type"] == "Deployment"
+    - set(datapoint.attributes["source.k8s.statefulset.name"], datapoint.attributes["source_workload"]) where datapoint.attributes["source_workload_type"] == "StatefulSet"
+    - set(datapoint.attributes["source.k8s.daemonset.name"], datapoint.attributes["source_workload"]) where datapoint.attributes["source_workload_type"] == "DaemonSet"
+    - set(datapoint.attributes["source.k8s.job.name"], datapoint.attributes["source_workload"]) where datapoint.attributes["source_workload_type"] == "Job"
+    - set(datapoint.attributes["source.k8s.cronjob.name"], datapoint.attributes["source_workload"]) where datapoint.attributes["source_workload_type"] == "CronJob"
+    - set(datapoint.attributes["source.k8s.namespace.name"], datapoint.attributes["source_workload_namespace"])
+    - set(datapoint.attributes["dest.k8s.service.name"], datapoint.attributes["destination_service_name"]) where datapoint.attributes["destination_service_type"] == "Service"
+    - set(datapoint.attributes["dest.k8s.namespace.name"], datapoint.attributes["destination_service_namespace"])
+
+transform/only-relationship-resource-attributes:
+  metric_statements:
+    - keep_keys(resource.attributes, ["sw.k8s.cluster.uid", "source.k8s.deployment.name", "source.k8s.statefulset.name", "source.k8s.daemonset.name", "source.k8s.job.name", "source.k8s.cronjob.name", "source.k8s.namespace.name", "dest.k8s.deployment.name", "dest.k8s.statefulset.name", "dest.k8s.daemonset.name", "dest.k8s.job.name", "dest.k8s.cronjob.name", "dest.k8s.service.name", "dest.k8s.namespace.name"])
+
+batch/stateevents:
+  send_batch_size: 1024
+  timeout: 1s
+  send_batch_max_size: 1024
+{{- end }}
+
+
+{{- define "common-discovery-config.connectors" -}}
+forward/relationship-state-events-workload-workload:
+forward/relationship-state-events-workload-service:
+routing/discovered_metrics:
+  default_pipelines: [metrics/discovery-custom]
+  table:
+    - context: metric
+      pipelines: [metrics/discovery-istio]
+      condition: |
+        IsMatch(name, "{{ .Values.otel.metrics.autodiscovery.prefix }}istio_")
+
+solarwindsentity/istio-workload-workload:
+  source_prefix: "source."
+  destination_prefix: "dest."
+  schema:
+    entities:
+      - entity: KubernetesDeployment
+        id:
+          - sw.k8s.cluster.uid
+          - k8s.namespace.name
+          - k8s.deployment.name
+      - entity: KubernetesStatefulSet
+        id:
+          - sw.k8s.cluster.uid
+          - k8s.namespace.name
+          - k8s.statefulset.name
+      - entity: KubernetesDaemonSet
+        id:
+          - sw.k8s.cluster.uid
+          - k8s.namespace.name
+          - k8s.daemonset.name
+      - entity: KubernetesJob
+        id:
+          - sw.k8s.cluster.uid
+          - k8s.namespace.name
+          - k8s.job.name
+      - entity: KubernetesCronJob
+        id:
+          - sw.k8s.cluster.uid
+          - k8s.namespace.name
+          - k8s.cronjob.name
+
+    events:
+      relationships:
+        # source KubernetesDeployment
+        - type: KubernetesCommunicatesWith
+          source_entity: KubernetesDeployment
+          destination_entity: KubernetesDeployment
+          attributes:
+        - type: KubernetesCommunicatesWith
+          source_entity: KubernetesDeployment
+          destination_entity: KubernetesStatefulSet
+          attributes:
+        - type: KubernetesCommunicatesWith
+          source_entity: KubernetesDeployment
+          destination_entity: KubernetesDaemonSet
+          attributes:
+        # source KubernetesStatefulSet
+        - type: KubernetesCommunicatesWith
+          source_entity: KubernetesStatefulSet
+          destination_entity: KubernetesDeployment
+          attributes:
+        - type: KubernetesCommunicatesWith
+          source_entity: KubernetesStatefulSet
+          destination_entity: KubernetesStatefulSet
+          attributes:
+        - type: KubernetesCommunicatesWith
+          source_entity: KubernetesStatefulSet
+          destination_entity: KubernetesDaemonSet
+          attributes:
+        # source KubernetesDaemonSet
+        - type: KubernetesCommunicatesWith
+          source_entity: KubernetesDaemonSet
+          destination_entity: KubernetesDeployment
+          attributes:
+        - type: KubernetesCommunicatesWith
+          source_entity: KubernetesDaemonSet
+          destination_entity: KubernetesStatefulSet
+          attributes:
+        - type: KubernetesCommunicatesWith
+          source_entity: KubernetesDaemonSet
+          destination_entity: KubernetesDaemonSet
+          attributes:
+        # source KubernetesJob
+        - type: KubernetesCommunicatesWith
+          source_entity: KubernetesJob
+          destination_entity: KubernetesDeployment
+          attributes:
+        - type: KubernetesCommunicatesWith
+          source_entity: KubernetesJob
+          destination_entity: KubernetesStatefulSet
+          attributes:
+        - type: KubernetesCommunicatesWith
+          source_entity: KubernetesJob
+          destination_entity: KubernetesDaemonSet
+          attributes:
+        # source KubernetesCronJob
+        - type: KubernetesCommunicatesWith
+          source_entity: KubernetesCronJob
+          destination_entity: KubernetesDeployment
+          attributes:
+        - type: KubernetesCommunicatesWith
+          source_entity: KubernetesCronJob
+          destination_entity: KubernetesStatefulSet
+          attributes:
+        - type: KubernetesCommunicatesWith
+          source_entity: KubernetesCronJob
+          destination_entity: KubernetesDaemonSet
+          attributes:
+
+
+solarwindsentity/istio-workload-service:
+  source_prefix: "source."
+  destination_prefix: "dest."
+  schema:
+    entities:
+      - entity: KubernetesDeployment
+        id:
+          - sw.k8s.cluster.uid
+          - k8s.namespace.name
+          - k8s.deployment.name
+      - entity: KubernetesStatefulSet
+        id:
+          - sw.k8s.cluster.uid
+          - k8s.namespace.name
+          - k8s.statefulset.name
+      - entity: KubernetesDaemonSet
+        id:
+          - sw.k8s.cluster.uid
+          - k8s.namespace.name
+          - k8s.daemonset.name
+      - entity: KubernetesJob
+        id:
+          - sw.k8s.cluster.uid
+          - k8s.namespace.name
+          - k8s.job.name
+      - entity: KubernetesCronJob
+        id:
+          - sw.k8s.cluster.uid
+          - k8s.namespace.name
+          - k8s.cronjob.name
+      - entity: KubernetesService
+        id:
+          - sw.k8s.cluster.uid
+          - k8s.namespace.name
+          - k8s.service.name
+    events:
+      relationships:
+        # source KubernetesDeployment
+        - type: KubernetesCommunicatesWith
+          source_entity: KubernetesDeployment
+          destination_entity: KubernetesService
+          attributes:
+        # source KubernetesStatefulSet
+        - type: KubernetesCommunicatesWith
+          source_entity: KubernetesStatefulSet
+          destination_entity: KubernetesService
+          attributes:
+        # source KubernetesDaemonSet
+        - type: KubernetesCommunicatesWith
+          source_entity: KubernetesDaemonSet
+          destination_entity: KubernetesService
+          attributes:
+        # source KubernetesJob
+        - type: KubernetesCommunicatesWith
+          source_entity: KubernetesJob
+          destination_entity: KubernetesService
+          attributes:
+        # source KubernetesCronJob
+        - type: KubernetesCommunicatesWith
+          source_entity: KubernetesCronJob
+          destination_entity: KubernetesService
+          attributes:
+{{- end }}
+
+{{- define "common-discovery-config.pipelines" -}}
+{{- $context := index . 0 -}}
+{{- $entryReceiver := index . 1 -}}
+{{- $metricExporter := index . 2 -}}
+metrics/discovery-scrape:
+  exporters:
+    - routing/discovered_metrics
+  processors:
+    - memory_limiter
+{{- if $context.Values.otel.metrics.autodiscovery.prometheusEndpoints.filter }}
+    - filter/metrics-discovery
+{{- end }}
+{{- if $context.Values.otel.metrics.autodiscovery.prefix }}
+    - metricstransform/rename/discovery
+{{- end }}
+{{- if ne $context.Values.otel.metrics.autodiscovery.prefix "k8s." }}
+    - metricstransform/copy-required-metrics
+{{- end }}
+  receivers:
+    - {{ $entryReceiver }}
+
+metrics/discovery-istio:
+  exporters:
+    - {{ $metricExporter }}
+    - forward/relationship-state-events-workload-workload
+    - forward/relationship-state-events-workload-service
+  processors:
+    - memory_limiter
+    - swok8sworkloadtype/istio
+    - transform/istio-metrics
+    - metricstransform/istio-metrics
+    - cumulativetodelta/istio-metrics
+    - deltatorate/istio-metrics
+    - metricsgeneration/istio-metrics
+    - groupbyattrs/common-all
+    - resource/all
+  receivers:
+    - routing/discovered_metrics
+
+metrics/relationship-state-events-workload-workload-preparation:
+  exporters:
+    - solarwindsentity/istio-workload-workload
+  processors:
+    - memory_limiter
+    - filter/keep-workload-workload-relationships
+    - transform/istio-workload-workload
+    - groupbyattrs/istio-relationships
+    - transform/only-relationship-resource-attributes
+  receivers:
+    - forward/relationship-state-events-workload-workload
+
+metrics/relationship-state-events-workload-service-preparation:
+  exporters:
+    - solarwindsentity/istio-workload-service
+  processors:
+    - memory_limiter
+    - filter/keep-workload-service-relationships
+    - transform/istio-workload-service
+    - groupbyattrs/istio-relationships
+    - transform/only-relationship-resource-attributes
+  receivers:
+    - forward/relationship-state-events-workload-service
+
+logs/stateevents:
+  exporters:
+    - otlp
+  processors:
+    - memory_limiter
+    - transform/scope
+    - batch/stateevents
+  receivers:
+    - solarwindsentity/istio-workload-workload
+    - solarwindsentity/istio-workload-service
+
+metrics/discovery-custom:
+  exporters:
+    - {{ $metricExporter }}
+  processors:
+    - memory_limiter
+{{- if $context.Values.otel.metrics.autodiscovery.prometheusEndpoints.customTransformations.counterToRate }}
+    - cumulativetodelta/discovery
+    - deltatorate/discovery
+{{- end }}
+    - groupbyattrs/common-all
+    - resource/all
+  receivers:
+    - routing/discovered_metrics
+{{- end }}

--- a/deploy/helm/templates/operator/discovery-collector.yaml
+++ b/deploy/helm/templates/operator/discovery-collector.yaml
@@ -205,6 +205,8 @@ spec:
     connectors:
       forward/metric-exporter: {}
 
+{{ include "common-discovery-config.connectors" . | indent 6 }}
+
     processors:
       memory_limiter:
 {{ toYaml .Values.otel.metrics.autodiscovery.discovery_collector.memory_limiter | indent 8 }}
@@ -253,132 +255,6 @@ spec:
       batch/metrics:
 {{ toYaml .Values.otel.metrics.autodiscovery.discovery_collector.batch | indent 8 }}
 
-{{- if .Values.otel.metrics.autodiscovery.prometheusEndpoints.filter }}
-      filter/metrics-discovery:
-        metrics:
-{{ toYaml .Values.otel.metrics.autodiscovery.prometheusEndpoints.filter | indent 10 }}
-{{- end }}
-
-      metricstransform/rename/discovery:
-        transforms:
-          # add `k8s.` prefix to all metrics
-          - include: ^(.*)$$
-            match_type: regexp
-            action: update
-            new_name: {{ .Values.otel.metrics.autodiscovery.prefix }}$${1}
-
-{{- if ne .Values.otel.metrics.autodiscovery.prefix "k8s." }}
-  # in case the prefix differs from "k8s." we need to copy the required metrics
-  # so that SWO built-in dashboards works correctly
-{{- $arrayOfRequiredMetrics := list 
-  "etcd_disk_backend_commit_duration_seconds"
-  "etcd_disk_wal_fsync_duration_seconds" 
-  "etcd_network_client_grpc_received_bytes_total" 
-  "etcd_network_client_grpc_sent_bytes_total" 
-  "etcd_network_peer_received_bytes_total" 
-  "etcd_network_peer_sent_bytes_total" 
-  "etcd_server_leader_changes_seen_total" 
-  "etcd_server_proposals_applied_total" 
-  "etcd_server_proposals_committed_total"
-  "etcd_server_proposals_failed_total"
-  "etcd_server_proposals_pending"
-  "etcd_server_has_leader"
-  "etcd_mvcc_db_total_size_in_bytes"
-  "process_resident_memory_bytes"
-  "grpc_server_started_total"
-  "grpc_server_handled_total"
-  "rest_client_request_duration_seconds"
-  "rest_client_requests_total"
-  "workqueue_adds_total"
-  "workqueue_depth"
-  "workqueue_queue_duration_seconds"
-}}
-      metricstransform/copy-required-metrics:
-        transforms:
-        {{- $root := . }}
-        {{- range $index, $metric := $arrayOfRequiredMetrics }}
-          - include: {{ $root.Values.otel.metrics.autodiscovery.prefix }}{{ $metric }}
-            action: insert
-            new_name: k8s.{{ $metric }}
-        {{- end }}
-{{- end }}
-
-      transform/istio-metrics:
-        metric_statements:
-          - statements:
-              - extract_sum_metric(true) where (metric.name == "{{ .Values.otel.metrics.autodiscovery.prefix }}istio_request_bytes" or metric.name == "{{ .Values.otel.metrics.autodiscovery.prefix }}istio_response_bytes" or metric.name == "{{ .Values.otel.metrics.autodiscovery.prefix }}istio_request_duration_milliseconds")
-              - extract_count_metric(true) where (metric.name == "{{ .Values.otel.metrics.autodiscovery.prefix }}istio_request_duration_milliseconds")
-              - set(metric.name, "k8s.istio_request_duration_milliseconds_sum_temp") where metric.name == "{{ .Values.otel.metrics.autodiscovery.prefix }}istio_request_duration_milliseconds_sum"
-              - set(metric.name, "k8s.istio_request_duration_milliseconds_count_temp") where metric.name == "{{ .Values.otel.metrics.autodiscovery.prefix }}istio_request_duration_milliseconds_count"
-
-      metricstransform/istio-metrics:
-        transforms:
-          - include: {{ .Values.otel.metrics.autodiscovery.prefix }}istio_request_bytes_sum
-            action: insert
-            new_name: k8s.istio_request_bytes.rate
-          - include: {{ .Values.otel.metrics.autodiscovery.prefix }}istio_response_bytes_sum
-            action: insert
-            new_name: k8s.istio_response_bytes.rate
-          - include: {{ .Values.otel.metrics.autodiscovery.prefix }}istio_requests_total
-            action: insert
-            new_name: k8s.istio_requests.rate
-          - include: {{ .Values.otel.metrics.autodiscovery.prefix }}istio_tcp_sent_bytes_total
-            action: insert
-            new_name: k8s.istio_tcp_sent_bytes.rate
-          - include: {{ .Values.otel.metrics.autodiscovery.prefix }}istio_tcp_received_bytes_total
-            action: insert
-            new_name: k8s.istio_tcp_received_bytes.rate
-          - include: k8s.istio_request_bytes.rate
-            action: insert
-            new_name: k8s.istio_request_bytes.delta
-          - include: k8s.istio_response_bytes.rate
-            action: insert
-            new_name: k8s.istio_response_bytes.delta
-          - include: k8s.istio_requests.rate
-            action: insert
-            new_name: k8s.istio_requests.delta
-          - include: k8s.istio_tcp_sent_bytes.rate
-            action: insert
-            new_name: k8s.istio_tcp_sent_bytes.delta
-          - include: k8s.istio_tcp_received_bytes.rate
-            action: insert
-            new_name: k8s.istio_tcp_received_bytes.delta
-
-      cumulativetodelta/istio-metrics:
-        include:
-          metrics:
-            - k8s.istio_request_bytes.rate
-            - k8s.istio_response_bytes.rate
-            - k8s.istio_request_duration_milliseconds_sum_temp
-            - k8s.istio_request_duration_milliseconds_count_temp
-            - k8s.istio_requests.rate
-            - k8s.istio_tcp_sent_bytes.rate
-            - k8s.istio_tcp_received_bytes.rate
-            - k8s.istio_request_bytes.delta
-            - k8s.istio_response_bytes.delta
-            - k8s.istio_requests.delta
-            - k8s.istio_tcp_sent_bytes.delta
-            - k8s.istio_tcp_received_bytes.delta
-          match_type: strict
-
-      deltatorate/istio-metrics:
-        metrics:
-          - k8s.istio_request_bytes.rate
-          - k8s.istio_response_bytes.rate
-          - k8s.istio_request_duration_milliseconds_sum_temp
-          - k8s.istio_request_duration_milliseconds_count_temp
-          - k8s.istio_requests.rate
-          - k8s.istio_tcp_sent_bytes.rate
-          - k8s.istio_tcp_received_bytes.rate
-
-      metricsgeneration/istio-metrics:
-        rules:
-          - name: k8s.istio_request_duration_milliseconds.rate
-            type: calculate
-            metric1: k8s.istio_request_duration_milliseconds_sum_temp
-            metric2: k8s.istio_request_duration_milliseconds_count_temp
-            operation: divide
-
       groupbyattrs/common-all:
         keys:
           - k8s.container.name
@@ -408,6 +284,8 @@ spec:
           - key: k8s.cluster.name
             value: ${CLUSTER_NAME}
             action: insert
+
+{{ include "common-discovery-config.processors" . | indent 6 }}
 
     exporters:
       otlp:
@@ -447,29 +325,8 @@ spec:
           receivers:
             - forward/metric-exporter
 
-        metrics/discovery:
-          exporters:
-            - forward/metric-exporter
-          processors:
-            - memory_limiter
-    {{- if .Values.otel.metrics.autodiscovery.prometheusEndpoints.filter }}
-            - filter/metrics-discovery
-    {{- end }}
-    {{- if .Values.otel.metrics.autodiscovery.prefix }}
-            - metricstransform/rename/discovery
-    {{- end }}
-    {{- if ne .Values.otel.metrics.autodiscovery.prefix "k8s." }}
-            - metricstransform/copy-required-metrics
-    {{- end }}
-            - transform/istio-metrics
-            - metricstransform/istio-metrics
-            - cumulativetodelta/istio-metrics
-            - deltatorate/istio-metrics
-            - metricsgeneration/istio-metrics
-            - groupbyattrs/common-all
-            - resource/all
-          receivers:
-            - prometheus
+{{ include "common-discovery-config.pipelines" (tuple . "prometheus" "forward/metric-exporter") | indent 8 }}
+
       telemetry:
     {{- if .Values.otel.metrics.autodiscovery.discovery_collector.telemetry.logs.enabled }}
         logs:

--- a/deploy/helm/tests/__snapshot__/discovery-collector_test.yaml.snap
+++ b/deploy/helm/tests/__snapshot__/discovery-collector_test.yaml.snap
@@ -26,6 +26,166 @@ Discovery collector spec should match snapshot when using default values:
     config:
       connectors:
         forward/metric-exporter: {}
+        forward/relationship-state-events-workload-service: null
+        forward/relationship-state-events-workload-workload: null
+        routing/discovered_metrics:
+          default_pipelines:
+            - metrics/discovery-custom
+          table:
+            - condition: |
+                IsMatch(name, "k8s.istio_")
+              context: metric
+              pipelines:
+                - metrics/discovery-istio
+        solarwindsentity/istio-workload-service:
+          destination_prefix: dest.
+          schema:
+            entities:
+              - entity: KubernetesDeployment
+                id:
+                  - sw.k8s.cluster.uid
+                  - k8s.namespace.name
+                  - k8s.deployment.name
+              - entity: KubernetesStatefulSet
+                id:
+                  - sw.k8s.cluster.uid
+                  - k8s.namespace.name
+                  - k8s.statefulset.name
+              - entity: KubernetesDaemonSet
+                id:
+                  - sw.k8s.cluster.uid
+                  - k8s.namespace.name
+                  - k8s.daemonset.name
+              - entity: KubernetesJob
+                id:
+                  - sw.k8s.cluster.uid
+                  - k8s.namespace.name
+                  - k8s.job.name
+              - entity: KubernetesCronJob
+                id:
+                  - sw.k8s.cluster.uid
+                  - k8s.namespace.name
+                  - k8s.cronjob.name
+              - entity: KubernetesService
+                id:
+                  - sw.k8s.cluster.uid
+                  - k8s.namespace.name
+                  - k8s.service.name
+            events:
+              relationships:
+                - attributes: null
+                  destination_entity: KubernetesService
+                  source_entity: KubernetesDeployment
+                  type: KubernetesCommunicatesWith
+                - attributes: null
+                  destination_entity: KubernetesService
+                  source_entity: KubernetesStatefulSet
+                  type: KubernetesCommunicatesWith
+                - attributes: null
+                  destination_entity: KubernetesService
+                  source_entity: KubernetesDaemonSet
+                  type: KubernetesCommunicatesWith
+                - attributes: null
+                  destination_entity: KubernetesService
+                  source_entity: KubernetesJob
+                  type: KubernetesCommunicatesWith
+                - attributes: null
+                  destination_entity: KubernetesService
+                  source_entity: KubernetesCronJob
+                  type: KubernetesCommunicatesWith
+          source_prefix: source.
+        solarwindsentity/istio-workload-workload:
+          destination_prefix: dest.
+          schema:
+            entities:
+              - entity: KubernetesDeployment
+                id:
+                  - sw.k8s.cluster.uid
+                  - k8s.namespace.name
+                  - k8s.deployment.name
+              - entity: KubernetesStatefulSet
+                id:
+                  - sw.k8s.cluster.uid
+                  - k8s.namespace.name
+                  - k8s.statefulset.name
+              - entity: KubernetesDaemonSet
+                id:
+                  - sw.k8s.cluster.uid
+                  - k8s.namespace.name
+                  - k8s.daemonset.name
+              - entity: KubernetesJob
+                id:
+                  - sw.k8s.cluster.uid
+                  - k8s.namespace.name
+                  - k8s.job.name
+              - entity: KubernetesCronJob
+                id:
+                  - sw.k8s.cluster.uid
+                  - k8s.namespace.name
+                  - k8s.cronjob.name
+            events:
+              relationships:
+                - attributes: null
+                  destination_entity: KubernetesDeployment
+                  source_entity: KubernetesDeployment
+                  type: KubernetesCommunicatesWith
+                - attributes: null
+                  destination_entity: KubernetesStatefulSet
+                  source_entity: KubernetesDeployment
+                  type: KubernetesCommunicatesWith
+                - attributes: null
+                  destination_entity: KubernetesDaemonSet
+                  source_entity: KubernetesDeployment
+                  type: KubernetesCommunicatesWith
+                - attributes: null
+                  destination_entity: KubernetesDeployment
+                  source_entity: KubernetesStatefulSet
+                  type: KubernetesCommunicatesWith
+                - attributes: null
+                  destination_entity: KubernetesStatefulSet
+                  source_entity: KubernetesStatefulSet
+                  type: KubernetesCommunicatesWith
+                - attributes: null
+                  destination_entity: KubernetesDaemonSet
+                  source_entity: KubernetesStatefulSet
+                  type: KubernetesCommunicatesWith
+                - attributes: null
+                  destination_entity: KubernetesDeployment
+                  source_entity: KubernetesDaemonSet
+                  type: KubernetesCommunicatesWith
+                - attributes: null
+                  destination_entity: KubernetesStatefulSet
+                  source_entity: KubernetesDaemonSet
+                  type: KubernetesCommunicatesWith
+                - attributes: null
+                  destination_entity: KubernetesDaemonSet
+                  source_entity: KubernetesDaemonSet
+                  type: KubernetesCommunicatesWith
+                - attributes: null
+                  destination_entity: KubernetesDeployment
+                  source_entity: KubernetesJob
+                  type: KubernetesCommunicatesWith
+                - attributes: null
+                  destination_entity: KubernetesStatefulSet
+                  source_entity: KubernetesJob
+                  type: KubernetesCommunicatesWith
+                - attributes: null
+                  destination_entity: KubernetesDaemonSet
+                  source_entity: KubernetesJob
+                  type: KubernetesCommunicatesWith
+                - attributes: null
+                  destination_entity: KubernetesDeployment
+                  source_entity: KubernetesCronJob
+                  type: KubernetesCommunicatesWith
+                - attributes: null
+                  destination_entity: KubernetesStatefulSet
+                  source_entity: KubernetesCronJob
+                  type: KubernetesCommunicatesWith
+                - attributes: null
+                  destination_entity: KubernetesDaemonSet
+                  source_entity: KubernetesCronJob
+                  type: KubernetesCommunicatesWith
+          source_prefix: source.
       exporters:
         otlp:
           endpoint: ${OTEL_ENVOY_ADDRESS}
@@ -50,6 +210,10 @@ Discovery collector spec should match snapshot when using default values:
         batch/metrics:
           send_batch_max_size: 512
           send_batch_size: 512
+          timeout: 1s
+        batch/stateevents:
+          send_batch_max_size: 1024
+          send_batch_size: 1024
           timeout: 1s
         cumulativetodelta/istio-metrics:
           include:
@@ -80,6 +244,20 @@ Discovery collector spec should match snapshot when using default values:
           metrics:
             metric:
               - type == METRIC_DATA_TYPE_HISTOGRAM and not(name == "k8s.rest_client_request_duration_seconds" or name == "k8s.workqueue_queue_duration_seconds" or name == "k8s.etcd_disk_wal_fsync_duration_seconds" or name == "k8s.etcd_disk_backend_commit_duration_seconds")
+        filter/keep-workload-service-relationships:
+          error_mode: ignore
+          metrics:
+            datapoint:
+              - datapoint.attributes["source_workload_type"] == nil or datapoint.attributes["destination_service_type"] == nil or datapoint.attributes["source_workload_type"] == "" or datapoint.attributes["destination_service_type"] == ""
+            metric:
+              - name != "k8s.istio_request_bytes_sum"
+        filter/keep-workload-workload-relationships:
+          error_mode: ignore
+          metrics:
+            datapoint:
+              - datapoint.attributes["source_workload_type"] == nil or datapoint.attributes["destination_workload_type"] == nil or datapoint.attributes["source_workload_type"] == "" or datapoint.attributes["destination_workload_type"] == ""
+            metric:
+              - name != "k8s.istio_request_bytes_sum"
         filter/remove_temporary_metrics:
           metrics:
             metric:
@@ -92,6 +270,22 @@ Discovery collector spec should match snapshot when using default values:
             - k8s.pod.uid
             - host.name
             - service.name
+        groupbyattrs/istio-relationships:
+          keys:
+            - sw.k8s.cluster.uid
+            - source.k8s.deployment.name
+            - source.k8s.statefulset.name
+            - source.k8s.daemonset.name
+            - source.k8s.job.name
+            - source.k8s.cronjob.name
+            - source.k8s.namespace.name
+            - dest.k8s.deployment.name
+            - dest.k8s.statefulset.name
+            - dest.k8s.daemonset.name
+            - dest.k8s.job.name
+            - dest.k8s.cronjob.name
+            - dest.k8s.namespace.name
+            - dest.k8s.service.name
         k8sattributes:
           auth_type: serviceAccount
           extract:
@@ -172,6 +366,33 @@ Discovery collector spec should match snapshot when using default values:
             - action: insert
               key: k8s.cluster.name
               value: ${CLUSTER_NAME}
+        swok8sworkloadtype/istio:
+          workload_mappings:
+            - expected_types:
+                - deployments
+                - daemonsets
+                - statefulsets
+                - jobs
+                - cronjobs
+                - pods
+              name_attr: source_workload
+              namespace_attr: source_workload_namespace
+              workload_type_attr: source_workload_type
+            - expected_types:
+                - deployments
+                - daemonsets
+                - statefulsets
+                - jobs
+                - cronjobs
+                - pods
+              name_attr: destination_workload
+              namespace_attr: destination_workload_namespace
+              workload_type_attr: destination_workload_type
+            - expected_types:
+                - services
+              name_attr: destination_service_name
+              namespace_attr: destination_service_namespace
+              workload_type_attr: destination_service_type
         transform/istio-metrics:
           metric_statements:
             - statements:
@@ -179,6 +400,35 @@ Discovery collector spec should match snapshot when using default values:
                 - extract_count_metric(true) where (metric.name == "k8s.istio_request_duration_milliseconds")
                 - set(metric.name, "k8s.istio_request_duration_milliseconds_sum_temp") where metric.name == "k8s.istio_request_duration_milliseconds_sum"
                 - set(metric.name, "k8s.istio_request_duration_milliseconds_count_temp") where metric.name == "k8s.istio_request_duration_milliseconds_count"
+        transform/istio-workload-service:
+          metric_statements:
+            - keep_keys(datapoint.attributes, ["source_workload", "source_workload_namespace", "destination_service_name", "destination_service_namespace", "source_workload_type", "destination_service_type"])
+            - set(datapoint.attributes["source.k8s.deployment.name"], datapoint.attributes["source_workload"]) where datapoint.attributes["source_workload_type"] == "Deployment"
+            - set(datapoint.attributes["source.k8s.statefulset.name"], datapoint.attributes["source_workload"]) where datapoint.attributes["source_workload_type"] == "StatefulSet"
+            - set(datapoint.attributes["source.k8s.daemonset.name"], datapoint.attributes["source_workload"]) where datapoint.attributes["source_workload_type"] == "DaemonSet"
+            - set(datapoint.attributes["source.k8s.job.name"], datapoint.attributes["source_workload"]) where datapoint.attributes["source_workload_type"] == "Job"
+            - set(datapoint.attributes["source.k8s.cronjob.name"], datapoint.attributes["source_workload"]) where datapoint.attributes["source_workload_type"] == "CronJob"
+            - set(datapoint.attributes["source.k8s.namespace.name"], datapoint.attributes["source_workload_namespace"])
+            - set(datapoint.attributes["dest.k8s.service.name"], datapoint.attributes["destination_service_name"]) where datapoint.attributes["destination_service_type"] == "Service"
+            - set(datapoint.attributes["dest.k8s.namespace.name"], datapoint.attributes["destination_service_namespace"])
+        transform/istio-workload-workload:
+          metric_statements:
+            - keep_keys(datapoint.attributes, ["source_workload", "source_workload_namespace", "destination_workload", "destination_workload_namespace", "source_workload_type", "destination_workload_type"])
+            - set(datapoint.attributes["source.k8s.deployment.name"], datapoint.attributes["source_workload"]) where datapoint.attributes["source_workload_type"] == "Deployment"
+            - set(datapoint.attributes["source.k8s.statefulset.name"], datapoint.attributes["source_workload"]) where datapoint.attributes["source_workload_type"] == "StatefulSet"
+            - set(datapoint.attributes["source.k8s.daemonset.name"], datapoint.attributes["source_workload"]) where datapoint.attributes["source_workload_type"] == "DaemonSet"
+            - set(datapoint.attributes["source.k8s.job.name"], datapoint.attributes["source_workload"]) where datapoint.attributes["source_workload_type"] == "Job"
+            - set(datapoint.attributes["source.k8s.cronjob.name"], datapoint.attributes["source_workload"]) where datapoint.attributes["source_workload_type"] == "CronJob"
+            - set(datapoint.attributes["source.k8s.namespace.name"], datapoint.attributes["source_workload_namespace"])
+            - set(datapoint.attributes["dest.k8s.deployment.name"], datapoint.attributes["destination_workload"]) where datapoint.attributes["destination_workload_type"] == "Deployment"
+            - set(datapoint.attributes["dest.k8s.statefulset.name"], datapoint.attributes["destination_workload"]) where datapoint.attributes["destination_workload_type"] == "StatefulSet"
+            - set(datapoint.attributes["dest.k8s.daemonset.name"], datapoint.attributes["destination_workload"]) where datapoint.attributes["destination_workload_type"] == "DaemonSet"
+            - set(datapoint.attributes["dest.k8s.job.name"], datapoint.attributes["destination_workload"]) where datapoint.attributes["destination_workload_type"] == "Job"
+            - set(datapoint.attributes["dest.k8s.cronjob.name"], datapoint.attributes["destination_workload"]) where datapoint.attributes["destination_workload_type"] == "CronJob"
+            - set(datapoint.attributes["dest.k8s.namespace.name"], datapoint.attributes["destination_workload_namespace"])
+        transform/only-relationship-resource-attributes:
+          metric_statements:
+            - keep_keys(resource.attributes, ["sw.k8s.cluster.uid", "source.k8s.deployment.name", "source.k8s.statefulset.name", "source.k8s.daemonset.name", "source.k8s.job.name", "source.k8s.cronjob.name", "source.k8s.namespace.name", "dest.k8s.deployment.name", "dest.k8s.statefulset.name", "dest.k8s.daemonset.name", "dest.k8s.job.name", "dest.k8s.cronjob.name", "dest.k8s.service.name", "dest.k8s.namespace.name"])
         transform/scope:
           log_statements:
             - statements:
@@ -201,6 +451,17 @@ Discovery collector spec should match snapshot when using default values:
         extensions:
           - health_check
         pipelines:
+          logs/stateevents:
+            exporters:
+              - otlp
+              - debug
+            processors:
+              - memory_limiter
+              - transform/scope
+              - batch/stateevents
+            receivers:
+              - solarwindsentity/istio-workload-workload
+              - solarwindsentity/istio-workload-service
           metrics:
             exporters:
               - otlp
@@ -213,12 +474,23 @@ Discovery collector spec should match snapshot when using default values:
               - batch/metrics
             receivers:
               - forward/metric-exporter
-          metrics/discovery:
+          metrics/discovery-custom:
             exporters:
               - forward/metric-exporter
             processors:
               - memory_limiter
-              - metricstransform/rename/discovery
+              - groupbyattrs/common-all
+              - resource/all
+            receivers:
+              - routing/discovered_metrics
+          metrics/discovery-istio:
+            exporters:
+              - forward/metric-exporter
+              - forward/relationship-state-events-workload-workload
+              - forward/relationship-state-events-workload-service
+            processors:
+              - memory_limiter
+              - swok8sworkloadtype/istio
               - transform/istio-metrics
               - metricstransform/istio-metrics
               - cumulativetodelta/istio-metrics
@@ -227,7 +499,37 @@ Discovery collector spec should match snapshot when using default values:
               - groupbyattrs/common-all
               - resource/all
             receivers:
+              - routing/discovered_metrics
+          metrics/discovery-scrape:
+            exporters:
+              - routing/discovered_metrics
+            processors:
+              - memory_limiter
+              - metricstransform/rename/discovery
+            receivers:
               - prometheus
+          metrics/relationship-state-events-workload-service-preparation:
+            exporters:
+              - solarwindsentity/istio-workload-service
+            processors:
+              - memory_limiter
+              - filter/keep-workload-service-relationships
+              - transform/istio-workload-service
+              - groupbyattrs/istio-relationships
+              - transform/only-relationship-resource-attributes
+            receivers:
+              - forward/relationship-state-events-workload-service
+          metrics/relationship-state-events-workload-workload-preparation:
+            exporters:
+              - solarwindsentity/istio-workload-workload
+            processors:
+              - memory_limiter
+              - filter/keep-workload-workload-relationships
+              - transform/istio-workload-workload
+              - groupbyattrs/istio-relationships
+              - transform/only-relationship-resource-attributes
+            receivers:
+              - forward/relationship-state-events-workload-workload
         telemetry:
           logs:
             level: info

--- a/deploy/helm/tests/__snapshot__/discovery-collector_test.yaml.snap
+++ b/deploy/helm/tests/__snapshot__/discovery-collector_test.yaml.snap
@@ -85,14 +85,6 @@ Discovery collector spec should match snapshot when using default values:
                   destination_entity: KubernetesService
                   source_entity: KubernetesDaemonSet
                   type: KubernetesCommunicatesWith
-                - attributes: null
-                  destination_entity: KubernetesService
-                  source_entity: KubernetesJob
-                  type: KubernetesCommunicatesWith
-                - attributes: null
-                  destination_entity: KubernetesService
-                  source_entity: KubernetesCronJob
-                  type: KubernetesCommunicatesWith
           source_prefix: source.
         solarwindsentity/istio-workload-workload:
           destination_prefix: dest.
@@ -113,16 +105,6 @@ Discovery collector spec should match snapshot when using default values:
                   - sw.k8s.cluster.uid
                   - k8s.namespace.name
                   - k8s.daemonset.name
-              - entity: KubernetesJob
-                id:
-                  - sw.k8s.cluster.uid
-                  - k8s.namespace.name
-                  - k8s.job.name
-              - entity: KubernetesCronJob
-                id:
-                  - sw.k8s.cluster.uid
-                  - k8s.namespace.name
-                  - k8s.cronjob.name
             events:
               relationships:
                 - attributes: null
@@ -160,30 +142,6 @@ Discovery collector spec should match snapshot when using default values:
                 - attributes: null
                   destination_entity: KubernetesDaemonSet
                   source_entity: KubernetesDaemonSet
-                  type: KubernetesCommunicatesWith
-                - attributes: null
-                  destination_entity: KubernetesDeployment
-                  source_entity: KubernetesJob
-                  type: KubernetesCommunicatesWith
-                - attributes: null
-                  destination_entity: KubernetesStatefulSet
-                  source_entity: KubernetesJob
-                  type: KubernetesCommunicatesWith
-                - attributes: null
-                  destination_entity: KubernetesDaemonSet
-                  source_entity: KubernetesJob
-                  type: KubernetesCommunicatesWith
-                - attributes: null
-                  destination_entity: KubernetesDeployment
-                  source_entity: KubernetesCronJob
-                  type: KubernetesCommunicatesWith
-                - attributes: null
-                  destination_entity: KubernetesStatefulSet
-                  source_entity: KubernetesCronJob
-                  type: KubernetesCommunicatesWith
-                - attributes: null
-                  destination_entity: KubernetesDaemonSet
-                  source_entity: KubernetesCronJob
                   type: KubernetesCommunicatesWith
           source_prefix: source.
       exporters:
@@ -276,14 +234,10 @@ Discovery collector spec should match snapshot when using default values:
             - source.k8s.deployment.name
             - source.k8s.statefulset.name
             - source.k8s.daemonset.name
-            - source.k8s.job.name
-            - source.k8s.cronjob.name
             - source.k8s.namespace.name
             - dest.k8s.deployment.name
             - dest.k8s.statefulset.name
             - dest.k8s.daemonset.name
-            - dest.k8s.job.name
-            - dest.k8s.cronjob.name
             - dest.k8s.namespace.name
             - dest.k8s.service.name
         k8sattributes:
@@ -372,9 +326,6 @@ Discovery collector spec should match snapshot when using default values:
                 - deployments
                 - daemonsets
                 - statefulsets
-                - jobs
-                - cronjobs
-                - pods
               name_attr: source_workload
               namespace_attr: source_workload_namespace
               workload_type_attr: source_workload_type
@@ -382,9 +333,6 @@ Discovery collector spec should match snapshot when using default values:
                 - deployments
                 - daemonsets
                 - statefulsets
-                - jobs
-                - cronjobs
-                - pods
               name_attr: destination_workload
               namespace_attr: destination_workload_namespace
               workload_type_attr: destination_workload_type
@@ -406,8 +354,6 @@ Discovery collector spec should match snapshot when using default values:
             - set(datapoint.attributes["source.k8s.deployment.name"], datapoint.attributes["source_workload"]) where datapoint.attributes["source_workload_type"] == "Deployment"
             - set(datapoint.attributes["source.k8s.statefulset.name"], datapoint.attributes["source_workload"]) where datapoint.attributes["source_workload_type"] == "StatefulSet"
             - set(datapoint.attributes["source.k8s.daemonset.name"], datapoint.attributes["source_workload"]) where datapoint.attributes["source_workload_type"] == "DaemonSet"
-            - set(datapoint.attributes["source.k8s.job.name"], datapoint.attributes["source_workload"]) where datapoint.attributes["source_workload_type"] == "Job"
-            - set(datapoint.attributes["source.k8s.cronjob.name"], datapoint.attributes["source_workload"]) where datapoint.attributes["source_workload_type"] == "CronJob"
             - set(datapoint.attributes["source.k8s.namespace.name"], datapoint.attributes["source_workload_namespace"])
             - set(datapoint.attributes["dest.k8s.service.name"], datapoint.attributes["destination_service_name"]) where datapoint.attributes["destination_service_type"] == "Service"
             - set(datapoint.attributes["dest.k8s.namespace.name"], datapoint.attributes["destination_service_namespace"])
@@ -417,14 +363,10 @@ Discovery collector spec should match snapshot when using default values:
             - set(datapoint.attributes["source.k8s.deployment.name"], datapoint.attributes["source_workload"]) where datapoint.attributes["source_workload_type"] == "Deployment"
             - set(datapoint.attributes["source.k8s.statefulset.name"], datapoint.attributes["source_workload"]) where datapoint.attributes["source_workload_type"] == "StatefulSet"
             - set(datapoint.attributes["source.k8s.daemonset.name"], datapoint.attributes["source_workload"]) where datapoint.attributes["source_workload_type"] == "DaemonSet"
-            - set(datapoint.attributes["source.k8s.job.name"], datapoint.attributes["source_workload"]) where datapoint.attributes["source_workload_type"] == "Job"
-            - set(datapoint.attributes["source.k8s.cronjob.name"], datapoint.attributes["source_workload"]) where datapoint.attributes["source_workload_type"] == "CronJob"
             - set(datapoint.attributes["source.k8s.namespace.name"], datapoint.attributes["source_workload_namespace"])
             - set(datapoint.attributes["dest.k8s.deployment.name"], datapoint.attributes["destination_workload"]) where datapoint.attributes["destination_workload_type"] == "Deployment"
             - set(datapoint.attributes["dest.k8s.statefulset.name"], datapoint.attributes["destination_workload"]) where datapoint.attributes["destination_workload_type"] == "StatefulSet"
             - set(datapoint.attributes["dest.k8s.daemonset.name"], datapoint.attributes["destination_workload"]) where datapoint.attributes["destination_workload_type"] == "DaemonSet"
-            - set(datapoint.attributes["dest.k8s.job.name"], datapoint.attributes["destination_workload"]) where datapoint.attributes["destination_workload_type"] == "Job"
-            - set(datapoint.attributes["dest.k8s.cronjob.name"], datapoint.attributes["destination_workload"]) where datapoint.attributes["destination_workload_type"] == "CronJob"
             - set(datapoint.attributes["dest.k8s.namespace.name"], datapoint.attributes["destination_workload_namespace"])
         transform/only-relationship-resource-attributes:
           metric_statements:

--- a/deploy/helm/tests/__snapshot__/discovery-collector_test.yaml.snap
+++ b/deploy/helm/tests/__snapshot__/discovery-collector_test.yaml.snap
@@ -454,7 +454,6 @@ Discovery collector spec should match snapshot when using default values:
           logs/stateevents:
             exporters:
               - otlp
-              - debug
             processors:
               - memory_limiter
               - transform/scope

--- a/deploy/helm/tests/__snapshot__/metrics-discovery-config-map_test.yaml.snap
+++ b/deploy/helm/tests/__snapshot__/metrics-discovery-config-map_test.yaml.snap
@@ -3,6 +3,166 @@ Metrics discovery config should match snapshot when Fargate is enabled:
     metrics-discovery.config: |
       connectors:
         forward/metric-exporter: null
+        forward/relationship-state-events-workload-service: null
+        forward/relationship-state-events-workload-workload: null
+        routing/discovered_metrics:
+          default_pipelines:
+          - metrics/discovery-custom
+          table:
+          - condition: |
+              IsMatch(name, "k8s.istio_")
+            context: metric
+            pipelines:
+            - metrics/discovery-istio
+        solarwindsentity/istio-workload-service:
+          destination_prefix: dest.
+          schema:
+            entities:
+            - entity: KubernetesDeployment
+              id:
+              - sw.k8s.cluster.uid
+              - k8s.namespace.name
+              - k8s.deployment.name
+            - entity: KubernetesStatefulSet
+              id:
+              - sw.k8s.cluster.uid
+              - k8s.namespace.name
+              - k8s.statefulset.name
+            - entity: KubernetesDaemonSet
+              id:
+              - sw.k8s.cluster.uid
+              - k8s.namespace.name
+              - k8s.daemonset.name
+            - entity: KubernetesJob
+              id:
+              - sw.k8s.cluster.uid
+              - k8s.namespace.name
+              - k8s.job.name
+            - entity: KubernetesCronJob
+              id:
+              - sw.k8s.cluster.uid
+              - k8s.namespace.name
+              - k8s.cronjob.name
+            - entity: KubernetesService
+              id:
+              - sw.k8s.cluster.uid
+              - k8s.namespace.name
+              - k8s.service.name
+            events:
+              relationships:
+              - attributes: null
+                destination_entity: KubernetesService
+                source_entity: KubernetesDeployment
+                type: KubernetesCommunicatesWith
+              - attributes: null
+                destination_entity: KubernetesService
+                source_entity: KubernetesStatefulSet
+                type: KubernetesCommunicatesWith
+              - attributes: null
+                destination_entity: KubernetesService
+                source_entity: KubernetesDaemonSet
+                type: KubernetesCommunicatesWith
+              - attributes: null
+                destination_entity: KubernetesService
+                source_entity: KubernetesJob
+                type: KubernetesCommunicatesWith
+              - attributes: null
+                destination_entity: KubernetesService
+                source_entity: KubernetesCronJob
+                type: KubernetesCommunicatesWith
+          source_prefix: source.
+        solarwindsentity/istio-workload-workload:
+          destination_prefix: dest.
+          schema:
+            entities:
+            - entity: KubernetesDeployment
+              id:
+              - sw.k8s.cluster.uid
+              - k8s.namespace.name
+              - k8s.deployment.name
+            - entity: KubernetesStatefulSet
+              id:
+              - sw.k8s.cluster.uid
+              - k8s.namespace.name
+              - k8s.statefulset.name
+            - entity: KubernetesDaemonSet
+              id:
+              - sw.k8s.cluster.uid
+              - k8s.namespace.name
+              - k8s.daemonset.name
+            - entity: KubernetesJob
+              id:
+              - sw.k8s.cluster.uid
+              - k8s.namespace.name
+              - k8s.job.name
+            - entity: KubernetesCronJob
+              id:
+              - sw.k8s.cluster.uid
+              - k8s.namespace.name
+              - k8s.cronjob.name
+            events:
+              relationships:
+              - attributes: null
+                destination_entity: KubernetesDeployment
+                source_entity: KubernetesDeployment
+                type: KubernetesCommunicatesWith
+              - attributes: null
+                destination_entity: KubernetesStatefulSet
+                source_entity: KubernetesDeployment
+                type: KubernetesCommunicatesWith
+              - attributes: null
+                destination_entity: KubernetesDaemonSet
+                source_entity: KubernetesDeployment
+                type: KubernetesCommunicatesWith
+              - attributes: null
+                destination_entity: KubernetesDeployment
+                source_entity: KubernetesStatefulSet
+                type: KubernetesCommunicatesWith
+              - attributes: null
+                destination_entity: KubernetesStatefulSet
+                source_entity: KubernetesStatefulSet
+                type: KubernetesCommunicatesWith
+              - attributes: null
+                destination_entity: KubernetesDaemonSet
+                source_entity: KubernetesStatefulSet
+                type: KubernetesCommunicatesWith
+              - attributes: null
+                destination_entity: KubernetesDeployment
+                source_entity: KubernetesDaemonSet
+                type: KubernetesCommunicatesWith
+              - attributes: null
+                destination_entity: KubernetesStatefulSet
+                source_entity: KubernetesDaemonSet
+                type: KubernetesCommunicatesWith
+              - attributes: null
+                destination_entity: KubernetesDaemonSet
+                source_entity: KubernetesDaemonSet
+                type: KubernetesCommunicatesWith
+              - attributes: null
+                destination_entity: KubernetesDeployment
+                source_entity: KubernetesJob
+                type: KubernetesCommunicatesWith
+              - attributes: null
+                destination_entity: KubernetesStatefulSet
+                source_entity: KubernetesJob
+                type: KubernetesCommunicatesWith
+              - attributes: null
+                destination_entity: KubernetesDaemonSet
+                source_entity: KubernetesJob
+                type: KubernetesCommunicatesWith
+              - attributes: null
+                destination_entity: KubernetesDeployment
+                source_entity: KubernetesCronJob
+                type: KubernetesCommunicatesWith
+              - attributes: null
+                destination_entity: KubernetesStatefulSet
+                source_entity: KubernetesCronJob
+                type: KubernetesCommunicatesWith
+              - attributes: null
+                destination_entity: KubernetesDaemonSet
+                source_entity: KubernetesCronJob
+                type: KubernetesCommunicatesWith
+          source_prefix: source.
       exporters:
         otlp:
           endpoint: ${OTEL_ENVOY_ADDRESS}
@@ -31,11 +191,58 @@ Metrics discovery config should match snapshot when Fargate is enabled:
           send_batch_max_size: 512
           send_batch_size: 512
           timeout: 1s
+        batch/stateevents:
+          send_batch_max_size: 1024
+          send_batch_size: 1024
+          timeout: 1s
+        cumulativetodelta/istio-metrics:
+          include:
+            match_type: strict
+            metrics:
+            - k8s.istio_request_bytes.rate
+            - k8s.istio_response_bytes.rate
+            - k8s.istio_request_duration_milliseconds_sum_temp
+            - k8s.istio_request_duration_milliseconds_count_temp
+            - k8s.istio_requests.rate
+            - k8s.istio_tcp_sent_bytes.rate
+            - k8s.istio_tcp_received_bytes.rate
+            - k8s.istio_request_bytes.delta
+            - k8s.istio_response_bytes.delta
+            - k8s.istio_requests.delta
+            - k8s.istio_tcp_sent_bytes.delta
+            - k8s.istio_tcp_received_bytes.delta
+        deltatorate/istio-metrics:
+          metrics:
+          - k8s.istio_request_bytes.rate
+          - k8s.istio_response_bytes.rate
+          - k8s.istio_request_duration_milliseconds_sum_temp
+          - k8s.istio_request_duration_milliseconds_count_temp
+          - k8s.istio_requests.rate
+          - k8s.istio_tcp_sent_bytes.rate
+          - k8s.istio_tcp_received_bytes.rate
         filter/histograms:
           metrics:
             metric:
             - type == METRIC_DATA_TYPE_HISTOGRAM and not(name == "k8s.rest_client_request_duration_seconds"
               or name == "k8s.workqueue_queue_duration_seconds")
+        filter/keep-workload-service-relationships:
+          error_mode: ignore
+          metrics:
+            datapoint:
+            - datapoint.attributes["source_workload_type"] == nil or datapoint.attributes["destination_service_type"]
+              == nil or datapoint.attributes["source_workload_type"] == "" or datapoint.attributes["destination_service_type"]
+              == ""
+            metric:
+            - name != "k8s.istio_request_bytes_sum"
+        filter/keep-workload-workload-relationships:
+          error_mode: ignore
+          metrics:
+            datapoint:
+            - datapoint.attributes["source_workload_type"] == nil or datapoint.attributes["destination_workload_type"]
+              == nil or datapoint.attributes["source_workload_type"] == "" or datapoint.attributes["destination_workload_type"]
+              == ""
+            metric:
+            - name != "k8s.istio_request_bytes_sum"
         filter/remove_temporary_metrics:
           metrics:
             metric:
@@ -49,6 +256,22 @@ Metrics discovery config should match snapshot when Fargate is enabled:
           - k8s.node.name
           - host.name
           - service.name
+        groupbyattrs/istio-relationships:
+          keys:
+          - sw.k8s.cluster.uid
+          - source.k8s.deployment.name
+          - source.k8s.statefulset.name
+          - source.k8s.daemonset.name
+          - source.k8s.job.name
+          - source.k8s.cronjob.name
+          - source.k8s.namespace.name
+          - dest.k8s.deployment.name
+          - dest.k8s.statefulset.name
+          - dest.k8s.daemonset.name
+          - dest.k8s.job.name
+          - dest.k8s.cronjob.name
+          - dest.k8s.namespace.name
+          - dest.k8s.service.name
         k8sattributes:
           auth_type: serviceAccount
           extract:
@@ -71,6 +294,45 @@ Metrics discovery config should match snapshot when Fargate is enabled:
           check_interval: 1s
           limit_mib: 2560
           spike_limit_mib: 512
+        metricsgeneration/istio-metrics:
+          rules:
+          - metric1: k8s.istio_request_duration_milliseconds_sum_temp
+            metric2: k8s.istio_request_duration_milliseconds_count_temp
+            name: k8s.istio_request_duration_milliseconds.rate
+            operation: divide
+            type: calculate
+        metricstransform/istio-metrics:
+          transforms:
+          - action: insert
+            include: k8s.istio_request_bytes_sum
+            new_name: k8s.istio_request_bytes.rate
+          - action: insert
+            include: k8s.istio_response_bytes_sum
+            new_name: k8s.istio_response_bytes.rate
+          - action: insert
+            include: k8s.istio_requests_total
+            new_name: k8s.istio_requests.rate
+          - action: insert
+            include: k8s.istio_tcp_sent_bytes_total
+            new_name: k8s.istio_tcp_sent_bytes.rate
+          - action: insert
+            include: k8s.istio_tcp_received_bytes_total
+            new_name: k8s.istio_tcp_received_bytes.rate
+          - action: insert
+            include: k8s.istio_request_bytes.rate
+            new_name: k8s.istio_request_bytes.delta
+          - action: insert
+            include: k8s.istio_response_bytes.rate
+            new_name: k8s.istio_response_bytes.delta
+          - action: insert
+            include: k8s.istio_requests.rate
+            new_name: k8s.istio_requests.delta
+          - action: insert
+            include: k8s.istio_tcp_sent_bytes.rate
+            new_name: k8s.istio_tcp_sent_bytes.delta
+          - action: insert
+            include: k8s.istio_tcp_received_bytes.rate
+            new_name: k8s.istio_tcp_received_bytes.delta
         metricstransform/rename/discovery:
           transforms:
           - action: update
@@ -91,6 +353,96 @@ Metrics discovery config should match snapshot when Fargate is enabled:
           - action: insert
             key: k8s.cluster.name
             value: ${CLUSTER_NAME}
+        swok8sworkloadtype/istio:
+          workload_mappings:
+          - expected_types:
+            - deployments
+            - daemonsets
+            - statefulsets
+            - jobs
+            - cronjobs
+            - pods
+            name_attr: source_workload
+            namespace_attr: source_workload_namespace
+            workload_type_attr: source_workload_type
+          - expected_types:
+            - deployments
+            - daemonsets
+            - statefulsets
+            - jobs
+            - cronjobs
+            - pods
+            name_attr: destination_workload
+            namespace_attr: destination_workload_namespace
+            workload_type_attr: destination_workload_type
+          - expected_types:
+            - services
+            name_attr: destination_service_name
+            namespace_attr: destination_service_namespace
+            workload_type_attr: destination_service_type
+        transform/istio-metrics:
+          metric_statements:
+          - statements:
+            - extract_sum_metric(true) where (metric.name == "k8s.istio_request_bytes" or
+              metric.name == "k8s.istio_response_bytes" or metric.name == "k8s.istio_request_duration_milliseconds")
+            - extract_count_metric(true) where (metric.name == "k8s.istio_request_duration_milliseconds")
+            - set(metric.name, "k8s.istio_request_duration_milliseconds_sum_temp") where
+              metric.name == "k8s.istio_request_duration_milliseconds_sum"
+            - set(metric.name, "k8s.istio_request_duration_milliseconds_count_temp") where
+              metric.name == "k8s.istio_request_duration_milliseconds_count"
+        transform/istio-workload-service:
+          metric_statements:
+          - keep_keys(datapoint.attributes, ["source_workload", "source_workload_namespace",
+            "destination_service_name", "destination_service_namespace", "source_workload_type",
+            "destination_service_type"])
+          - set(datapoint.attributes["source.k8s.deployment.name"], datapoint.attributes["source_workload"])
+            where datapoint.attributes["source_workload_type"] == "Deployment"
+          - set(datapoint.attributes["source.k8s.statefulset.name"], datapoint.attributes["source_workload"])
+            where datapoint.attributes["source_workload_type"] == "StatefulSet"
+          - set(datapoint.attributes["source.k8s.daemonset.name"], datapoint.attributes["source_workload"])
+            where datapoint.attributes["source_workload_type"] == "DaemonSet"
+          - set(datapoint.attributes["source.k8s.job.name"], datapoint.attributes["source_workload"])
+            where datapoint.attributes["source_workload_type"] == "Job"
+          - set(datapoint.attributes["source.k8s.cronjob.name"], datapoint.attributes["source_workload"])
+            where datapoint.attributes["source_workload_type"] == "CronJob"
+          - set(datapoint.attributes["source.k8s.namespace.name"], datapoint.attributes["source_workload_namespace"])
+          - set(datapoint.attributes["dest.k8s.service.name"], datapoint.attributes["destination_service_name"])
+            where datapoint.attributes["destination_service_type"] == "Service"
+          - set(datapoint.attributes["dest.k8s.namespace.name"], datapoint.attributes["destination_service_namespace"])
+        transform/istio-workload-workload:
+          metric_statements:
+          - keep_keys(datapoint.attributes, ["source_workload", "source_workload_namespace",
+            "destination_workload", "destination_workload_namespace", "source_workload_type",
+            "destination_workload_type"])
+          - set(datapoint.attributes["source.k8s.deployment.name"], datapoint.attributes["source_workload"])
+            where datapoint.attributes["source_workload_type"] == "Deployment"
+          - set(datapoint.attributes["source.k8s.statefulset.name"], datapoint.attributes["source_workload"])
+            where datapoint.attributes["source_workload_type"] == "StatefulSet"
+          - set(datapoint.attributes["source.k8s.daemonset.name"], datapoint.attributes["source_workload"])
+            where datapoint.attributes["source_workload_type"] == "DaemonSet"
+          - set(datapoint.attributes["source.k8s.job.name"], datapoint.attributes["source_workload"])
+            where datapoint.attributes["source_workload_type"] == "Job"
+          - set(datapoint.attributes["source.k8s.cronjob.name"], datapoint.attributes["source_workload"])
+            where datapoint.attributes["source_workload_type"] == "CronJob"
+          - set(datapoint.attributes["source.k8s.namespace.name"], datapoint.attributes["source_workload_namespace"])
+          - set(datapoint.attributes["dest.k8s.deployment.name"], datapoint.attributes["destination_workload"])
+            where datapoint.attributes["destination_workload_type"] == "Deployment"
+          - set(datapoint.attributes["dest.k8s.statefulset.name"], datapoint.attributes["destination_workload"])
+            where datapoint.attributes["destination_workload_type"] == "StatefulSet"
+          - set(datapoint.attributes["dest.k8s.daemonset.name"], datapoint.attributes["destination_workload"])
+            where datapoint.attributes["destination_workload_type"] == "DaemonSet"
+          - set(datapoint.attributes["dest.k8s.job.name"], datapoint.attributes["destination_workload"])
+            where datapoint.attributes["destination_workload_type"] == "Job"
+          - set(datapoint.attributes["dest.k8s.cronjob.name"], datapoint.attributes["destination_workload"])
+            where datapoint.attributes["destination_workload_type"] == "CronJob"
+          - set(datapoint.attributes["dest.k8s.namespace.name"], datapoint.attributes["destination_workload_namespace"])
+        transform/only-relationship-resource-attributes:
+          metric_statements:
+          - keep_keys(resource.attributes, ["sw.k8s.cluster.uid", "source.k8s.deployment.name",
+            "source.k8s.statefulset.name", "source.k8s.daemonset.name", "source.k8s.job.name",
+            "source.k8s.cronjob.name", "source.k8s.namespace.name", "dest.k8s.deployment.name",
+            "dest.k8s.statefulset.name", "dest.k8s.daemonset.name", "dest.k8s.job.name",
+            "dest.k8s.cronjob.name", "dest.k8s.service.name", "dest.k8s.namespace.name"])
         transform/scope:
           metric_statements:
           - statements:
@@ -148,6 +500,17 @@ Metrics discovery config should match snapshot when Fargate is enabled:
         - health_check
         - k8s_observer
         pipelines:
+          logs/stateevents:
+            exporters:
+            - otlp
+            - debug
+            processors:
+            - memory_limiter
+            - transform/scope
+            - batch/stateevents
+            receivers:
+            - solarwindsentity/istio-workload-workload
+            - solarwindsentity/istio-workload-service
           metrics:
             exporters:
             - otlp
@@ -160,16 +523,62 @@ Metrics discovery config should match snapshot when Fargate is enabled:
             - batch/metrics
             receivers:
             - forward/metric-exporter
-          metrics/discovery:
+          metrics/discovery-custom:
             exporters:
             - forward/metric-exporter
             processors:
             - memory_limiter
-            - metricstransform/rename/discovery
             - groupbyattrs/common-all
             - resource/all
             receivers:
+            - routing/discovered_metrics
+          metrics/discovery-istio:
+            exporters:
+            - forward/metric-exporter
+            - forward/relationship-state-events-workload-workload
+            - forward/relationship-state-events-workload-service
+            processors:
+            - memory_limiter
+            - swok8sworkloadtype/istio
+            - transform/istio-metrics
+            - metricstransform/istio-metrics
+            - cumulativetodelta/istio-metrics
+            - deltatorate/istio-metrics
+            - metricsgeneration/istio-metrics
+            - groupbyattrs/common-all
+            - resource/all
+            receivers:
+            - routing/discovered_metrics
+          metrics/discovery-scrape:
+            exporters:
+            - routing/discovered_metrics
+            processors:
+            - memory_limiter
+            - metricstransform/rename/discovery
+            receivers:
             - receiver_creator/discovery
+          metrics/relationship-state-events-workload-service-preparation:
+            exporters:
+            - solarwindsentity/istio-workload-service
+            processors:
+            - memory_limiter
+            - filter/keep-workload-service-relationships
+            - transform/istio-workload-service
+            - groupbyattrs/istio-relationships
+            - transform/only-relationship-resource-attributes
+            receivers:
+            - forward/relationship-state-events-workload-service
+          metrics/relationship-state-events-workload-workload-preparation:
+            exporters:
+            - solarwindsentity/istio-workload-workload
+            processors:
+            - memory_limiter
+            - filter/keep-workload-workload-relationships
+            - transform/istio-workload-workload
+            - groupbyattrs/istio-relationships
+            - transform/only-relationship-resource-attributes
+            receivers:
+            - forward/relationship-state-events-workload-workload
         telemetry:
           logs:
             level: info

--- a/deploy/helm/tests/__snapshot__/metrics-discovery-config-map_test.yaml.snap
+++ b/deploy/helm/tests/__snapshot__/metrics-discovery-config-map_test.yaml.snap
@@ -503,7 +503,6 @@ Metrics discovery config should match snapshot when Fargate is enabled:
           logs/stateevents:
             exporters:
             - otlp
-            - debug
             processors:
             - memory_limiter
             - transform/scope

--- a/deploy/helm/tests/__snapshot__/metrics-discovery-config-map_test.yaml.snap
+++ b/deploy/helm/tests/__snapshot__/metrics-discovery-config-map_test.yaml.snap
@@ -62,14 +62,6 @@ Metrics discovery config should match snapshot when Fargate is enabled:
                 destination_entity: KubernetesService
                 source_entity: KubernetesDaemonSet
                 type: KubernetesCommunicatesWith
-              - attributes: null
-                destination_entity: KubernetesService
-                source_entity: KubernetesJob
-                type: KubernetesCommunicatesWith
-              - attributes: null
-                destination_entity: KubernetesService
-                source_entity: KubernetesCronJob
-                type: KubernetesCommunicatesWith
           source_prefix: source.
         solarwindsentity/istio-workload-workload:
           destination_prefix: dest.
@@ -90,16 +82,6 @@ Metrics discovery config should match snapshot when Fargate is enabled:
               - sw.k8s.cluster.uid
               - k8s.namespace.name
               - k8s.daemonset.name
-            - entity: KubernetesJob
-              id:
-              - sw.k8s.cluster.uid
-              - k8s.namespace.name
-              - k8s.job.name
-            - entity: KubernetesCronJob
-              id:
-              - sw.k8s.cluster.uid
-              - k8s.namespace.name
-              - k8s.cronjob.name
             events:
               relationships:
               - attributes: null
@@ -137,30 +119,6 @@ Metrics discovery config should match snapshot when Fargate is enabled:
               - attributes: null
                 destination_entity: KubernetesDaemonSet
                 source_entity: KubernetesDaemonSet
-                type: KubernetesCommunicatesWith
-              - attributes: null
-                destination_entity: KubernetesDeployment
-                source_entity: KubernetesJob
-                type: KubernetesCommunicatesWith
-              - attributes: null
-                destination_entity: KubernetesStatefulSet
-                source_entity: KubernetesJob
-                type: KubernetesCommunicatesWith
-              - attributes: null
-                destination_entity: KubernetesDaemonSet
-                source_entity: KubernetesJob
-                type: KubernetesCommunicatesWith
-              - attributes: null
-                destination_entity: KubernetesDeployment
-                source_entity: KubernetesCronJob
-                type: KubernetesCommunicatesWith
-              - attributes: null
-                destination_entity: KubernetesStatefulSet
-                source_entity: KubernetesCronJob
-                type: KubernetesCommunicatesWith
-              - attributes: null
-                destination_entity: KubernetesDaemonSet
-                source_entity: KubernetesCronJob
                 type: KubernetesCommunicatesWith
           source_prefix: source.
       exporters:
@@ -262,14 +220,10 @@ Metrics discovery config should match snapshot when Fargate is enabled:
           - source.k8s.deployment.name
           - source.k8s.statefulset.name
           - source.k8s.daemonset.name
-          - source.k8s.job.name
-          - source.k8s.cronjob.name
           - source.k8s.namespace.name
           - dest.k8s.deployment.name
           - dest.k8s.statefulset.name
           - dest.k8s.daemonset.name
-          - dest.k8s.job.name
-          - dest.k8s.cronjob.name
           - dest.k8s.namespace.name
           - dest.k8s.service.name
         k8sattributes:
@@ -359,9 +313,6 @@ Metrics discovery config should match snapshot when Fargate is enabled:
             - deployments
             - daemonsets
             - statefulsets
-            - jobs
-            - cronjobs
-            - pods
             name_attr: source_workload
             namespace_attr: source_workload_namespace
             workload_type_attr: source_workload_type
@@ -369,9 +320,6 @@ Metrics discovery config should match snapshot when Fargate is enabled:
             - deployments
             - daemonsets
             - statefulsets
-            - jobs
-            - cronjobs
-            - pods
             name_attr: destination_workload
             namespace_attr: destination_workload_namespace
             workload_type_attr: destination_workload_type
@@ -401,10 +349,6 @@ Metrics discovery config should match snapshot when Fargate is enabled:
             where datapoint.attributes["source_workload_type"] == "StatefulSet"
           - set(datapoint.attributes["source.k8s.daemonset.name"], datapoint.attributes["source_workload"])
             where datapoint.attributes["source_workload_type"] == "DaemonSet"
-          - set(datapoint.attributes["source.k8s.job.name"], datapoint.attributes["source_workload"])
-            where datapoint.attributes["source_workload_type"] == "Job"
-          - set(datapoint.attributes["source.k8s.cronjob.name"], datapoint.attributes["source_workload"])
-            where datapoint.attributes["source_workload_type"] == "CronJob"
           - set(datapoint.attributes["source.k8s.namespace.name"], datapoint.attributes["source_workload_namespace"])
           - set(datapoint.attributes["dest.k8s.service.name"], datapoint.attributes["destination_service_name"])
             where datapoint.attributes["destination_service_type"] == "Service"
@@ -420,10 +364,6 @@ Metrics discovery config should match snapshot when Fargate is enabled:
             where datapoint.attributes["source_workload_type"] == "StatefulSet"
           - set(datapoint.attributes["source.k8s.daemonset.name"], datapoint.attributes["source_workload"])
             where datapoint.attributes["source_workload_type"] == "DaemonSet"
-          - set(datapoint.attributes["source.k8s.job.name"], datapoint.attributes["source_workload"])
-            where datapoint.attributes["source_workload_type"] == "Job"
-          - set(datapoint.attributes["source.k8s.cronjob.name"], datapoint.attributes["source_workload"])
-            where datapoint.attributes["source_workload_type"] == "CronJob"
           - set(datapoint.attributes["source.k8s.namespace.name"], datapoint.attributes["source_workload_namespace"])
           - set(datapoint.attributes["dest.k8s.deployment.name"], datapoint.attributes["destination_workload"])
             where datapoint.attributes["destination_workload_type"] == "Deployment"
@@ -431,10 +371,6 @@ Metrics discovery config should match snapshot when Fargate is enabled:
             where datapoint.attributes["destination_workload_type"] == "StatefulSet"
           - set(datapoint.attributes["dest.k8s.daemonset.name"], datapoint.attributes["destination_workload"])
             where datapoint.attributes["destination_workload_type"] == "DaemonSet"
-          - set(datapoint.attributes["dest.k8s.job.name"], datapoint.attributes["destination_workload"])
-            where datapoint.attributes["destination_workload_type"] == "Job"
-          - set(datapoint.attributes["dest.k8s.cronjob.name"], datapoint.attributes["destination_workload"])
-            where datapoint.attributes["destination_workload_type"] == "CronJob"
           - set(datapoint.attributes["dest.k8s.namespace.name"], datapoint.attributes["destination_workload_namespace"])
         transform/only-relationship-resource-attributes:
           metric_statements:

--- a/deploy/helm/tests/__snapshot__/node-collector-config-map-windows_test.yaml.snap
+++ b/deploy/helm/tests/__snapshot__/node-collector-config-map-windows_test.yaml.snap
@@ -1375,7 +1375,6 @@ Node collector config for windows nodes should match snapshot when using default
           logs/stateevents:
             exporters:
             - otlp
-            - debug
             processors:
             - memory_limiter
             - transform/scope
@@ -2950,7 +2949,6 @@ Node collector config for windows nodes should match snapshot when using legacy 
           logs/stateevents:
             exporters:
             - otlp
-            - debug
             processors:
             - memory_limiter
             - transform/scope

--- a/deploy/helm/tests/__snapshot__/node-collector-config-map-windows_test.yaml.snap
+++ b/deploy/helm/tests/__snapshot__/node-collector-config-map-windows_test.yaml.snap
@@ -4,7 +4,171 @@ Node collector config for windows nodes should match snapshot when using default
       connectors:
         forward/logs-exporter: null
         forward/metric-exporter: null
+        forward/relationship-state-events-workload-service: null
+        forward/relationship-state-events-workload-workload: null
+        routing/discovered_metrics:
+          default_pipelines:
+          - metrics/discovery-custom
+          table:
+          - condition: |
+              IsMatch(name, "k8s.istio_")
+            context: metric
+            pipelines:
+            - metrics/discovery-istio
+        solarwindsentity/istio-workload-service:
+          destination_prefix: dest.
+          schema:
+            entities:
+            - entity: KubernetesDeployment
+              id:
+              - sw.k8s.cluster.uid
+              - k8s.namespace.name
+              - k8s.deployment.name
+            - entity: KubernetesStatefulSet
+              id:
+              - sw.k8s.cluster.uid
+              - k8s.namespace.name
+              - k8s.statefulset.name
+            - entity: KubernetesDaemonSet
+              id:
+              - sw.k8s.cluster.uid
+              - k8s.namespace.name
+              - k8s.daemonset.name
+            - entity: KubernetesJob
+              id:
+              - sw.k8s.cluster.uid
+              - k8s.namespace.name
+              - k8s.job.name
+            - entity: KubernetesCronJob
+              id:
+              - sw.k8s.cluster.uid
+              - k8s.namespace.name
+              - k8s.cronjob.name
+            - entity: KubernetesService
+              id:
+              - sw.k8s.cluster.uid
+              - k8s.namespace.name
+              - k8s.service.name
+            events:
+              relationships:
+              - attributes: null
+                destination_entity: KubernetesService
+                source_entity: KubernetesDeployment
+                type: KubernetesCommunicatesWith
+              - attributes: null
+                destination_entity: KubernetesService
+                source_entity: KubernetesStatefulSet
+                type: KubernetesCommunicatesWith
+              - attributes: null
+                destination_entity: KubernetesService
+                source_entity: KubernetesDaemonSet
+                type: KubernetesCommunicatesWith
+              - attributes: null
+                destination_entity: KubernetesService
+                source_entity: KubernetesJob
+                type: KubernetesCommunicatesWith
+              - attributes: null
+                destination_entity: KubernetesService
+                source_entity: KubernetesCronJob
+                type: KubernetesCommunicatesWith
+          source_prefix: source.
+        solarwindsentity/istio-workload-workload:
+          destination_prefix: dest.
+          schema:
+            entities:
+            - entity: KubernetesDeployment
+              id:
+              - sw.k8s.cluster.uid
+              - k8s.namespace.name
+              - k8s.deployment.name
+            - entity: KubernetesStatefulSet
+              id:
+              - sw.k8s.cluster.uid
+              - k8s.namespace.name
+              - k8s.statefulset.name
+            - entity: KubernetesDaemonSet
+              id:
+              - sw.k8s.cluster.uid
+              - k8s.namespace.name
+              - k8s.daemonset.name
+            - entity: KubernetesJob
+              id:
+              - sw.k8s.cluster.uid
+              - k8s.namespace.name
+              - k8s.job.name
+            - entity: KubernetesCronJob
+              id:
+              - sw.k8s.cluster.uid
+              - k8s.namespace.name
+              - k8s.cronjob.name
+            events:
+              relationships:
+              - attributes: null
+                destination_entity: KubernetesDeployment
+                source_entity: KubernetesDeployment
+                type: KubernetesCommunicatesWith
+              - attributes: null
+                destination_entity: KubernetesStatefulSet
+                source_entity: KubernetesDeployment
+                type: KubernetesCommunicatesWith
+              - attributes: null
+                destination_entity: KubernetesDaemonSet
+                source_entity: KubernetesDeployment
+                type: KubernetesCommunicatesWith
+              - attributes: null
+                destination_entity: KubernetesDeployment
+                source_entity: KubernetesStatefulSet
+                type: KubernetesCommunicatesWith
+              - attributes: null
+                destination_entity: KubernetesStatefulSet
+                source_entity: KubernetesStatefulSet
+                type: KubernetesCommunicatesWith
+              - attributes: null
+                destination_entity: KubernetesDaemonSet
+                source_entity: KubernetesStatefulSet
+                type: KubernetesCommunicatesWith
+              - attributes: null
+                destination_entity: KubernetesDeployment
+                source_entity: KubernetesDaemonSet
+                type: KubernetesCommunicatesWith
+              - attributes: null
+                destination_entity: KubernetesStatefulSet
+                source_entity: KubernetesDaemonSet
+                type: KubernetesCommunicatesWith
+              - attributes: null
+                destination_entity: KubernetesDaemonSet
+                source_entity: KubernetesDaemonSet
+                type: KubernetesCommunicatesWith
+              - attributes: null
+                destination_entity: KubernetesDeployment
+                source_entity: KubernetesJob
+                type: KubernetesCommunicatesWith
+              - attributes: null
+                destination_entity: KubernetesStatefulSet
+                source_entity: KubernetesJob
+                type: KubernetesCommunicatesWith
+              - attributes: null
+                destination_entity: KubernetesDaemonSet
+                source_entity: KubernetesJob
+                type: KubernetesCommunicatesWith
+              - attributes: null
+                destination_entity: KubernetesDeployment
+                source_entity: KubernetesCronJob
+                type: KubernetesCommunicatesWith
+              - attributes: null
+                destination_entity: KubernetesStatefulSet
+                source_entity: KubernetesCronJob
+                type: KubernetesCommunicatesWith
+              - attributes: null
+                destination_entity: KubernetesDaemonSet
+                source_entity: KubernetesCronJob
+                type: KubernetesCommunicatesWith
+          source_prefix: source.
       exporters:
+        debug:
+          sampling_initial: 5
+          sampling_thereafter: 200
+          verbosity: detailed
         otlp:
           endpoint: ${OTEL_ENVOY_ADDRESS}
           headers:
@@ -68,6 +232,10 @@ Node collector config for windows nodes should match snapshot when using default
         batch/metrics:
           send_batch_max_size: 512
           send_batch_size: 512
+          timeout: 1s
+        batch/stateevents:
+          send_batch_max_size: 1024
+          send_batch_size: 1024
           timeout: 1s
         cumulativetodelta/cadvisor:
           include:
@@ -160,6 +328,24 @@ Node collector config for windows nodes should match snapshot when using default
             - type == METRIC_DATA_TYPE_HISTOGRAM and not(name == "k8s.rest_client_request_duration_seconds"
               or name == "k8s.workqueue_queue_duration_seconds" or name == "k8s.etcd_disk_wal_fsync_duration_seconds"
               or name == "k8s.etcd_disk_backend_commit_duration_seconds")
+        filter/keep-workload-service-relationships:
+          error_mode: ignore
+          metrics:
+            datapoint:
+            - datapoint.attributes["source_workload_type"] == nil or datapoint.attributes["destination_service_type"]
+              == nil or datapoint.attributes["source_workload_type"] == "" or datapoint.attributes["destination_service_type"]
+              == ""
+            metric:
+            - name != "k8s.istio_request_bytes_sum"
+        filter/keep-workload-workload-relationships:
+          error_mode: ignore
+          metrics:
+            datapoint:
+            - datapoint.attributes["source_workload_type"] == nil or datapoint.attributes["destination_workload_type"]
+              == nil or datapoint.attributes["source_workload_type"] == "" or datapoint.attributes["destination_workload_type"]
+              == ""
+            metric:
+            - name != "k8s.istio_request_bytes_sum"
         filter/receiver:
           metrics:
             metric:
@@ -232,6 +418,22 @@ Node collector config for windows nodes should match snapshot when using default
           - k8s.pod.uid
           - host.name
           - service.name
+        groupbyattrs/istio-relationships:
+          keys:
+          - sw.k8s.cluster.uid
+          - source.k8s.deployment.name
+          - source.k8s.statefulset.name
+          - source.k8s.daemonset.name
+          - source.k8s.job.name
+          - source.k8s.cronjob.name
+          - source.k8s.namespace.name
+          - dest.k8s.deployment.name
+          - dest.k8s.statefulset.name
+          - dest.k8s.daemonset.name
+          - dest.k8s.job.name
+          - dest.k8s.cronjob.name
+          - dest.k8s.namespace.name
+          - dest.k8s.service.name
         groupbyattrs/node:
           keys:
           - k8s.node.name
@@ -892,6 +1094,33 @@ Node collector config for windows nodes should match snapshot when using default
           - action: insert
             from_attribute: persistentvolumeclaim
             key: k8s.persistentvolumeclaim.name
+        swok8sworkloadtype/istio:
+          workload_mappings:
+          - expected_types:
+            - deployments
+            - daemonsets
+            - statefulsets
+            - jobs
+            - cronjobs
+            - pods
+            name_attr: source_workload
+            namespace_attr: source_workload_namespace
+            workload_type_attr: source_workload_type
+          - expected_types:
+            - deployments
+            - daemonsets
+            - statefulsets
+            - jobs
+            - cronjobs
+            - pods
+            name_attr: destination_workload
+            namespace_attr: destination_workload_namespace
+            workload_type_attr: destination_workload_type
+          - expected_types:
+            - services
+            name_attr: destination_service_name
+            namespace_attr: destination_service_namespace
+            workload_type_attr: destination_service_type
         transform/istio-metrics:
           metric_statements:
           - statements:
@@ -902,6 +1131,59 @@ Node collector config for windows nodes should match snapshot when using default
               metric.name == "k8s.istio_request_duration_milliseconds_sum"
             - set(metric.name, "k8s.istio_request_duration_milliseconds_count_temp") where
               metric.name == "k8s.istio_request_duration_milliseconds_count"
+        transform/istio-workload-service:
+          metric_statements:
+          - keep_keys(datapoint.attributes, ["source_workload", "source_workload_namespace",
+            "destination_service_name", "destination_service_namespace", "source_workload_type",
+            "destination_service_type"])
+          - set(datapoint.attributes["source.k8s.deployment.name"], datapoint.attributes["source_workload"])
+            where datapoint.attributes["source_workload_type"] == "Deployment"
+          - set(datapoint.attributes["source.k8s.statefulset.name"], datapoint.attributes["source_workload"])
+            where datapoint.attributes["source_workload_type"] == "StatefulSet"
+          - set(datapoint.attributes["source.k8s.daemonset.name"], datapoint.attributes["source_workload"])
+            where datapoint.attributes["source_workload_type"] == "DaemonSet"
+          - set(datapoint.attributes["source.k8s.job.name"], datapoint.attributes["source_workload"])
+            where datapoint.attributes["source_workload_type"] == "Job"
+          - set(datapoint.attributes["source.k8s.cronjob.name"], datapoint.attributes["source_workload"])
+            where datapoint.attributes["source_workload_type"] == "CronJob"
+          - set(datapoint.attributes["source.k8s.namespace.name"], datapoint.attributes["source_workload_namespace"])
+          - set(datapoint.attributes["dest.k8s.service.name"], datapoint.attributes["destination_service_name"])
+            where datapoint.attributes["destination_service_type"] == "Service"
+          - set(datapoint.attributes["dest.k8s.namespace.name"], datapoint.attributes["destination_service_namespace"])
+        transform/istio-workload-workload:
+          metric_statements:
+          - keep_keys(datapoint.attributes, ["source_workload", "source_workload_namespace",
+            "destination_workload", "destination_workload_namespace", "source_workload_type",
+            "destination_workload_type"])
+          - set(datapoint.attributes["source.k8s.deployment.name"], datapoint.attributes["source_workload"])
+            where datapoint.attributes["source_workload_type"] == "Deployment"
+          - set(datapoint.attributes["source.k8s.statefulset.name"], datapoint.attributes["source_workload"])
+            where datapoint.attributes["source_workload_type"] == "StatefulSet"
+          - set(datapoint.attributes["source.k8s.daemonset.name"], datapoint.attributes["source_workload"])
+            where datapoint.attributes["source_workload_type"] == "DaemonSet"
+          - set(datapoint.attributes["source.k8s.job.name"], datapoint.attributes["source_workload"])
+            where datapoint.attributes["source_workload_type"] == "Job"
+          - set(datapoint.attributes["source.k8s.cronjob.name"], datapoint.attributes["source_workload"])
+            where datapoint.attributes["source_workload_type"] == "CronJob"
+          - set(datapoint.attributes["source.k8s.namespace.name"], datapoint.attributes["source_workload_namespace"])
+          - set(datapoint.attributes["dest.k8s.deployment.name"], datapoint.attributes["destination_workload"])
+            where datapoint.attributes["destination_workload_type"] == "Deployment"
+          - set(datapoint.attributes["dest.k8s.statefulset.name"], datapoint.attributes["destination_workload"])
+            where datapoint.attributes["destination_workload_type"] == "StatefulSet"
+          - set(datapoint.attributes["dest.k8s.daemonset.name"], datapoint.attributes["destination_workload"])
+            where datapoint.attributes["destination_workload_type"] == "DaemonSet"
+          - set(datapoint.attributes["dest.k8s.job.name"], datapoint.attributes["destination_workload"])
+            where datapoint.attributes["destination_workload_type"] == "Job"
+          - set(datapoint.attributes["dest.k8s.cronjob.name"], datapoint.attributes["destination_workload"])
+            where datapoint.attributes["destination_workload_type"] == "CronJob"
+          - set(datapoint.attributes["dest.k8s.namespace.name"], datapoint.attributes["destination_workload_namespace"])
+        transform/only-relationship-resource-attributes:
+          metric_statements:
+          - keep_keys(resource.attributes, ["sw.k8s.cluster.uid", "source.k8s.deployment.name",
+            "source.k8s.statefulset.name", "source.k8s.daemonset.name", "source.k8s.job.name",
+            "source.k8s.cronjob.name", "source.k8s.namespace.name", "dest.k8s.deployment.name",
+            "dest.k8s.statefulset.name", "dest.k8s.daemonset.name", "dest.k8s.job.name",
+            "dest.k8s.cronjob.name", "dest.k8s.service.name", "dest.k8s.namespace.name"])
         transform/scope:
           log_statements:
           - statements:
@@ -1090,6 +1372,17 @@ Node collector config for windows nodes should match snapshot when using default
             - k8sattributes
             receivers:
             - filelog
+          logs/stateevents:
+            exporters:
+            - otlp
+            - debug
+            processors:
+            - memory_limiter
+            - transform/scope
+            - batch/stateevents
+            receivers:
+            - solarwindsentity/istio-workload-workload
+            - solarwindsentity/istio-workload-service
           metrics:
             exporters:
             - otlp
@@ -1102,12 +1395,23 @@ Node collector config for windows nodes should match snapshot when using default
             - batch/metrics
             receivers:
             - forward/metric-exporter
-          metrics/discovery:
+          metrics/discovery-custom:
             exporters:
             - forward/metric-exporter
             processors:
             - memory_limiter
-            - metricstransform/rename/discovery
+            - groupbyattrs/common-all
+            - resource/all
+            receivers:
+            - routing/discovered_metrics
+          metrics/discovery-istio:
+            exporters:
+            - forward/metric-exporter
+            - forward/relationship-state-events-workload-workload
+            - forward/relationship-state-events-workload-service
+            processors:
+            - memory_limiter
+            - swok8sworkloadtype/istio
             - transform/istio-metrics
             - metricstransform/istio-metrics
             - cumulativetodelta/istio-metrics
@@ -1115,6 +1419,14 @@ Node collector config for windows nodes should match snapshot when using default
             - metricsgeneration/istio-metrics
             - groupbyattrs/common-all
             - resource/all
+            receivers:
+            - routing/discovered_metrics
+          metrics/discovery-scrape:
+            exporters:
+            - routing/discovered_metrics
+            processors:
+            - memory_limiter
+            - metricstransform/rename/discovery
             receivers:
             - receiver_creator/discovery
           metrics/node:
@@ -1140,6 +1452,28 @@ Node collector config for windows nodes should match snapshot when using default
             - resource/all
             receivers:
             - receiver_creator/node
+          metrics/relationship-state-events-workload-service-preparation:
+            exporters:
+            - solarwindsentity/istio-workload-service
+            processors:
+            - memory_limiter
+            - filter/keep-workload-service-relationships
+            - transform/istio-workload-service
+            - groupbyattrs/istio-relationships
+            - transform/only-relationship-resource-attributes
+            receivers:
+            - forward/relationship-state-events-workload-service
+          metrics/relationship-state-events-workload-workload-preparation:
+            exporters:
+            - solarwindsentity/istio-workload-workload
+            processors:
+            - memory_limiter
+            - filter/keep-workload-workload-relationships
+            - transform/istio-workload-workload
+            - groupbyattrs/istio-relationships
+            - transform/only-relationship-resource-attributes
+            receivers:
+            - forward/relationship-state-events-workload-workload
         telemetry:
           logs:
             level: info
@@ -1156,7 +1490,171 @@ Node collector config for windows nodes should match snapshot when using legacy 
       connectors:
         forward/logs-exporter: null
         forward/metric-exporter: null
+        forward/relationship-state-events-workload-service: null
+        forward/relationship-state-events-workload-workload: null
+        routing/discovered_metrics:
+          default_pipelines:
+          - metrics/discovery-custom
+          table:
+          - condition: |
+              IsMatch(name, "k8s.istio_")
+            context: metric
+            pipelines:
+            - metrics/discovery-istio
+        solarwindsentity/istio-workload-service:
+          destination_prefix: dest.
+          schema:
+            entities:
+            - entity: KubernetesDeployment
+              id:
+              - sw.k8s.cluster.uid
+              - k8s.namespace.name
+              - k8s.deployment.name
+            - entity: KubernetesStatefulSet
+              id:
+              - sw.k8s.cluster.uid
+              - k8s.namespace.name
+              - k8s.statefulset.name
+            - entity: KubernetesDaemonSet
+              id:
+              - sw.k8s.cluster.uid
+              - k8s.namespace.name
+              - k8s.daemonset.name
+            - entity: KubernetesJob
+              id:
+              - sw.k8s.cluster.uid
+              - k8s.namespace.name
+              - k8s.job.name
+            - entity: KubernetesCronJob
+              id:
+              - sw.k8s.cluster.uid
+              - k8s.namespace.name
+              - k8s.cronjob.name
+            - entity: KubernetesService
+              id:
+              - sw.k8s.cluster.uid
+              - k8s.namespace.name
+              - k8s.service.name
+            events:
+              relationships:
+              - attributes: null
+                destination_entity: KubernetesService
+                source_entity: KubernetesDeployment
+                type: KubernetesCommunicatesWith
+              - attributes: null
+                destination_entity: KubernetesService
+                source_entity: KubernetesStatefulSet
+                type: KubernetesCommunicatesWith
+              - attributes: null
+                destination_entity: KubernetesService
+                source_entity: KubernetesDaemonSet
+                type: KubernetesCommunicatesWith
+              - attributes: null
+                destination_entity: KubernetesService
+                source_entity: KubernetesJob
+                type: KubernetesCommunicatesWith
+              - attributes: null
+                destination_entity: KubernetesService
+                source_entity: KubernetesCronJob
+                type: KubernetesCommunicatesWith
+          source_prefix: source.
+        solarwindsentity/istio-workload-workload:
+          destination_prefix: dest.
+          schema:
+            entities:
+            - entity: KubernetesDeployment
+              id:
+              - sw.k8s.cluster.uid
+              - k8s.namespace.name
+              - k8s.deployment.name
+            - entity: KubernetesStatefulSet
+              id:
+              - sw.k8s.cluster.uid
+              - k8s.namespace.name
+              - k8s.statefulset.name
+            - entity: KubernetesDaemonSet
+              id:
+              - sw.k8s.cluster.uid
+              - k8s.namespace.name
+              - k8s.daemonset.name
+            - entity: KubernetesJob
+              id:
+              - sw.k8s.cluster.uid
+              - k8s.namespace.name
+              - k8s.job.name
+            - entity: KubernetesCronJob
+              id:
+              - sw.k8s.cluster.uid
+              - k8s.namespace.name
+              - k8s.cronjob.name
+            events:
+              relationships:
+              - attributes: null
+                destination_entity: KubernetesDeployment
+                source_entity: KubernetesDeployment
+                type: KubernetesCommunicatesWith
+              - attributes: null
+                destination_entity: KubernetesStatefulSet
+                source_entity: KubernetesDeployment
+                type: KubernetesCommunicatesWith
+              - attributes: null
+                destination_entity: KubernetesDaemonSet
+                source_entity: KubernetesDeployment
+                type: KubernetesCommunicatesWith
+              - attributes: null
+                destination_entity: KubernetesDeployment
+                source_entity: KubernetesStatefulSet
+                type: KubernetesCommunicatesWith
+              - attributes: null
+                destination_entity: KubernetesStatefulSet
+                source_entity: KubernetesStatefulSet
+                type: KubernetesCommunicatesWith
+              - attributes: null
+                destination_entity: KubernetesDaemonSet
+                source_entity: KubernetesStatefulSet
+                type: KubernetesCommunicatesWith
+              - attributes: null
+                destination_entity: KubernetesDeployment
+                source_entity: KubernetesDaemonSet
+                type: KubernetesCommunicatesWith
+              - attributes: null
+                destination_entity: KubernetesStatefulSet
+                source_entity: KubernetesDaemonSet
+                type: KubernetesCommunicatesWith
+              - attributes: null
+                destination_entity: KubernetesDaemonSet
+                source_entity: KubernetesDaemonSet
+                type: KubernetesCommunicatesWith
+              - attributes: null
+                destination_entity: KubernetesDeployment
+                source_entity: KubernetesJob
+                type: KubernetesCommunicatesWith
+              - attributes: null
+                destination_entity: KubernetesStatefulSet
+                source_entity: KubernetesJob
+                type: KubernetesCommunicatesWith
+              - attributes: null
+                destination_entity: KubernetesDaemonSet
+                source_entity: KubernetesJob
+                type: KubernetesCommunicatesWith
+              - attributes: null
+                destination_entity: KubernetesDeployment
+                source_entity: KubernetesCronJob
+                type: KubernetesCommunicatesWith
+              - attributes: null
+                destination_entity: KubernetesStatefulSet
+                source_entity: KubernetesCronJob
+                type: KubernetesCommunicatesWith
+              - attributes: null
+                destination_entity: KubernetesDaemonSet
+                source_entity: KubernetesCronJob
+                type: KubernetesCommunicatesWith
+          source_prefix: source.
       exporters:
+        debug:
+          sampling_initial: 5
+          sampling_thereafter: 200
+          verbosity: detailed
         otlp:
           endpoint: ${OTEL_ENVOY_ADDRESS}
           headers:
@@ -1220,6 +1718,10 @@ Node collector config for windows nodes should match snapshot when using legacy 
         batch/metrics:
           send_batch_max_size: 512
           send_batch_size: 512
+          timeout: 1s
+        batch/stateevents:
+          send_batch_max_size: 1024
+          send_batch_size: 1024
           timeout: 1s
         cumulativetodelta/cadvisor:
           include:
@@ -1312,6 +1814,24 @@ Node collector config for windows nodes should match snapshot when using legacy 
             - type == METRIC_DATA_TYPE_HISTOGRAM and not(name == "k8s.rest_client_request_duration_seconds"
               or name == "k8s.workqueue_queue_duration_seconds" or name == "k8s.etcd_disk_wal_fsync_duration_seconds"
               or name == "k8s.etcd_disk_backend_commit_duration_seconds")
+        filter/keep-workload-service-relationships:
+          error_mode: ignore
+          metrics:
+            datapoint:
+            - datapoint.attributes["source_workload_type"] == nil or datapoint.attributes["destination_service_type"]
+              == nil or datapoint.attributes["source_workload_type"] == "" or datapoint.attributes["destination_service_type"]
+              == ""
+            metric:
+            - name != "k8s.istio_request_bytes_sum"
+        filter/keep-workload-workload-relationships:
+          error_mode: ignore
+          metrics:
+            datapoint:
+            - datapoint.attributes["source_workload_type"] == nil or datapoint.attributes["destination_workload_type"]
+              == nil or datapoint.attributes["source_workload_type"] == "" or datapoint.attributes["destination_workload_type"]
+              == ""
+            metric:
+            - name != "k8s.istio_request_bytes_sum"
         filter/logs:
           logs:
             include:
@@ -1391,6 +1911,22 @@ Node collector config for windows nodes should match snapshot when using legacy 
           - k8s.pod.uid
           - host.name
           - service.name
+        groupbyattrs/istio-relationships:
+          keys:
+          - sw.k8s.cluster.uid
+          - source.k8s.deployment.name
+          - source.k8s.statefulset.name
+          - source.k8s.daemonset.name
+          - source.k8s.job.name
+          - source.k8s.cronjob.name
+          - source.k8s.namespace.name
+          - dest.k8s.deployment.name
+          - dest.k8s.statefulset.name
+          - dest.k8s.daemonset.name
+          - dest.k8s.job.name
+          - dest.k8s.cronjob.name
+          - dest.k8s.namespace.name
+          - dest.k8s.service.name
         groupbyattrs/node:
           keys:
           - k8s.node.name
@@ -2051,6 +2587,33 @@ Node collector config for windows nodes should match snapshot when using legacy 
           - action: insert
             from_attribute: persistentvolumeclaim
             key: k8s.persistentvolumeclaim.name
+        swok8sworkloadtype/istio:
+          workload_mappings:
+          - expected_types:
+            - deployments
+            - daemonsets
+            - statefulsets
+            - jobs
+            - cronjobs
+            - pods
+            name_attr: source_workload
+            namespace_attr: source_workload_namespace
+            workload_type_attr: source_workload_type
+          - expected_types:
+            - deployments
+            - daemonsets
+            - statefulsets
+            - jobs
+            - cronjobs
+            - pods
+            name_attr: destination_workload
+            namespace_attr: destination_workload_namespace
+            workload_type_attr: destination_workload_type
+          - expected_types:
+            - services
+            name_attr: destination_service_name
+            namespace_attr: destination_service_namespace
+            workload_type_attr: destination_service_type
         transform/istio-metrics:
           metric_statements:
           - statements:
@@ -2061,6 +2624,59 @@ Node collector config for windows nodes should match snapshot when using legacy 
               metric.name == "k8s.istio_request_duration_milliseconds_sum"
             - set(metric.name, "k8s.istio_request_duration_milliseconds_count_temp") where
               metric.name == "k8s.istio_request_duration_milliseconds_count"
+        transform/istio-workload-service:
+          metric_statements:
+          - keep_keys(datapoint.attributes, ["source_workload", "source_workload_namespace",
+            "destination_service_name", "destination_service_namespace", "source_workload_type",
+            "destination_service_type"])
+          - set(datapoint.attributes["source.k8s.deployment.name"], datapoint.attributes["source_workload"])
+            where datapoint.attributes["source_workload_type"] == "Deployment"
+          - set(datapoint.attributes["source.k8s.statefulset.name"], datapoint.attributes["source_workload"])
+            where datapoint.attributes["source_workload_type"] == "StatefulSet"
+          - set(datapoint.attributes["source.k8s.daemonset.name"], datapoint.attributes["source_workload"])
+            where datapoint.attributes["source_workload_type"] == "DaemonSet"
+          - set(datapoint.attributes["source.k8s.job.name"], datapoint.attributes["source_workload"])
+            where datapoint.attributes["source_workload_type"] == "Job"
+          - set(datapoint.attributes["source.k8s.cronjob.name"], datapoint.attributes["source_workload"])
+            where datapoint.attributes["source_workload_type"] == "CronJob"
+          - set(datapoint.attributes["source.k8s.namespace.name"], datapoint.attributes["source_workload_namespace"])
+          - set(datapoint.attributes["dest.k8s.service.name"], datapoint.attributes["destination_service_name"])
+            where datapoint.attributes["destination_service_type"] == "Service"
+          - set(datapoint.attributes["dest.k8s.namespace.name"], datapoint.attributes["destination_service_namespace"])
+        transform/istio-workload-workload:
+          metric_statements:
+          - keep_keys(datapoint.attributes, ["source_workload", "source_workload_namespace",
+            "destination_workload", "destination_workload_namespace", "source_workload_type",
+            "destination_workload_type"])
+          - set(datapoint.attributes["source.k8s.deployment.name"], datapoint.attributes["source_workload"])
+            where datapoint.attributes["source_workload_type"] == "Deployment"
+          - set(datapoint.attributes["source.k8s.statefulset.name"], datapoint.attributes["source_workload"])
+            where datapoint.attributes["source_workload_type"] == "StatefulSet"
+          - set(datapoint.attributes["source.k8s.daemonset.name"], datapoint.attributes["source_workload"])
+            where datapoint.attributes["source_workload_type"] == "DaemonSet"
+          - set(datapoint.attributes["source.k8s.job.name"], datapoint.attributes["source_workload"])
+            where datapoint.attributes["source_workload_type"] == "Job"
+          - set(datapoint.attributes["source.k8s.cronjob.name"], datapoint.attributes["source_workload"])
+            where datapoint.attributes["source_workload_type"] == "CronJob"
+          - set(datapoint.attributes["source.k8s.namespace.name"], datapoint.attributes["source_workload_namespace"])
+          - set(datapoint.attributes["dest.k8s.deployment.name"], datapoint.attributes["destination_workload"])
+            where datapoint.attributes["destination_workload_type"] == "Deployment"
+          - set(datapoint.attributes["dest.k8s.statefulset.name"], datapoint.attributes["destination_workload"])
+            where datapoint.attributes["destination_workload_type"] == "StatefulSet"
+          - set(datapoint.attributes["dest.k8s.daemonset.name"], datapoint.attributes["destination_workload"])
+            where datapoint.attributes["destination_workload_type"] == "DaemonSet"
+          - set(datapoint.attributes["dest.k8s.job.name"], datapoint.attributes["destination_workload"])
+            where datapoint.attributes["destination_workload_type"] == "Job"
+          - set(datapoint.attributes["dest.k8s.cronjob.name"], datapoint.attributes["destination_workload"])
+            where datapoint.attributes["destination_workload_type"] == "CronJob"
+          - set(datapoint.attributes["dest.k8s.namespace.name"], datapoint.attributes["destination_workload_namespace"])
+        transform/only-relationship-resource-attributes:
+          metric_statements:
+          - keep_keys(resource.attributes, ["sw.k8s.cluster.uid", "source.k8s.deployment.name",
+            "source.k8s.statefulset.name", "source.k8s.daemonset.name", "source.k8s.job.name",
+            "source.k8s.cronjob.name", "source.k8s.namespace.name", "dest.k8s.deployment.name",
+            "dest.k8s.statefulset.name", "dest.k8s.daemonset.name", "dest.k8s.job.name",
+            "dest.k8s.cronjob.name", "dest.k8s.service.name", "dest.k8s.namespace.name"])
         transform/scope:
           log_statements:
           - statements:
@@ -2331,6 +2947,17 @@ Node collector config for windows nodes should match snapshot when using legacy 
             - k8sattributes
             receivers:
             - filelog
+          logs/stateevents:
+            exporters:
+            - otlp
+            - debug
+            processors:
+            - memory_limiter
+            - transform/scope
+            - batch/stateevents
+            receivers:
+            - solarwindsentity/istio-workload-workload
+            - solarwindsentity/istio-workload-service
           metrics:
             exporters:
             - otlp
@@ -2343,12 +2970,23 @@ Node collector config for windows nodes should match snapshot when using legacy 
             - batch/metrics
             receivers:
             - forward/metric-exporter
-          metrics/discovery:
+          metrics/discovery-custom:
             exporters:
             - forward/metric-exporter
             processors:
             - memory_limiter
-            - metricstransform/rename/discovery
+            - groupbyattrs/common-all
+            - resource/all
+            receivers:
+            - routing/discovered_metrics
+          metrics/discovery-istio:
+            exporters:
+            - forward/metric-exporter
+            - forward/relationship-state-events-workload-workload
+            - forward/relationship-state-events-workload-service
+            processors:
+            - memory_limiter
+            - swok8sworkloadtype/istio
             - transform/istio-metrics
             - metricstransform/istio-metrics
             - cumulativetodelta/istio-metrics
@@ -2356,6 +2994,14 @@ Node collector config for windows nodes should match snapshot when using legacy 
             - metricsgeneration/istio-metrics
             - groupbyattrs/common-all
             - resource/all
+            receivers:
+            - routing/discovered_metrics
+          metrics/discovery-scrape:
+            exporters:
+            - routing/discovered_metrics
+            processors:
+            - memory_limiter
+            - metricstransform/rename/discovery
             receivers:
             - receiver_creator/discovery
           metrics/node:
@@ -2381,6 +3027,28 @@ Node collector config for windows nodes should match snapshot when using legacy 
             - resource/all
             receivers:
             - receiver_creator/node
+          metrics/relationship-state-events-workload-service-preparation:
+            exporters:
+            - solarwindsentity/istio-workload-service
+            processors:
+            - memory_limiter
+            - filter/keep-workload-service-relationships
+            - transform/istio-workload-service
+            - groupbyattrs/istio-relationships
+            - transform/only-relationship-resource-attributes
+            receivers:
+            - forward/relationship-state-events-workload-service
+          metrics/relationship-state-events-workload-workload-preparation:
+            exporters:
+            - solarwindsentity/istio-workload-workload
+            processors:
+            - memory_limiter
+            - filter/keep-workload-workload-relationships
+            - transform/istio-workload-workload
+            - groupbyattrs/istio-relationships
+            - transform/only-relationship-resource-attributes
+            receivers:
+            - forward/relationship-state-events-workload-workload
         telemetry:
           logs:
             level: info

--- a/deploy/helm/tests/__snapshot__/node-collector-config-map-windows_test.yaml.snap
+++ b/deploy/helm/tests/__snapshot__/node-collector-config-map-windows_test.yaml.snap
@@ -63,14 +63,6 @@ Node collector config for windows nodes should match snapshot when using default
                 destination_entity: KubernetesService
                 source_entity: KubernetesDaemonSet
                 type: KubernetesCommunicatesWith
-              - attributes: null
-                destination_entity: KubernetesService
-                source_entity: KubernetesJob
-                type: KubernetesCommunicatesWith
-              - attributes: null
-                destination_entity: KubernetesService
-                source_entity: KubernetesCronJob
-                type: KubernetesCommunicatesWith
           source_prefix: source.
         solarwindsentity/istio-workload-workload:
           destination_prefix: dest.
@@ -91,16 +83,6 @@ Node collector config for windows nodes should match snapshot when using default
               - sw.k8s.cluster.uid
               - k8s.namespace.name
               - k8s.daemonset.name
-            - entity: KubernetesJob
-              id:
-              - sw.k8s.cluster.uid
-              - k8s.namespace.name
-              - k8s.job.name
-            - entity: KubernetesCronJob
-              id:
-              - sw.k8s.cluster.uid
-              - k8s.namespace.name
-              - k8s.cronjob.name
             events:
               relationships:
               - attributes: null
@@ -139,36 +121,8 @@ Node collector config for windows nodes should match snapshot when using default
                 destination_entity: KubernetesDaemonSet
                 source_entity: KubernetesDaemonSet
                 type: KubernetesCommunicatesWith
-              - attributes: null
-                destination_entity: KubernetesDeployment
-                source_entity: KubernetesJob
-                type: KubernetesCommunicatesWith
-              - attributes: null
-                destination_entity: KubernetesStatefulSet
-                source_entity: KubernetesJob
-                type: KubernetesCommunicatesWith
-              - attributes: null
-                destination_entity: KubernetesDaemonSet
-                source_entity: KubernetesJob
-                type: KubernetesCommunicatesWith
-              - attributes: null
-                destination_entity: KubernetesDeployment
-                source_entity: KubernetesCronJob
-                type: KubernetesCommunicatesWith
-              - attributes: null
-                destination_entity: KubernetesStatefulSet
-                source_entity: KubernetesCronJob
-                type: KubernetesCommunicatesWith
-              - attributes: null
-                destination_entity: KubernetesDaemonSet
-                source_entity: KubernetesCronJob
-                type: KubernetesCommunicatesWith
           source_prefix: source.
       exporters:
-        debug:
-          sampling_initial: 5
-          sampling_thereafter: 200
-          verbosity: detailed
         otlp:
           endpoint: ${OTEL_ENVOY_ADDRESS}
           headers:
@@ -424,14 +378,10 @@ Node collector config for windows nodes should match snapshot when using default
           - source.k8s.deployment.name
           - source.k8s.statefulset.name
           - source.k8s.daemonset.name
-          - source.k8s.job.name
-          - source.k8s.cronjob.name
           - source.k8s.namespace.name
           - dest.k8s.deployment.name
           - dest.k8s.statefulset.name
           - dest.k8s.daemonset.name
-          - dest.k8s.job.name
-          - dest.k8s.cronjob.name
           - dest.k8s.namespace.name
           - dest.k8s.service.name
         groupbyattrs/node:
@@ -1100,9 +1050,6 @@ Node collector config for windows nodes should match snapshot when using default
             - deployments
             - daemonsets
             - statefulsets
-            - jobs
-            - cronjobs
-            - pods
             name_attr: source_workload
             namespace_attr: source_workload_namespace
             workload_type_attr: source_workload_type
@@ -1110,9 +1057,6 @@ Node collector config for windows nodes should match snapshot when using default
             - deployments
             - daemonsets
             - statefulsets
-            - jobs
-            - cronjobs
-            - pods
             name_attr: destination_workload
             namespace_attr: destination_workload_namespace
             workload_type_attr: destination_workload_type
@@ -1142,10 +1086,6 @@ Node collector config for windows nodes should match snapshot when using default
             where datapoint.attributes["source_workload_type"] == "StatefulSet"
           - set(datapoint.attributes["source.k8s.daemonset.name"], datapoint.attributes["source_workload"])
             where datapoint.attributes["source_workload_type"] == "DaemonSet"
-          - set(datapoint.attributes["source.k8s.job.name"], datapoint.attributes["source_workload"])
-            where datapoint.attributes["source_workload_type"] == "Job"
-          - set(datapoint.attributes["source.k8s.cronjob.name"], datapoint.attributes["source_workload"])
-            where datapoint.attributes["source_workload_type"] == "CronJob"
           - set(datapoint.attributes["source.k8s.namespace.name"], datapoint.attributes["source_workload_namespace"])
           - set(datapoint.attributes["dest.k8s.service.name"], datapoint.attributes["destination_service_name"])
             where datapoint.attributes["destination_service_type"] == "Service"
@@ -1161,10 +1101,6 @@ Node collector config for windows nodes should match snapshot when using default
             where datapoint.attributes["source_workload_type"] == "StatefulSet"
           - set(datapoint.attributes["source.k8s.daemonset.name"], datapoint.attributes["source_workload"])
             where datapoint.attributes["source_workload_type"] == "DaemonSet"
-          - set(datapoint.attributes["source.k8s.job.name"], datapoint.attributes["source_workload"])
-            where datapoint.attributes["source_workload_type"] == "Job"
-          - set(datapoint.attributes["source.k8s.cronjob.name"], datapoint.attributes["source_workload"])
-            where datapoint.attributes["source_workload_type"] == "CronJob"
           - set(datapoint.attributes["source.k8s.namespace.name"], datapoint.attributes["source_workload_namespace"])
           - set(datapoint.attributes["dest.k8s.deployment.name"], datapoint.attributes["destination_workload"])
             where datapoint.attributes["destination_workload_type"] == "Deployment"
@@ -1172,10 +1108,6 @@ Node collector config for windows nodes should match snapshot when using default
             where datapoint.attributes["destination_workload_type"] == "StatefulSet"
           - set(datapoint.attributes["dest.k8s.daemonset.name"], datapoint.attributes["destination_workload"])
             where datapoint.attributes["destination_workload_type"] == "DaemonSet"
-          - set(datapoint.attributes["dest.k8s.job.name"], datapoint.attributes["destination_workload"])
-            where datapoint.attributes["destination_workload_type"] == "Job"
-          - set(datapoint.attributes["dest.k8s.cronjob.name"], datapoint.attributes["destination_workload"])
-            where datapoint.attributes["destination_workload_type"] == "CronJob"
           - set(datapoint.attributes["dest.k8s.namespace.name"], datapoint.attributes["destination_workload_namespace"])
         transform/only-relationship-resource-attributes:
           metric_statements:
@@ -1548,14 +1480,6 @@ Node collector config for windows nodes should match snapshot when using legacy 
                 destination_entity: KubernetesService
                 source_entity: KubernetesDaemonSet
                 type: KubernetesCommunicatesWith
-              - attributes: null
-                destination_entity: KubernetesService
-                source_entity: KubernetesJob
-                type: KubernetesCommunicatesWith
-              - attributes: null
-                destination_entity: KubernetesService
-                source_entity: KubernetesCronJob
-                type: KubernetesCommunicatesWith
           source_prefix: source.
         solarwindsentity/istio-workload-workload:
           destination_prefix: dest.
@@ -1576,16 +1500,6 @@ Node collector config for windows nodes should match snapshot when using legacy 
               - sw.k8s.cluster.uid
               - k8s.namespace.name
               - k8s.daemonset.name
-            - entity: KubernetesJob
-              id:
-              - sw.k8s.cluster.uid
-              - k8s.namespace.name
-              - k8s.job.name
-            - entity: KubernetesCronJob
-              id:
-              - sw.k8s.cluster.uid
-              - k8s.namespace.name
-              - k8s.cronjob.name
             events:
               relationships:
               - attributes: null
@@ -1624,36 +1538,8 @@ Node collector config for windows nodes should match snapshot when using legacy 
                 destination_entity: KubernetesDaemonSet
                 source_entity: KubernetesDaemonSet
                 type: KubernetesCommunicatesWith
-              - attributes: null
-                destination_entity: KubernetesDeployment
-                source_entity: KubernetesJob
-                type: KubernetesCommunicatesWith
-              - attributes: null
-                destination_entity: KubernetesStatefulSet
-                source_entity: KubernetesJob
-                type: KubernetesCommunicatesWith
-              - attributes: null
-                destination_entity: KubernetesDaemonSet
-                source_entity: KubernetesJob
-                type: KubernetesCommunicatesWith
-              - attributes: null
-                destination_entity: KubernetesDeployment
-                source_entity: KubernetesCronJob
-                type: KubernetesCommunicatesWith
-              - attributes: null
-                destination_entity: KubernetesStatefulSet
-                source_entity: KubernetesCronJob
-                type: KubernetesCommunicatesWith
-              - attributes: null
-                destination_entity: KubernetesDaemonSet
-                source_entity: KubernetesCronJob
-                type: KubernetesCommunicatesWith
           source_prefix: source.
       exporters:
-        debug:
-          sampling_initial: 5
-          sampling_thereafter: 200
-          verbosity: detailed
         otlp:
           endpoint: ${OTEL_ENVOY_ADDRESS}
           headers:
@@ -1916,14 +1802,10 @@ Node collector config for windows nodes should match snapshot when using legacy 
           - source.k8s.deployment.name
           - source.k8s.statefulset.name
           - source.k8s.daemonset.name
-          - source.k8s.job.name
-          - source.k8s.cronjob.name
           - source.k8s.namespace.name
           - dest.k8s.deployment.name
           - dest.k8s.statefulset.name
           - dest.k8s.daemonset.name
-          - dest.k8s.job.name
-          - dest.k8s.cronjob.name
           - dest.k8s.namespace.name
           - dest.k8s.service.name
         groupbyattrs/node:
@@ -2592,9 +2474,6 @@ Node collector config for windows nodes should match snapshot when using legacy 
             - deployments
             - daemonsets
             - statefulsets
-            - jobs
-            - cronjobs
-            - pods
             name_attr: source_workload
             namespace_attr: source_workload_namespace
             workload_type_attr: source_workload_type
@@ -2602,9 +2481,6 @@ Node collector config for windows nodes should match snapshot when using legacy 
             - deployments
             - daemonsets
             - statefulsets
-            - jobs
-            - cronjobs
-            - pods
             name_attr: destination_workload
             namespace_attr: destination_workload_namespace
             workload_type_attr: destination_workload_type
@@ -2634,10 +2510,6 @@ Node collector config for windows nodes should match snapshot when using legacy 
             where datapoint.attributes["source_workload_type"] == "StatefulSet"
           - set(datapoint.attributes["source.k8s.daemonset.name"], datapoint.attributes["source_workload"])
             where datapoint.attributes["source_workload_type"] == "DaemonSet"
-          - set(datapoint.attributes["source.k8s.job.name"], datapoint.attributes["source_workload"])
-            where datapoint.attributes["source_workload_type"] == "Job"
-          - set(datapoint.attributes["source.k8s.cronjob.name"], datapoint.attributes["source_workload"])
-            where datapoint.attributes["source_workload_type"] == "CronJob"
           - set(datapoint.attributes["source.k8s.namespace.name"], datapoint.attributes["source_workload_namespace"])
           - set(datapoint.attributes["dest.k8s.service.name"], datapoint.attributes["destination_service_name"])
             where datapoint.attributes["destination_service_type"] == "Service"
@@ -2653,10 +2525,6 @@ Node collector config for windows nodes should match snapshot when using legacy 
             where datapoint.attributes["source_workload_type"] == "StatefulSet"
           - set(datapoint.attributes["source.k8s.daemonset.name"], datapoint.attributes["source_workload"])
             where datapoint.attributes["source_workload_type"] == "DaemonSet"
-          - set(datapoint.attributes["source.k8s.job.name"], datapoint.attributes["source_workload"])
-            where datapoint.attributes["source_workload_type"] == "Job"
-          - set(datapoint.attributes["source.k8s.cronjob.name"], datapoint.attributes["source_workload"])
-            where datapoint.attributes["source_workload_type"] == "CronJob"
           - set(datapoint.attributes["source.k8s.namespace.name"], datapoint.attributes["source_workload_namespace"])
           - set(datapoint.attributes["dest.k8s.deployment.name"], datapoint.attributes["destination_workload"])
             where datapoint.attributes["destination_workload_type"] == "Deployment"
@@ -2664,10 +2532,6 @@ Node collector config for windows nodes should match snapshot when using legacy 
             where datapoint.attributes["destination_workload_type"] == "StatefulSet"
           - set(datapoint.attributes["dest.k8s.daemonset.name"], datapoint.attributes["destination_workload"])
             where datapoint.attributes["destination_workload_type"] == "DaemonSet"
-          - set(datapoint.attributes["dest.k8s.job.name"], datapoint.attributes["destination_workload"])
-            where datapoint.attributes["destination_workload_type"] == "Job"
-          - set(datapoint.attributes["dest.k8s.cronjob.name"], datapoint.attributes["destination_workload"])
-            where datapoint.attributes["destination_workload_type"] == "CronJob"
           - set(datapoint.attributes["dest.k8s.namespace.name"], datapoint.attributes["destination_workload_namespace"])
         transform/only-relationship-resource-attributes:
           metric_statements:

--- a/deploy/helm/tests/__snapshot__/node-collector-config-map_test.yaml.snap
+++ b/deploy/helm/tests/__snapshot__/node-collector-config-map_test.yaml.snap
@@ -63,14 +63,6 @@ Custom logs filter with new syntax:
                 destination_entity: KubernetesService
                 source_entity: KubernetesDaemonSet
                 type: KubernetesCommunicatesWith
-              - attributes: null
-                destination_entity: KubernetesService
-                source_entity: KubernetesJob
-                type: KubernetesCommunicatesWith
-              - attributes: null
-                destination_entity: KubernetesService
-                source_entity: KubernetesCronJob
-                type: KubernetesCommunicatesWith
           source_prefix: source.
         solarwindsentity/istio-workload-workload:
           destination_prefix: dest.
@@ -91,16 +83,6 @@ Custom logs filter with new syntax:
               - sw.k8s.cluster.uid
               - k8s.namespace.name
               - k8s.daemonset.name
-            - entity: KubernetesJob
-              id:
-              - sw.k8s.cluster.uid
-              - k8s.namespace.name
-              - k8s.job.name
-            - entity: KubernetesCronJob
-              id:
-              - sw.k8s.cluster.uid
-              - k8s.namespace.name
-              - k8s.cronjob.name
             events:
               relationships:
               - attributes: null
@@ -139,36 +121,8 @@ Custom logs filter with new syntax:
                 destination_entity: KubernetesDaemonSet
                 source_entity: KubernetesDaemonSet
                 type: KubernetesCommunicatesWith
-              - attributes: null
-                destination_entity: KubernetesDeployment
-                source_entity: KubernetesJob
-                type: KubernetesCommunicatesWith
-              - attributes: null
-                destination_entity: KubernetesStatefulSet
-                source_entity: KubernetesJob
-                type: KubernetesCommunicatesWith
-              - attributes: null
-                destination_entity: KubernetesDaemonSet
-                source_entity: KubernetesJob
-                type: KubernetesCommunicatesWith
-              - attributes: null
-                destination_entity: KubernetesDeployment
-                source_entity: KubernetesCronJob
-                type: KubernetesCommunicatesWith
-              - attributes: null
-                destination_entity: KubernetesStatefulSet
-                source_entity: KubernetesCronJob
-                type: KubernetesCommunicatesWith
-              - attributes: null
-                destination_entity: KubernetesDaemonSet
-                source_entity: KubernetesCronJob
-                type: KubernetesCommunicatesWith
           source_prefix: source.
       exporters:
-        debug:
-          sampling_initial: 5
-          sampling_thereafter: 200
-          verbosity: detailed
         otlp:
           endpoint: ${OTEL_ENVOY_ADDRESS}
           headers:
@@ -428,14 +382,10 @@ Custom logs filter with new syntax:
           - source.k8s.deployment.name
           - source.k8s.statefulset.name
           - source.k8s.daemonset.name
-          - source.k8s.job.name
-          - source.k8s.cronjob.name
           - source.k8s.namespace.name
           - dest.k8s.deployment.name
           - dest.k8s.statefulset.name
           - dest.k8s.daemonset.name
-          - dest.k8s.job.name
-          - dest.k8s.cronjob.name
           - dest.k8s.namespace.name
           - dest.k8s.service.name
         groupbyattrs/node:
@@ -1124,9 +1074,6 @@ Custom logs filter with new syntax:
             - deployments
             - daemonsets
             - statefulsets
-            - jobs
-            - cronjobs
-            - pods
             name_attr: source_workload
             namespace_attr: source_workload_namespace
             workload_type_attr: source_workload_type
@@ -1134,9 +1081,6 @@ Custom logs filter with new syntax:
             - deployments
             - daemonsets
             - statefulsets
-            - jobs
-            - cronjobs
-            - pods
             name_attr: destination_workload
             namespace_attr: destination_workload_namespace
             workload_type_attr: destination_workload_type
@@ -1166,10 +1110,6 @@ Custom logs filter with new syntax:
             where datapoint.attributes["source_workload_type"] == "StatefulSet"
           - set(datapoint.attributes["source.k8s.daemonset.name"], datapoint.attributes["source_workload"])
             where datapoint.attributes["source_workload_type"] == "DaemonSet"
-          - set(datapoint.attributes["source.k8s.job.name"], datapoint.attributes["source_workload"])
-            where datapoint.attributes["source_workload_type"] == "Job"
-          - set(datapoint.attributes["source.k8s.cronjob.name"], datapoint.attributes["source_workload"])
-            where datapoint.attributes["source_workload_type"] == "CronJob"
           - set(datapoint.attributes["source.k8s.namespace.name"], datapoint.attributes["source_workload_namespace"])
           - set(datapoint.attributes["dest.k8s.service.name"], datapoint.attributes["destination_service_name"])
             where datapoint.attributes["destination_service_type"] == "Service"
@@ -1185,10 +1125,6 @@ Custom logs filter with new syntax:
             where datapoint.attributes["source_workload_type"] == "StatefulSet"
           - set(datapoint.attributes["source.k8s.daemonset.name"], datapoint.attributes["source_workload"])
             where datapoint.attributes["source_workload_type"] == "DaemonSet"
-          - set(datapoint.attributes["source.k8s.job.name"], datapoint.attributes["source_workload"])
-            where datapoint.attributes["source_workload_type"] == "Job"
-          - set(datapoint.attributes["source.k8s.cronjob.name"], datapoint.attributes["source_workload"])
-            where datapoint.attributes["source_workload_type"] == "CronJob"
           - set(datapoint.attributes["source.k8s.namespace.name"], datapoint.attributes["source_workload_namespace"])
           - set(datapoint.attributes["dest.k8s.deployment.name"], datapoint.attributes["destination_workload"])
             where datapoint.attributes["destination_workload_type"] == "Deployment"
@@ -1196,10 +1132,6 @@ Custom logs filter with new syntax:
             where datapoint.attributes["destination_workload_type"] == "StatefulSet"
           - set(datapoint.attributes["dest.k8s.daemonset.name"], datapoint.attributes["destination_workload"])
             where datapoint.attributes["destination_workload_type"] == "DaemonSet"
-          - set(datapoint.attributes["dest.k8s.job.name"], datapoint.attributes["destination_workload"])
-            where datapoint.attributes["destination_workload_type"] == "Job"
-          - set(datapoint.attributes["dest.k8s.cronjob.name"], datapoint.attributes["destination_workload"])
-            where datapoint.attributes["destination_workload_type"] == "CronJob"
           - set(datapoint.attributes["dest.k8s.namespace.name"], datapoint.attributes["destination_workload_namespace"])
         transform/only-relationship-resource-attributes:
           metric_statements:
@@ -1589,14 +1521,6 @@ Custom logs filter with old syntax:
                 destination_entity: KubernetesService
                 source_entity: KubernetesDaemonSet
                 type: KubernetesCommunicatesWith
-              - attributes: null
-                destination_entity: KubernetesService
-                source_entity: KubernetesJob
-                type: KubernetesCommunicatesWith
-              - attributes: null
-                destination_entity: KubernetesService
-                source_entity: KubernetesCronJob
-                type: KubernetesCommunicatesWith
           source_prefix: source.
         solarwindsentity/istio-workload-workload:
           destination_prefix: dest.
@@ -1617,16 +1541,6 @@ Custom logs filter with old syntax:
               - sw.k8s.cluster.uid
               - k8s.namespace.name
               - k8s.daemonset.name
-            - entity: KubernetesJob
-              id:
-              - sw.k8s.cluster.uid
-              - k8s.namespace.name
-              - k8s.job.name
-            - entity: KubernetesCronJob
-              id:
-              - sw.k8s.cluster.uid
-              - k8s.namespace.name
-              - k8s.cronjob.name
             events:
               relationships:
               - attributes: null
@@ -1665,36 +1579,8 @@ Custom logs filter with old syntax:
                 destination_entity: KubernetesDaemonSet
                 source_entity: KubernetesDaemonSet
                 type: KubernetesCommunicatesWith
-              - attributes: null
-                destination_entity: KubernetesDeployment
-                source_entity: KubernetesJob
-                type: KubernetesCommunicatesWith
-              - attributes: null
-                destination_entity: KubernetesStatefulSet
-                source_entity: KubernetesJob
-                type: KubernetesCommunicatesWith
-              - attributes: null
-                destination_entity: KubernetesDaemonSet
-                source_entity: KubernetesJob
-                type: KubernetesCommunicatesWith
-              - attributes: null
-                destination_entity: KubernetesDeployment
-                source_entity: KubernetesCronJob
-                type: KubernetesCommunicatesWith
-              - attributes: null
-                destination_entity: KubernetesStatefulSet
-                source_entity: KubernetesCronJob
-                type: KubernetesCommunicatesWith
-              - attributes: null
-                destination_entity: KubernetesDaemonSet
-                source_entity: KubernetesCronJob
-                type: KubernetesCommunicatesWith
           source_prefix: source.
       exporters:
-        debug:
-          sampling_initial: 5
-          sampling_thereafter: 200
-          verbosity: detailed
         otlp:
           endpoint: ${OTEL_ENVOY_ADDRESS}
           headers:
@@ -1957,14 +1843,10 @@ Custom logs filter with old syntax:
           - source.k8s.deployment.name
           - source.k8s.statefulset.name
           - source.k8s.daemonset.name
-          - source.k8s.job.name
-          - source.k8s.cronjob.name
           - source.k8s.namespace.name
           - dest.k8s.deployment.name
           - dest.k8s.statefulset.name
           - dest.k8s.daemonset.name
-          - dest.k8s.job.name
-          - dest.k8s.cronjob.name
           - dest.k8s.namespace.name
           - dest.k8s.service.name
         groupbyattrs/node:
@@ -2653,9 +2535,6 @@ Custom logs filter with old syntax:
             - deployments
             - daemonsets
             - statefulsets
-            - jobs
-            - cronjobs
-            - pods
             name_attr: source_workload
             namespace_attr: source_workload_namespace
             workload_type_attr: source_workload_type
@@ -2663,9 +2542,6 @@ Custom logs filter with old syntax:
             - deployments
             - daemonsets
             - statefulsets
-            - jobs
-            - cronjobs
-            - pods
             name_attr: destination_workload
             namespace_attr: destination_workload_namespace
             workload_type_attr: destination_workload_type
@@ -2695,10 +2571,6 @@ Custom logs filter with old syntax:
             where datapoint.attributes["source_workload_type"] == "StatefulSet"
           - set(datapoint.attributes["source.k8s.daemonset.name"], datapoint.attributes["source_workload"])
             where datapoint.attributes["source_workload_type"] == "DaemonSet"
-          - set(datapoint.attributes["source.k8s.job.name"], datapoint.attributes["source_workload"])
-            where datapoint.attributes["source_workload_type"] == "Job"
-          - set(datapoint.attributes["source.k8s.cronjob.name"], datapoint.attributes["source_workload"])
-            where datapoint.attributes["source_workload_type"] == "CronJob"
           - set(datapoint.attributes["source.k8s.namespace.name"], datapoint.attributes["source_workload_namespace"])
           - set(datapoint.attributes["dest.k8s.service.name"], datapoint.attributes["destination_service_name"])
             where datapoint.attributes["destination_service_type"] == "Service"
@@ -2714,10 +2586,6 @@ Custom logs filter with old syntax:
             where datapoint.attributes["source_workload_type"] == "StatefulSet"
           - set(datapoint.attributes["source.k8s.daemonset.name"], datapoint.attributes["source_workload"])
             where datapoint.attributes["source_workload_type"] == "DaemonSet"
-          - set(datapoint.attributes["source.k8s.job.name"], datapoint.attributes["source_workload"])
-            where datapoint.attributes["source_workload_type"] == "Job"
-          - set(datapoint.attributes["source.k8s.cronjob.name"], datapoint.attributes["source_workload"])
-            where datapoint.attributes["source_workload_type"] == "CronJob"
           - set(datapoint.attributes["source.k8s.namespace.name"], datapoint.attributes["source_workload_namespace"])
           - set(datapoint.attributes["dest.k8s.deployment.name"], datapoint.attributes["destination_workload"])
             where datapoint.attributes["destination_workload_type"] == "Deployment"
@@ -2725,10 +2593,6 @@ Custom logs filter with old syntax:
             where datapoint.attributes["destination_workload_type"] == "StatefulSet"
           - set(datapoint.attributes["dest.k8s.daemonset.name"], datapoint.attributes["destination_workload"])
             where datapoint.attributes["destination_workload_type"] == "DaemonSet"
-          - set(datapoint.attributes["dest.k8s.job.name"], datapoint.attributes["destination_workload"])
-            where datapoint.attributes["destination_workload_type"] == "Job"
-          - set(datapoint.attributes["dest.k8s.cronjob.name"], datapoint.attributes["destination_workload"])
-            where datapoint.attributes["destination_workload_type"] == "CronJob"
           - set(datapoint.attributes["dest.k8s.namespace.name"], datapoint.attributes["destination_workload_namespace"])
         transform/only-relationship-resource-attributes:
           metric_statements:
@@ -3199,14 +3063,6 @@ Node collector config should match snapshot when autodiscovery is disabled:
                 destination_entity: KubernetesService
                 source_entity: KubernetesDaemonSet
                 type: KubernetesCommunicatesWith
-              - attributes: null
-                destination_entity: KubernetesService
-                source_entity: KubernetesJob
-                type: KubernetesCommunicatesWith
-              - attributes: null
-                destination_entity: KubernetesService
-                source_entity: KubernetesCronJob
-                type: KubernetesCommunicatesWith
           source_prefix: source.
         solarwindsentity/istio-workload-workload:
           destination_prefix: dest.
@@ -3227,16 +3083,6 @@ Node collector config should match snapshot when autodiscovery is disabled:
               - sw.k8s.cluster.uid
               - k8s.namespace.name
               - k8s.daemonset.name
-            - entity: KubernetesJob
-              id:
-              - sw.k8s.cluster.uid
-              - k8s.namespace.name
-              - k8s.job.name
-            - entity: KubernetesCronJob
-              id:
-              - sw.k8s.cluster.uid
-              - k8s.namespace.name
-              - k8s.cronjob.name
             events:
               relationships:
               - attributes: null
@@ -3275,36 +3121,8 @@ Node collector config should match snapshot when autodiscovery is disabled:
                 destination_entity: KubernetesDaemonSet
                 source_entity: KubernetesDaemonSet
                 type: KubernetesCommunicatesWith
-              - attributes: null
-                destination_entity: KubernetesDeployment
-                source_entity: KubernetesJob
-                type: KubernetesCommunicatesWith
-              - attributes: null
-                destination_entity: KubernetesStatefulSet
-                source_entity: KubernetesJob
-                type: KubernetesCommunicatesWith
-              - attributes: null
-                destination_entity: KubernetesDaemonSet
-                source_entity: KubernetesJob
-                type: KubernetesCommunicatesWith
-              - attributes: null
-                destination_entity: KubernetesDeployment
-                source_entity: KubernetesCronJob
-                type: KubernetesCommunicatesWith
-              - attributes: null
-                destination_entity: KubernetesStatefulSet
-                source_entity: KubernetesCronJob
-                type: KubernetesCommunicatesWith
-              - attributes: null
-                destination_entity: KubernetesDaemonSet
-                source_entity: KubernetesCronJob
-                type: KubernetesCommunicatesWith
           source_prefix: source.
       exporters:
-        debug:
-          sampling_initial: 5
-          sampling_thereafter: 200
-          verbosity: detailed
         otlp:
           endpoint: ${OTEL_ENVOY_ADDRESS}
           headers:
@@ -3560,14 +3378,10 @@ Node collector config should match snapshot when autodiscovery is disabled:
           - source.k8s.deployment.name
           - source.k8s.statefulset.name
           - source.k8s.daemonset.name
-          - source.k8s.job.name
-          - source.k8s.cronjob.name
           - source.k8s.namespace.name
           - dest.k8s.deployment.name
           - dest.k8s.statefulset.name
           - dest.k8s.daemonset.name
-          - dest.k8s.job.name
-          - dest.k8s.cronjob.name
           - dest.k8s.namespace.name
           - dest.k8s.service.name
         groupbyattrs/node:
@@ -4256,9 +4070,6 @@ Node collector config should match snapshot when autodiscovery is disabled:
             - deployments
             - daemonsets
             - statefulsets
-            - jobs
-            - cronjobs
-            - pods
             name_attr: source_workload
             namespace_attr: source_workload_namespace
             workload_type_attr: source_workload_type
@@ -4266,9 +4077,6 @@ Node collector config should match snapshot when autodiscovery is disabled:
             - deployments
             - daemonsets
             - statefulsets
-            - jobs
-            - cronjobs
-            - pods
             name_attr: destination_workload
             namespace_attr: destination_workload_namespace
             workload_type_attr: destination_workload_type
@@ -4298,10 +4106,6 @@ Node collector config should match snapshot when autodiscovery is disabled:
             where datapoint.attributes["source_workload_type"] == "StatefulSet"
           - set(datapoint.attributes["source.k8s.daemonset.name"], datapoint.attributes["source_workload"])
             where datapoint.attributes["source_workload_type"] == "DaemonSet"
-          - set(datapoint.attributes["source.k8s.job.name"], datapoint.attributes["source_workload"])
-            where datapoint.attributes["source_workload_type"] == "Job"
-          - set(datapoint.attributes["source.k8s.cronjob.name"], datapoint.attributes["source_workload"])
-            where datapoint.attributes["source_workload_type"] == "CronJob"
           - set(datapoint.attributes["source.k8s.namespace.name"], datapoint.attributes["source_workload_namespace"])
           - set(datapoint.attributes["dest.k8s.service.name"], datapoint.attributes["destination_service_name"])
             where datapoint.attributes["destination_service_type"] == "Service"
@@ -4317,10 +4121,6 @@ Node collector config should match snapshot when autodiscovery is disabled:
             where datapoint.attributes["source_workload_type"] == "StatefulSet"
           - set(datapoint.attributes["source.k8s.daemonset.name"], datapoint.attributes["source_workload"])
             where datapoint.attributes["source_workload_type"] == "DaemonSet"
-          - set(datapoint.attributes["source.k8s.job.name"], datapoint.attributes["source_workload"])
-            where datapoint.attributes["source_workload_type"] == "Job"
-          - set(datapoint.attributes["source.k8s.cronjob.name"], datapoint.attributes["source_workload"])
-            where datapoint.attributes["source_workload_type"] == "CronJob"
           - set(datapoint.attributes["source.k8s.namespace.name"], datapoint.attributes["source_workload_namespace"])
           - set(datapoint.attributes["dest.k8s.deployment.name"], datapoint.attributes["destination_workload"])
             where datapoint.attributes["destination_workload_type"] == "Deployment"
@@ -4328,10 +4128,6 @@ Node collector config should match snapshot when autodiscovery is disabled:
             where datapoint.attributes["destination_workload_type"] == "StatefulSet"
           - set(datapoint.attributes["dest.k8s.daemonset.name"], datapoint.attributes["destination_workload"])
             where datapoint.attributes["destination_workload_type"] == "DaemonSet"
-          - set(datapoint.attributes["dest.k8s.job.name"], datapoint.attributes["destination_workload"])
-            where datapoint.attributes["destination_workload_type"] == "Job"
-          - set(datapoint.attributes["dest.k8s.cronjob.name"], datapoint.attributes["destination_workload"])
-            where datapoint.attributes["destination_workload_type"] == "CronJob"
           - set(datapoint.attributes["dest.k8s.namespace.name"], datapoint.attributes["destination_workload_namespace"])
         transform/only-relationship-resource-attributes:
           metric_statements:
@@ -4678,14 +4474,6 @@ Node collector config should match snapshot when fargate is enabled:
                 destination_entity: KubernetesService
                 source_entity: KubernetesDaemonSet
                 type: KubernetesCommunicatesWith
-              - attributes: null
-                destination_entity: KubernetesService
-                source_entity: KubernetesJob
-                type: KubernetesCommunicatesWith
-              - attributes: null
-                destination_entity: KubernetesService
-                source_entity: KubernetesCronJob
-                type: KubernetesCommunicatesWith
           source_prefix: source.
         solarwindsentity/istio-workload-workload:
           destination_prefix: dest.
@@ -4706,16 +4494,6 @@ Node collector config should match snapshot when fargate is enabled:
               - sw.k8s.cluster.uid
               - k8s.namespace.name
               - k8s.daemonset.name
-            - entity: KubernetesJob
-              id:
-              - sw.k8s.cluster.uid
-              - k8s.namespace.name
-              - k8s.job.name
-            - entity: KubernetesCronJob
-              id:
-              - sw.k8s.cluster.uid
-              - k8s.namespace.name
-              - k8s.cronjob.name
             events:
               relationships:
               - attributes: null
@@ -4754,36 +4532,8 @@ Node collector config should match snapshot when fargate is enabled:
                 destination_entity: KubernetesDaemonSet
                 source_entity: KubernetesDaemonSet
                 type: KubernetesCommunicatesWith
-              - attributes: null
-                destination_entity: KubernetesDeployment
-                source_entity: KubernetesJob
-                type: KubernetesCommunicatesWith
-              - attributes: null
-                destination_entity: KubernetesStatefulSet
-                source_entity: KubernetesJob
-                type: KubernetesCommunicatesWith
-              - attributes: null
-                destination_entity: KubernetesDaemonSet
-                source_entity: KubernetesJob
-                type: KubernetesCommunicatesWith
-              - attributes: null
-                destination_entity: KubernetesDeployment
-                source_entity: KubernetesCronJob
-                type: KubernetesCommunicatesWith
-              - attributes: null
-                destination_entity: KubernetesStatefulSet
-                source_entity: KubernetesCronJob
-                type: KubernetesCommunicatesWith
-              - attributes: null
-                destination_entity: KubernetesDaemonSet
-                source_entity: KubernetesCronJob
-                type: KubernetesCommunicatesWith
           source_prefix: source.
       exporters:
-        debug:
-          sampling_initial: 5
-          sampling_thereafter: 200
-          verbosity: detailed
         otlp:
           endpoint: ${OTEL_ENVOY_ADDRESS}
           headers:
@@ -5036,14 +4786,10 @@ Node collector config should match snapshot when fargate is enabled:
           - source.k8s.deployment.name
           - source.k8s.statefulset.name
           - source.k8s.daemonset.name
-          - source.k8s.job.name
-          - source.k8s.cronjob.name
           - source.k8s.namespace.name
           - dest.k8s.deployment.name
           - dest.k8s.statefulset.name
           - dest.k8s.daemonset.name
-          - dest.k8s.job.name
-          - dest.k8s.cronjob.name
           - dest.k8s.namespace.name
           - dest.k8s.service.name
         groupbyattrs/node:
@@ -5732,9 +5478,6 @@ Node collector config should match snapshot when fargate is enabled:
             - deployments
             - daemonsets
             - statefulsets
-            - jobs
-            - cronjobs
-            - pods
             name_attr: source_workload
             namespace_attr: source_workload_namespace
             workload_type_attr: source_workload_type
@@ -5742,9 +5485,6 @@ Node collector config should match snapshot when fargate is enabled:
             - deployments
             - daemonsets
             - statefulsets
-            - jobs
-            - cronjobs
-            - pods
             name_attr: destination_workload
             namespace_attr: destination_workload_namespace
             workload_type_attr: destination_workload_type
@@ -5774,10 +5514,6 @@ Node collector config should match snapshot when fargate is enabled:
             where datapoint.attributes["source_workload_type"] == "StatefulSet"
           - set(datapoint.attributes["source.k8s.daemonset.name"], datapoint.attributes["source_workload"])
             where datapoint.attributes["source_workload_type"] == "DaemonSet"
-          - set(datapoint.attributes["source.k8s.job.name"], datapoint.attributes["source_workload"])
-            where datapoint.attributes["source_workload_type"] == "Job"
-          - set(datapoint.attributes["source.k8s.cronjob.name"], datapoint.attributes["source_workload"])
-            where datapoint.attributes["source_workload_type"] == "CronJob"
           - set(datapoint.attributes["source.k8s.namespace.name"], datapoint.attributes["source_workload_namespace"])
           - set(datapoint.attributes["dest.k8s.service.name"], datapoint.attributes["destination_service_name"])
             where datapoint.attributes["destination_service_type"] == "Service"
@@ -5793,10 +5529,6 @@ Node collector config should match snapshot when fargate is enabled:
             where datapoint.attributes["source_workload_type"] == "StatefulSet"
           - set(datapoint.attributes["source.k8s.daemonset.name"], datapoint.attributes["source_workload"])
             where datapoint.attributes["source_workload_type"] == "DaemonSet"
-          - set(datapoint.attributes["source.k8s.job.name"], datapoint.attributes["source_workload"])
-            where datapoint.attributes["source_workload_type"] == "Job"
-          - set(datapoint.attributes["source.k8s.cronjob.name"], datapoint.attributes["source_workload"])
-            where datapoint.attributes["source_workload_type"] == "CronJob"
           - set(datapoint.attributes["source.k8s.namespace.name"], datapoint.attributes["source_workload_namespace"])
           - set(datapoint.attributes["dest.k8s.deployment.name"], datapoint.attributes["destination_workload"])
             where datapoint.attributes["destination_workload_type"] == "Deployment"
@@ -5804,10 +5536,6 @@ Node collector config should match snapshot when fargate is enabled:
             where datapoint.attributes["destination_workload_type"] == "StatefulSet"
           - set(datapoint.attributes["dest.k8s.daemonset.name"], datapoint.attributes["destination_workload"])
             where datapoint.attributes["destination_workload_type"] == "DaemonSet"
-          - set(datapoint.attributes["dest.k8s.job.name"], datapoint.attributes["destination_workload"])
-            where datapoint.attributes["destination_workload_type"] == "Job"
-          - set(datapoint.attributes["dest.k8s.cronjob.name"], datapoint.attributes["destination_workload"])
-            where datapoint.attributes["destination_workload_type"] == "CronJob"
           - set(datapoint.attributes["dest.k8s.namespace.name"], datapoint.attributes["destination_workload_namespace"])
         transform/only-relationship-resource-attributes:
           metric_statements:
@@ -6135,14 +5863,6 @@ Node collector config should match snapshot when fargate is enabled and autodisc
                 destination_entity: KubernetesService
                 source_entity: KubernetesDaemonSet
                 type: KubernetesCommunicatesWith
-              - attributes: null
-                destination_entity: KubernetesService
-                source_entity: KubernetesJob
-                type: KubernetesCommunicatesWith
-              - attributes: null
-                destination_entity: KubernetesService
-                source_entity: KubernetesCronJob
-                type: KubernetesCommunicatesWith
           source_prefix: source.
         solarwindsentity/istio-workload-workload:
           destination_prefix: dest.
@@ -6163,16 +5883,6 @@ Node collector config should match snapshot when fargate is enabled and autodisc
               - sw.k8s.cluster.uid
               - k8s.namespace.name
               - k8s.daemonset.name
-            - entity: KubernetesJob
-              id:
-              - sw.k8s.cluster.uid
-              - k8s.namespace.name
-              - k8s.job.name
-            - entity: KubernetesCronJob
-              id:
-              - sw.k8s.cluster.uid
-              - k8s.namespace.name
-              - k8s.cronjob.name
             events:
               relationships:
               - attributes: null
@@ -6211,36 +5921,8 @@ Node collector config should match snapshot when fargate is enabled and autodisc
                 destination_entity: KubernetesDaemonSet
                 source_entity: KubernetesDaemonSet
                 type: KubernetesCommunicatesWith
-              - attributes: null
-                destination_entity: KubernetesDeployment
-                source_entity: KubernetesJob
-                type: KubernetesCommunicatesWith
-              - attributes: null
-                destination_entity: KubernetesStatefulSet
-                source_entity: KubernetesJob
-                type: KubernetesCommunicatesWith
-              - attributes: null
-                destination_entity: KubernetesDaemonSet
-                source_entity: KubernetesJob
-                type: KubernetesCommunicatesWith
-              - attributes: null
-                destination_entity: KubernetesDeployment
-                source_entity: KubernetesCronJob
-                type: KubernetesCommunicatesWith
-              - attributes: null
-                destination_entity: KubernetesStatefulSet
-                source_entity: KubernetesCronJob
-                type: KubernetesCommunicatesWith
-              - attributes: null
-                destination_entity: KubernetesDaemonSet
-                source_entity: KubernetesCronJob
-                type: KubernetesCommunicatesWith
           source_prefix: source.
       exporters:
-        debug:
-          sampling_initial: 5
-          sampling_thereafter: 200
-          verbosity: detailed
         otlp:
           endpoint: ${OTEL_ENVOY_ADDRESS}
           headers:
@@ -6488,14 +6170,10 @@ Node collector config should match snapshot when fargate is enabled and autodisc
           - source.k8s.deployment.name
           - source.k8s.statefulset.name
           - source.k8s.daemonset.name
-          - source.k8s.job.name
-          - source.k8s.cronjob.name
           - source.k8s.namespace.name
           - dest.k8s.deployment.name
           - dest.k8s.statefulset.name
           - dest.k8s.daemonset.name
-          - dest.k8s.job.name
-          - dest.k8s.cronjob.name
           - dest.k8s.namespace.name
           - dest.k8s.service.name
         groupbyattrs/node:
@@ -7184,9 +6862,6 @@ Node collector config should match snapshot when fargate is enabled and autodisc
             - deployments
             - daemonsets
             - statefulsets
-            - jobs
-            - cronjobs
-            - pods
             name_attr: source_workload
             namespace_attr: source_workload_namespace
             workload_type_attr: source_workload_type
@@ -7194,9 +6869,6 @@ Node collector config should match snapshot when fargate is enabled and autodisc
             - deployments
             - daemonsets
             - statefulsets
-            - jobs
-            - cronjobs
-            - pods
             name_attr: destination_workload
             namespace_attr: destination_workload_namespace
             workload_type_attr: destination_workload_type
@@ -7226,10 +6898,6 @@ Node collector config should match snapshot when fargate is enabled and autodisc
             where datapoint.attributes["source_workload_type"] == "StatefulSet"
           - set(datapoint.attributes["source.k8s.daemonset.name"], datapoint.attributes["source_workload"])
             where datapoint.attributes["source_workload_type"] == "DaemonSet"
-          - set(datapoint.attributes["source.k8s.job.name"], datapoint.attributes["source_workload"])
-            where datapoint.attributes["source_workload_type"] == "Job"
-          - set(datapoint.attributes["source.k8s.cronjob.name"], datapoint.attributes["source_workload"])
-            where datapoint.attributes["source_workload_type"] == "CronJob"
           - set(datapoint.attributes["source.k8s.namespace.name"], datapoint.attributes["source_workload_namespace"])
           - set(datapoint.attributes["dest.k8s.service.name"], datapoint.attributes["destination_service_name"])
             where datapoint.attributes["destination_service_type"] == "Service"
@@ -7245,10 +6913,6 @@ Node collector config should match snapshot when fargate is enabled and autodisc
             where datapoint.attributes["source_workload_type"] == "StatefulSet"
           - set(datapoint.attributes["source.k8s.daemonset.name"], datapoint.attributes["source_workload"])
             where datapoint.attributes["source_workload_type"] == "DaemonSet"
-          - set(datapoint.attributes["source.k8s.job.name"], datapoint.attributes["source_workload"])
-            where datapoint.attributes["source_workload_type"] == "Job"
-          - set(datapoint.attributes["source.k8s.cronjob.name"], datapoint.attributes["source_workload"])
-            where datapoint.attributes["source_workload_type"] == "CronJob"
           - set(datapoint.attributes["source.k8s.namespace.name"], datapoint.attributes["source_workload_namespace"])
           - set(datapoint.attributes["dest.k8s.deployment.name"], datapoint.attributes["destination_workload"])
             where datapoint.attributes["destination_workload_type"] == "Deployment"
@@ -7256,10 +6920,6 @@ Node collector config should match snapshot when fargate is enabled and autodisc
             where datapoint.attributes["destination_workload_type"] == "StatefulSet"
           - set(datapoint.attributes["dest.k8s.daemonset.name"], datapoint.attributes["destination_workload"])
             where datapoint.attributes["destination_workload_type"] == "DaemonSet"
-          - set(datapoint.attributes["dest.k8s.job.name"], datapoint.attributes["destination_workload"])
-            where datapoint.attributes["destination_workload_type"] == "Job"
-          - set(datapoint.attributes["dest.k8s.cronjob.name"], datapoint.attributes["destination_workload"])
-            where datapoint.attributes["destination_workload_type"] == "CronJob"
           - set(datapoint.attributes["dest.k8s.namespace.name"], datapoint.attributes["destination_workload_namespace"])
         transform/only-relationship-resource-attributes:
           metric_statements:
@@ -7533,14 +7193,6 @@ Node collector config should match snapshot when using default values:
                 destination_entity: KubernetesService
                 source_entity: KubernetesDaemonSet
                 type: KubernetesCommunicatesWith
-              - attributes: null
-                destination_entity: KubernetesService
-                source_entity: KubernetesJob
-                type: KubernetesCommunicatesWith
-              - attributes: null
-                destination_entity: KubernetesService
-                source_entity: KubernetesCronJob
-                type: KubernetesCommunicatesWith
           source_prefix: source.
         solarwindsentity/istio-workload-workload:
           destination_prefix: dest.
@@ -7561,16 +7213,6 @@ Node collector config should match snapshot when using default values:
               - sw.k8s.cluster.uid
               - k8s.namespace.name
               - k8s.daemonset.name
-            - entity: KubernetesJob
-              id:
-              - sw.k8s.cluster.uid
-              - k8s.namespace.name
-              - k8s.job.name
-            - entity: KubernetesCronJob
-              id:
-              - sw.k8s.cluster.uid
-              - k8s.namespace.name
-              - k8s.cronjob.name
             events:
               relationships:
               - attributes: null
@@ -7609,36 +7251,8 @@ Node collector config should match snapshot when using default values:
                 destination_entity: KubernetesDaemonSet
                 source_entity: KubernetesDaemonSet
                 type: KubernetesCommunicatesWith
-              - attributes: null
-                destination_entity: KubernetesDeployment
-                source_entity: KubernetesJob
-                type: KubernetesCommunicatesWith
-              - attributes: null
-                destination_entity: KubernetesStatefulSet
-                source_entity: KubernetesJob
-                type: KubernetesCommunicatesWith
-              - attributes: null
-                destination_entity: KubernetesDaemonSet
-                source_entity: KubernetesJob
-                type: KubernetesCommunicatesWith
-              - attributes: null
-                destination_entity: KubernetesDeployment
-                source_entity: KubernetesCronJob
-                type: KubernetesCommunicatesWith
-              - attributes: null
-                destination_entity: KubernetesStatefulSet
-                source_entity: KubernetesCronJob
-                type: KubernetesCommunicatesWith
-              - attributes: null
-                destination_entity: KubernetesDaemonSet
-                source_entity: KubernetesCronJob
-                type: KubernetesCommunicatesWith
           source_prefix: source.
       exporters:
-        debug:
-          sampling_initial: 5
-          sampling_thereafter: 200
-          verbosity: detailed
         otlp:
           endpoint: ${OTEL_ENVOY_ADDRESS}
           headers:
@@ -7894,14 +7508,10 @@ Node collector config should match snapshot when using default values:
           - source.k8s.deployment.name
           - source.k8s.statefulset.name
           - source.k8s.daemonset.name
-          - source.k8s.job.name
-          - source.k8s.cronjob.name
           - source.k8s.namespace.name
           - dest.k8s.deployment.name
           - dest.k8s.statefulset.name
           - dest.k8s.daemonset.name
-          - dest.k8s.job.name
-          - dest.k8s.cronjob.name
           - dest.k8s.namespace.name
           - dest.k8s.service.name
         groupbyattrs/node:
@@ -8590,9 +8200,6 @@ Node collector config should match snapshot when using default values:
             - deployments
             - daemonsets
             - statefulsets
-            - jobs
-            - cronjobs
-            - pods
             name_attr: source_workload
             namespace_attr: source_workload_namespace
             workload_type_attr: source_workload_type
@@ -8600,9 +8207,6 @@ Node collector config should match snapshot when using default values:
             - deployments
             - daemonsets
             - statefulsets
-            - jobs
-            - cronjobs
-            - pods
             name_attr: destination_workload
             namespace_attr: destination_workload_namespace
             workload_type_attr: destination_workload_type
@@ -8632,10 +8236,6 @@ Node collector config should match snapshot when using default values:
             where datapoint.attributes["source_workload_type"] == "StatefulSet"
           - set(datapoint.attributes["source.k8s.daemonset.name"], datapoint.attributes["source_workload"])
             where datapoint.attributes["source_workload_type"] == "DaemonSet"
-          - set(datapoint.attributes["source.k8s.job.name"], datapoint.attributes["source_workload"])
-            where datapoint.attributes["source_workload_type"] == "Job"
-          - set(datapoint.attributes["source.k8s.cronjob.name"], datapoint.attributes["source_workload"])
-            where datapoint.attributes["source_workload_type"] == "CronJob"
           - set(datapoint.attributes["source.k8s.namespace.name"], datapoint.attributes["source_workload_namespace"])
           - set(datapoint.attributes["dest.k8s.service.name"], datapoint.attributes["destination_service_name"])
             where datapoint.attributes["destination_service_type"] == "Service"
@@ -8651,10 +8251,6 @@ Node collector config should match snapshot when using default values:
             where datapoint.attributes["source_workload_type"] == "StatefulSet"
           - set(datapoint.attributes["source.k8s.daemonset.name"], datapoint.attributes["source_workload"])
             where datapoint.attributes["source_workload_type"] == "DaemonSet"
-          - set(datapoint.attributes["source.k8s.job.name"], datapoint.attributes["source_workload"])
-            where datapoint.attributes["source_workload_type"] == "Job"
-          - set(datapoint.attributes["source.k8s.cronjob.name"], datapoint.attributes["source_workload"])
-            where datapoint.attributes["source_workload_type"] == "CronJob"
           - set(datapoint.attributes["source.k8s.namespace.name"], datapoint.attributes["source_workload_namespace"])
           - set(datapoint.attributes["dest.k8s.deployment.name"], datapoint.attributes["destination_workload"])
             where datapoint.attributes["destination_workload_type"] == "Deployment"
@@ -8662,10 +8258,6 @@ Node collector config should match snapshot when using default values:
             where datapoint.attributes["destination_workload_type"] == "StatefulSet"
           - set(datapoint.attributes["dest.k8s.daemonset.name"], datapoint.attributes["destination_workload"])
             where datapoint.attributes["destination_workload_type"] == "DaemonSet"
-          - set(datapoint.attributes["dest.k8s.job.name"], datapoint.attributes["destination_workload"])
-            where datapoint.attributes["destination_workload_type"] == "Job"
-          - set(datapoint.attributes["dest.k8s.cronjob.name"], datapoint.attributes["destination_workload"])
-            where datapoint.attributes["destination_workload_type"] == "CronJob"
           - set(datapoint.attributes["dest.k8s.namespace.name"], datapoint.attributes["destination_workload_namespace"])
         transform/only-relationship-resource-attributes:
           metric_statements:

--- a/deploy/helm/tests/__snapshot__/node-collector-config-map_test.yaml.snap
+++ b/deploy/helm/tests/__snapshot__/node-collector-config-map_test.yaml.snap
@@ -1416,7 +1416,6 @@ Custom logs filter with new syntax:
           logs/stateevents:
             exporters:
             - otlp
-            - debug
             processors:
             - memory_limiter
             - transform/scope
@@ -3027,7 +3026,6 @@ Custom logs filter with old syntax:
           logs/stateevents:
             exporters:
             - otlp
-            - debug
             processors:
             - memory_limiter
             - transform/scope
@@ -4507,7 +4505,6 @@ Node collector config should match snapshot when autodiscovery is disabled:
           logs/stateevents:
             exporters:
             - otlp
-            - debug
             processors:
             - memory_limiter
             - transform/scope
@@ -5989,7 +5986,6 @@ Node collector config should match snapshot when fargate is enabled:
           logs/stateevents:
             exporters:
             - otlp
-            - debug
             processors:
             - memory_limiter
             - transform/scope
@@ -7399,7 +7395,6 @@ Node collector config should match snapshot when fargate is enabled and autodisc
           logs/stateevents:
             exporters:
             - otlp
-            - debug
             processors:
             - memory_limiter
             - transform/scope
@@ -8886,7 +8881,6 @@ Node collector config should match snapshot when using default values:
           logs/stateevents:
             exporters:
             - otlp
-            - debug
             processors:
             - memory_limiter
             - transform/scope

--- a/deploy/helm/tests/__snapshot__/node-collector-config-map_test.yaml.snap
+++ b/deploy/helm/tests/__snapshot__/node-collector-config-map_test.yaml.snap
@@ -4,7 +4,171 @@ Custom logs filter with new syntax:
       connectors:
         forward/logs-exporter: null
         forward/metric-exporter: null
+        forward/relationship-state-events-workload-service: null
+        forward/relationship-state-events-workload-workload: null
+        routing/discovered_metrics:
+          default_pipelines:
+          - metrics/discovery-custom
+          table:
+          - condition: |
+              IsMatch(name, "k8s.istio_")
+            context: metric
+            pipelines:
+            - metrics/discovery-istio
+        solarwindsentity/istio-workload-service:
+          destination_prefix: dest.
+          schema:
+            entities:
+            - entity: KubernetesDeployment
+              id:
+              - sw.k8s.cluster.uid
+              - k8s.namespace.name
+              - k8s.deployment.name
+            - entity: KubernetesStatefulSet
+              id:
+              - sw.k8s.cluster.uid
+              - k8s.namespace.name
+              - k8s.statefulset.name
+            - entity: KubernetesDaemonSet
+              id:
+              - sw.k8s.cluster.uid
+              - k8s.namespace.name
+              - k8s.daemonset.name
+            - entity: KubernetesJob
+              id:
+              - sw.k8s.cluster.uid
+              - k8s.namespace.name
+              - k8s.job.name
+            - entity: KubernetesCronJob
+              id:
+              - sw.k8s.cluster.uid
+              - k8s.namespace.name
+              - k8s.cronjob.name
+            - entity: KubernetesService
+              id:
+              - sw.k8s.cluster.uid
+              - k8s.namespace.name
+              - k8s.service.name
+            events:
+              relationships:
+              - attributes: null
+                destination_entity: KubernetesService
+                source_entity: KubernetesDeployment
+                type: KubernetesCommunicatesWith
+              - attributes: null
+                destination_entity: KubernetesService
+                source_entity: KubernetesStatefulSet
+                type: KubernetesCommunicatesWith
+              - attributes: null
+                destination_entity: KubernetesService
+                source_entity: KubernetesDaemonSet
+                type: KubernetesCommunicatesWith
+              - attributes: null
+                destination_entity: KubernetesService
+                source_entity: KubernetesJob
+                type: KubernetesCommunicatesWith
+              - attributes: null
+                destination_entity: KubernetesService
+                source_entity: KubernetesCronJob
+                type: KubernetesCommunicatesWith
+          source_prefix: source.
+        solarwindsentity/istio-workload-workload:
+          destination_prefix: dest.
+          schema:
+            entities:
+            - entity: KubernetesDeployment
+              id:
+              - sw.k8s.cluster.uid
+              - k8s.namespace.name
+              - k8s.deployment.name
+            - entity: KubernetesStatefulSet
+              id:
+              - sw.k8s.cluster.uid
+              - k8s.namespace.name
+              - k8s.statefulset.name
+            - entity: KubernetesDaemonSet
+              id:
+              - sw.k8s.cluster.uid
+              - k8s.namespace.name
+              - k8s.daemonset.name
+            - entity: KubernetesJob
+              id:
+              - sw.k8s.cluster.uid
+              - k8s.namespace.name
+              - k8s.job.name
+            - entity: KubernetesCronJob
+              id:
+              - sw.k8s.cluster.uid
+              - k8s.namespace.name
+              - k8s.cronjob.name
+            events:
+              relationships:
+              - attributes: null
+                destination_entity: KubernetesDeployment
+                source_entity: KubernetesDeployment
+                type: KubernetesCommunicatesWith
+              - attributes: null
+                destination_entity: KubernetesStatefulSet
+                source_entity: KubernetesDeployment
+                type: KubernetesCommunicatesWith
+              - attributes: null
+                destination_entity: KubernetesDaemonSet
+                source_entity: KubernetesDeployment
+                type: KubernetesCommunicatesWith
+              - attributes: null
+                destination_entity: KubernetesDeployment
+                source_entity: KubernetesStatefulSet
+                type: KubernetesCommunicatesWith
+              - attributes: null
+                destination_entity: KubernetesStatefulSet
+                source_entity: KubernetesStatefulSet
+                type: KubernetesCommunicatesWith
+              - attributes: null
+                destination_entity: KubernetesDaemonSet
+                source_entity: KubernetesStatefulSet
+                type: KubernetesCommunicatesWith
+              - attributes: null
+                destination_entity: KubernetesDeployment
+                source_entity: KubernetesDaemonSet
+                type: KubernetesCommunicatesWith
+              - attributes: null
+                destination_entity: KubernetesStatefulSet
+                source_entity: KubernetesDaemonSet
+                type: KubernetesCommunicatesWith
+              - attributes: null
+                destination_entity: KubernetesDaemonSet
+                source_entity: KubernetesDaemonSet
+                type: KubernetesCommunicatesWith
+              - attributes: null
+                destination_entity: KubernetesDeployment
+                source_entity: KubernetesJob
+                type: KubernetesCommunicatesWith
+              - attributes: null
+                destination_entity: KubernetesStatefulSet
+                source_entity: KubernetesJob
+                type: KubernetesCommunicatesWith
+              - attributes: null
+                destination_entity: KubernetesDaemonSet
+                source_entity: KubernetesJob
+                type: KubernetesCommunicatesWith
+              - attributes: null
+                destination_entity: KubernetesDeployment
+                source_entity: KubernetesCronJob
+                type: KubernetesCommunicatesWith
+              - attributes: null
+                destination_entity: KubernetesStatefulSet
+                source_entity: KubernetesCronJob
+                type: KubernetesCommunicatesWith
+              - attributes: null
+                destination_entity: KubernetesDaemonSet
+                source_entity: KubernetesCronJob
+                type: KubernetesCommunicatesWith
+          source_prefix: source.
       exporters:
+        debug:
+          sampling_initial: 5
+          sampling_thereafter: 200
+          verbosity: detailed
         otlp:
           endpoint: ${OTEL_ENVOY_ADDRESS}
           headers:
@@ -68,6 +232,10 @@ Custom logs filter with new syntax:
         batch/metrics:
           send_batch_max_size: 512
           send_batch_size: 512
+          timeout: 1s
+        batch/stateevents:
+          send_batch_max_size: 1024
+          send_batch_size: 1024
           timeout: 1s
         cumulativetodelta/cadvisor:
           include:
@@ -160,6 +328,24 @@ Custom logs filter with new syntax:
             - type == METRIC_DATA_TYPE_HISTOGRAM and not(name == "k8s.rest_client_request_duration_seconds"
               or name == "k8s.workqueue_queue_duration_seconds" or name == "k8s.etcd_disk_wal_fsync_duration_seconds"
               or name == "k8s.etcd_disk_backend_commit_duration_seconds")
+        filter/keep-workload-service-relationships:
+          error_mode: ignore
+          metrics:
+            datapoint:
+            - datapoint.attributes["source_workload_type"] == nil or datapoint.attributes["destination_service_type"]
+              == nil or datapoint.attributes["source_workload_type"] == "" or datapoint.attributes["destination_service_type"]
+              == ""
+            metric:
+            - name != "k8s.istio_request_bytes_sum"
+        filter/keep-workload-workload-relationships:
+          error_mode: ignore
+          metrics:
+            datapoint:
+            - datapoint.attributes["source_workload_type"] == nil or datapoint.attributes["destination_workload_type"]
+              == nil or datapoint.attributes["source_workload_type"] == "" or datapoint.attributes["destination_workload_type"]
+              == ""
+            metric:
+            - name != "k8s.istio_request_bytes_sum"
         filter/logs:
           logs:
             log_record:
@@ -236,6 +422,22 @@ Custom logs filter with new syntax:
           - k8s.pod.uid
           - host.name
           - service.name
+        groupbyattrs/istio-relationships:
+          keys:
+          - sw.k8s.cluster.uid
+          - source.k8s.deployment.name
+          - source.k8s.statefulset.name
+          - source.k8s.daemonset.name
+          - source.k8s.job.name
+          - source.k8s.cronjob.name
+          - source.k8s.namespace.name
+          - dest.k8s.deployment.name
+          - dest.k8s.statefulset.name
+          - dest.k8s.daemonset.name
+          - dest.k8s.job.name
+          - dest.k8s.cronjob.name
+          - dest.k8s.namespace.name
+          - dest.k8s.service.name
         groupbyattrs/node:
           keys:
           - k8s.node.name
@@ -916,6 +1118,33 @@ Custom logs filter with new syntax:
           - action: insert
             from_attribute: persistentvolumeclaim
             key: k8s.persistentvolumeclaim.name
+        swok8sworkloadtype/istio:
+          workload_mappings:
+          - expected_types:
+            - deployments
+            - daemonsets
+            - statefulsets
+            - jobs
+            - cronjobs
+            - pods
+            name_attr: source_workload
+            namespace_attr: source_workload_namespace
+            workload_type_attr: source_workload_type
+          - expected_types:
+            - deployments
+            - daemonsets
+            - statefulsets
+            - jobs
+            - cronjobs
+            - pods
+            name_attr: destination_workload
+            namespace_attr: destination_workload_namespace
+            workload_type_attr: destination_workload_type
+          - expected_types:
+            - services
+            name_attr: destination_service_name
+            namespace_attr: destination_service_namespace
+            workload_type_attr: destination_service_type
         transform/istio-metrics:
           metric_statements:
           - statements:
@@ -926,6 +1155,59 @@ Custom logs filter with new syntax:
               metric.name == "k8s.istio_request_duration_milliseconds_sum"
             - set(metric.name, "k8s.istio_request_duration_milliseconds_count_temp") where
               metric.name == "k8s.istio_request_duration_milliseconds_count"
+        transform/istio-workload-service:
+          metric_statements:
+          - keep_keys(datapoint.attributes, ["source_workload", "source_workload_namespace",
+            "destination_service_name", "destination_service_namespace", "source_workload_type",
+            "destination_service_type"])
+          - set(datapoint.attributes["source.k8s.deployment.name"], datapoint.attributes["source_workload"])
+            where datapoint.attributes["source_workload_type"] == "Deployment"
+          - set(datapoint.attributes["source.k8s.statefulset.name"], datapoint.attributes["source_workload"])
+            where datapoint.attributes["source_workload_type"] == "StatefulSet"
+          - set(datapoint.attributes["source.k8s.daemonset.name"], datapoint.attributes["source_workload"])
+            where datapoint.attributes["source_workload_type"] == "DaemonSet"
+          - set(datapoint.attributes["source.k8s.job.name"], datapoint.attributes["source_workload"])
+            where datapoint.attributes["source_workload_type"] == "Job"
+          - set(datapoint.attributes["source.k8s.cronjob.name"], datapoint.attributes["source_workload"])
+            where datapoint.attributes["source_workload_type"] == "CronJob"
+          - set(datapoint.attributes["source.k8s.namespace.name"], datapoint.attributes["source_workload_namespace"])
+          - set(datapoint.attributes["dest.k8s.service.name"], datapoint.attributes["destination_service_name"])
+            where datapoint.attributes["destination_service_type"] == "Service"
+          - set(datapoint.attributes["dest.k8s.namespace.name"], datapoint.attributes["destination_service_namespace"])
+        transform/istio-workload-workload:
+          metric_statements:
+          - keep_keys(datapoint.attributes, ["source_workload", "source_workload_namespace",
+            "destination_workload", "destination_workload_namespace", "source_workload_type",
+            "destination_workload_type"])
+          - set(datapoint.attributes["source.k8s.deployment.name"], datapoint.attributes["source_workload"])
+            where datapoint.attributes["source_workload_type"] == "Deployment"
+          - set(datapoint.attributes["source.k8s.statefulset.name"], datapoint.attributes["source_workload"])
+            where datapoint.attributes["source_workload_type"] == "StatefulSet"
+          - set(datapoint.attributes["source.k8s.daemonset.name"], datapoint.attributes["source_workload"])
+            where datapoint.attributes["source_workload_type"] == "DaemonSet"
+          - set(datapoint.attributes["source.k8s.job.name"], datapoint.attributes["source_workload"])
+            where datapoint.attributes["source_workload_type"] == "Job"
+          - set(datapoint.attributes["source.k8s.cronjob.name"], datapoint.attributes["source_workload"])
+            where datapoint.attributes["source_workload_type"] == "CronJob"
+          - set(datapoint.attributes["source.k8s.namespace.name"], datapoint.attributes["source_workload_namespace"])
+          - set(datapoint.attributes["dest.k8s.deployment.name"], datapoint.attributes["destination_workload"])
+            where datapoint.attributes["destination_workload_type"] == "Deployment"
+          - set(datapoint.attributes["dest.k8s.statefulset.name"], datapoint.attributes["destination_workload"])
+            where datapoint.attributes["destination_workload_type"] == "StatefulSet"
+          - set(datapoint.attributes["dest.k8s.daemonset.name"], datapoint.attributes["destination_workload"])
+            where datapoint.attributes["destination_workload_type"] == "DaemonSet"
+          - set(datapoint.attributes["dest.k8s.job.name"], datapoint.attributes["destination_workload"])
+            where datapoint.attributes["destination_workload_type"] == "Job"
+          - set(datapoint.attributes["dest.k8s.cronjob.name"], datapoint.attributes["destination_workload"])
+            where datapoint.attributes["destination_workload_type"] == "CronJob"
+          - set(datapoint.attributes["dest.k8s.namespace.name"], datapoint.attributes["destination_workload_namespace"])
+        transform/only-relationship-resource-attributes:
+          metric_statements:
+          - keep_keys(resource.attributes, ["sw.k8s.cluster.uid", "source.k8s.deployment.name",
+            "source.k8s.statefulset.name", "source.k8s.daemonset.name", "source.k8s.job.name",
+            "source.k8s.cronjob.name", "source.k8s.namespace.name", "dest.k8s.deployment.name",
+            "dest.k8s.statefulset.name", "dest.k8s.daemonset.name", "dest.k8s.job.name",
+            "dest.k8s.cronjob.name", "dest.k8s.service.name", "dest.k8s.namespace.name"])
         transform/scope:
           log_statements:
           - statements:
@@ -1131,6 +1413,17 @@ Custom logs filter with new syntax:
             - resource/journal
             receivers:
             - journald
+          logs/stateevents:
+            exporters:
+            - otlp
+            - debug
+            processors:
+            - memory_limiter
+            - transform/scope
+            - batch/stateevents
+            receivers:
+            - solarwindsentity/istio-workload-workload
+            - solarwindsentity/istio-workload-service
           metrics:
             exporters:
             - otlp
@@ -1143,12 +1436,23 @@ Custom logs filter with new syntax:
             - batch/metrics
             receivers:
             - forward/metric-exporter
-          metrics/discovery:
+          metrics/discovery-custom:
             exporters:
             - forward/metric-exporter
             processors:
             - memory_limiter
-            - metricstransform/rename/discovery
+            - groupbyattrs/common-all
+            - resource/all
+            receivers:
+            - routing/discovered_metrics
+          metrics/discovery-istio:
+            exporters:
+            - forward/metric-exporter
+            - forward/relationship-state-events-workload-workload
+            - forward/relationship-state-events-workload-service
+            processors:
+            - memory_limiter
+            - swok8sworkloadtype/istio
             - transform/istio-metrics
             - metricstransform/istio-metrics
             - cumulativetodelta/istio-metrics
@@ -1156,6 +1460,14 @@ Custom logs filter with new syntax:
             - metricsgeneration/istio-metrics
             - groupbyattrs/common-all
             - resource/all
+            receivers:
+            - routing/discovered_metrics
+          metrics/discovery-scrape:
+            exporters:
+            - routing/discovered_metrics
+            processors:
+            - memory_limiter
+            - metricstransform/rename/discovery
             receivers:
             - receiver_creator/discovery
           metrics/node:
@@ -1181,6 +1493,28 @@ Custom logs filter with new syntax:
             - resource/all
             receivers:
             - receiver_creator/node
+          metrics/relationship-state-events-workload-service-preparation:
+            exporters:
+            - solarwindsentity/istio-workload-service
+            processors:
+            - memory_limiter
+            - filter/keep-workload-service-relationships
+            - transform/istio-workload-service
+            - groupbyattrs/istio-relationships
+            - transform/only-relationship-resource-attributes
+            receivers:
+            - forward/relationship-state-events-workload-service
+          metrics/relationship-state-events-workload-workload-preparation:
+            exporters:
+            - solarwindsentity/istio-workload-workload
+            processors:
+            - memory_limiter
+            - filter/keep-workload-workload-relationships
+            - transform/istio-workload-workload
+            - groupbyattrs/istio-relationships
+            - transform/only-relationship-resource-attributes
+            receivers:
+            - forward/relationship-state-events-workload-workload
         telemetry:
           logs:
             level: info
@@ -1197,7 +1531,171 @@ Custom logs filter with old syntax:
       connectors:
         forward/logs-exporter: null
         forward/metric-exporter: null
+        forward/relationship-state-events-workload-service: null
+        forward/relationship-state-events-workload-workload: null
+        routing/discovered_metrics:
+          default_pipelines:
+          - metrics/discovery-custom
+          table:
+          - condition: |
+              IsMatch(name, "k8s.istio_")
+            context: metric
+            pipelines:
+            - metrics/discovery-istio
+        solarwindsentity/istio-workload-service:
+          destination_prefix: dest.
+          schema:
+            entities:
+            - entity: KubernetesDeployment
+              id:
+              - sw.k8s.cluster.uid
+              - k8s.namespace.name
+              - k8s.deployment.name
+            - entity: KubernetesStatefulSet
+              id:
+              - sw.k8s.cluster.uid
+              - k8s.namespace.name
+              - k8s.statefulset.name
+            - entity: KubernetesDaemonSet
+              id:
+              - sw.k8s.cluster.uid
+              - k8s.namespace.name
+              - k8s.daemonset.name
+            - entity: KubernetesJob
+              id:
+              - sw.k8s.cluster.uid
+              - k8s.namespace.name
+              - k8s.job.name
+            - entity: KubernetesCronJob
+              id:
+              - sw.k8s.cluster.uid
+              - k8s.namespace.name
+              - k8s.cronjob.name
+            - entity: KubernetesService
+              id:
+              - sw.k8s.cluster.uid
+              - k8s.namespace.name
+              - k8s.service.name
+            events:
+              relationships:
+              - attributes: null
+                destination_entity: KubernetesService
+                source_entity: KubernetesDeployment
+                type: KubernetesCommunicatesWith
+              - attributes: null
+                destination_entity: KubernetesService
+                source_entity: KubernetesStatefulSet
+                type: KubernetesCommunicatesWith
+              - attributes: null
+                destination_entity: KubernetesService
+                source_entity: KubernetesDaemonSet
+                type: KubernetesCommunicatesWith
+              - attributes: null
+                destination_entity: KubernetesService
+                source_entity: KubernetesJob
+                type: KubernetesCommunicatesWith
+              - attributes: null
+                destination_entity: KubernetesService
+                source_entity: KubernetesCronJob
+                type: KubernetesCommunicatesWith
+          source_prefix: source.
+        solarwindsentity/istio-workload-workload:
+          destination_prefix: dest.
+          schema:
+            entities:
+            - entity: KubernetesDeployment
+              id:
+              - sw.k8s.cluster.uid
+              - k8s.namespace.name
+              - k8s.deployment.name
+            - entity: KubernetesStatefulSet
+              id:
+              - sw.k8s.cluster.uid
+              - k8s.namespace.name
+              - k8s.statefulset.name
+            - entity: KubernetesDaemonSet
+              id:
+              - sw.k8s.cluster.uid
+              - k8s.namespace.name
+              - k8s.daemonset.name
+            - entity: KubernetesJob
+              id:
+              - sw.k8s.cluster.uid
+              - k8s.namespace.name
+              - k8s.job.name
+            - entity: KubernetesCronJob
+              id:
+              - sw.k8s.cluster.uid
+              - k8s.namespace.name
+              - k8s.cronjob.name
+            events:
+              relationships:
+              - attributes: null
+                destination_entity: KubernetesDeployment
+                source_entity: KubernetesDeployment
+                type: KubernetesCommunicatesWith
+              - attributes: null
+                destination_entity: KubernetesStatefulSet
+                source_entity: KubernetesDeployment
+                type: KubernetesCommunicatesWith
+              - attributes: null
+                destination_entity: KubernetesDaemonSet
+                source_entity: KubernetesDeployment
+                type: KubernetesCommunicatesWith
+              - attributes: null
+                destination_entity: KubernetesDeployment
+                source_entity: KubernetesStatefulSet
+                type: KubernetesCommunicatesWith
+              - attributes: null
+                destination_entity: KubernetesStatefulSet
+                source_entity: KubernetesStatefulSet
+                type: KubernetesCommunicatesWith
+              - attributes: null
+                destination_entity: KubernetesDaemonSet
+                source_entity: KubernetesStatefulSet
+                type: KubernetesCommunicatesWith
+              - attributes: null
+                destination_entity: KubernetesDeployment
+                source_entity: KubernetesDaemonSet
+                type: KubernetesCommunicatesWith
+              - attributes: null
+                destination_entity: KubernetesStatefulSet
+                source_entity: KubernetesDaemonSet
+                type: KubernetesCommunicatesWith
+              - attributes: null
+                destination_entity: KubernetesDaemonSet
+                source_entity: KubernetesDaemonSet
+                type: KubernetesCommunicatesWith
+              - attributes: null
+                destination_entity: KubernetesDeployment
+                source_entity: KubernetesJob
+                type: KubernetesCommunicatesWith
+              - attributes: null
+                destination_entity: KubernetesStatefulSet
+                source_entity: KubernetesJob
+                type: KubernetesCommunicatesWith
+              - attributes: null
+                destination_entity: KubernetesDaemonSet
+                source_entity: KubernetesJob
+                type: KubernetesCommunicatesWith
+              - attributes: null
+                destination_entity: KubernetesDeployment
+                source_entity: KubernetesCronJob
+                type: KubernetesCommunicatesWith
+              - attributes: null
+                destination_entity: KubernetesStatefulSet
+                source_entity: KubernetesCronJob
+                type: KubernetesCommunicatesWith
+              - attributes: null
+                destination_entity: KubernetesDaemonSet
+                source_entity: KubernetesCronJob
+                type: KubernetesCommunicatesWith
+          source_prefix: source.
       exporters:
+        debug:
+          sampling_initial: 5
+          sampling_thereafter: 200
+          verbosity: detailed
         otlp:
           endpoint: ${OTEL_ENVOY_ADDRESS}
           headers:
@@ -1261,6 +1759,10 @@ Custom logs filter with old syntax:
         batch/metrics:
           send_batch_max_size: 512
           send_batch_size: 512
+          timeout: 1s
+        batch/stateevents:
+          send_batch_max_size: 1024
+          send_batch_size: 1024
           timeout: 1s
         cumulativetodelta/cadvisor:
           include:
@@ -1353,6 +1855,24 @@ Custom logs filter with old syntax:
             - type == METRIC_DATA_TYPE_HISTOGRAM and not(name == "k8s.rest_client_request_duration_seconds"
               or name == "k8s.workqueue_queue_duration_seconds" or name == "k8s.etcd_disk_wal_fsync_duration_seconds"
               or name == "k8s.etcd_disk_backend_commit_duration_seconds")
+        filter/keep-workload-service-relationships:
+          error_mode: ignore
+          metrics:
+            datapoint:
+            - datapoint.attributes["source_workload_type"] == nil or datapoint.attributes["destination_service_type"]
+              == nil or datapoint.attributes["source_workload_type"] == "" or datapoint.attributes["destination_service_type"]
+              == ""
+            metric:
+            - name != "k8s.istio_request_bytes_sum"
+        filter/keep-workload-workload-relationships:
+          error_mode: ignore
+          metrics:
+            datapoint:
+            - datapoint.attributes["source_workload_type"] == nil or datapoint.attributes["destination_workload_type"]
+              == nil or datapoint.attributes["source_workload_type"] == "" or datapoint.attributes["destination_workload_type"]
+              == ""
+            metric:
+            - name != "k8s.istio_request_bytes_sum"
         filter/logs:
           logs:
             include:
@@ -1432,6 +1952,22 @@ Custom logs filter with old syntax:
           - k8s.pod.uid
           - host.name
           - service.name
+        groupbyattrs/istio-relationships:
+          keys:
+          - sw.k8s.cluster.uid
+          - source.k8s.deployment.name
+          - source.k8s.statefulset.name
+          - source.k8s.daemonset.name
+          - source.k8s.job.name
+          - source.k8s.cronjob.name
+          - source.k8s.namespace.name
+          - dest.k8s.deployment.name
+          - dest.k8s.statefulset.name
+          - dest.k8s.daemonset.name
+          - dest.k8s.job.name
+          - dest.k8s.cronjob.name
+          - dest.k8s.namespace.name
+          - dest.k8s.service.name
         groupbyattrs/node:
           keys:
           - k8s.node.name
@@ -2112,6 +2648,33 @@ Custom logs filter with old syntax:
           - action: insert
             from_attribute: persistentvolumeclaim
             key: k8s.persistentvolumeclaim.name
+        swok8sworkloadtype/istio:
+          workload_mappings:
+          - expected_types:
+            - deployments
+            - daemonsets
+            - statefulsets
+            - jobs
+            - cronjobs
+            - pods
+            name_attr: source_workload
+            namespace_attr: source_workload_namespace
+            workload_type_attr: source_workload_type
+          - expected_types:
+            - deployments
+            - daemonsets
+            - statefulsets
+            - jobs
+            - cronjobs
+            - pods
+            name_attr: destination_workload
+            namespace_attr: destination_workload_namespace
+            workload_type_attr: destination_workload_type
+          - expected_types:
+            - services
+            name_attr: destination_service_name
+            namespace_attr: destination_service_namespace
+            workload_type_attr: destination_service_type
         transform/istio-metrics:
           metric_statements:
           - statements:
@@ -2122,6 +2685,59 @@ Custom logs filter with old syntax:
               metric.name == "k8s.istio_request_duration_milliseconds_sum"
             - set(metric.name, "k8s.istio_request_duration_milliseconds_count_temp") where
               metric.name == "k8s.istio_request_duration_milliseconds_count"
+        transform/istio-workload-service:
+          metric_statements:
+          - keep_keys(datapoint.attributes, ["source_workload", "source_workload_namespace",
+            "destination_service_name", "destination_service_namespace", "source_workload_type",
+            "destination_service_type"])
+          - set(datapoint.attributes["source.k8s.deployment.name"], datapoint.attributes["source_workload"])
+            where datapoint.attributes["source_workload_type"] == "Deployment"
+          - set(datapoint.attributes["source.k8s.statefulset.name"], datapoint.attributes["source_workload"])
+            where datapoint.attributes["source_workload_type"] == "StatefulSet"
+          - set(datapoint.attributes["source.k8s.daemonset.name"], datapoint.attributes["source_workload"])
+            where datapoint.attributes["source_workload_type"] == "DaemonSet"
+          - set(datapoint.attributes["source.k8s.job.name"], datapoint.attributes["source_workload"])
+            where datapoint.attributes["source_workload_type"] == "Job"
+          - set(datapoint.attributes["source.k8s.cronjob.name"], datapoint.attributes["source_workload"])
+            where datapoint.attributes["source_workload_type"] == "CronJob"
+          - set(datapoint.attributes["source.k8s.namespace.name"], datapoint.attributes["source_workload_namespace"])
+          - set(datapoint.attributes["dest.k8s.service.name"], datapoint.attributes["destination_service_name"])
+            where datapoint.attributes["destination_service_type"] == "Service"
+          - set(datapoint.attributes["dest.k8s.namespace.name"], datapoint.attributes["destination_service_namespace"])
+        transform/istio-workload-workload:
+          metric_statements:
+          - keep_keys(datapoint.attributes, ["source_workload", "source_workload_namespace",
+            "destination_workload", "destination_workload_namespace", "source_workload_type",
+            "destination_workload_type"])
+          - set(datapoint.attributes["source.k8s.deployment.name"], datapoint.attributes["source_workload"])
+            where datapoint.attributes["source_workload_type"] == "Deployment"
+          - set(datapoint.attributes["source.k8s.statefulset.name"], datapoint.attributes["source_workload"])
+            where datapoint.attributes["source_workload_type"] == "StatefulSet"
+          - set(datapoint.attributes["source.k8s.daemonset.name"], datapoint.attributes["source_workload"])
+            where datapoint.attributes["source_workload_type"] == "DaemonSet"
+          - set(datapoint.attributes["source.k8s.job.name"], datapoint.attributes["source_workload"])
+            where datapoint.attributes["source_workload_type"] == "Job"
+          - set(datapoint.attributes["source.k8s.cronjob.name"], datapoint.attributes["source_workload"])
+            where datapoint.attributes["source_workload_type"] == "CronJob"
+          - set(datapoint.attributes["source.k8s.namespace.name"], datapoint.attributes["source_workload_namespace"])
+          - set(datapoint.attributes["dest.k8s.deployment.name"], datapoint.attributes["destination_workload"])
+            where datapoint.attributes["destination_workload_type"] == "Deployment"
+          - set(datapoint.attributes["dest.k8s.statefulset.name"], datapoint.attributes["destination_workload"])
+            where datapoint.attributes["destination_workload_type"] == "StatefulSet"
+          - set(datapoint.attributes["dest.k8s.daemonset.name"], datapoint.attributes["destination_workload"])
+            where datapoint.attributes["destination_workload_type"] == "DaemonSet"
+          - set(datapoint.attributes["dest.k8s.job.name"], datapoint.attributes["destination_workload"])
+            where datapoint.attributes["destination_workload_type"] == "Job"
+          - set(datapoint.attributes["dest.k8s.cronjob.name"], datapoint.attributes["destination_workload"])
+            where datapoint.attributes["destination_workload_type"] == "CronJob"
+          - set(datapoint.attributes["dest.k8s.namespace.name"], datapoint.attributes["destination_workload_namespace"])
+        transform/only-relationship-resource-attributes:
+          metric_statements:
+          - keep_keys(resource.attributes, ["sw.k8s.cluster.uid", "source.k8s.deployment.name",
+            "source.k8s.statefulset.name", "source.k8s.daemonset.name", "source.k8s.job.name",
+            "source.k8s.cronjob.name", "source.k8s.namespace.name", "dest.k8s.deployment.name",
+            "dest.k8s.statefulset.name", "dest.k8s.daemonset.name", "dest.k8s.job.name",
+            "dest.k8s.cronjob.name", "dest.k8s.service.name", "dest.k8s.namespace.name"])
         transform/scope:
           log_statements:
           - statements:
@@ -2408,6 +3024,17 @@ Custom logs filter with old syntax:
             - resource/journal
             receivers:
             - journald
+          logs/stateevents:
+            exporters:
+            - otlp
+            - debug
+            processors:
+            - memory_limiter
+            - transform/scope
+            - batch/stateevents
+            receivers:
+            - solarwindsentity/istio-workload-workload
+            - solarwindsentity/istio-workload-service
           metrics:
             exporters:
             - otlp
@@ -2420,12 +3047,23 @@ Custom logs filter with old syntax:
             - batch/metrics
             receivers:
             - forward/metric-exporter
-          metrics/discovery:
+          metrics/discovery-custom:
             exporters:
             - forward/metric-exporter
             processors:
             - memory_limiter
-            - metricstransform/rename/discovery
+            - groupbyattrs/common-all
+            - resource/all
+            receivers:
+            - routing/discovered_metrics
+          metrics/discovery-istio:
+            exporters:
+            - forward/metric-exporter
+            - forward/relationship-state-events-workload-workload
+            - forward/relationship-state-events-workload-service
+            processors:
+            - memory_limiter
+            - swok8sworkloadtype/istio
             - transform/istio-metrics
             - metricstransform/istio-metrics
             - cumulativetodelta/istio-metrics
@@ -2433,6 +3071,14 @@ Custom logs filter with old syntax:
             - metricsgeneration/istio-metrics
             - groupbyattrs/common-all
             - resource/all
+            receivers:
+            - routing/discovered_metrics
+          metrics/discovery-scrape:
+            exporters:
+            - routing/discovered_metrics
+            processors:
+            - memory_limiter
+            - metricstransform/rename/discovery
             receivers:
             - receiver_creator/discovery
           metrics/node:
@@ -2458,6 +3104,28 @@ Custom logs filter with old syntax:
             - resource/all
             receivers:
             - receiver_creator/node
+          metrics/relationship-state-events-workload-service-preparation:
+            exporters:
+            - solarwindsentity/istio-workload-service
+            processors:
+            - memory_limiter
+            - filter/keep-workload-service-relationships
+            - transform/istio-workload-service
+            - groupbyattrs/istio-relationships
+            - transform/only-relationship-resource-attributes
+            receivers:
+            - forward/relationship-state-events-workload-service
+          metrics/relationship-state-events-workload-workload-preparation:
+            exporters:
+            - solarwindsentity/istio-workload-workload
+            processors:
+            - memory_limiter
+            - filter/keep-workload-workload-relationships
+            - transform/istio-workload-workload
+            - groupbyattrs/istio-relationships
+            - transform/only-relationship-resource-attributes
+            receivers:
+            - forward/relationship-state-events-workload-workload
         telemetry:
           logs:
             level: info
@@ -2474,7 +3142,171 @@ Node collector config should match snapshot when autodiscovery is disabled:
       connectors:
         forward/logs-exporter: null
         forward/metric-exporter: null
+        forward/relationship-state-events-workload-service: null
+        forward/relationship-state-events-workload-workload: null
+        routing/discovered_metrics:
+          default_pipelines:
+          - metrics/discovery-custom
+          table:
+          - condition: |
+              IsMatch(name, "k8s.istio_")
+            context: metric
+            pipelines:
+            - metrics/discovery-istio
+        solarwindsentity/istio-workload-service:
+          destination_prefix: dest.
+          schema:
+            entities:
+            - entity: KubernetesDeployment
+              id:
+              - sw.k8s.cluster.uid
+              - k8s.namespace.name
+              - k8s.deployment.name
+            - entity: KubernetesStatefulSet
+              id:
+              - sw.k8s.cluster.uid
+              - k8s.namespace.name
+              - k8s.statefulset.name
+            - entity: KubernetesDaemonSet
+              id:
+              - sw.k8s.cluster.uid
+              - k8s.namespace.name
+              - k8s.daemonset.name
+            - entity: KubernetesJob
+              id:
+              - sw.k8s.cluster.uid
+              - k8s.namespace.name
+              - k8s.job.name
+            - entity: KubernetesCronJob
+              id:
+              - sw.k8s.cluster.uid
+              - k8s.namespace.name
+              - k8s.cronjob.name
+            - entity: KubernetesService
+              id:
+              - sw.k8s.cluster.uid
+              - k8s.namespace.name
+              - k8s.service.name
+            events:
+              relationships:
+              - attributes: null
+                destination_entity: KubernetesService
+                source_entity: KubernetesDeployment
+                type: KubernetesCommunicatesWith
+              - attributes: null
+                destination_entity: KubernetesService
+                source_entity: KubernetesStatefulSet
+                type: KubernetesCommunicatesWith
+              - attributes: null
+                destination_entity: KubernetesService
+                source_entity: KubernetesDaemonSet
+                type: KubernetesCommunicatesWith
+              - attributes: null
+                destination_entity: KubernetesService
+                source_entity: KubernetesJob
+                type: KubernetesCommunicatesWith
+              - attributes: null
+                destination_entity: KubernetesService
+                source_entity: KubernetesCronJob
+                type: KubernetesCommunicatesWith
+          source_prefix: source.
+        solarwindsentity/istio-workload-workload:
+          destination_prefix: dest.
+          schema:
+            entities:
+            - entity: KubernetesDeployment
+              id:
+              - sw.k8s.cluster.uid
+              - k8s.namespace.name
+              - k8s.deployment.name
+            - entity: KubernetesStatefulSet
+              id:
+              - sw.k8s.cluster.uid
+              - k8s.namespace.name
+              - k8s.statefulset.name
+            - entity: KubernetesDaemonSet
+              id:
+              - sw.k8s.cluster.uid
+              - k8s.namespace.name
+              - k8s.daemonset.name
+            - entity: KubernetesJob
+              id:
+              - sw.k8s.cluster.uid
+              - k8s.namespace.name
+              - k8s.job.name
+            - entity: KubernetesCronJob
+              id:
+              - sw.k8s.cluster.uid
+              - k8s.namespace.name
+              - k8s.cronjob.name
+            events:
+              relationships:
+              - attributes: null
+                destination_entity: KubernetesDeployment
+                source_entity: KubernetesDeployment
+                type: KubernetesCommunicatesWith
+              - attributes: null
+                destination_entity: KubernetesStatefulSet
+                source_entity: KubernetesDeployment
+                type: KubernetesCommunicatesWith
+              - attributes: null
+                destination_entity: KubernetesDaemonSet
+                source_entity: KubernetesDeployment
+                type: KubernetesCommunicatesWith
+              - attributes: null
+                destination_entity: KubernetesDeployment
+                source_entity: KubernetesStatefulSet
+                type: KubernetesCommunicatesWith
+              - attributes: null
+                destination_entity: KubernetesStatefulSet
+                source_entity: KubernetesStatefulSet
+                type: KubernetesCommunicatesWith
+              - attributes: null
+                destination_entity: KubernetesDaemonSet
+                source_entity: KubernetesStatefulSet
+                type: KubernetesCommunicatesWith
+              - attributes: null
+                destination_entity: KubernetesDeployment
+                source_entity: KubernetesDaemonSet
+                type: KubernetesCommunicatesWith
+              - attributes: null
+                destination_entity: KubernetesStatefulSet
+                source_entity: KubernetesDaemonSet
+                type: KubernetesCommunicatesWith
+              - attributes: null
+                destination_entity: KubernetesDaemonSet
+                source_entity: KubernetesDaemonSet
+                type: KubernetesCommunicatesWith
+              - attributes: null
+                destination_entity: KubernetesDeployment
+                source_entity: KubernetesJob
+                type: KubernetesCommunicatesWith
+              - attributes: null
+                destination_entity: KubernetesStatefulSet
+                source_entity: KubernetesJob
+                type: KubernetesCommunicatesWith
+              - attributes: null
+                destination_entity: KubernetesDaemonSet
+                source_entity: KubernetesJob
+                type: KubernetesCommunicatesWith
+              - attributes: null
+                destination_entity: KubernetesDeployment
+                source_entity: KubernetesCronJob
+                type: KubernetesCommunicatesWith
+              - attributes: null
+                destination_entity: KubernetesStatefulSet
+                source_entity: KubernetesCronJob
+                type: KubernetesCommunicatesWith
+              - attributes: null
+                destination_entity: KubernetesDaemonSet
+                source_entity: KubernetesCronJob
+                type: KubernetesCommunicatesWith
+          source_prefix: source.
       exporters:
+        debug:
+          sampling_initial: 5
+          sampling_thereafter: 200
+          verbosity: detailed
         otlp:
           endpoint: ${OTEL_ENVOY_ADDRESS}
           headers:
@@ -2538,6 +3370,10 @@ Node collector config should match snapshot when autodiscovery is disabled:
         batch/metrics:
           send_batch_max_size: 512
           send_batch_size: 512
+          timeout: 1s
+        batch/stateevents:
+          send_batch_max_size: 1024
+          send_batch_size: 1024
           timeout: 1s
         cumulativetodelta/cadvisor:
           include:
@@ -2630,6 +3466,24 @@ Node collector config should match snapshot when autodiscovery is disabled:
             - type == METRIC_DATA_TYPE_HISTOGRAM and not(name == "k8s.rest_client_request_duration_seconds"
               or name == "k8s.workqueue_queue_duration_seconds" or name == "k8s.etcd_disk_wal_fsync_duration_seconds"
               or name == "k8s.etcd_disk_backend_commit_duration_seconds")
+        filter/keep-workload-service-relationships:
+          error_mode: ignore
+          metrics:
+            datapoint:
+            - datapoint.attributes["source_workload_type"] == nil or datapoint.attributes["destination_service_type"]
+              == nil or datapoint.attributes["source_workload_type"] == "" or datapoint.attributes["destination_service_type"]
+              == ""
+            metric:
+            - name != "k8s.istio_request_bytes_sum"
+        filter/keep-workload-workload-relationships:
+          error_mode: ignore
+          metrics:
+            datapoint:
+            - datapoint.attributes["source_workload_type"] == nil or datapoint.attributes["destination_workload_type"]
+              == nil or datapoint.attributes["source_workload_type"] == "" or datapoint.attributes["destination_workload_type"]
+              == ""
+            metric:
+            - name != "k8s.istio_request_bytes_sum"
         filter/receiver:
           metrics:
             metric:
@@ -2702,6 +3556,22 @@ Node collector config should match snapshot when autodiscovery is disabled:
           - k8s.pod.uid
           - host.name
           - service.name
+        groupbyattrs/istio-relationships:
+          keys:
+          - sw.k8s.cluster.uid
+          - source.k8s.deployment.name
+          - source.k8s.statefulset.name
+          - source.k8s.daemonset.name
+          - source.k8s.job.name
+          - source.k8s.cronjob.name
+          - source.k8s.namespace.name
+          - dest.k8s.deployment.name
+          - dest.k8s.statefulset.name
+          - dest.k8s.daemonset.name
+          - dest.k8s.job.name
+          - dest.k8s.cronjob.name
+          - dest.k8s.namespace.name
+          - dest.k8s.service.name
         groupbyattrs/node:
           keys:
           - k8s.node.name
@@ -3382,6 +4252,33 @@ Node collector config should match snapshot when autodiscovery is disabled:
           - action: insert
             from_attribute: persistentvolumeclaim
             key: k8s.persistentvolumeclaim.name
+        swok8sworkloadtype/istio:
+          workload_mappings:
+          - expected_types:
+            - deployments
+            - daemonsets
+            - statefulsets
+            - jobs
+            - cronjobs
+            - pods
+            name_attr: source_workload
+            namespace_attr: source_workload_namespace
+            workload_type_attr: source_workload_type
+          - expected_types:
+            - deployments
+            - daemonsets
+            - statefulsets
+            - jobs
+            - cronjobs
+            - pods
+            name_attr: destination_workload
+            namespace_attr: destination_workload_namespace
+            workload_type_attr: destination_workload_type
+          - expected_types:
+            - services
+            name_attr: destination_service_name
+            namespace_attr: destination_service_namespace
+            workload_type_attr: destination_service_type
         transform/istio-metrics:
           metric_statements:
           - statements:
@@ -3392,6 +4289,59 @@ Node collector config should match snapshot when autodiscovery is disabled:
               metric.name == "k8s.istio_request_duration_milliseconds_sum"
             - set(metric.name, "k8s.istio_request_duration_milliseconds_count_temp") where
               metric.name == "k8s.istio_request_duration_milliseconds_count"
+        transform/istio-workload-service:
+          metric_statements:
+          - keep_keys(datapoint.attributes, ["source_workload", "source_workload_namespace",
+            "destination_service_name", "destination_service_namespace", "source_workload_type",
+            "destination_service_type"])
+          - set(datapoint.attributes["source.k8s.deployment.name"], datapoint.attributes["source_workload"])
+            where datapoint.attributes["source_workload_type"] == "Deployment"
+          - set(datapoint.attributes["source.k8s.statefulset.name"], datapoint.attributes["source_workload"])
+            where datapoint.attributes["source_workload_type"] == "StatefulSet"
+          - set(datapoint.attributes["source.k8s.daemonset.name"], datapoint.attributes["source_workload"])
+            where datapoint.attributes["source_workload_type"] == "DaemonSet"
+          - set(datapoint.attributes["source.k8s.job.name"], datapoint.attributes["source_workload"])
+            where datapoint.attributes["source_workload_type"] == "Job"
+          - set(datapoint.attributes["source.k8s.cronjob.name"], datapoint.attributes["source_workload"])
+            where datapoint.attributes["source_workload_type"] == "CronJob"
+          - set(datapoint.attributes["source.k8s.namespace.name"], datapoint.attributes["source_workload_namespace"])
+          - set(datapoint.attributes["dest.k8s.service.name"], datapoint.attributes["destination_service_name"])
+            where datapoint.attributes["destination_service_type"] == "Service"
+          - set(datapoint.attributes["dest.k8s.namespace.name"], datapoint.attributes["destination_service_namespace"])
+        transform/istio-workload-workload:
+          metric_statements:
+          - keep_keys(datapoint.attributes, ["source_workload", "source_workload_namespace",
+            "destination_workload", "destination_workload_namespace", "source_workload_type",
+            "destination_workload_type"])
+          - set(datapoint.attributes["source.k8s.deployment.name"], datapoint.attributes["source_workload"])
+            where datapoint.attributes["source_workload_type"] == "Deployment"
+          - set(datapoint.attributes["source.k8s.statefulset.name"], datapoint.attributes["source_workload"])
+            where datapoint.attributes["source_workload_type"] == "StatefulSet"
+          - set(datapoint.attributes["source.k8s.daemonset.name"], datapoint.attributes["source_workload"])
+            where datapoint.attributes["source_workload_type"] == "DaemonSet"
+          - set(datapoint.attributes["source.k8s.job.name"], datapoint.attributes["source_workload"])
+            where datapoint.attributes["source_workload_type"] == "Job"
+          - set(datapoint.attributes["source.k8s.cronjob.name"], datapoint.attributes["source_workload"])
+            where datapoint.attributes["source_workload_type"] == "CronJob"
+          - set(datapoint.attributes["source.k8s.namespace.name"], datapoint.attributes["source_workload_namespace"])
+          - set(datapoint.attributes["dest.k8s.deployment.name"], datapoint.attributes["destination_workload"])
+            where datapoint.attributes["destination_workload_type"] == "Deployment"
+          - set(datapoint.attributes["dest.k8s.statefulset.name"], datapoint.attributes["destination_workload"])
+            where datapoint.attributes["destination_workload_type"] == "StatefulSet"
+          - set(datapoint.attributes["dest.k8s.daemonset.name"], datapoint.attributes["destination_workload"])
+            where datapoint.attributes["destination_workload_type"] == "DaemonSet"
+          - set(datapoint.attributes["dest.k8s.job.name"], datapoint.attributes["destination_workload"])
+            where datapoint.attributes["destination_workload_type"] == "Job"
+          - set(datapoint.attributes["dest.k8s.cronjob.name"], datapoint.attributes["destination_workload"])
+            where datapoint.attributes["destination_workload_type"] == "CronJob"
+          - set(datapoint.attributes["dest.k8s.namespace.name"], datapoint.attributes["destination_workload_namespace"])
+        transform/only-relationship-resource-attributes:
+          metric_statements:
+          - keep_keys(resource.attributes, ["sw.k8s.cluster.uid", "source.k8s.deployment.name",
+            "source.k8s.statefulset.name", "source.k8s.daemonset.name", "source.k8s.job.name",
+            "source.k8s.cronjob.name", "source.k8s.namespace.name", "dest.k8s.deployment.name",
+            "dest.k8s.statefulset.name", "dest.k8s.daemonset.name", "dest.k8s.job.name",
+            "dest.k8s.cronjob.name", "dest.k8s.service.name", "dest.k8s.namespace.name"])
         transform/scope:
           log_statements:
           - statements:
@@ -3554,6 +4504,17 @@ Node collector config should match snapshot when autodiscovery is disabled:
             - resource/journal
             receivers:
             - journald
+          logs/stateevents:
+            exporters:
+            - otlp
+            - debug
+            processors:
+            - memory_limiter
+            - transform/scope
+            - batch/stateevents
+            receivers:
+            - solarwindsentity/istio-workload-workload
+            - solarwindsentity/istio-workload-service
           metrics:
             exporters:
             - otlp
@@ -3566,12 +4527,23 @@ Node collector config should match snapshot when autodiscovery is disabled:
             - batch/metrics
             receivers:
             - forward/metric-exporter
-          metrics/discovery:
+          metrics/discovery-custom:
             exporters:
             - forward/metric-exporter
             processors:
             - memory_limiter
-            - metricstransform/rename/discovery
+            - groupbyattrs/common-all
+            - resource/all
+            receivers:
+            - routing/discovered_metrics
+          metrics/discovery-istio:
+            exporters:
+            - forward/metric-exporter
+            - forward/relationship-state-events-workload-workload
+            - forward/relationship-state-events-workload-service
+            processors:
+            - memory_limiter
+            - swok8sworkloadtype/istio
             - transform/istio-metrics
             - metricstransform/istio-metrics
             - cumulativetodelta/istio-metrics
@@ -3579,6 +4551,14 @@ Node collector config should match snapshot when autodiscovery is disabled:
             - metricsgeneration/istio-metrics
             - groupbyattrs/common-all
             - resource/all
+            receivers:
+            - routing/discovered_metrics
+          metrics/discovery-scrape:
+            exporters:
+            - routing/discovered_metrics
+            processors:
+            - memory_limiter
+            - metricstransform/rename/discovery
             receivers:
             - receiver_creator/discovery
           metrics/node:
@@ -3604,6 +4584,28 @@ Node collector config should match snapshot when autodiscovery is disabled:
             - resource/all
             receivers:
             - receiver_creator/node
+          metrics/relationship-state-events-workload-service-preparation:
+            exporters:
+            - solarwindsentity/istio-workload-service
+            processors:
+            - memory_limiter
+            - filter/keep-workload-service-relationships
+            - transform/istio-workload-service
+            - groupbyattrs/istio-relationships
+            - transform/only-relationship-resource-attributes
+            receivers:
+            - forward/relationship-state-events-workload-service
+          metrics/relationship-state-events-workload-workload-preparation:
+            exporters:
+            - solarwindsentity/istio-workload-workload
+            processors:
+            - memory_limiter
+            - filter/keep-workload-workload-relationships
+            - transform/istio-workload-workload
+            - groupbyattrs/istio-relationships
+            - transform/only-relationship-resource-attributes
+            receivers:
+            - forward/relationship-state-events-workload-workload
         telemetry:
           logs:
             level: info
@@ -3620,7 +4622,171 @@ Node collector config should match snapshot when fargate is enabled:
       connectors:
         forward/logs-exporter: null
         forward/metric-exporter: null
+        forward/relationship-state-events-workload-service: null
+        forward/relationship-state-events-workload-workload: null
+        routing/discovered_metrics:
+          default_pipelines:
+          - metrics/discovery-custom
+          table:
+          - condition: |
+              IsMatch(name, "k8s.istio_")
+            context: metric
+            pipelines:
+            - metrics/discovery-istio
+        solarwindsentity/istio-workload-service:
+          destination_prefix: dest.
+          schema:
+            entities:
+            - entity: KubernetesDeployment
+              id:
+              - sw.k8s.cluster.uid
+              - k8s.namespace.name
+              - k8s.deployment.name
+            - entity: KubernetesStatefulSet
+              id:
+              - sw.k8s.cluster.uid
+              - k8s.namespace.name
+              - k8s.statefulset.name
+            - entity: KubernetesDaemonSet
+              id:
+              - sw.k8s.cluster.uid
+              - k8s.namespace.name
+              - k8s.daemonset.name
+            - entity: KubernetesJob
+              id:
+              - sw.k8s.cluster.uid
+              - k8s.namespace.name
+              - k8s.job.name
+            - entity: KubernetesCronJob
+              id:
+              - sw.k8s.cluster.uid
+              - k8s.namespace.name
+              - k8s.cronjob.name
+            - entity: KubernetesService
+              id:
+              - sw.k8s.cluster.uid
+              - k8s.namespace.name
+              - k8s.service.name
+            events:
+              relationships:
+              - attributes: null
+                destination_entity: KubernetesService
+                source_entity: KubernetesDeployment
+                type: KubernetesCommunicatesWith
+              - attributes: null
+                destination_entity: KubernetesService
+                source_entity: KubernetesStatefulSet
+                type: KubernetesCommunicatesWith
+              - attributes: null
+                destination_entity: KubernetesService
+                source_entity: KubernetesDaemonSet
+                type: KubernetesCommunicatesWith
+              - attributes: null
+                destination_entity: KubernetesService
+                source_entity: KubernetesJob
+                type: KubernetesCommunicatesWith
+              - attributes: null
+                destination_entity: KubernetesService
+                source_entity: KubernetesCronJob
+                type: KubernetesCommunicatesWith
+          source_prefix: source.
+        solarwindsentity/istio-workload-workload:
+          destination_prefix: dest.
+          schema:
+            entities:
+            - entity: KubernetesDeployment
+              id:
+              - sw.k8s.cluster.uid
+              - k8s.namespace.name
+              - k8s.deployment.name
+            - entity: KubernetesStatefulSet
+              id:
+              - sw.k8s.cluster.uid
+              - k8s.namespace.name
+              - k8s.statefulset.name
+            - entity: KubernetesDaemonSet
+              id:
+              - sw.k8s.cluster.uid
+              - k8s.namespace.name
+              - k8s.daemonset.name
+            - entity: KubernetesJob
+              id:
+              - sw.k8s.cluster.uid
+              - k8s.namespace.name
+              - k8s.job.name
+            - entity: KubernetesCronJob
+              id:
+              - sw.k8s.cluster.uid
+              - k8s.namespace.name
+              - k8s.cronjob.name
+            events:
+              relationships:
+              - attributes: null
+                destination_entity: KubernetesDeployment
+                source_entity: KubernetesDeployment
+                type: KubernetesCommunicatesWith
+              - attributes: null
+                destination_entity: KubernetesStatefulSet
+                source_entity: KubernetesDeployment
+                type: KubernetesCommunicatesWith
+              - attributes: null
+                destination_entity: KubernetesDaemonSet
+                source_entity: KubernetesDeployment
+                type: KubernetesCommunicatesWith
+              - attributes: null
+                destination_entity: KubernetesDeployment
+                source_entity: KubernetesStatefulSet
+                type: KubernetesCommunicatesWith
+              - attributes: null
+                destination_entity: KubernetesStatefulSet
+                source_entity: KubernetesStatefulSet
+                type: KubernetesCommunicatesWith
+              - attributes: null
+                destination_entity: KubernetesDaemonSet
+                source_entity: KubernetesStatefulSet
+                type: KubernetesCommunicatesWith
+              - attributes: null
+                destination_entity: KubernetesDeployment
+                source_entity: KubernetesDaemonSet
+                type: KubernetesCommunicatesWith
+              - attributes: null
+                destination_entity: KubernetesStatefulSet
+                source_entity: KubernetesDaemonSet
+                type: KubernetesCommunicatesWith
+              - attributes: null
+                destination_entity: KubernetesDaemonSet
+                source_entity: KubernetesDaemonSet
+                type: KubernetesCommunicatesWith
+              - attributes: null
+                destination_entity: KubernetesDeployment
+                source_entity: KubernetesJob
+                type: KubernetesCommunicatesWith
+              - attributes: null
+                destination_entity: KubernetesStatefulSet
+                source_entity: KubernetesJob
+                type: KubernetesCommunicatesWith
+              - attributes: null
+                destination_entity: KubernetesDaemonSet
+                source_entity: KubernetesJob
+                type: KubernetesCommunicatesWith
+              - attributes: null
+                destination_entity: KubernetesDeployment
+                source_entity: KubernetesCronJob
+                type: KubernetesCommunicatesWith
+              - attributes: null
+                destination_entity: KubernetesStatefulSet
+                source_entity: KubernetesCronJob
+                type: KubernetesCommunicatesWith
+              - attributes: null
+                destination_entity: KubernetesDaemonSet
+                source_entity: KubernetesCronJob
+                type: KubernetesCommunicatesWith
+          source_prefix: source.
       exporters:
+        debug:
+          sampling_initial: 5
+          sampling_thereafter: 200
+          verbosity: detailed
         otlp:
           endpoint: ${OTEL_ENVOY_ADDRESS}
           headers:
@@ -3681,6 +4847,10 @@ Node collector config should match snapshot when fargate is enabled:
         batch/metrics:
           send_batch_max_size: 512
           send_batch_size: 512
+          timeout: 1s
+        batch/stateevents:
+          send_batch_max_size: 1024
+          send_batch_size: 1024
           timeout: 1s
         cumulativetodelta/cadvisor:
           include:
@@ -3773,6 +4943,24 @@ Node collector config should match snapshot when fargate is enabled:
             - type == METRIC_DATA_TYPE_HISTOGRAM and not(name == "k8s.rest_client_request_duration_seconds"
               or name == "k8s.workqueue_queue_duration_seconds" or name == "k8s.etcd_disk_wal_fsync_duration_seconds"
               or name == "k8s.etcd_disk_backend_commit_duration_seconds")
+        filter/keep-workload-service-relationships:
+          error_mode: ignore
+          metrics:
+            datapoint:
+            - datapoint.attributes["source_workload_type"] == nil or datapoint.attributes["destination_service_type"]
+              == nil or datapoint.attributes["source_workload_type"] == "" or datapoint.attributes["destination_service_type"]
+              == ""
+            metric:
+            - name != "k8s.istio_request_bytes_sum"
+        filter/keep-workload-workload-relationships:
+          error_mode: ignore
+          metrics:
+            datapoint:
+            - datapoint.attributes["source_workload_type"] == nil or datapoint.attributes["destination_workload_type"]
+              == nil or datapoint.attributes["source_workload_type"] == "" or datapoint.attributes["destination_workload_type"]
+              == ""
+            metric:
+            - name != "k8s.istio_request_bytes_sum"
         filter/receiver:
           metrics:
             metric:
@@ -3845,6 +5033,22 @@ Node collector config should match snapshot when fargate is enabled:
           - k8s.pod.uid
           - host.name
           - service.name
+        groupbyattrs/istio-relationships:
+          keys:
+          - sw.k8s.cluster.uid
+          - source.k8s.deployment.name
+          - source.k8s.statefulset.name
+          - source.k8s.daemonset.name
+          - source.k8s.job.name
+          - source.k8s.cronjob.name
+          - source.k8s.namespace.name
+          - dest.k8s.deployment.name
+          - dest.k8s.statefulset.name
+          - dest.k8s.daemonset.name
+          - dest.k8s.job.name
+          - dest.k8s.cronjob.name
+          - dest.k8s.namespace.name
+          - dest.k8s.service.name
         groupbyattrs/node:
           keys:
           - k8s.node.name
@@ -4525,6 +5729,33 @@ Node collector config should match snapshot when fargate is enabled:
           - action: insert
             from_attribute: persistentvolumeclaim
             key: k8s.persistentvolumeclaim.name
+        swok8sworkloadtype/istio:
+          workload_mappings:
+          - expected_types:
+            - deployments
+            - daemonsets
+            - statefulsets
+            - jobs
+            - cronjobs
+            - pods
+            name_attr: source_workload
+            namespace_attr: source_workload_namespace
+            workload_type_attr: source_workload_type
+          - expected_types:
+            - deployments
+            - daemonsets
+            - statefulsets
+            - jobs
+            - cronjobs
+            - pods
+            name_attr: destination_workload
+            namespace_attr: destination_workload_namespace
+            workload_type_attr: destination_workload_type
+          - expected_types:
+            - services
+            name_attr: destination_service_name
+            namespace_attr: destination_service_namespace
+            workload_type_attr: destination_service_type
         transform/istio-metrics:
           metric_statements:
           - statements:
@@ -4535,6 +5766,59 @@ Node collector config should match snapshot when fargate is enabled:
               metric.name == "k8s.istio_request_duration_milliseconds_sum"
             - set(metric.name, "k8s.istio_request_duration_milliseconds_count_temp") where
               metric.name == "k8s.istio_request_duration_milliseconds_count"
+        transform/istio-workload-service:
+          metric_statements:
+          - keep_keys(datapoint.attributes, ["source_workload", "source_workload_namespace",
+            "destination_service_name", "destination_service_namespace", "source_workload_type",
+            "destination_service_type"])
+          - set(datapoint.attributes["source.k8s.deployment.name"], datapoint.attributes["source_workload"])
+            where datapoint.attributes["source_workload_type"] == "Deployment"
+          - set(datapoint.attributes["source.k8s.statefulset.name"], datapoint.attributes["source_workload"])
+            where datapoint.attributes["source_workload_type"] == "StatefulSet"
+          - set(datapoint.attributes["source.k8s.daemonset.name"], datapoint.attributes["source_workload"])
+            where datapoint.attributes["source_workload_type"] == "DaemonSet"
+          - set(datapoint.attributes["source.k8s.job.name"], datapoint.attributes["source_workload"])
+            where datapoint.attributes["source_workload_type"] == "Job"
+          - set(datapoint.attributes["source.k8s.cronjob.name"], datapoint.attributes["source_workload"])
+            where datapoint.attributes["source_workload_type"] == "CronJob"
+          - set(datapoint.attributes["source.k8s.namespace.name"], datapoint.attributes["source_workload_namespace"])
+          - set(datapoint.attributes["dest.k8s.service.name"], datapoint.attributes["destination_service_name"])
+            where datapoint.attributes["destination_service_type"] == "Service"
+          - set(datapoint.attributes["dest.k8s.namespace.name"], datapoint.attributes["destination_service_namespace"])
+        transform/istio-workload-workload:
+          metric_statements:
+          - keep_keys(datapoint.attributes, ["source_workload", "source_workload_namespace",
+            "destination_workload", "destination_workload_namespace", "source_workload_type",
+            "destination_workload_type"])
+          - set(datapoint.attributes["source.k8s.deployment.name"], datapoint.attributes["source_workload"])
+            where datapoint.attributes["source_workload_type"] == "Deployment"
+          - set(datapoint.attributes["source.k8s.statefulset.name"], datapoint.attributes["source_workload"])
+            where datapoint.attributes["source_workload_type"] == "StatefulSet"
+          - set(datapoint.attributes["source.k8s.daemonset.name"], datapoint.attributes["source_workload"])
+            where datapoint.attributes["source_workload_type"] == "DaemonSet"
+          - set(datapoint.attributes["source.k8s.job.name"], datapoint.attributes["source_workload"])
+            where datapoint.attributes["source_workload_type"] == "Job"
+          - set(datapoint.attributes["source.k8s.cronjob.name"], datapoint.attributes["source_workload"])
+            where datapoint.attributes["source_workload_type"] == "CronJob"
+          - set(datapoint.attributes["source.k8s.namespace.name"], datapoint.attributes["source_workload_namespace"])
+          - set(datapoint.attributes["dest.k8s.deployment.name"], datapoint.attributes["destination_workload"])
+            where datapoint.attributes["destination_workload_type"] == "Deployment"
+          - set(datapoint.attributes["dest.k8s.statefulset.name"], datapoint.attributes["destination_workload"])
+            where datapoint.attributes["destination_workload_type"] == "StatefulSet"
+          - set(datapoint.attributes["dest.k8s.daemonset.name"], datapoint.attributes["destination_workload"])
+            where datapoint.attributes["destination_workload_type"] == "DaemonSet"
+          - set(datapoint.attributes["dest.k8s.job.name"], datapoint.attributes["destination_workload"])
+            where datapoint.attributes["destination_workload_type"] == "Job"
+          - set(datapoint.attributes["dest.k8s.cronjob.name"], datapoint.attributes["destination_workload"])
+            where datapoint.attributes["destination_workload_type"] == "CronJob"
+          - set(datapoint.attributes["dest.k8s.namespace.name"], datapoint.attributes["destination_workload_namespace"])
+        transform/only-relationship-resource-attributes:
+          metric_statements:
+          - keep_keys(resource.attributes, ["sw.k8s.cluster.uid", "source.k8s.deployment.name",
+            "source.k8s.statefulset.name", "source.k8s.daemonset.name", "source.k8s.job.name",
+            "source.k8s.cronjob.name", "source.k8s.namespace.name", "dest.k8s.deployment.name",
+            "dest.k8s.statefulset.name", "dest.k8s.daemonset.name", "dest.k8s.job.name",
+            "dest.k8s.cronjob.name", "dest.k8s.service.name", "dest.k8s.namespace.name"])
         transform/scope:
           log_statements:
           - statements:
@@ -4702,6 +5986,17 @@ Node collector config should match snapshot when fargate is enabled:
             - resource/journal
             receivers:
             - journald
+          logs/stateevents:
+            exporters:
+            - otlp
+            - debug
+            processors:
+            - memory_limiter
+            - transform/scope
+            - batch/stateevents
+            receivers:
+            - solarwindsentity/istio-workload-workload
+            - solarwindsentity/istio-workload-service
           metrics:
             exporters:
             - otlp
@@ -4714,12 +6009,23 @@ Node collector config should match snapshot when fargate is enabled:
             - batch/metrics
             receivers:
             - forward/metric-exporter
-          metrics/discovery:
+          metrics/discovery-custom:
             exporters:
             - forward/metric-exporter
             processors:
             - memory_limiter
-            - metricstransform/rename/discovery
+            - groupbyattrs/common-all
+            - resource/all
+            receivers:
+            - routing/discovered_metrics
+          metrics/discovery-istio:
+            exporters:
+            - forward/metric-exporter
+            - forward/relationship-state-events-workload-workload
+            - forward/relationship-state-events-workload-service
+            processors:
+            - memory_limiter
+            - swok8sworkloadtype/istio
             - transform/istio-metrics
             - metricstransform/istio-metrics
             - cumulativetodelta/istio-metrics
@@ -4728,7 +6034,37 @@ Node collector config should match snapshot when fargate is enabled:
             - groupbyattrs/common-all
             - resource/all
             receivers:
+            - routing/discovered_metrics
+          metrics/discovery-scrape:
+            exporters:
+            - routing/discovered_metrics
+            processors:
+            - memory_limiter
+            - metricstransform/rename/discovery
+            receivers:
             - receiver_creator/discovery
+          metrics/relationship-state-events-workload-service-preparation:
+            exporters:
+            - solarwindsentity/istio-workload-service
+            processors:
+            - memory_limiter
+            - filter/keep-workload-service-relationships
+            - transform/istio-workload-service
+            - groupbyattrs/istio-relationships
+            - transform/only-relationship-resource-attributes
+            receivers:
+            - forward/relationship-state-events-workload-service
+          metrics/relationship-state-events-workload-workload-preparation:
+            exporters:
+            - solarwindsentity/istio-workload-workload
+            processors:
+            - memory_limiter
+            - filter/keep-workload-workload-relationships
+            - transform/istio-workload-workload
+            - groupbyattrs/istio-relationships
+            - transform/only-relationship-resource-attributes
+            receivers:
+            - forward/relationship-state-events-workload-workload
         telemetry:
           logs:
             level: info
@@ -4744,7 +6080,171 @@ Node collector config should match snapshot when fargate is enabled and autodisc
     logs.config: |
       connectors:
         forward/logs-exporter: null
+        forward/relationship-state-events-workload-service: null
+        forward/relationship-state-events-workload-workload: null
+        routing/discovered_metrics:
+          default_pipelines:
+          - metrics/discovery-custom
+          table:
+          - condition: |
+              IsMatch(name, "k8s.istio_")
+            context: metric
+            pipelines:
+            - metrics/discovery-istio
+        solarwindsentity/istio-workload-service:
+          destination_prefix: dest.
+          schema:
+            entities:
+            - entity: KubernetesDeployment
+              id:
+              - sw.k8s.cluster.uid
+              - k8s.namespace.name
+              - k8s.deployment.name
+            - entity: KubernetesStatefulSet
+              id:
+              - sw.k8s.cluster.uid
+              - k8s.namespace.name
+              - k8s.statefulset.name
+            - entity: KubernetesDaemonSet
+              id:
+              - sw.k8s.cluster.uid
+              - k8s.namespace.name
+              - k8s.daemonset.name
+            - entity: KubernetesJob
+              id:
+              - sw.k8s.cluster.uid
+              - k8s.namespace.name
+              - k8s.job.name
+            - entity: KubernetesCronJob
+              id:
+              - sw.k8s.cluster.uid
+              - k8s.namespace.name
+              - k8s.cronjob.name
+            - entity: KubernetesService
+              id:
+              - sw.k8s.cluster.uid
+              - k8s.namespace.name
+              - k8s.service.name
+            events:
+              relationships:
+              - attributes: null
+                destination_entity: KubernetesService
+                source_entity: KubernetesDeployment
+                type: KubernetesCommunicatesWith
+              - attributes: null
+                destination_entity: KubernetesService
+                source_entity: KubernetesStatefulSet
+                type: KubernetesCommunicatesWith
+              - attributes: null
+                destination_entity: KubernetesService
+                source_entity: KubernetesDaemonSet
+                type: KubernetesCommunicatesWith
+              - attributes: null
+                destination_entity: KubernetesService
+                source_entity: KubernetesJob
+                type: KubernetesCommunicatesWith
+              - attributes: null
+                destination_entity: KubernetesService
+                source_entity: KubernetesCronJob
+                type: KubernetesCommunicatesWith
+          source_prefix: source.
+        solarwindsentity/istio-workload-workload:
+          destination_prefix: dest.
+          schema:
+            entities:
+            - entity: KubernetesDeployment
+              id:
+              - sw.k8s.cluster.uid
+              - k8s.namespace.name
+              - k8s.deployment.name
+            - entity: KubernetesStatefulSet
+              id:
+              - sw.k8s.cluster.uid
+              - k8s.namespace.name
+              - k8s.statefulset.name
+            - entity: KubernetesDaemonSet
+              id:
+              - sw.k8s.cluster.uid
+              - k8s.namespace.name
+              - k8s.daemonset.name
+            - entity: KubernetesJob
+              id:
+              - sw.k8s.cluster.uid
+              - k8s.namespace.name
+              - k8s.job.name
+            - entity: KubernetesCronJob
+              id:
+              - sw.k8s.cluster.uid
+              - k8s.namespace.name
+              - k8s.cronjob.name
+            events:
+              relationships:
+              - attributes: null
+                destination_entity: KubernetesDeployment
+                source_entity: KubernetesDeployment
+                type: KubernetesCommunicatesWith
+              - attributes: null
+                destination_entity: KubernetesStatefulSet
+                source_entity: KubernetesDeployment
+                type: KubernetesCommunicatesWith
+              - attributes: null
+                destination_entity: KubernetesDaemonSet
+                source_entity: KubernetesDeployment
+                type: KubernetesCommunicatesWith
+              - attributes: null
+                destination_entity: KubernetesDeployment
+                source_entity: KubernetesStatefulSet
+                type: KubernetesCommunicatesWith
+              - attributes: null
+                destination_entity: KubernetesStatefulSet
+                source_entity: KubernetesStatefulSet
+                type: KubernetesCommunicatesWith
+              - attributes: null
+                destination_entity: KubernetesDaemonSet
+                source_entity: KubernetesStatefulSet
+                type: KubernetesCommunicatesWith
+              - attributes: null
+                destination_entity: KubernetesDeployment
+                source_entity: KubernetesDaemonSet
+                type: KubernetesCommunicatesWith
+              - attributes: null
+                destination_entity: KubernetesStatefulSet
+                source_entity: KubernetesDaemonSet
+                type: KubernetesCommunicatesWith
+              - attributes: null
+                destination_entity: KubernetesDaemonSet
+                source_entity: KubernetesDaemonSet
+                type: KubernetesCommunicatesWith
+              - attributes: null
+                destination_entity: KubernetesDeployment
+                source_entity: KubernetesJob
+                type: KubernetesCommunicatesWith
+              - attributes: null
+                destination_entity: KubernetesStatefulSet
+                source_entity: KubernetesJob
+                type: KubernetesCommunicatesWith
+              - attributes: null
+                destination_entity: KubernetesDaemonSet
+                source_entity: KubernetesJob
+                type: KubernetesCommunicatesWith
+              - attributes: null
+                destination_entity: KubernetesDeployment
+                source_entity: KubernetesCronJob
+                type: KubernetesCommunicatesWith
+              - attributes: null
+                destination_entity: KubernetesStatefulSet
+                source_entity: KubernetesCronJob
+                type: KubernetesCommunicatesWith
+              - attributes: null
+                destination_entity: KubernetesDaemonSet
+                source_entity: KubernetesCronJob
+                type: KubernetesCommunicatesWith
+          source_prefix: source.
       exporters:
+        debug:
+          sampling_initial: 5
+          sampling_thereafter: 200
+          verbosity: detailed
         otlp:
           endpoint: ${OTEL_ENVOY_ADDRESS}
           headers:
@@ -4800,6 +6300,10 @@ Node collector config should match snapshot when fargate is enabled and autodisc
         batch/metrics:
           send_batch_max_size: 512
           send_batch_size: 512
+          timeout: 1s
+        batch/stateevents:
+          send_batch_max_size: 1024
+          send_batch_size: 1024
           timeout: 1s
         cumulativetodelta/cadvisor:
           include:
@@ -4892,6 +6396,24 @@ Node collector config should match snapshot when fargate is enabled and autodisc
             - type == METRIC_DATA_TYPE_HISTOGRAM and not(name == "k8s.rest_client_request_duration_seconds"
               or name == "k8s.workqueue_queue_duration_seconds" or name == "k8s.etcd_disk_wal_fsync_duration_seconds"
               or name == "k8s.etcd_disk_backend_commit_duration_seconds")
+        filter/keep-workload-service-relationships:
+          error_mode: ignore
+          metrics:
+            datapoint:
+            - datapoint.attributes["source_workload_type"] == nil or datapoint.attributes["destination_service_type"]
+              == nil or datapoint.attributes["source_workload_type"] == "" or datapoint.attributes["destination_service_type"]
+              == ""
+            metric:
+            - name != "k8s.istio_request_bytes_sum"
+        filter/keep-workload-workload-relationships:
+          error_mode: ignore
+          metrics:
+            datapoint:
+            - datapoint.attributes["source_workload_type"] == nil or datapoint.attributes["destination_workload_type"]
+              == nil or datapoint.attributes["source_workload_type"] == "" or datapoint.attributes["destination_workload_type"]
+              == ""
+            metric:
+            - name != "k8s.istio_request_bytes_sum"
         filter/receiver:
           metrics:
             metric:
@@ -4964,6 +6486,22 @@ Node collector config should match snapshot when fargate is enabled and autodisc
           - k8s.pod.uid
           - host.name
           - service.name
+        groupbyattrs/istio-relationships:
+          keys:
+          - sw.k8s.cluster.uid
+          - source.k8s.deployment.name
+          - source.k8s.statefulset.name
+          - source.k8s.daemonset.name
+          - source.k8s.job.name
+          - source.k8s.cronjob.name
+          - source.k8s.namespace.name
+          - dest.k8s.deployment.name
+          - dest.k8s.statefulset.name
+          - dest.k8s.daemonset.name
+          - dest.k8s.job.name
+          - dest.k8s.cronjob.name
+          - dest.k8s.namespace.name
+          - dest.k8s.service.name
         groupbyattrs/node:
           keys:
           - k8s.node.name
@@ -5644,6 +7182,33 @@ Node collector config should match snapshot when fargate is enabled and autodisc
           - action: insert
             from_attribute: persistentvolumeclaim
             key: k8s.persistentvolumeclaim.name
+        swok8sworkloadtype/istio:
+          workload_mappings:
+          - expected_types:
+            - deployments
+            - daemonsets
+            - statefulsets
+            - jobs
+            - cronjobs
+            - pods
+            name_attr: source_workload
+            namespace_attr: source_workload_namespace
+            workload_type_attr: source_workload_type
+          - expected_types:
+            - deployments
+            - daemonsets
+            - statefulsets
+            - jobs
+            - cronjobs
+            - pods
+            name_attr: destination_workload
+            namespace_attr: destination_workload_namespace
+            workload_type_attr: destination_workload_type
+          - expected_types:
+            - services
+            name_attr: destination_service_name
+            namespace_attr: destination_service_namespace
+            workload_type_attr: destination_service_type
         transform/istio-metrics:
           metric_statements:
           - statements:
@@ -5654,6 +7219,59 @@ Node collector config should match snapshot when fargate is enabled and autodisc
               metric.name == "k8s.istio_request_duration_milliseconds_sum"
             - set(metric.name, "k8s.istio_request_duration_milliseconds_count_temp") where
               metric.name == "k8s.istio_request_duration_milliseconds_count"
+        transform/istio-workload-service:
+          metric_statements:
+          - keep_keys(datapoint.attributes, ["source_workload", "source_workload_namespace",
+            "destination_service_name", "destination_service_namespace", "source_workload_type",
+            "destination_service_type"])
+          - set(datapoint.attributes["source.k8s.deployment.name"], datapoint.attributes["source_workload"])
+            where datapoint.attributes["source_workload_type"] == "Deployment"
+          - set(datapoint.attributes["source.k8s.statefulset.name"], datapoint.attributes["source_workload"])
+            where datapoint.attributes["source_workload_type"] == "StatefulSet"
+          - set(datapoint.attributes["source.k8s.daemonset.name"], datapoint.attributes["source_workload"])
+            where datapoint.attributes["source_workload_type"] == "DaemonSet"
+          - set(datapoint.attributes["source.k8s.job.name"], datapoint.attributes["source_workload"])
+            where datapoint.attributes["source_workload_type"] == "Job"
+          - set(datapoint.attributes["source.k8s.cronjob.name"], datapoint.attributes["source_workload"])
+            where datapoint.attributes["source_workload_type"] == "CronJob"
+          - set(datapoint.attributes["source.k8s.namespace.name"], datapoint.attributes["source_workload_namespace"])
+          - set(datapoint.attributes["dest.k8s.service.name"], datapoint.attributes["destination_service_name"])
+            where datapoint.attributes["destination_service_type"] == "Service"
+          - set(datapoint.attributes["dest.k8s.namespace.name"], datapoint.attributes["destination_service_namespace"])
+        transform/istio-workload-workload:
+          metric_statements:
+          - keep_keys(datapoint.attributes, ["source_workload", "source_workload_namespace",
+            "destination_workload", "destination_workload_namespace", "source_workload_type",
+            "destination_workload_type"])
+          - set(datapoint.attributes["source.k8s.deployment.name"], datapoint.attributes["source_workload"])
+            where datapoint.attributes["source_workload_type"] == "Deployment"
+          - set(datapoint.attributes["source.k8s.statefulset.name"], datapoint.attributes["source_workload"])
+            where datapoint.attributes["source_workload_type"] == "StatefulSet"
+          - set(datapoint.attributes["source.k8s.daemonset.name"], datapoint.attributes["source_workload"])
+            where datapoint.attributes["source_workload_type"] == "DaemonSet"
+          - set(datapoint.attributes["source.k8s.job.name"], datapoint.attributes["source_workload"])
+            where datapoint.attributes["source_workload_type"] == "Job"
+          - set(datapoint.attributes["source.k8s.cronjob.name"], datapoint.attributes["source_workload"])
+            where datapoint.attributes["source_workload_type"] == "CronJob"
+          - set(datapoint.attributes["source.k8s.namespace.name"], datapoint.attributes["source_workload_namespace"])
+          - set(datapoint.attributes["dest.k8s.deployment.name"], datapoint.attributes["destination_workload"])
+            where datapoint.attributes["destination_workload_type"] == "Deployment"
+          - set(datapoint.attributes["dest.k8s.statefulset.name"], datapoint.attributes["destination_workload"])
+            where datapoint.attributes["destination_workload_type"] == "StatefulSet"
+          - set(datapoint.attributes["dest.k8s.daemonset.name"], datapoint.attributes["destination_workload"])
+            where datapoint.attributes["destination_workload_type"] == "DaemonSet"
+          - set(datapoint.attributes["dest.k8s.job.name"], datapoint.attributes["destination_workload"])
+            where datapoint.attributes["destination_workload_type"] == "Job"
+          - set(datapoint.attributes["dest.k8s.cronjob.name"], datapoint.attributes["destination_workload"])
+            where datapoint.attributes["destination_workload_type"] == "CronJob"
+          - set(datapoint.attributes["dest.k8s.namespace.name"], datapoint.attributes["destination_workload_namespace"])
+        transform/only-relationship-resource-attributes:
+          metric_statements:
+          - keep_keys(resource.attributes, ["sw.k8s.cluster.uid", "source.k8s.deployment.name",
+            "source.k8s.statefulset.name", "source.k8s.daemonset.name", "source.k8s.job.name",
+            "source.k8s.cronjob.name", "source.k8s.namespace.name", "dest.k8s.deployment.name",
+            "dest.k8s.statefulset.name", "dest.k8s.daemonset.name", "dest.k8s.job.name",
+            "dest.k8s.cronjob.name", "dest.k8s.service.name", "dest.k8s.namespace.name"])
         transform/scope:
           log_statements:
           - statements:
@@ -5778,12 +7396,34 @@ Node collector config should match snapshot when fargate is enabled and autodisc
             - resource/journal
             receivers:
             - journald
-          metrics/discovery:
+          logs/stateevents:
+            exporters:
+            - otlp
+            - debug
+            processors:
+            - memory_limiter
+            - transform/scope
+            - batch/stateevents
+            receivers:
+            - solarwindsentity/istio-workload-workload
+            - solarwindsentity/istio-workload-service
+          metrics/discovery-custom:
             exporters:
             - forward/metric-exporter
             processors:
             - memory_limiter
-            - metricstransform/rename/discovery
+            - groupbyattrs/common-all
+            - resource/all
+            receivers:
+            - routing/discovered_metrics
+          metrics/discovery-istio:
+            exporters:
+            - forward/metric-exporter
+            - forward/relationship-state-events-workload-workload
+            - forward/relationship-state-events-workload-service
+            processors:
+            - memory_limiter
+            - swok8sworkloadtype/istio
             - transform/istio-metrics
             - metricstransform/istio-metrics
             - cumulativetodelta/istio-metrics
@@ -5792,7 +7432,37 @@ Node collector config should match snapshot when fargate is enabled and autodisc
             - groupbyattrs/common-all
             - resource/all
             receivers:
+            - routing/discovered_metrics
+          metrics/discovery-scrape:
+            exporters:
+            - routing/discovered_metrics
+            processors:
+            - memory_limiter
+            - metricstransform/rename/discovery
+            receivers:
             - receiver_creator/discovery
+          metrics/relationship-state-events-workload-service-preparation:
+            exporters:
+            - solarwindsentity/istio-workload-service
+            processors:
+            - memory_limiter
+            - filter/keep-workload-service-relationships
+            - transform/istio-workload-service
+            - groupbyattrs/istio-relationships
+            - transform/only-relationship-resource-attributes
+            receivers:
+            - forward/relationship-state-events-workload-service
+          metrics/relationship-state-events-workload-workload-preparation:
+            exporters:
+            - solarwindsentity/istio-workload-workload
+            processors:
+            - memory_limiter
+            - filter/keep-workload-workload-relationships
+            - transform/istio-workload-workload
+            - groupbyattrs/istio-relationships
+            - transform/only-relationship-resource-attributes
+            receivers:
+            - forward/relationship-state-events-workload-workload
         telemetry:
           logs:
             level: info
@@ -5809,7 +7479,171 @@ Node collector config should match snapshot when using default values:
       connectors:
         forward/logs-exporter: null
         forward/metric-exporter: null
+        forward/relationship-state-events-workload-service: null
+        forward/relationship-state-events-workload-workload: null
+        routing/discovered_metrics:
+          default_pipelines:
+          - metrics/discovery-custom
+          table:
+          - condition: |
+              IsMatch(name, "k8s.istio_")
+            context: metric
+            pipelines:
+            - metrics/discovery-istio
+        solarwindsentity/istio-workload-service:
+          destination_prefix: dest.
+          schema:
+            entities:
+            - entity: KubernetesDeployment
+              id:
+              - sw.k8s.cluster.uid
+              - k8s.namespace.name
+              - k8s.deployment.name
+            - entity: KubernetesStatefulSet
+              id:
+              - sw.k8s.cluster.uid
+              - k8s.namespace.name
+              - k8s.statefulset.name
+            - entity: KubernetesDaemonSet
+              id:
+              - sw.k8s.cluster.uid
+              - k8s.namespace.name
+              - k8s.daemonset.name
+            - entity: KubernetesJob
+              id:
+              - sw.k8s.cluster.uid
+              - k8s.namespace.name
+              - k8s.job.name
+            - entity: KubernetesCronJob
+              id:
+              - sw.k8s.cluster.uid
+              - k8s.namespace.name
+              - k8s.cronjob.name
+            - entity: KubernetesService
+              id:
+              - sw.k8s.cluster.uid
+              - k8s.namespace.name
+              - k8s.service.name
+            events:
+              relationships:
+              - attributes: null
+                destination_entity: KubernetesService
+                source_entity: KubernetesDeployment
+                type: KubernetesCommunicatesWith
+              - attributes: null
+                destination_entity: KubernetesService
+                source_entity: KubernetesStatefulSet
+                type: KubernetesCommunicatesWith
+              - attributes: null
+                destination_entity: KubernetesService
+                source_entity: KubernetesDaemonSet
+                type: KubernetesCommunicatesWith
+              - attributes: null
+                destination_entity: KubernetesService
+                source_entity: KubernetesJob
+                type: KubernetesCommunicatesWith
+              - attributes: null
+                destination_entity: KubernetesService
+                source_entity: KubernetesCronJob
+                type: KubernetesCommunicatesWith
+          source_prefix: source.
+        solarwindsentity/istio-workload-workload:
+          destination_prefix: dest.
+          schema:
+            entities:
+            - entity: KubernetesDeployment
+              id:
+              - sw.k8s.cluster.uid
+              - k8s.namespace.name
+              - k8s.deployment.name
+            - entity: KubernetesStatefulSet
+              id:
+              - sw.k8s.cluster.uid
+              - k8s.namespace.name
+              - k8s.statefulset.name
+            - entity: KubernetesDaemonSet
+              id:
+              - sw.k8s.cluster.uid
+              - k8s.namespace.name
+              - k8s.daemonset.name
+            - entity: KubernetesJob
+              id:
+              - sw.k8s.cluster.uid
+              - k8s.namespace.name
+              - k8s.job.name
+            - entity: KubernetesCronJob
+              id:
+              - sw.k8s.cluster.uid
+              - k8s.namespace.name
+              - k8s.cronjob.name
+            events:
+              relationships:
+              - attributes: null
+                destination_entity: KubernetesDeployment
+                source_entity: KubernetesDeployment
+                type: KubernetesCommunicatesWith
+              - attributes: null
+                destination_entity: KubernetesStatefulSet
+                source_entity: KubernetesDeployment
+                type: KubernetesCommunicatesWith
+              - attributes: null
+                destination_entity: KubernetesDaemonSet
+                source_entity: KubernetesDeployment
+                type: KubernetesCommunicatesWith
+              - attributes: null
+                destination_entity: KubernetesDeployment
+                source_entity: KubernetesStatefulSet
+                type: KubernetesCommunicatesWith
+              - attributes: null
+                destination_entity: KubernetesStatefulSet
+                source_entity: KubernetesStatefulSet
+                type: KubernetesCommunicatesWith
+              - attributes: null
+                destination_entity: KubernetesDaemonSet
+                source_entity: KubernetesStatefulSet
+                type: KubernetesCommunicatesWith
+              - attributes: null
+                destination_entity: KubernetesDeployment
+                source_entity: KubernetesDaemonSet
+                type: KubernetesCommunicatesWith
+              - attributes: null
+                destination_entity: KubernetesStatefulSet
+                source_entity: KubernetesDaemonSet
+                type: KubernetesCommunicatesWith
+              - attributes: null
+                destination_entity: KubernetesDaemonSet
+                source_entity: KubernetesDaemonSet
+                type: KubernetesCommunicatesWith
+              - attributes: null
+                destination_entity: KubernetesDeployment
+                source_entity: KubernetesJob
+                type: KubernetesCommunicatesWith
+              - attributes: null
+                destination_entity: KubernetesStatefulSet
+                source_entity: KubernetesJob
+                type: KubernetesCommunicatesWith
+              - attributes: null
+                destination_entity: KubernetesDaemonSet
+                source_entity: KubernetesJob
+                type: KubernetesCommunicatesWith
+              - attributes: null
+                destination_entity: KubernetesDeployment
+                source_entity: KubernetesCronJob
+                type: KubernetesCommunicatesWith
+              - attributes: null
+                destination_entity: KubernetesStatefulSet
+                source_entity: KubernetesCronJob
+                type: KubernetesCommunicatesWith
+              - attributes: null
+                destination_entity: KubernetesDaemonSet
+                source_entity: KubernetesCronJob
+                type: KubernetesCommunicatesWith
+          source_prefix: source.
       exporters:
+        debug:
+          sampling_initial: 5
+          sampling_thereafter: 200
+          verbosity: detailed
         otlp:
           endpoint: ${OTEL_ENVOY_ADDRESS}
           headers:
@@ -5873,6 +7707,10 @@ Node collector config should match snapshot when using default values:
         batch/metrics:
           send_batch_max_size: 512
           send_batch_size: 512
+          timeout: 1s
+        batch/stateevents:
+          send_batch_max_size: 1024
+          send_batch_size: 1024
           timeout: 1s
         cumulativetodelta/cadvisor:
           include:
@@ -5965,6 +7803,24 @@ Node collector config should match snapshot when using default values:
             - type == METRIC_DATA_TYPE_HISTOGRAM and not(name == "k8s.rest_client_request_duration_seconds"
               or name == "k8s.workqueue_queue_duration_seconds" or name == "k8s.etcd_disk_wal_fsync_duration_seconds"
               or name == "k8s.etcd_disk_backend_commit_duration_seconds")
+        filter/keep-workload-service-relationships:
+          error_mode: ignore
+          metrics:
+            datapoint:
+            - datapoint.attributes["source_workload_type"] == nil or datapoint.attributes["destination_service_type"]
+              == nil or datapoint.attributes["source_workload_type"] == "" or datapoint.attributes["destination_service_type"]
+              == ""
+            metric:
+            - name != "k8s.istio_request_bytes_sum"
+        filter/keep-workload-workload-relationships:
+          error_mode: ignore
+          metrics:
+            datapoint:
+            - datapoint.attributes["source_workload_type"] == nil or datapoint.attributes["destination_workload_type"]
+              == nil or datapoint.attributes["source_workload_type"] == "" or datapoint.attributes["destination_workload_type"]
+              == ""
+            metric:
+            - name != "k8s.istio_request_bytes_sum"
         filter/receiver:
           metrics:
             metric:
@@ -6037,6 +7893,22 @@ Node collector config should match snapshot when using default values:
           - k8s.pod.uid
           - host.name
           - service.name
+        groupbyattrs/istio-relationships:
+          keys:
+          - sw.k8s.cluster.uid
+          - source.k8s.deployment.name
+          - source.k8s.statefulset.name
+          - source.k8s.daemonset.name
+          - source.k8s.job.name
+          - source.k8s.cronjob.name
+          - source.k8s.namespace.name
+          - dest.k8s.deployment.name
+          - dest.k8s.statefulset.name
+          - dest.k8s.daemonset.name
+          - dest.k8s.job.name
+          - dest.k8s.cronjob.name
+          - dest.k8s.namespace.name
+          - dest.k8s.service.name
         groupbyattrs/node:
           keys:
           - k8s.node.name
@@ -6717,6 +8589,33 @@ Node collector config should match snapshot when using default values:
           - action: insert
             from_attribute: persistentvolumeclaim
             key: k8s.persistentvolumeclaim.name
+        swok8sworkloadtype/istio:
+          workload_mappings:
+          - expected_types:
+            - deployments
+            - daemonsets
+            - statefulsets
+            - jobs
+            - cronjobs
+            - pods
+            name_attr: source_workload
+            namespace_attr: source_workload_namespace
+            workload_type_attr: source_workload_type
+          - expected_types:
+            - deployments
+            - daemonsets
+            - statefulsets
+            - jobs
+            - cronjobs
+            - pods
+            name_attr: destination_workload
+            namespace_attr: destination_workload_namespace
+            workload_type_attr: destination_workload_type
+          - expected_types:
+            - services
+            name_attr: destination_service_name
+            namespace_attr: destination_service_namespace
+            workload_type_attr: destination_service_type
         transform/istio-metrics:
           metric_statements:
           - statements:
@@ -6727,6 +8626,59 @@ Node collector config should match snapshot when using default values:
               metric.name == "k8s.istio_request_duration_milliseconds_sum"
             - set(metric.name, "k8s.istio_request_duration_milliseconds_count_temp") where
               metric.name == "k8s.istio_request_duration_milliseconds_count"
+        transform/istio-workload-service:
+          metric_statements:
+          - keep_keys(datapoint.attributes, ["source_workload", "source_workload_namespace",
+            "destination_service_name", "destination_service_namespace", "source_workload_type",
+            "destination_service_type"])
+          - set(datapoint.attributes["source.k8s.deployment.name"], datapoint.attributes["source_workload"])
+            where datapoint.attributes["source_workload_type"] == "Deployment"
+          - set(datapoint.attributes["source.k8s.statefulset.name"], datapoint.attributes["source_workload"])
+            where datapoint.attributes["source_workload_type"] == "StatefulSet"
+          - set(datapoint.attributes["source.k8s.daemonset.name"], datapoint.attributes["source_workload"])
+            where datapoint.attributes["source_workload_type"] == "DaemonSet"
+          - set(datapoint.attributes["source.k8s.job.name"], datapoint.attributes["source_workload"])
+            where datapoint.attributes["source_workload_type"] == "Job"
+          - set(datapoint.attributes["source.k8s.cronjob.name"], datapoint.attributes["source_workload"])
+            where datapoint.attributes["source_workload_type"] == "CronJob"
+          - set(datapoint.attributes["source.k8s.namespace.name"], datapoint.attributes["source_workload_namespace"])
+          - set(datapoint.attributes["dest.k8s.service.name"], datapoint.attributes["destination_service_name"])
+            where datapoint.attributes["destination_service_type"] == "Service"
+          - set(datapoint.attributes["dest.k8s.namespace.name"], datapoint.attributes["destination_service_namespace"])
+        transform/istio-workload-workload:
+          metric_statements:
+          - keep_keys(datapoint.attributes, ["source_workload", "source_workload_namespace",
+            "destination_workload", "destination_workload_namespace", "source_workload_type",
+            "destination_workload_type"])
+          - set(datapoint.attributes["source.k8s.deployment.name"], datapoint.attributes["source_workload"])
+            where datapoint.attributes["source_workload_type"] == "Deployment"
+          - set(datapoint.attributes["source.k8s.statefulset.name"], datapoint.attributes["source_workload"])
+            where datapoint.attributes["source_workload_type"] == "StatefulSet"
+          - set(datapoint.attributes["source.k8s.daemonset.name"], datapoint.attributes["source_workload"])
+            where datapoint.attributes["source_workload_type"] == "DaemonSet"
+          - set(datapoint.attributes["source.k8s.job.name"], datapoint.attributes["source_workload"])
+            where datapoint.attributes["source_workload_type"] == "Job"
+          - set(datapoint.attributes["source.k8s.cronjob.name"], datapoint.attributes["source_workload"])
+            where datapoint.attributes["source_workload_type"] == "CronJob"
+          - set(datapoint.attributes["source.k8s.namespace.name"], datapoint.attributes["source_workload_namespace"])
+          - set(datapoint.attributes["dest.k8s.deployment.name"], datapoint.attributes["destination_workload"])
+            where datapoint.attributes["destination_workload_type"] == "Deployment"
+          - set(datapoint.attributes["dest.k8s.statefulset.name"], datapoint.attributes["destination_workload"])
+            where datapoint.attributes["destination_workload_type"] == "StatefulSet"
+          - set(datapoint.attributes["dest.k8s.daemonset.name"], datapoint.attributes["destination_workload"])
+            where datapoint.attributes["destination_workload_type"] == "DaemonSet"
+          - set(datapoint.attributes["dest.k8s.job.name"], datapoint.attributes["destination_workload"])
+            where datapoint.attributes["destination_workload_type"] == "Job"
+          - set(datapoint.attributes["dest.k8s.cronjob.name"], datapoint.attributes["destination_workload"])
+            where datapoint.attributes["destination_workload_type"] == "CronJob"
+          - set(datapoint.attributes["dest.k8s.namespace.name"], datapoint.attributes["destination_workload_namespace"])
+        transform/only-relationship-resource-attributes:
+          metric_statements:
+          - keep_keys(resource.attributes, ["sw.k8s.cluster.uid", "source.k8s.deployment.name",
+            "source.k8s.statefulset.name", "source.k8s.daemonset.name", "source.k8s.job.name",
+            "source.k8s.cronjob.name", "source.k8s.namespace.name", "dest.k8s.deployment.name",
+            "dest.k8s.statefulset.name", "dest.k8s.daemonset.name", "dest.k8s.job.name",
+            "dest.k8s.cronjob.name", "dest.k8s.service.name", "dest.k8s.namespace.name"])
         transform/scope:
           log_statements:
           - statements:
@@ -6931,6 +8883,17 @@ Node collector config should match snapshot when using default values:
             - resource/journal
             receivers:
             - journald
+          logs/stateevents:
+            exporters:
+            - otlp
+            - debug
+            processors:
+            - memory_limiter
+            - transform/scope
+            - batch/stateevents
+            receivers:
+            - solarwindsentity/istio-workload-workload
+            - solarwindsentity/istio-workload-service
           metrics:
             exporters:
             - otlp
@@ -6943,12 +8906,23 @@ Node collector config should match snapshot when using default values:
             - batch/metrics
             receivers:
             - forward/metric-exporter
-          metrics/discovery:
+          metrics/discovery-custom:
             exporters:
             - forward/metric-exporter
             processors:
             - memory_limiter
-            - metricstransform/rename/discovery
+            - groupbyattrs/common-all
+            - resource/all
+            receivers:
+            - routing/discovered_metrics
+          metrics/discovery-istio:
+            exporters:
+            - forward/metric-exporter
+            - forward/relationship-state-events-workload-workload
+            - forward/relationship-state-events-workload-service
+            processors:
+            - memory_limiter
+            - swok8sworkloadtype/istio
             - transform/istio-metrics
             - metricstransform/istio-metrics
             - cumulativetodelta/istio-metrics
@@ -6956,6 +8930,14 @@ Node collector config should match snapshot when using default values:
             - metricsgeneration/istio-metrics
             - groupbyattrs/common-all
             - resource/all
+            receivers:
+            - routing/discovered_metrics
+          metrics/discovery-scrape:
+            exporters:
+            - routing/discovered_metrics
+            processors:
+            - memory_limiter
+            - metricstransform/rename/discovery
             receivers:
             - receiver_creator/discovery
           metrics/node:
@@ -6981,6 +8963,28 @@ Node collector config should match snapshot when using default values:
             - resource/all
             receivers:
             - receiver_creator/node
+          metrics/relationship-state-events-workload-service-preparation:
+            exporters:
+            - solarwindsentity/istio-workload-service
+            processors:
+            - memory_limiter
+            - filter/keep-workload-service-relationships
+            - transform/istio-workload-service
+            - groupbyattrs/istio-relationships
+            - transform/only-relationship-resource-attributes
+            receivers:
+            - forward/relationship-state-events-workload-service
+          metrics/relationship-state-events-workload-workload-preparation:
+            exporters:
+            - solarwindsentity/istio-workload-workload
+            processors:
+            - memory_limiter
+            - filter/keep-workload-workload-relationships
+            - transform/istio-workload-workload
+            - groupbyattrs/istio-relationships
+            - transform/only-relationship-resource-attributes
+            receivers:
+            - forward/relationship-state-events-workload-workload
         telemetry:
           logs:
             level: info

--- a/doc/collectorPipeline.md
+++ b/doc/collectorPipeline.md
@@ -62,21 +62,60 @@ stateDiagram-v2
 
   metricsDiscoveryDeployment: MetricsDiscovery Deployment
   state metricsDiscoveryDeployment {
-    md_metricsDiscoveryPipeline: 'metrics/discovery' pipeline
-    state md_metricsDiscoveryPipeline {
+    md_metricsDiscoveryScrapePipeline: 'metrics/discovery-scrape' pipeline
+    state md_metricsDiscoveryScrapePipeline {
       md_r1: 'receiver_creator/discovery' receiver
-      md_e1: 'forward/metric-exporter' connector
+      md_e1: 'routing/discovered_metrics' connector
       md_r1 --> md_e1 : processors
     }
 
-    md_metricsPipeline: 'metrics' pipeline
-    state md_metricsPipeline {
-      md_r2: 'forward/metric-exporter' connector
-      md_e2: 'otlp' exporter
-      md_r2 --> md_e2 : processors
+    md_metricsDiscoveryIstioPipeline: 'metrics/discovery-istio' pipeline
+    state md_metricsDiscoveryIstioPipeline {
+      md_r2: 'routing/discovered_metrics' connector
+      md_e2a: 'forward/metric-exporter' connector
+      md_e2b: 'forward/relationship-state-events-workload-workload' connector
+      md_e2c: 'forward/relationship-state-events-workload-service' connector
+      md_r2 --> md_e2a : processors
+      md_r2 --> md_e2b : processors
+      md_r2 --> md_e2c : processors
     }
 
-    md_metricsDiscoveryPipeline --> md_metricsPipeline
+    md_metricsRelationshipWorkloadPipeline: 'metrics/relationship-state-events-workload-workload-preparation' pipeline
+    state md_metricsRelationshipWorkloadPipeline {
+      md_r3: 'forward/relationship-state-events-workload-workload' connector
+      md_e3: 'solarwindsentity/istio-workload-workload' connector
+      md_r3 --> md_e3 : processors
+    }
+
+    md_metricsRelationshipServicePipeline: 'metrics/relationship-state-events-workload-service-preparation' pipeline
+    state md_metricsRelationshipServicePipeline {
+      md_r4: 'forward/relationship-state-events-workload-service' connector
+      md_e4: 'solarwindsentity/istio-workload-service' connector
+      md_r4 --> md_e4 : processors
+    }
+
+    md_logsStateEventsPipeline: 'logs/stateevents' pipeline
+    state md_logsStateEventsPipeline {
+      md_r5a: 'solarwindsentity/istio-workload-workload' connector
+      md_r5b: 'solarwindsentity/istio-workload-service' connector
+      md_e5: 'otlp' exporter
+      md_r5a --> md_e5 : processors
+      md_r5b --> md_e5 : processors
+    }
+
+    md_metricsDiscoveryCustomPipeline: 'metrics/discovery-custom' pipeline
+    state md_metricsDiscoveryCustomPipeline {
+      md_r6: 'routing/discovered_metrics' connector
+      md_e6: 'otlp' exporter
+      md_r6 --> md_e6 : processors
+    }
+
+    md_metricsDiscoveryScrapePipeline --> md_metricsDiscoveryCustomPipeline
+    md_metricsDiscoveryScrapePipeline --> md_metricsDiscoveryIstioPipeline
+    md_metricsDiscoveryIstioPipeline --> md_metricsRelationshipWorkloadPipeline
+    md_metricsDiscoveryIstioPipeline --> md_metricsRelationshipServicePipeline
+    md_metricsRelationshipWorkloadPipeline --> md_logsStateEventsPipeline
+    md_metricsRelationshipServicePipeline --> md_logsStateEventsPipeline
   }
 
   eventsCollectorDeployment: EventsCollector Deployment
@@ -161,26 +200,158 @@ stateDiagram-v2
       nc_r4 --> nc_e4 : processors
     }
 
-    nc_metricsDiscoveryPipeline: 'metrics/discovery' pipeline
-    state nc_metricsDiscoveryPipeline {
+    nc_metricsDiscoveryScrapePipeline: 'metrics/discovery-scrape' pipeline
+    state nc_metricsDiscoveryScrapePipeline {
       nc_r5: 'receiver_creator/discovery' receiver
-      nc_e5: 'forward/metric-exporter' connector
+      nc_e5: 'routing/discovered_metrics' connector
       nc_r5 --> nc_e5 : processors
+    }
+
+    nc_metricsDiscoveryIstioPipeline: 'metrics/discovery-istio' pipeline
+    state nc_metricsDiscoveryIstioPipeline {
+      nc_r6: 'routing/discovered_metrics' connector
+      nc_e6a: 'forward/metric-exporter' connector
+      nc_e6b: 'forward/relationship-state-events-workload-workload' connector
+      nc_e6c: 'forward/relationship-state-events-workload-service' connector
+      nc_r6 --> nc_e6a : processors
+      nc_r6 --> nc_e6b : processors
+      nc_r6 --> nc_e6c : processors
+    }
+
+    nc_metricsRelationshipWorkloadPipeline: 'metrics/relationship-state-events-workload-workload-preparation' pipeline
+    state nc_metricsRelationshipWorkloadPipeline {
+      nc_r7: 'forward/relationship-state-events-workload-workload' connector
+      nc_e7: 'solarwindsentity/istio-workload-workload' connector
+      nc_r7 --> nc_e7 : processors
+    }
+
+    nc_metricsRelationshipServicePipeline: 'metrics/relationship-state-events-workload-service-preparation' pipeline
+    state nc_metricsRelationshipServicePipeline {
+      nc_r8: 'forward/relationship-state-events-workload-service' connector
+      nc_e8: 'solarwindsentity/istio-workload-service' connector
+      nc_r8 --> nc_e8 : processors
+    }
+
+    nc_logsStateEventsPipeline: 'logs/stateevents' pipeline
+    state nc_logsStateEventsPipeline {
+      nc_r9a: 'solarwindsentity/istio-workload-workload' connector
+      nc_r9b: 'solarwindsentity/istio-workload-service' connector
+      nc_e9: 'otlp' exporter
+      nc_r9a --> nc_e9 : processors
+      nc_r9b --> nc_e9 : processors
+    }
+
+    nc_metricsDiscoveryCustomPipeline: 'metrics/discovery-custom' pipeline
+    state nc_metricsDiscoveryCustomPipeline {
+      nc_r10: 'routing/discovered_metrics' connector
+      nc_e10: 'forward/metric-exporter' connector
+      nc_r10 --> nc_e10 : processors
     }
 
     nc_metricsNodePipeline: 'metrics/node' pipeline
     state nc_metricsNodePipeline {
-      nc_r6: 'receiver_creator/node' receiver
-      nc_e6: 'forward/metric-exporter' connector
-      nc_r6 --> nc_e6 : processors
+      nc_r11: 'receiver_creator/node' receiver
+      nc_e11: 'forward/metric-exporter' connector
+      nc_r11 --> nc_e11 : processors
     }
 
     nc_logsContainerPipeline --> nc_logsPipeline
     nc_logsJournalPipeline --> nc_logsPipeline
 
-    nc_metricsDiscoveryPipeline --> nc_metricsPipeline
+    nc_metricsDiscoveryScrapePipeline --> nc_metricsDiscoveryCustomPipeline
+    nc_metricsDiscoveryScrapePipeline --> nc_metricsDiscoveryIstioPipeline
+    nc_metricsDiscoveryIstioPipeline --> nc_metricsRelationshipWorkloadPipeline
+    nc_metricsDiscoveryIstioPipeline --> nc_metricsRelationshipServicePipeline
+    nc_metricsRelationshipWorkloadPipeline --> nc_logsStateEventsPipeline
+    nc_metricsRelationshipServicePipeline --> nc_logsStateEventsPipeline
+    
+    nc_metricsDiscoveryCustomPipeline --> nc_metricsPipeline
     nc_metricsNodePipeline --> nc_metricsPipeline
 
   }
 
+  metricsDiscoveryDeployment: MetricsDiscovery Deployment
+  state metricsDiscoveryDeployment {
+    md_metricsDiscoveryScrapePipeline: 'metrics/discovery-scrape' pipeline
+    state md_metricsDiscoveryScrapePipeline {
+      md_r1: 'receiver_creator/discovery' receiver
+      md_e1: 'routing/discovered_metrics' connector
+      md_r1 --> md_e1 : processors
+    }
+
+    md_metricsDiscoveryIstioPipeline: 'metrics/discovery-istio' pipeline
+    state md_metricsDiscoveryIstioPipeline {
+      md_r2: 'routing/discovered_metrics' connector
+      md_e2a: 'forward/metric-exporter' connector
+      md_e2b: 'forward/relationship-state-events-workload-workload' connector
+      md_e2c: 'forward/relationship-state-events-workload-service' connector
+      md_r2 --> md_e2a : processors
+      md_r2 --> md_e2b : processors
+      md_r2 --> md_e2c : processors
+    }
+
+    md_metricsRelationshipWorkloadPipeline: 'metrics/relationship-state-events-workload-workload-preparation' pipeline
+    state md_metricsRelationshipWorkloadPipeline {
+      md_r3: 'forward/relationship-state-events-workload-workload' connector
+      md_e3: 'solarwindsentity/istio-workload-workload' connector
+      md_r3 --> md_e3 : processors
+    }
+
+    md_metricsRelationshipServicePipeline: 'metrics/relationship-state-events-workload-service-preparation' pipeline
+    state md_metricsRelationshipServicePipeline {
+      md_r4: 'forward/relationship-state-events-workload-service' connector
+      md_e4: 'solarwindsentity/istio-workload-service' connector
+      md_r4 --> md_e4 : processors
+    }
+
+    md_logsStateEventsPipeline: 'logs/stateevents' pipeline
+    state md_logsStateEventsPipeline {
+      md_r5a: 'solarwindsentity/istio-workload-workload' connector
+      md_r5b: 'solarwindsentity/istio-workload-service' connector
+      md_e5: 'otlp' exporter
+      md_r5a --> md_e5 : processors
+      md_r5b --> md_e5 : processors
+    }
+
+    md_metricsDiscoveryCustomPipeline: 'metrics/discovery-custom' pipeline
+    state md_metricsDiscoveryCustomPipeline {
+      md_r6: 'routing/discovered_metrics' connector
+      md_e6: 'otlp' exporter
+      md_r6 --> md_e6 : processors
+    }
+
+    md_metricsDiscoveryScrapePipeline --> md_metricsDiscoveryCustomPipeline
+    md_metricsDiscoveryScrapePipeline --> md_metricsDiscoveryIstioPipeline
+    md_metricsDiscoveryIstioPipeline --> md_metricsRelationshipWorkloadPipeline
+    md_metricsDiscoveryIstioPipeline --> md_metricsRelationshipServicePipeline
+    md_metricsRelationshipWorkloadPipeline --> md_logsStateEventsPipeline
+    md_metricsRelationshipServicePipeline --> md_logsStateEventsPipeline
+  }
+
+  gatewayCollectorDeployment: Gateway Collector Deployment
+  state gatewayCollectorDeployment {
+    gw_metricsPipeline: 'metrics' pipeline
+    state gw_metricsPipeline {
+      gw_mr: 'otlp' receiver
+      gw_me: 'otlp' exporter
+      gw_mr --> gw_me : processors
+    }
+    
+    gw_logsPipeline: 'logs' pipeline
+    state gw_logsPipeline {
+      gw_lr: 'otlp' receiver
+      gw_le: 'otlp' exporter
+      gw_lr --> gw_le : processors
+    }
+
+    gw_tracesPipeline: 'traces' pipeline
+    state gw_tracesPipeline {
+      gw_tr: 'otlp' receiver
+      gw_te: 'otlp' exporter
+      gw_tr --> gw_te : processors
+    }
+  }
+
+  beylaComponent: Beyla Auto-Instrumentation
+  beylaComponent --> gatewayCollectorDeployment : traces/metrics
 ```


### PR DESCRIPTION
I added several pipelines to Node Collector, Metrics Discovery Collector and Discovery Collector (see `_common-discovery-config.tpl` for definitions):

* metrics/discovery-custom
* metrics/discovery-scrape (this replaces previous metrics/discovery)
* metrics/discovery-istio
* metrics/relationship-state-events-workload-workload-preparation
* metrics/relationship-state-events-workload-service-preparation
* logs/stateevents

This uses [solarwindsentityconnector](https://github.com/solarwinds/solarwinds-otel-collector-contrib/tree/main/connector/solarwindsentityconnector)

as the results there should be stream of relationship state events sent based on `istio_request_bytes_sum` metric, which should produce following relationships:
* Workload -> Workload
* Workload -> Service