### PR TITLE
Limitting kube-state-metrics default collectors to those that are actually used

### DIFF
--- a/deploy/helm/values.yaml
+++ b/deploy/helm/values.yaml
@@ -896,6 +896,92 @@ kube-state-metrics:
     - services
     - statefulsets
 
+  # List of metrics that are actually scraped by the collector.
+  # see https://github.com/prometheus-community/helm-charts/blob/main/charts/kube-state-metrics/values.yaml#L370
+  metricAllowlist:
+    - kube_deployment_created
+    - kube_daemonset_created
+    - kube_namespace_created
+    - kube_node_info
+    - kube_node_created
+    - kube_node_status_capacity
+    - kube_node_status_condition
+    - kube_pod_created
+    - kube_pod_info
+    - kube_pod_owner
+    - kube_pod_completion_time
+    - kube_pod_status_phase
+    - kube_pod_status_ready
+    - kube_pod_status_reason
+    - kube_pod_start_time
+    - kube_pod_container_.*
+    - kube_pod_init_container_.*
+    - kube_namespace_status_phase
+    - kube_deployment_spec_replicas
+    - kube_deployment_spec_paused
+    - kube_deployment_status_replicas
+    - kube_deployment_status_replicas_ready
+    - kube_deployment_status_replicas_available
+    - kube_deployment_status_replicas_updated
+    - kube_deployment_status_replicas_unavailable
+    - kube_deployment_status_condition
+    - kube_replicaset_owner
+    - kube_replicaset_created
+    - kube_replicaset_spec_replicas
+    - kube_replicaset_status_ready_replicas
+    - kube_replicaset_status_replicas
+    - kube_statefulset_replicas
+    - kube_statefulset_status_replicas_ready
+    - kube_statefulset_status_replicas_current
+    - kube_statefulset_status_replicas_updated
+    - kube_statefulset_created
+    - kube_daemonset_status_current_number_scheduled
+    - kube_daemonset_status_desired_number_scheduled
+    - kube_daemonset_status_updated_number_scheduled
+    - kube_daemonset_status_number_available
+    - kube_daemonset_status_number_misscheduled
+    - kube_daemonset_status_number_ready
+    - kube_daemonset_status_number_unavailable
+    - kube_resourcequota
+    - kube_node_status_allocatable
+    - kube_node_spec_unschedulable
+    - kube_cronjob_info
+    - kube_cronjob_created
+    - kube_cronjob_status_last_schedule_time
+    - kube_job_info
+    - kube_job_owner
+    - kube_job_created
+    - kube_job_complete
+    - kube_job_failed
+    - kube_job_status_active
+    - kube_job_status_succeeded
+    - kube_job_status_failed
+    - kube_job_status_start_time
+    - kube_job_status_completion_time
+    - kube_job_spec_completions
+    - kube_job_spec_parallelism
+    - kube_persistentvolume_capacity_bytes
+    - kube_persistentvolume_info
+    - kube_persistentvolume_status_phase
+    - kube_persistentvolume_claim_ref
+    - kube_persistentvolume_created
+    - kube_persistentvolumeclaim_info
+    - kube_persistentvolumeclaim_access_mode
+    - kube_persistentvolumeclaim_status_phase
+    - kube_persistentvolumeclaim_resource_requests_storage_bytes
+    - kube_persistentvolumeclaim_created
+    - kube_pod_spec_volumes_persistentvolumeclaims_info
+    - kube_service_info
+    - kube_service_created
+    - kube_service_spec_type
+    - kube_service_spec_external_ip
+    - kube_service_status_load_balancer_ingress
+    - kube_endpoint_info
+    - kube_endpoint_created
+    - kube_endpoint_ports
+    - kube_endpoint_address
+    - kube_configmap_created
+
 # DEPRECATED: Node exporter is deployed only in case opencost section is enabled. Otherwise this section can be ignored.
 # prometheus-node-exporter:
 


### PR DESCRIPTION
This should reduce load on API server. 

Full list of collectors: https://github.com/prometheus-community/helm-charts/blob/main/charts/kube-state-metrics/values.yaml#L397

By default there are 28 collectors, we need just 15 of them