### PR TITLE
NH-108743: Configuring relabel config of prometheus reciever to set `service.name`

### DIFF
--- a/deploy/helm/metrics-discovery-config.yaml
+++ b/deploy/helm/metrics-discovery-config.yaml
@@ -186,6 +186,7 @@ receivers:
                 metrics_path: '`"prometheus.io/path" in annotations ? annotations["prometheus.io/path"] : "/metrics"`'
                 honor_timestamps: false
                 honor_labels: true
+{{ include "common.prometheus.relabelconfigs" . | indent 16 }}
                 static_configs:
                   - targets:
                       - '`endpoint`:`"prometheus.io/port" in annotations ? annotations["prometheus.io/port"] : 9090`'
@@ -213,6 +214,7 @@ receivers:
                   insecure_skip_verify: true
                 follow_redirects: true
                 enable_http2: true
+{{ include "common.prometheus.relabelconfigs" . | indent 16 }}
                 static_configs:
                   - targets:
                       - '`endpoint`:`"prometheus.io/port" in annotations ? annotations["prometheus.io/port"] : 9090`'

--- a/deploy/helm/node-collector-config.yaml
+++ b/deploy/helm/node-collector-config.yaml
@@ -580,6 +580,7 @@ receivers:
                 metrics_path: '`"prometheus.io/path" in annotations ? annotations["prometheus.io/path"] : "/metrics"`'
                 honor_timestamps: false
                 honor_labels: true
+{{ include "common.prometheus.relabelconfigs" . | indent 16 }}
                 static_configs:
                   - targets:
                       - '`endpoint`:`"prometheus.io/port" in annotations ? annotations["prometheus.io/port"] : 9090`'
@@ -607,6 +608,7 @@ receivers:
                   insecure_skip_verify: true
                 follow_redirects: true
                 enable_http2: true
+{{ include "common.prometheus.relabelconfigs" . | indent 16 }}
                 static_configs:
                   - targets:
                       - '`endpoint`:`"prometheus.io/port" in annotations ? annotations["prometheus.io/port"] : 9090`'
@@ -626,6 +628,7 @@ receivers:
                 metrics_path: {{ $rule.metrics_path | default "/metrics" | quote }}
                 honor_timestamps: false
                 honor_labels: true
+{{ include "common.prometheus.relabelconfigs" . | indent 16 }}
                 static_configs:
                   - targets:
                     - '`endpoint`:{{ $rule.endpoint_port | default "9090" }}'
@@ -656,6 +659,7 @@ receivers:
                 follow_redirects: true
                 enable_http2: true
                 {{- end }}
+{{ include "common.prometheus.relabelconfigs" . | indent 16 }}
                 static_configs:
                   - targets:
                       - '`endpoint`:{{ .Values.otel.metrics.control_plane.controller_manager.port }}'
@@ -683,6 +687,7 @@ receivers:
                 follow_redirects: true
                 enable_http2: true
                 {{- end }}
+{{ include "common.prometheus.relabelconfigs" . | indent 16 }}
                 static_configs:
                   - targets:
                       - '`endpoint`:{{ .Values.otel.metrics.control_plane.etcd.port }}'
@@ -710,6 +715,7 @@ receivers:
                   ca_file: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
                   insecure_skip_verify: true
                 bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
+{{ include "common.prometheus.relabelconfigs" . | indent 16 }}
                 static_configs:
                   - targets:
                       - '`endpoint`:`kubelet_endpoint_port`'
@@ -724,6 +730,7 @@ receivers:
                   ca_file: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
                   insecure_skip_verify: true
                 bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
+{{ include "common.prometheus.relabelconfigs" . | indent 16 }}
                 static_configs:
                   - targets:
                       - '`endpoint`:`kubelet_endpoint_port`'

--- a/deploy/helm/templates/_helpers.tpl
+++ b/deploy/helm/templates/_helpers.tpl
@@ -377,3 +377,14 @@ Usage:
 - not({{ $joinedConditions }}) 
 {{- end -}}
 {{- end -}}
+
+{{- define "common.prometheus.relabelconfigs" -}}
+metric_relabel_configs:
+  - source_labels: [service_name]
+    regex: (.+)
+    target_label: job
+    replacement: $1
+    action: replace
+  - regex: ^service_name$
+    action: labeldrop
+{{- end -}}

--- a/deploy/helm/templates/operator/discovery-collector.yaml
+++ b/deploy/helm/templates/operator/discovery-collector.yaml
@@ -195,6 +195,7 @@ spec:
           scrape_configs:
             - job_name: 'otel-collector'
               scrape_interval: {{ quote .Values.otel.metrics.prometheus.scrape_interval }}
+{{ include "common.prometheus.relabelconfigs" . | indent 14 }}
               static_configs:
               - targets: [ '0.0.0.0:8888' ]
     

--- a/deploy/helm/tests/__snapshot__/discovery-collector_test.yaml.snap
+++ b/deploy/helm/tests/__snapshot__/discovery-collector_test.yaml.snap
@@ -193,6 +193,15 @@ Discovery collector spec should match snapshot when using default values:
           config:
             scrape_configs:
               - job_name: otel-collector
+                metric_relabel_configs:
+                  - action: replace
+                    regex: (.+)
+                    replacement: $1
+                    source_labels:
+                      - service_name
+                    target_label: job
+                  - action: labeldrop
+                    regex: ^service_name$
                 scrape_interval: 60s
                 static_configs:
                   - targets:

--- a/deploy/helm/tests/__snapshot__/metrics-discovery-config-map_test.yaml.snap
+++ b/deploy/helm/tests/__snapshot__/metrics-discovery-config-map_test.yaml.snap
@@ -106,6 +106,15 @@ Metrics discovery config should match snapshot when Fargate is enabled:
                   - honor_labels: true
                     honor_timestamps: false
                     job_name: pod
+                    metric_relabel_configs:
+                    - action: replace
+                      regex: (.+)
+                      replacement: $1
+                      source_labels:
+                      - service_name
+                      target_label: job
+                    - action: labeldrop
+                      regex: ^service_name$
                     metrics_path: '`"prometheus.io/path" in annotations ? annotations["prometheus.io/path"]
                       : "/metrics"`'
                     scheme: http
@@ -128,6 +137,15 @@ Metrics discovery config should match snapshot when Fargate is enabled:
                     honor_labels: true
                     honor_timestamps: false
                     job_name: pod
+                    metric_relabel_configs:
+                    - action: replace
+                      regex: (.+)
+                      replacement: $1
+                      source_labels:
+                      - service_name
+                      target_label: job
+                    - action: labeldrop
+                      regex: ^service_name$
                     metrics_path: '`"prometheus.io/path" in annotations ? annotations["prometheus.io/path"]
                       : "/metrics"`'
                     scheme: https

--- a/deploy/helm/tests/__snapshot__/node-collector-config-map-windows_test.yaml.snap
+++ b/deploy/helm/tests/__snapshot__/node-collector-config-map-windows_test.yaml.snap
@@ -959,6 +959,15 @@ Node collector config for windows nodes should match snapshot when using default
                     honor_labels: true
                     honor_timestamps: false
                     job_name: kubernetes-controller-manager
+                    metric_relabel_configs:
+                    - action: replace
+                      regex: (.+)
+                      replacement: $1
+                      source_labels:
+                      - service_name
+                      target_label: job
+                    - action: labeldrop
+                      regex: ^service_name$
                     metrics_path: /metrics
                     scheme: https
                     scrape_interval: 60s
@@ -976,6 +985,15 @@ Node collector config for windows nodes should match snapshot when using default
                   - honor_labels: true
                     honor_timestamps: false
                     job_name: pod
+                    metric_relabel_configs:
+                    - action: replace
+                      regex: (.+)
+                      replacement: $1
+                      source_labels:
+                      - service_name
+                      target_label: job
+                    - action: labeldrop
+                      regex: ^service_name$
                     metrics_path: '`"prometheus.io/path" in annotations ? annotations["prometheus.io/path"]
                       : "/metrics"`'
                     scheme: http
@@ -998,6 +1016,15 @@ Node collector config for windows nodes should match snapshot when using default
                     honor_labels: true
                     honor_timestamps: false
                     job_name: pod
+                    metric_relabel_configs:
+                    - action: replace
+                      regex: (.+)
+                      replacement: $1
+                      source_labels:
+                      - service_name
+                      target_label: job
+                    - action: labeldrop
+                      regex: ^service_name$
                     metrics_path: '`"prometheus.io/path" in annotations ? annotations["prometheus.io/path"]
                       : "/metrics"`'
                     scheme: https
@@ -1018,6 +1045,15 @@ Node collector config for windows nodes should match snapshot when using default
                   - honor_labels: true
                     honor_timestamps: false
                     job_name: kubernetes-etcd
+                    metric_relabel_configs:
+                    - action: replace
+                      regex: (.+)
+                      replacement: $1
+                      source_labels:
+                      - service_name
+                      target_label: job
+                    - action: labeldrop
+                      regex: ^service_name$
                     metrics_path: /metrics
                     scheme: http
                     scrape_interval: 60s
@@ -1037,6 +1073,15 @@ Node collector config for windows nodes should match snapshot when using default
                     honor_labels: true
                     honor_timestamps: false
                     job_name: kubernetes-nodes-cadvisor
+                    metric_relabel_configs:
+                    - action: replace
+                      regex: (.+)
+                      replacement: $1
+                      source_labels:
+                      - service_name
+                      target_label: job
+                    - action: labeldrop
+                      regex: ^service_name$
                     metrics_path: /metrics/cadvisor
                     scheme: https
                     scrape_interval: 60s
@@ -1051,6 +1096,15 @@ Node collector config for windows nodes should match snapshot when using default
                     honor_labels: true
                     honor_timestamps: false
                     job_name: kubernetes-nodes
+                    metric_relabel_configs:
+                    - action: replace
+                      regex: (.+)
+                      replacement: $1
+                      source_labels:
+                      - service_name
+                      target_label: job
+                    - action: labeldrop
+                      regex: ^service_name$
                     metrics_path: /metrics
                     scheme: https
                     scrape_interval: 60s
@@ -2199,6 +2253,15 @@ Node collector config for windows nodes should match snapshot when using legacy 
                     honor_labels: true
                     honor_timestamps: false
                     job_name: kubernetes-controller-manager
+                    metric_relabel_configs:
+                    - action: replace
+                      regex: (.+)
+                      replacement: $1
+                      source_labels:
+                      - service_name
+                      target_label: job
+                    - action: labeldrop
+                      regex: ^service_name$
                     metrics_path: /metrics
                     scheme: https
                     scrape_interval: 60s
@@ -2216,6 +2279,15 @@ Node collector config for windows nodes should match snapshot when using legacy 
                   - honor_labels: true
                     honor_timestamps: false
                     job_name: pod
+                    metric_relabel_configs:
+                    - action: replace
+                      regex: (.+)
+                      replacement: $1
+                      source_labels:
+                      - service_name
+                      target_label: job
+                    - action: labeldrop
+                      regex: ^service_name$
                     metrics_path: '`"prometheus.io/path" in annotations ? annotations["prometheus.io/path"]
                       : "/metrics"`'
                     scheme: http
@@ -2238,6 +2310,15 @@ Node collector config for windows nodes should match snapshot when using legacy 
                     honor_labels: true
                     honor_timestamps: false
                     job_name: pod
+                    metric_relabel_configs:
+                    - action: replace
+                      regex: (.+)
+                      replacement: $1
+                      source_labels:
+                      - service_name
+                      target_label: job
+                    - action: labeldrop
+                      regex: ^service_name$
                     metrics_path: '`"prometheus.io/path" in annotations ? annotations["prometheus.io/path"]
                       : "/metrics"`'
                     scheme: https
@@ -2258,6 +2339,15 @@ Node collector config for windows nodes should match snapshot when using legacy 
                   - honor_labels: true
                     honor_timestamps: false
                     job_name: kubernetes-etcd
+                    metric_relabel_configs:
+                    - action: replace
+                      regex: (.+)
+                      replacement: $1
+                      source_labels:
+                      - service_name
+                      target_label: job
+                    - action: labeldrop
+                      regex: ^service_name$
                     metrics_path: /metrics
                     scheme: http
                     scrape_interval: 60s
@@ -2277,6 +2367,15 @@ Node collector config for windows nodes should match snapshot when using legacy 
                     honor_labels: true
                     honor_timestamps: false
                     job_name: kubernetes-nodes-cadvisor
+                    metric_relabel_configs:
+                    - action: replace
+                      regex: (.+)
+                      replacement: $1
+                      source_labels:
+                      - service_name
+                      target_label: job
+                    - action: labeldrop
+                      regex: ^service_name$
                     metrics_path: /metrics/cadvisor
                     scheme: https
                     scrape_interval: 60s
@@ -2291,6 +2390,15 @@ Node collector config for windows nodes should match snapshot when using legacy 
                     honor_labels: true
                     honor_timestamps: false
                     job_name: kubernetes-nodes
+                    metric_relabel_configs:
+                    - action: replace
+                      regex: (.+)
+                      replacement: $1
+                      source_labels:
+                      - service_name
+                      target_label: job
+                    - action: labeldrop
+                      regex: ^service_name$
                     metrics_path: /metrics
                     scheme: https
                     scrape_interval: 60s

--- a/deploy/helm/tests/__snapshot__/node-collector-config-map_test.yaml.snap
+++ b/deploy/helm/tests/__snapshot__/node-collector-config-map_test.yaml.snap
@@ -990,6 +990,15 @@ Custom logs filter with new syntax:
                     honor_labels: true
                     honor_timestamps: false
                     job_name: kubernetes-controller-manager
+                    metric_relabel_configs:
+                    - action: replace
+                      regex: (.+)
+                      replacement: $1
+                      source_labels:
+                      - service_name
+                      target_label: job
+                    - action: labeldrop
+                      regex: ^service_name$
                     metrics_path: /metrics
                     scheme: https
                     scrape_interval: 60s
@@ -1007,6 +1016,15 @@ Custom logs filter with new syntax:
                   - honor_labels: true
                     honor_timestamps: false
                     job_name: pod
+                    metric_relabel_configs:
+                    - action: replace
+                      regex: (.+)
+                      replacement: $1
+                      source_labels:
+                      - service_name
+                      target_label: job
+                    - action: labeldrop
+                      regex: ^service_name$
                     metrics_path: '`"prometheus.io/path" in annotations ? annotations["prometheus.io/path"]
                       : "/metrics"`'
                     scheme: http
@@ -1029,6 +1047,15 @@ Custom logs filter with new syntax:
                     honor_labels: true
                     honor_timestamps: false
                     job_name: pod
+                    metric_relabel_configs:
+                    - action: replace
+                      regex: (.+)
+                      replacement: $1
+                      source_labels:
+                      - service_name
+                      target_label: job
+                    - action: labeldrop
+                      regex: ^service_name$
                     metrics_path: '`"prometheus.io/path" in annotations ? annotations["prometheus.io/path"]
                       : "/metrics"`'
                     scheme: https
@@ -1049,6 +1076,15 @@ Custom logs filter with new syntax:
                   - honor_labels: true
                     honor_timestamps: false
                     job_name: kubernetes-etcd
+                    metric_relabel_configs:
+                    - action: replace
+                      regex: (.+)
+                      replacement: $1
+                      source_labels:
+                      - service_name
+                      target_label: job
+                    - action: labeldrop
+                      regex: ^service_name$
                     metrics_path: /metrics
                     scheme: http
                     scrape_interval: 60s
@@ -1068,6 +1104,15 @@ Custom logs filter with new syntax:
                     honor_labels: true
                     honor_timestamps: false
                     job_name: kubernetes-nodes-cadvisor
+                    metric_relabel_configs:
+                    - action: replace
+                      regex: (.+)
+                      replacement: $1
+                      source_labels:
+                      - service_name
+                      target_label: job
+                    - action: labeldrop
+                      regex: ^service_name$
                     metrics_path: /metrics/cadvisor
                     scheme: https
                     scrape_interval: 60s
@@ -1082,6 +1127,15 @@ Custom logs filter with new syntax:
                     honor_labels: true
                     honor_timestamps: false
                     job_name: kubernetes-nodes
+                    metric_relabel_configs:
+                    - action: replace
+                      regex: (.+)
+                      replacement: $1
+                      source_labels:
+                      - service_name
+                      target_label: job
+                    - action: labeldrop
+                      regex: ^service_name$
                     metrics_path: /metrics
                     scheme: https
                     scrape_interval: 60s
@@ -2267,6 +2321,15 @@ Custom logs filter with old syntax:
                     honor_labels: true
                     honor_timestamps: false
                     job_name: kubernetes-controller-manager
+                    metric_relabel_configs:
+                    - action: replace
+                      regex: (.+)
+                      replacement: $1
+                      source_labels:
+                      - service_name
+                      target_label: job
+                    - action: labeldrop
+                      regex: ^service_name$
                     metrics_path: /metrics
                     scheme: https
                     scrape_interval: 60s
@@ -2284,6 +2347,15 @@ Custom logs filter with old syntax:
                   - honor_labels: true
                     honor_timestamps: false
                     job_name: pod
+                    metric_relabel_configs:
+                    - action: replace
+                      regex: (.+)
+                      replacement: $1
+                      source_labels:
+                      - service_name
+                      target_label: job
+                    - action: labeldrop
+                      regex: ^service_name$
                     metrics_path: '`"prometheus.io/path" in annotations ? annotations["prometheus.io/path"]
                       : "/metrics"`'
                     scheme: http
@@ -2306,6 +2378,15 @@ Custom logs filter with old syntax:
                     honor_labels: true
                     honor_timestamps: false
                     job_name: pod
+                    metric_relabel_configs:
+                    - action: replace
+                      regex: (.+)
+                      replacement: $1
+                      source_labels:
+                      - service_name
+                      target_label: job
+                    - action: labeldrop
+                      regex: ^service_name$
                     metrics_path: '`"prometheus.io/path" in annotations ? annotations["prometheus.io/path"]
                       : "/metrics"`'
                     scheme: https
@@ -2326,6 +2407,15 @@ Custom logs filter with old syntax:
                   - honor_labels: true
                     honor_timestamps: false
                     job_name: kubernetes-etcd
+                    metric_relabel_configs:
+                    - action: replace
+                      regex: (.+)
+                      replacement: $1
+                      source_labels:
+                      - service_name
+                      target_label: job
+                    - action: labeldrop
+                      regex: ^service_name$
                     metrics_path: /metrics
                     scheme: http
                     scrape_interval: 60s
@@ -2345,6 +2435,15 @@ Custom logs filter with old syntax:
                     honor_labels: true
                     honor_timestamps: false
                     job_name: kubernetes-nodes-cadvisor
+                    metric_relabel_configs:
+                    - action: replace
+                      regex: (.+)
+                      replacement: $1
+                      source_labels:
+                      - service_name
+                      target_label: job
+                    - action: labeldrop
+                      regex: ^service_name$
                     metrics_path: /metrics/cadvisor
                     scheme: https
                     scrape_interval: 60s
@@ -2359,6 +2458,15 @@ Custom logs filter with old syntax:
                     honor_labels: true
                     honor_timestamps: false
                     job_name: kubernetes-nodes
+                    metric_relabel_configs:
+                    - action: replace
+                      regex: (.+)
+                      replacement: $1
+                      source_labels:
+                      - service_name
+                      target_label: job
+                    - action: labeldrop
+                      regex: ^service_name$
                     metrics_path: /metrics
                     scheme: https
                     scrape_interval: 60s
@@ -3456,6 +3564,15 @@ Node collector config should match snapshot when autodiscovery is disabled:
                     honor_labels: true
                     honor_timestamps: false
                     job_name: kubernetes-controller-manager
+                    metric_relabel_configs:
+                    - action: replace
+                      regex: (.+)
+                      replacement: $1
+                      source_labels:
+                      - service_name
+                      target_label: job
+                    - action: labeldrop
+                      regex: ^service_name$
                     metrics_path: /metrics
                     scheme: https
                     scrape_interval: 60s
@@ -3473,6 +3590,15 @@ Node collector config should match snapshot when autodiscovery is disabled:
                   - honor_labels: true
                     honor_timestamps: false
                     job_name: kubernetes-etcd
+                    metric_relabel_configs:
+                    - action: replace
+                      regex: (.+)
+                      replacement: $1
+                      source_labels:
+                      - service_name
+                      target_label: job
+                    - action: labeldrop
+                      regex: ^service_name$
                     metrics_path: /metrics
                     scheme: http
                     scrape_interval: 60s
@@ -3492,6 +3618,15 @@ Node collector config should match snapshot when autodiscovery is disabled:
                     honor_labels: true
                     honor_timestamps: false
                     job_name: kubernetes-nodes-cadvisor
+                    metric_relabel_configs:
+                    - action: replace
+                      regex: (.+)
+                      replacement: $1
+                      source_labels:
+                      - service_name
+                      target_label: job
+                    - action: labeldrop
+                      regex: ^service_name$
                     metrics_path: /metrics/cadvisor
                     scheme: https
                     scrape_interval: 60s
@@ -3506,6 +3641,15 @@ Node collector config should match snapshot when autodiscovery is disabled:
                     honor_labels: true
                     honor_timestamps: false
                     job_name: kubernetes-nodes
+                    metric_relabel_configs:
+                    - action: replace
+                      regex: (.+)
+                      replacement: $1
+                      source_labels:
+                      - service_name
+                      target_label: job
+                    - action: labeldrop
+                      regex: ^service_name$
                     metrics_path: /metrics
                     scheme: https
                     scrape_interval: 60s
@@ -4599,6 +4743,15 @@ Node collector config should match snapshot when fargate is enabled:
                     honor_labels: true
                     honor_timestamps: false
                     job_name: kubernetes-controller-manager
+                    metric_relabel_configs:
+                    - action: replace
+                      regex: (.+)
+                      replacement: $1
+                      source_labels:
+                      - service_name
+                      target_label: job
+                    - action: labeldrop
+                      regex: ^service_name$
                     metrics_path: /metrics
                     scheme: https
                     scrape_interval: 60s
@@ -4616,6 +4769,15 @@ Node collector config should match snapshot when fargate is enabled:
                   - honor_labels: true
                     honor_timestamps: false
                     job_name: pod
+                    metric_relabel_configs:
+                    - action: replace
+                      regex: (.+)
+                      replacement: $1
+                      source_labels:
+                      - service_name
+                      target_label: job
+                    - action: labeldrop
+                      regex: ^service_name$
                     metrics_path: '`"prometheus.io/path" in annotations ? annotations["prometheus.io/path"]
                       : "/metrics"`'
                     scheme: http
@@ -4638,6 +4800,15 @@ Node collector config should match snapshot when fargate is enabled:
                     honor_labels: true
                     honor_timestamps: false
                     job_name: pod
+                    metric_relabel_configs:
+                    - action: replace
+                      regex: (.+)
+                      replacement: $1
+                      source_labels:
+                      - service_name
+                      target_label: job
+                    - action: labeldrop
+                      regex: ^service_name$
                     metrics_path: '`"prometheus.io/path" in annotations ? annotations["prometheus.io/path"]
                       : "/metrics"`'
                     scheme: https
@@ -4658,6 +4829,15 @@ Node collector config should match snapshot when fargate is enabled:
                   - honor_labels: true
                     honor_timestamps: false
                     job_name: kubernetes-etcd
+                    metric_relabel_configs:
+                    - action: replace
+                      regex: (.+)
+                      replacement: $1
+                      source_labels:
+                      - service_name
+                      target_label: job
+                    - action: labeldrop
+                      regex: ^service_name$
                     metrics_path: /metrics
                     scheme: http
                     scrape_interval: 60s
@@ -5718,6 +5898,15 @@ Node collector config should match snapshot when fargate is enabled and autodisc
                     honor_labels: true
                     honor_timestamps: false
                     job_name: kubernetes-controller-manager
+                    metric_relabel_configs:
+                    - action: replace
+                      regex: (.+)
+                      replacement: $1
+                      source_labels:
+                      - service_name
+                      target_label: job
+                    - action: labeldrop
+                      regex: ^service_name$
                     metrics_path: /metrics
                     scheme: https
                     scrape_interval: 60s
@@ -5735,6 +5924,15 @@ Node collector config should match snapshot when fargate is enabled and autodisc
                   - honor_labels: true
                     honor_timestamps: false
                     job_name: kubernetes-etcd
+                    metric_relabel_configs:
+                    - action: replace
+                      regex: (.+)
+                      replacement: $1
+                      source_labels:
+                      - service_name
+                      target_label: job
+                    - action: labeldrop
+                      regex: ^service_name$
                     metrics_path: /metrics
                     scheme: http
                     scrape_interval: 60s
@@ -6791,6 +6989,15 @@ Node collector config should match snapshot when using default values:
                     honor_labels: true
                     honor_timestamps: false
                     job_name: kubernetes-controller-manager
+                    metric_relabel_configs:
+                    - action: replace
+                      regex: (.+)
+                      replacement: $1
+                      source_labels:
+                      - service_name
+                      target_label: job
+                    - action: labeldrop
+                      regex: ^service_name$
                     metrics_path: /metrics
                     scheme: https
                     scrape_interval: 60s
@@ -6808,6 +7015,15 @@ Node collector config should match snapshot when using default values:
                   - honor_labels: true
                     honor_timestamps: false
                     job_name: pod
+                    metric_relabel_configs:
+                    - action: replace
+                      regex: (.+)
+                      replacement: $1
+                      source_labels:
+                      - service_name
+                      target_label: job
+                    - action: labeldrop
+                      regex: ^service_name$
                     metrics_path: '`"prometheus.io/path" in annotations ? annotations["prometheus.io/path"]
                       : "/metrics"`'
                     scheme: http
@@ -6830,6 +7046,15 @@ Node collector config should match snapshot when using default values:
                     honor_labels: true
                     honor_timestamps: false
                     job_name: pod
+                    metric_relabel_configs:
+                    - action: replace
+                      regex: (.+)
+                      replacement: $1
+                      source_labels:
+                      - service_name
+                      target_label: job
+                    - action: labeldrop
+                      regex: ^service_name$
                     metrics_path: '`"prometheus.io/path" in annotations ? annotations["prometheus.io/path"]
                       : "/metrics"`'
                     scheme: https
@@ -6850,6 +7075,15 @@ Node collector config should match snapshot when using default values:
                   - honor_labels: true
                     honor_timestamps: false
                     job_name: kubernetes-etcd
+                    metric_relabel_configs:
+                    - action: replace
+                      regex: (.+)
+                      replacement: $1
+                      source_labels:
+                      - service_name
+                      target_label: job
+                    - action: labeldrop
+                      regex: ^service_name$
                     metrics_path: /metrics
                     scheme: http
                     scrape_interval: 60s
@@ -6869,6 +7103,15 @@ Node collector config should match snapshot when using default values:
                     honor_labels: true
                     honor_timestamps: false
                     job_name: kubernetes-nodes-cadvisor
+                    metric_relabel_configs:
+                    - action: replace
+                      regex: (.+)
+                      replacement: $1
+                      source_labels:
+                      - service_name
+                      target_label: job
+                    - action: labeldrop
+                      regex: ^service_name$
                     metrics_path: /metrics/cadvisor
                     scheme: https
                     scrape_interval: 60s
@@ -6883,6 +7126,15 @@ Node collector config should match snapshot when using default values:
                     honor_labels: true
                     honor_timestamps: false
                     job_name: kubernetes-nodes
+                    metric_relabel_configs:
+                    - action: replace
+                      regex: (.+)
+                      replacement: $1
+                      source_labels:
+                      - service_name
+                      target_label: job
+                    - action: labeldrop
+                      regex: ^service_name$
                     metrics_path: /metrics
                     scheme: https
                     scrape_interval: 60s

--- a/tests/deploy/tests/templates/testResources.yaml
+++ b/tests/deploy/tests/templates/testResources.yaml
@@ -48,7 +48,7 @@ spec:
       containers:
       - name: test-container
         image: busybox
-        command: ["sh", "-c", "echo 'test_metric_from_deployment 1' > /custom_metrics; httpd -f -p 8081 -h /; sleep infinity"]
+        command: ["sh", "-c", "echo 'test_metric_from_deployment{service_name=\"ad\"} 1' > /custom_metrics; httpd -f -p 8081 -h /; sleep infinity"]
         ports:
         - containerPort: 8081
 ---

--- a/tests/integration/expected_telemetry/deployment_with_metric.json
+++ b/tests/integration/expected_telemetry/deployment_with_metric.json
@@ -6,6 +6,7 @@
         "sw.k8s.cluster.uid",
         { "key":"k8s.cluster.name", "value": "cluster name" },
         { "key":"k8s.namespace.name", "value": "test-namespace" }, 
-        { "key":"k8s.deployment.name", "value": "test-deployment" }
+        { "key":"k8s.deployment.name", "value": "test-deployment" },
+        { "key":"service.name", "value": "ad" }
     ]
 }


### PR DESCRIPTION
* `prometheusreceiver` automatically set `job` attribute based on the `job_name` in scrape config.
* `job` is automatically converted to `service.name` by OTEL Collector and there is nothing we can do about it (https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/8060). This means that `service.name` of application metrics are usually set to `pod` as that is `job_name` for our scrape_config.
* As part of this PR I am configuring Prometheus config to set `job` from `service_name` attribute if it exists in the metric, so that `service.name` resource attribute matches to `service_name` provided by application metric.

