### PR TITLE
Check for cert-manager when enabling deployment of OTEL operator

### DIFF
--- a/deploy/helm/templates/asserts.yaml
+++ b/deploy/helm/templates/asserts.yaml
@@ -21,3 +21,17 @@
 {{- if and (or (not (empty .Values.cluster.filter.exclude_namespaces)) (not (empty .Values.cluster.filter.exclude_namespaces_regex))) (or (not (empty .Values.cluster.filter.include_namespaces)) (not (empty .Values.cluster.filter.include_namespaces_regex))) -}}
 {{ fail "Only one namespace filter can be used at time, either include or exclude." }}
 {{- end -}}
+
+{{- if and .Values.operator.enabled .Values.operator.admissionWebhooks.certManager.enabled (not .Values.certmanager.enabled) -}}
+{{- $certManagerFound:=false -}}
+{{- range $index, $conf := (lookup "admissionregistration.k8s.io/v1" "MutatingWebhookConfiguration" "" "").items -}}
+{{- range $index, $webhook := $conf.webhooks -}}
+{{- if eq $webhook.name "webhook.cert-manager.io" -}}
+{{- $certManagerFound = true -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+{{- if not $certManagerFound -}}
+{{ fail "Deployment of the OpenTelemetry Operator is enabled but cert-manager was not detected in your cluster. The operator's admission webhooks require valid certificates to function properly. Please set `certmanager.enabled` to `true` or follow the operator's documentation (https://opentelemetry.io/docs/platforms/kubernetes/helm/operator/#configuration) to ensure proper certificate management." }}
+{{- end -}}
+{{- end -}}

--- a/deploy/helm/tests/assert_test.yaml
+++ b/deploy/helm/tests/assert_test.yaml
@@ -32,3 +32,9 @@ tests:
     asserts:
       - failedTemplate:
           errorMessage: If specified, the custom cluster UID should be a valid string.
+  - it: should fail when operator.enabled is set to true but certmanager.enabled is not enabled (as is by default)
+    set:
+      operator.enabled: true
+    asserts:
+      - failedTemplate:
+          errorMessage: Deployment of the OpenTelemetry Operator is enabled but cert-manager was not detected in your cluster. The operator's admission webhooks require valid certificates to function properly. Please set `certmanager.enabled` to `true` or follow the operator's documentation (https://opentelemetry.io/docs/platforms/kubernetes/helm/operator/#configuration) to ensure proper certificate management.


### PR DESCRIPTION
If `operator.enabled` is set to `true`, check if `certmanager.enabled` is also `true` or if there is an already running `cert-manager` in the cluster.