### PR TITLE
Add support for Go profiler

### DIFF
--- a/deploy/helm/events-collector-config.yaml
+++ b/deploy/helm/events-collector-config.yaml
@@ -54,6 +54,10 @@ extensions:
 {{- end }}
   health_check:
     endpoint: 0.0.0.0:13133
+{{- if .Values.diagnostics.profiling.enabled }}
+  pprof:
+    endpoint: localhost:{{ .Values.diagnostics.profiling.port }}
+{{- end }}
 
 connectors:
 {{- if and .Values.otel.manifests.enabled .Values.otel.manifests.keepalive_events.enabled }}
@@ -465,6 +469,9 @@ service:
     - file_storage/manifests
 {{- end}}
     - health_check
+{{- if .Values.diagnostics.profiling.enabled }}
+    - pprof
+{{- end }}
   pipelines:
 {{- if .Values.otel.events.enabled }}
     logs:

--- a/deploy/helm/gateway-collector-config.yaml
+++ b/deploy/helm/gateway-collector-config.yaml
@@ -27,6 +27,10 @@ extensions:
 {{- end }}
   health_check:
     endpoint: 0.0.0.0:13133
+{{- if .Values.diagnostics.profiling.enabled }}
+  pprof:
+    endpoint: localhost:{{ .Values.diagnostics.profiling.port }}
+{{- end }}
 
 processors:
   batch:
@@ -200,6 +204,9 @@ service:
     - file_storage/sending_queue
 {{- end }}
     - health_check
+{{- if .Values.diagnostics.profiling.enabled }}
+    - pprof
+{{- end }}
   pipelines:
     metrics:
       exporters:

--- a/deploy/helm/metrics-collector-config.yaml
+++ b/deploy/helm/metrics-collector-config.yaml
@@ -26,6 +26,10 @@ extensions:
 {{- end }}
   health_check:
     endpoint: 0.0.0.0:13133
+{{- if .Values.diagnostics.profiling.enabled }}
+  pprof:
+    endpoint: localhost:{{ .Values.diagnostics.profiling.port }}
+{{- end }}
 
 processors:
   k8sattributes:
@@ -1056,6 +1060,9 @@ service:
     - file_storage/sending_queue
 {{- end }}
     - health_check
+{{- if .Values.diagnostics.profiling.enabled }}
+    - pprof
+{{- end }}
   pipelines:
 {{- if and (and .Values.otel.metrics.extra_scrape_metrics (or (not .Values.otel.metrics.autodiscovery.prometheusEndpoints.enabled) .Values.otel.metrics.force_extra_scrape_metrics)) .Values.otel.metrics.prometheus.url }}
     metrics/prometheus-server:

--- a/deploy/helm/metrics-discovery-config.yaml
+++ b/deploy/helm/metrics-discovery-config.yaml
@@ -28,7 +28,11 @@ extensions:
     endpoint: 0.0.0.0:13133
   k8s_observer:
     auth_type: serviceAccount
-    observe_pods: true    
+    observe_pods: true
+{{- if .Values.diagnostics.profiling.enabled }}
+  pprof:
+    endpoint: localhost:{{ .Values.diagnostics.profiling.port }}
+{{- end }}
 
 processors:
   k8sattributes:
@@ -164,6 +168,9 @@ service:
 {{- end }}
     - health_check
     - k8s_observer
+{{- if .Values.diagnostics.profiling.enabled }}
+    - pprof
+{{- end }}
   pipelines:
 
 {{ include "common-discovery-config.pipelines" (tuple . "receiver_creator/discovery" "forward/metric-exporter") | indent 4 }}

--- a/deploy/helm/node-collector-config.yaml
+++ b/deploy/helm/node-collector-config.yaml
@@ -35,6 +35,10 @@ extensions:
     observe_pods: true
     observe_nodes: true
 {{- end }}
+{{- if .Values.diagnostics.profiling.enabled }}
+  pprof:
+    endpoint: localhost:{{ .Values.diagnostics.profiling.port }}
+{{- end }}
 
 processors:
   memory_limiter:
@@ -610,6 +614,9 @@ service:
 {{- if and .Values.otel.metrics.enabled (or (not .Values.aws_fargate.enabled) .Values.otel.metrics.autodiscovery.prometheusEndpoints.enabled) }}
     - k8s_observer
 {{- end}}
+{{- if .Values.diagnostics.profiling.enabled }}
+    - pprof
+{{- end }}
   pipelines:
 {{- if and .Values.otel.logs.enabled (or .Values.otel.logs.container (and (not .isWindows) .Values.otel.logs.journal))}}
 {{- if .Values.otel.logs.container }}

--- a/deploy/helm/templates/NOTES.txt
+++ b/deploy/helm/templates/NOTES.txt
@@ -151,3 +151,8 @@ WARNING: Network observability using Beyla is experimental
 WARNING: Value `otel.metrics.otlp_endpoint` was deprecated and will be removed in a future release. Please use `otel.gateway.otlp_endpoint` instead.
 {{- println -}}
 {{- end -}}
+
+{{- if .Values.diagnostics.profiling.enabled -}}
+WARNING: Collector profiling is enabled. Profiler endpoint is available on port {{ .Values.diagnostics.profiling.port }}.
+{{- println -}}
+{{- end -}}

--- a/deploy/helm/templates/events-collector-statefulset.yaml
+++ b/deploy/helm/templates/events-collector-statefulset.yaml
@@ -125,12 +125,16 @@ spec:
           envFrom:
             - configMapRef:
                 name: {{ include "common.fullname" (tuple . "-common-env") }}
-{{- if .Values.otel.events.telemetry.metrics.enabled }}
           ports:
+{{- if .Values.otel.events.telemetry.metrics.enabled }}
             - name: http
               containerPort: {{ (split ":" .Values.otel.events.telemetry.metrics.address)._1 }}
               protocol: TCP
-{{- end}}
+{{- end }}
+{{- if .Values.diagnostics.profiling.enabled }}
+            - name: pprof
+              containerPort: {{ .Values.diagnostics.profiling.port }}
+{{- end }}
           livenessProbe:
             httpGet:
               path: /

--- a/deploy/helm/templates/gateway/gateway-deployment.yaml
+++ b/deploy/helm/templates/gateway/gateway-deployment.yaml
@@ -140,6 +140,10 @@ spec:
               containerPort: {{ (split ":" .Values.otel.gateway.telemetry.metrics.address)._1 }}
               protocol: TCP
 {{- end}}
+{{- if .Values.diagnostics.profiling.enabled }}
+            - name: pprof
+              containerPort: {{ .Values.diagnostics.profiling.port }}
+{{- end }}
           livenessProbe:
             httpGet:
               path: /

--- a/deploy/helm/templates/metrics-deployment.yaml
+++ b/deploy/helm/templates/metrics-deployment.yaml
@@ -139,6 +139,10 @@ spec:
               containerPort: {{ (split ":" .Values.otel.metrics.telemetry.metrics.address)._1 }}
               protocol: TCP
 {{- end}}
+{{- if .Values.diagnostics.profiling.enabled }}
+            - name: pprof
+              containerPort: {{ .Values.diagnostics.profiling.port }}
+{{- end }}
           envFrom:
             - configMapRef:
                 name: {{ include "common.fullname" (tuple . "-common-env") }}

--- a/deploy/helm/templates/metrics-discovery-deployment.yaml
+++ b/deploy/helm/templates/metrics-discovery-deployment.yaml
@@ -122,6 +122,10 @@ spec:
               containerPort: {{ (split ":" .Values.aws_fargate.metrics.autodiscovery.telemetry.metrics.address)._1 }}
               protocol: TCP
 {{- end}}
+{{- if .Values.diagnostics.profiling.enabled }}
+            - name: pprof
+              containerPort: {{ .Values.diagnostics.profiling.port }}
+{{- end }}
           envFrom:
             - configMapRef:
                 name: {{ include "common.fullname" (tuple . "-common-env") }}

--- a/deploy/helm/templates/node-collector-daemon-set-windows.yaml
+++ b/deploy/helm/templates/node-collector-daemon-set-windows.yaml
@@ -124,12 +124,16 @@ spec:
           envFrom:
             - configMapRef:
                 name: {{ include "common.fullname" (tuple . "-common-env") }}
-{{- if .Values.otel.logs.telemetry.metrics.enabled }}
           ports:
+{{- if .Values.otel.logs.telemetry.metrics.enabled }}
             - name: http
               containerPort: {{ (split ":" .Values.otel.logs.telemetry.metrics.address)._1 }}
               protocol: TCP
-{{- end}}
+{{- end }}
+{{- if .Values.diagnostics.profiling.enabled }}
+            - name: pprof
+              containerPort: {{ .Values.diagnostics.profiling.port }}
+{{- end }}
           livenessProbe:
             httpGet:
               path: /

--- a/deploy/helm/templates/node-collector-daemon-set.yaml
+++ b/deploy/helm/templates/node-collector-daemon-set.yaml
@@ -151,12 +151,16 @@ spec:
           envFrom:
             - configMapRef:
                 name: {{ include "common.fullname" (tuple . "-common-env") }}
-{{- if .Values.otel.logs.telemetry.metrics.enabled }}
           ports:
+{{- if .Values.otel.logs.telemetry.metrics.enabled }}
             - name: http
               containerPort: {{ (split ":" .Values.otel.logs.telemetry.metrics.address)._1 }}
               protocol: TCP
-{{- end}}
+{{- end }}
+{{- if .Values.diagnostics.profiling.enabled }}
+            - name: pprof
+              containerPort: {{ .Values.diagnostics.profiling.port }}
+{{- end }}
           livenessProbe:
             httpGet:
               path: /

--- a/deploy/helm/tests/events-collector-config-map_test.yaml
+++ b/deploy/helm/tests/events-collector-config-map_test.yaml
@@ -37,3 +37,17 @@ tests:
     asserts:
       - matchSnapshot:
           path: data
+  - it: Pprof should not be in the configuration by default
+    template: events-collector-config-map.yaml
+    asserts:
+      - notMatchRegex:
+          path: data["events.config"]
+          pattern: "pprof"
+  - it: Pprof should be in the configuration when enabled
+    template: events-collector-config-map.yaml
+    set:
+      diagnostics.profiling.enabled: true
+    asserts:
+      - matchRegex:
+          path: data["events.config"]
+          pattern: "pprof"

--- a/deploy/helm/tests/gateway-config-map_test.yaml
+++ b/deploy/helm/tests/gateway-config-map_test.yaml
@@ -8,3 +8,17 @@ tests:
     asserts:
       - matchSnapshot:
           path: data
+  - it: Pprof should not be in the configuration by default
+    template: gateway/gateway-config-map.yaml
+    asserts:
+      - notMatchRegex:
+          path: data["gateway.config"]
+          pattern: "pprof"
+  - it: Pprof should be in the configuration when enabled
+    template: gateway/gateway-config-map.yaml
+    set:
+      diagnostics.profiling.enabled: true
+    asserts:
+      - matchRegex:
+          path: data["gateway.config"]
+          pattern: "pprof"

--- a/deploy/helm/tests/metrics-collector-config-map_test.yaml
+++ b/deploy/helm/tests/metrics-collector-config-map_test.yaml
@@ -24,3 +24,17 @@ tests:
     asserts:
       - matchSnapshot:
           path: data
+  - it: Pprof should not be in the configuration by default
+    template: metrics-collector-config-map.yaml
+    asserts:
+      - notMatchRegex:
+          path: data["metrics.config"]
+          pattern: "pprof"
+  - it: Pprof should be in the configuration when enabled
+    template: metrics-collector-config-map.yaml
+    set:
+      diagnostics.profiling.enabled: true
+    asserts:
+      - matchRegex:
+          path: data["metrics.config"]
+          pattern: "pprof"

--- a/deploy/helm/tests/metrics-discovery-config-map_test.yaml
+++ b/deploy/helm/tests/metrics-discovery-config-map_test.yaml
@@ -14,4 +14,21 @@ tests:
     template: metrics-discovery-config-map.yaml
     asserts:
       - hasDocuments:
-          count: 0      
+          count: 0
+  - it: Pprof should not be in the configuration by default
+    template: metrics-discovery-config-map.yaml
+    set:
+      aws_fargate.enabled: true
+    asserts:
+      - notMatchRegex:
+          path: data["metrics-discovery.config"]
+          pattern: "pprof"
+  - it: Pprof should be in the configuration when enabled
+    template: metrics-discovery-config-map.yaml
+    set:
+      aws_fargate.enabled: true
+      diagnostics.profiling.enabled: true
+    asserts:
+      - matchRegex:
+          path: data["metrics-discovery.config"]
+          pattern: "pprof"

--- a/deploy/helm/tests/node-collector-config-map-windows_test.yaml
+++ b/deploy/helm/tests/node-collector-config-map-windows_test.yaml
@@ -20,3 +20,17 @@ tests:
     asserts:
       - matchSnapshot:
           path: data
+  - it: Pprof should not be in the configuration by default
+    template: node-collector-config-map-windows.yaml
+    asserts:
+      - notMatchRegex:
+          path: data["logs.config"]
+          pattern: "pprof"
+  - it: Pprof should be in the configuration when enabled
+    template: node-collector-config-map-windows.yaml
+    set:
+      diagnostics.profiling.enabled: true
+    asserts:
+      - matchRegex:
+          path: data["logs.config"]
+          pattern: "pprof"

--- a/deploy/helm/tests/node-collector-config-map_test.yaml
+++ b/deploy/helm/tests/node-collector-config-map_test.yaml
@@ -51,3 +51,17 @@ tests:
     asserts:
       - matchSnapshot:
           path: data
+  - it: Pprof should not be in the configuration by default
+    template: node-collector-config-map.yaml
+    asserts:
+      - notMatchRegex:
+          path: data["logs.config"]
+          pattern: "pprof"
+  - it: Pprof should be in the configuration when enabled
+    template: node-collector-config-map.yaml
+    set:
+      diagnostics.profiling.enabled: true
+    asserts:
+      - matchRegex:
+          path: data["logs.config"]
+          pattern: "pprof"

--- a/deploy/helm/tests/notes_test.yaml
+++ b/deploy/helm/tests/notes_test.yaml
@@ -148,4 +148,11 @@ tests:
       - equalRaw:
           value: |
             WARNING: Configuration `otel.events.k8s_instrumentation.annotations` is deprecated and will be removed in a future release.
-            
+
+  - it: should show warning when profiler is enabled
+    set:
+      diagnostics.profiling.enabled: true
+    asserts:
+      - equalRaw:
+          value: |
+            WARNING: Collector profiling is enabled. Profiler endpoint is available on port 1777.

--- a/deploy/helm/values.schema.json
+++ b/deploy/helm/values.schema.json
@@ -1699,6 +1699,26 @@
                 },
                 "additionalProperties": false
             }
+        },
+        "diagnostics": {
+            "description": "Section for diagnostics configuration.",
+            "type": "object",
+            "properties": {
+                "profiling": {
+                    "description": "Configures profiling of the collector.",
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean"
+                        },
+                        "port": {
+                            "$ref": "#/definitions/port"
+                        },
+                        "additionalProperties": false
+                    }
+                },
+                "additionalProperties": false
+            }
         }
     },
     "required": [

--- a/deploy/helm/values.yaml
+++ b/deploy/helm/values.yaml
@@ -1181,5 +1181,10 @@ beyla:
   # - SYS_RESOURCE       # <-- pre 5.11 only. Allows Beyla to increase the amount of locked memory.
   # - SYS_ADMIN          # <-- Required for Go application trace context propagation, or if kernel.perf_event_paranoid >= 3 on Debian distributions.
 
+diagnostics:
+  profiling:
+    enabled: false
+    # The port on which the profiling server will listen
+    port: 1777
 
 

--- a/doc/development.md
+++ b/doc/development.md
@@ -8,6 +8,7 @@
 - [Develop against remote prometheus](#develop-against-remote-prometheus)
 - [Helm Unit tests](#helm-unit-tests)
 - [Integration tests](#integration-tests)
+- [Performance profiling](#performance-profiling)
 - [Updating Chart dependencies](#updating-chart-dependencies)
 - [Updating Chart configuration](#updating-chart-configuration)
 - [Release](#release)
@@ -233,6 +234,46 @@ Deploy cluster locally using `skaffold dev`
 ### Updating utils used for testing
 
 Whenever there is a need to improve the test tooling, eg. the script for scraping test data from a Prometheus (`utils/cleanup_mocked_prometheus_response.py`), or data comparison code, or versions or Python packages, ..., it should always happen in a separate PR. Do not mix changes to the test framework with changes to the k8s collector itself. Otherwise a change to the testing framework might hide an unintentional change to the collector code.
+
+## Performance profiling
+
+The `k8s collector` can be configured to enable performance profiling with `pprof`.
+
+Steps:
+
+1. Deploy the `k8s collector` with setting:
+
+    ```yaml
+    diagnostics:
+     profiling:
+       enabled: true
+    ```
+
+2. Port-forward the `pprof` port on any of the `k8s collector`'s Pods:
+
+    ```shell
+    kubectl -n <namespace> port-forward pod/<pod-name> 1777:pprof
+    ```
+
+3. On a machine with Go runtime, run command:
+
+    ```shell
+    go tool pprof http://localhost:1777/debug/pprof/<command>
+    ```
+
+    Alternatively, get the `pprof` binary already compiled and use that.
+
+    It will connect to the port-forwarded instance of the `k8s collector`, get the requested data, store it in a local file (path will be mentioned on the screen) and open the file in an interactive mode.
+
+    For documentation about available commands, see [net/http/pprof](https://pkg.go.dev/net/http/pprof).
+
+Note:
+
+To render the data as graphs, `pprof` requires `Graphwiz` to be installed on the machine:
+
+```shell
+choco install graphviz
+```
 
 ## Updating Chart dependencies
 


### PR DESCRIPTION
Add a new Helm chart setting for enabling `pprof` profiler on `k8s collector`'s workloads.

```yaml
diagnostics:
 profiling:
   enabled: true
```

When enabled, we display a warning during chart's installation/upgrade.

Depends on https://github.com/solarwinds/solarwinds-otel-collector-releases/pull/197 and release of a new image.