### PR TITLE
NH-112478: Splitting entity state events and relationship state events into two separate pipelines

### DIFF
--- a/deploy/helm/tests/__snapshot__/discovery-collector_test.yaml.snap
+++ b/deploy/helm/tests/__snapshot__/discovery-collector_test.yaml.snap
@@ -250,6 +250,14 @@ Discovery collector spec should match snapshot when using default values:
           metrics:
             metric:
               - type == METRIC_DATA_TYPE_HISTOGRAM and not(name == "k8s.rest_client_request_duration_seconds" or name == "k8s.workqueue_queue_duration_seconds" or name == "k8s.etcd_disk_wal_fsync_duration_seconds" or name == "k8s.etcd_disk_backend_commit_duration_seconds")
+        filter/keep-entity-state-events:
+          logs:
+            log_record:
+              - not(attributes["otel.entity.event.type"] == "entity_state")
+        filter/keep-relationship-state-events:
+          logs:
+            log_record:
+              - not(attributes["otel.entity.event.type"] == "entity_relationship_state")
         filter/keep-workload-service-relationships:
           error_mode: ignore
           metrics:
@@ -456,11 +464,23 @@ Discovery collector spec should match snapshot when using default values:
         extensions:
           - health_check
         pipelines:
-          logs/stateevents:
+          logs/stateevents-entities:
             exporters:
               - otlp
             processors:
               - memory_limiter
+              - filter/keep-entity-state-events
+              - transform/scope
+              - batch/stateevents
+            receivers:
+              - solarwindsentity/istio-workload-workload
+              - solarwindsentity/istio-workload-service
+          logs/stateevents-relationships:
+            exporters:
+              - otlp
+            processors:
+              - memory_limiter
+              - filter/keep-relationship-state-events
               - transform/scope
               - batch/stateevents
             receivers:

--- a/deploy/helm/tests/__snapshot__/metrics-discovery-config-map_test.yaml.snap
+++ b/deploy/helm/tests/__snapshot__/metrics-discovery-config-map_test.yaml.snap
@@ -231,6 +231,14 @@ Metrics discovery config should match snapshot when Fargate is enabled:
             metric:
             - type == METRIC_DATA_TYPE_HISTOGRAM and not(name == "k8s.rest_client_request_duration_seconds"
               or name == "k8s.workqueue_queue_duration_seconds")
+        filter/keep-entity-state-events:
+          logs:
+            log_record:
+            - not(attributes["otel.entity.event.type"] == "entity_state")
+        filter/keep-relationship-state-events:
+          logs:
+            log_record:
+            - not(attributes["otel.entity.event.type"] == "entity_relationship_state")
         filter/keep-workload-service-relationships:
           error_mode: ignore
           metrics:
@@ -515,11 +523,23 @@ Metrics discovery config should match snapshot when Fargate is enabled:
         - health_check
         - k8s_observer
         pipelines:
-          logs/stateevents:
+          logs/stateevents-entities:
             exporters:
             - otlp
             processors:
             - memory_limiter
+            - filter/keep-entity-state-events
+            - transform/scope
+            - batch/stateevents
+            receivers:
+            - solarwindsentity/istio-workload-workload
+            - solarwindsentity/istio-workload-service
+          logs/stateevents-relationships:
+            exporters:
+            - otlp
+            processors:
+            - memory_limiter
+            - filter/keep-relationship-state-events
             - transform/scope
             - batch/stateevents
             receivers:

--- a/deploy/helm/tests/__snapshot__/node-collector-config-map-windows_test.yaml.snap
+++ b/deploy/helm/tests/__snapshot__/node-collector-config-map-windows_test.yaml.snap
@@ -330,6 +330,14 @@ Node collector config for windows nodes should match snapshot when using default
             - type == METRIC_DATA_TYPE_HISTOGRAM and not(name == "k8s.rest_client_request_duration_seconds"
               or name == "k8s.workqueue_queue_duration_seconds" or name == "k8s.etcd_disk_wal_fsync_duration_seconds"
               or name == "k8s.etcd_disk_backend_commit_duration_seconds")
+        filter/keep-entity-state-events:
+          logs:
+            log_record:
+            - not(attributes["otel.entity.event.type"] == "entity_state")
+        filter/keep-relationship-state-events:
+          logs:
+            log_record:
+            - not(attributes["otel.entity.event.type"] == "entity_relationship_state")
         filter/keep-workload-service-relationships:
           error_mode: ignore
           metrics:
@@ -1419,11 +1427,23 @@ Node collector config for windows nodes should match snapshot when using default
             - k8sattributes
             receivers:
             - filelog
-          logs/stateevents:
+          logs/stateevents-entities:
             exporters:
             - otlp
             processors:
             - memory_limiter
+            - filter/keep-entity-state-events
+            - transform/scope
+            - batch/stateevents
+            receivers:
+            - solarwindsentity/istio-workload-workload
+            - solarwindsentity/istio-workload-service
+          logs/stateevents-relationships:
+            exporters:
+            - otlp
+            processors:
+            - memory_limiter
+            - filter/keep-relationship-state-events
             - transform/scope
             - batch/stateevents
             receivers:
@@ -1863,6 +1883,14 @@ Node collector config for windows nodes should match snapshot when using legacy 
             - type == METRIC_DATA_TYPE_HISTOGRAM and not(name == "k8s.rest_client_request_duration_seconds"
               or name == "k8s.workqueue_queue_duration_seconds" or name == "k8s.etcd_disk_wal_fsync_duration_seconds"
               or name == "k8s.etcd_disk_backend_commit_duration_seconds")
+        filter/keep-entity-state-events:
+          logs:
+            log_record:
+            - not(attributes["otel.entity.event.type"] == "entity_state")
+        filter/keep-relationship-state-events:
+          logs:
+            log_record:
+            - not(attributes["otel.entity.event.type"] == "entity_relationship_state")
         filter/keep-workload-service-relationships:
           error_mode: ignore
           metrics:
@@ -3041,11 +3069,23 @@ Node collector config for windows nodes should match snapshot when using legacy 
             - k8sattributes
             receivers:
             - filelog
-          logs/stateevents:
+          logs/stateevents-entities:
             exporters:
             - otlp
             processors:
             - memory_limiter
+            - filter/keep-entity-state-events
+            - transform/scope
+            - batch/stateevents
+            receivers:
+            - solarwindsentity/istio-workload-workload
+            - solarwindsentity/istio-workload-service
+          logs/stateevents-relationships:
+            exporters:
+            - otlp
+            processors:
+            - memory_limiter
+            - filter/keep-relationship-state-events
             - transform/scope
             - batch/stateevents
             receivers:

--- a/deploy/helm/tests/__snapshot__/node-collector-config-map_test.yaml.snap
+++ b/deploy/helm/tests/__snapshot__/node-collector-config-map_test.yaml.snap
@@ -330,6 +330,14 @@ Custom logs filter with new syntax:
             - type == METRIC_DATA_TYPE_HISTOGRAM and not(name == "k8s.rest_client_request_duration_seconds"
               or name == "k8s.workqueue_queue_duration_seconds" or name == "k8s.etcd_disk_wal_fsync_duration_seconds"
               or name == "k8s.etcd_disk_backend_commit_duration_seconds")
+        filter/keep-entity-state-events:
+          logs:
+            log_record:
+            - not(attributes["otel.entity.event.type"] == "entity_state")
+        filter/keep-relationship-state-events:
+          logs:
+            log_record:
+            - not(attributes["otel.entity.event.type"] == "entity_relationship_state")
         filter/keep-workload-service-relationships:
           error_mode: ignore
           metrics:
@@ -1460,11 +1468,23 @@ Custom logs filter with new syntax:
             - resource/journal
             receivers:
             - journald
-          logs/stateevents:
+          logs/stateevents-entities:
             exporters:
             - otlp
             processors:
             - memory_limiter
+            - filter/keep-entity-state-events
+            - transform/scope
+            - batch/stateevents
+            receivers:
+            - solarwindsentity/istio-workload-workload
+            - solarwindsentity/istio-workload-service
+          logs/stateevents-relationships:
+            exporters:
+            - otlp
+            processors:
+            - memory_limiter
+            - filter/keep-relationship-state-events
             - transform/scope
             - batch/stateevents
             receivers:
@@ -1904,6 +1924,14 @@ Custom logs filter with old syntax:
             - type == METRIC_DATA_TYPE_HISTOGRAM and not(name == "k8s.rest_client_request_duration_seconds"
               or name == "k8s.workqueue_queue_duration_seconds" or name == "k8s.etcd_disk_wal_fsync_duration_seconds"
               or name == "k8s.etcd_disk_backend_commit_duration_seconds")
+        filter/keep-entity-state-events:
+          logs:
+            log_record:
+            - not(attributes["otel.entity.event.type"] == "entity_state")
+        filter/keep-relationship-state-events:
+          logs:
+            log_record:
+            - not(attributes["otel.entity.event.type"] == "entity_relationship_state")
         filter/keep-workload-service-relationships:
           error_mode: ignore
           metrics:
@@ -3118,11 +3146,23 @@ Custom logs filter with old syntax:
             - resource/journal
             receivers:
             - journald
-          logs/stateevents:
+          logs/stateevents-entities:
             exporters:
             - otlp
             processors:
             - memory_limiter
+            - filter/keep-entity-state-events
+            - transform/scope
+            - batch/stateevents
+            receivers:
+            - solarwindsentity/istio-workload-workload
+            - solarwindsentity/istio-workload-service
+          logs/stateevents-relationships:
+            exporters:
+            - otlp
+            processors:
+            - memory_limiter
+            - filter/keep-relationship-state-events
             - transform/scope
             - batch/stateevents
             receivers:
@@ -3562,6 +3602,14 @@ Node collector config should match snapshot when autodiscovery is disabled:
             - type == METRIC_DATA_TYPE_HISTOGRAM and not(name == "k8s.rest_client_request_duration_seconds"
               or name == "k8s.workqueue_queue_duration_seconds" or name == "k8s.etcd_disk_wal_fsync_duration_seconds"
               or name == "k8s.etcd_disk_backend_commit_duration_seconds")
+        filter/keep-entity-state-events:
+          logs:
+            log_record:
+            - not(attributes["otel.entity.event.type"] == "entity_state")
+        filter/keep-relationship-state-events:
+          logs:
+            log_record:
+            - not(attributes["otel.entity.event.type"] == "entity_relationship_state")
         filter/keep-workload-service-relationships:
           error_mode: ignore
           metrics:
@@ -4627,11 +4675,23 @@ Node collector config should match snapshot when autodiscovery is disabled:
             - resource/journal
             receivers:
             - journald
-          logs/stateevents:
+          logs/stateevents-entities:
             exporters:
             - otlp
             processors:
             - memory_limiter
+            - filter/keep-entity-state-events
+            - transform/scope
+            - batch/stateevents
+            receivers:
+            - solarwindsentity/istio-workload-workload
+            - solarwindsentity/istio-workload-service
+          logs/stateevents-relationships:
+            exporters:
+            - otlp
+            processors:
+            - memory_limiter
+            - filter/keep-relationship-state-events
             - transform/scope
             - batch/stateevents
             receivers:
@@ -5068,6 +5128,14 @@ Node collector config should match snapshot when fargate is enabled:
             - type == METRIC_DATA_TYPE_HISTOGRAM and not(name == "k8s.rest_client_request_duration_seconds"
               or name == "k8s.workqueue_queue_duration_seconds" or name == "k8s.etcd_disk_wal_fsync_duration_seconds"
               or name == "k8s.etcd_disk_backend_commit_duration_seconds")
+        filter/keep-entity-state-events:
+          logs:
+            log_record:
+            - not(attributes["otel.entity.event.type"] == "entity_state")
+        filter/keep-relationship-state-events:
+          logs:
+            log_record:
+            - not(attributes["otel.entity.event.type"] == "entity_relationship_state")
         filter/keep-workload-service-relationships:
           error_mode: ignore
           metrics:
@@ -6138,11 +6206,23 @@ Node collector config should match snapshot when fargate is enabled:
             - resource/journal
             receivers:
             - journald
-          logs/stateevents:
+          logs/stateevents-entities:
             exporters:
             - otlp
             processors:
             - memory_limiter
+            - filter/keep-entity-state-events
+            - transform/scope
+            - batch/stateevents
+            receivers:
+            - solarwindsentity/istio-workload-workload
+            - solarwindsentity/istio-workload-service
+          logs/stateevents-relationships:
+            exporters:
+            - otlp
+            processors:
+            - memory_limiter
+            - filter/keep-relationship-state-events
             - transform/scope
             - batch/stateevents
             receivers:
@@ -6550,6 +6630,14 @@ Node collector config should match snapshot when fargate is enabled and autodisc
             - type == METRIC_DATA_TYPE_HISTOGRAM and not(name == "k8s.rest_client_request_duration_seconds"
               or name == "k8s.workqueue_queue_duration_seconds" or name == "k8s.etcd_disk_wal_fsync_duration_seconds"
               or name == "k8s.etcd_disk_backend_commit_duration_seconds")
+        filter/keep-entity-state-events:
+          logs:
+            log_record:
+            - not(attributes["otel.entity.event.type"] == "entity_state")
+        filter/keep-relationship-state-events:
+          logs:
+            log_record:
+            - not(attributes["otel.entity.event.type"] == "entity_relationship_state")
         filter/keep-workload-service-relationships:
           error_mode: ignore
           metrics:
@@ -7559,11 +7647,23 @@ Node collector config should match snapshot when fargate is enabled and autodisc
             - resource/journal
             receivers:
             - journald
-          logs/stateevents:
+          logs/stateevents-entities:
             exporters:
             - otlp
             processors:
             - memory_limiter
+            - filter/keep-entity-state-events
+            - transform/scope
+            - batch/stateevents
+            receivers:
+            - solarwindsentity/istio-workload-workload
+            - solarwindsentity/istio-workload-service
+          logs/stateevents-relationships:
+            exporters:
+            - otlp
+            processors:
+            - memory_limiter
+            - filter/keep-relationship-state-events
             - transform/scope
             - batch/stateevents
             receivers:
@@ -7968,6 +8068,14 @@ Node collector config should match snapshot when using default values:
             - type == METRIC_DATA_TYPE_HISTOGRAM and not(name == "k8s.rest_client_request_duration_seconds"
               or name == "k8s.workqueue_queue_duration_seconds" or name == "k8s.etcd_disk_wal_fsync_duration_seconds"
               or name == "k8s.etcd_disk_backend_commit_duration_seconds")
+        filter/keep-entity-state-events:
+          logs:
+            log_record:
+            - not(attributes["otel.entity.event.type"] == "entity_state")
+        filter/keep-relationship-state-events:
+          logs:
+            log_record:
+            - not(attributes["otel.entity.event.type"] == "entity_relationship_state")
         filter/keep-workload-service-relationships:
           error_mode: ignore
           metrics:
@@ -9093,11 +9201,23 @@ Node collector config should match snapshot when using default values:
             - resource/journal
             receivers:
             - journald
-          logs/stateevents:
+          logs/stateevents-entities:
             exporters:
             - otlp
             processors:
             - memory_limiter
+            - filter/keep-entity-state-events
+            - transform/scope
+            - batch/stateevents
+            receivers:
+            - solarwindsentity/istio-workload-workload
+            - solarwindsentity/istio-workload-service
+          logs/stateevents-relationships:
+            exporters:
+            - otlp
+            processors:
+            - memory_limiter
+            - filter/keep-relationship-state-events
             - transform/scope
             - batch/stateevents
             receivers:


### PR DESCRIPTION
* SWO currently has issue during state events processing, cannot handle both types in the same messages, so we need to split them
