### PR TITLE
Collect 'k8s.object.name' in manifest namespace

### DIFF
--- a/deploy/helm/events-collector-config.yaml
+++ b/deploy/helm/events-collector-config.yaml
@@ -279,6 +279,7 @@ processors:
             - set(log.attributes["k8s.ingress.name"], log.body["metadata"]["name"]) where log.body["kind"] == "Ingress" or log.body["kind"] == "VirtualService"
             - set(log.attributes["sw.k8s.ingress.type"], log.body["kind"]) where log.body["kind"] == "Ingress" or log.body["kind"] == "VirtualService"
             - set(log.attributes["k8s.object.kind"], log.body["kind"]) where log.body["kind"] != nil
+            - set(log.attributes["k8s.object.name"], log.body["metadata"]["name"]) where log.body["metadata"]["name"] != nil
 
             # There are some attributes added by k8sobjects receiver, SWO do not need them so removing it
             - delete_key(log.attributes, "k8s.resource.name")

--- a/deploy/helm/tests/__snapshot__/events-collector-config-map_test.yaml.snap
+++ b/deploy/helm/tests/__snapshot__/events-collector-config-map_test.yaml.snap
@@ -326,6 +326,8 @@ Custom events filter with new syntax:
               == "Ingress" or log.body["kind"] == "VirtualService"
             - set(log.attributes["k8s.object.kind"], log.body["kind"]) where log.body["kind"]
               != nil
+            - set(log.attributes["k8s.object.name"], log.body["metadata"]["name"]) where
+              log.body["metadata"]["name"] != nil
             - delete_key(log.attributes, "k8s.resource.name")
             - delete_key(log.attributes, "event.name")
             - delete_key(log.attributes, "event.domain")
@@ -1066,6 +1068,8 @@ Custom events filter with old syntax:
               == "Ingress" or log.body["kind"] == "VirtualService"
             - set(log.attributes["k8s.object.kind"], log.body["kind"]) where log.body["kind"]
               != nil
+            - set(log.attributes["k8s.object.name"], log.body["metadata"]["name"]) where
+              log.body["metadata"]["name"] != nil
             - delete_key(log.attributes, "k8s.resource.name")
             - delete_key(log.attributes, "event.name")
             - delete_key(log.attributes, "event.domain")
@@ -1799,6 +1803,8 @@ Events config should match snapshot when using default values:
               == "Ingress" or log.body["kind"] == "VirtualService"
             - set(log.attributes["k8s.object.kind"], log.body["kind"]) where log.body["kind"]
               != nil
+            - set(log.attributes["k8s.object.name"], log.body["metadata"]["name"]) where
+              log.body["metadata"]["name"] != nil
             - delete_key(log.attributes, "k8s.resource.name")
             - delete_key(log.attributes, "event.name")
             - delete_key(log.attributes, "event.domain")
@@ -2459,6 +2465,8 @@ Events config should not contain manifest collection pipeline when disabled:
               == "Ingress" or log.body["kind"] == "VirtualService"
             - set(log.attributes["k8s.object.kind"], log.body["kind"]) where log.body["kind"]
               != nil
+            - set(log.attributes["k8s.object.name"], log.body["metadata"]["name"]) where
+              log.body["metadata"]["name"] != nil
             - delete_key(log.attributes, "k8s.resource.name")
             - delete_key(log.attributes, "event.name")
             - delete_key(log.attributes, "event.domain")


### PR DESCRIPTION
If we want to filter by "source", we need to have an attribute that is present in all events, same as in the regular event namespace.
https://swicloud.atlassian.net/browse/NH-112613