### PR TITLE
Update `kube-state-metrics` Helm chart to 6.1

### DIFF
--- a/deploy/helm/Chart.lock
+++ b/deploy/helm/Chart.lock
@@ -1,12 +1,12 @@
 dependencies:
 - name: kube-state-metrics
   repository: https://prometheus-community.github.io/helm-charts
-  version: 5.31.0
+  version: 6.1.0
 - name: opentelemetry-operator
   repository: https://open-telemetry.github.io/opentelemetry-helm-charts
   version: 0.82.2
 - name: cert-manager
   repository: https://charts.jetstack.io
   version: v1.16.1
-digest: sha256:258f8804e01a65e791e2c167b86089ed6c739e32191a504e5ca4cb0492034381
-generated: "2025-04-01T18:45:06.7987085+02:00"
+digest: sha256:b5b101d8158a72151498a286e916fa490f8bff8ee93413c733ba05369f705139
+generated: "2025-07-08T17:37:52.0954763+02:00"

--- a/deploy/helm/Chart.yaml
+++ b/deploy/helm/Chart.yaml
@@ -20,7 +20,7 @@ maintainers:
 dependencies:
   - name: kube-state-metrics
     repository: https://prometheus-community.github.io/helm-charts
-    version: 5.31.0
+    version: 6.1.0
     condition: kube-state-metrics.enabled
   - name: opentelemetry-operator
     repository: https://open-telemetry.github.io/opentelemetry-helm-charts


### PR DESCRIPTION
Interesting changes:
* Fixed reporting `reason` in `kube_pod_status_reason`
* Removed support for ApiGroups that were deprecated years ago
* KSM Deployment can now have custom labels set via the Helm chart
* KSM no longer tries to create deprecated `PodSecurityPolicy` resources (this was complicating support for AWS/Azure extensions)
* 3rd party security fixes