### PR TITLE
Adding self identification

### DIFF
--- a/deploy/helm/events-collector-config.yaml
+++ b/deploy/helm/events-collector-config.yaml
@@ -28,6 +28,7 @@ exporters:
       insecure: ${OTEL_ENVOY_ADDRESS_TLS_INSECURE}
     headers:
       "Authorization": "Bearer ${SOLARWINDS_API_TOKEN}"
+      "swi-reporter": "k8s swo-k8s-collector/{{ .Chart.Version }}"
     retry_on_failure:
       enabled: {{ .Values.otel.events.retry_on_failure.enabled }}
       initial_interval: {{ .Values.otel.events.retry_on_failure.initial_interval }}

--- a/deploy/helm/gateway-collector-config.yaml
+++ b/deploy/helm/gateway-collector-config.yaml
@@ -5,6 +5,7 @@ exporters:
       insecure: ${OTEL_ENVOY_ADDRESS_TLS_INSECURE}
     headers:
       "Authorization": "Bearer ${SOLARWINDS_API_TOKEN}"
+      "swi-reporter": "k8s swo-k8s-collector/{{ .Chart.Version }}"
     retry_on_failure:
       enabled: {{ .Values.otel.gateway.retry_on_failure.enabled }}
       initial_interval: {{ .Values.otel.gateway.retry_on_failure.initial_interval }}

--- a/deploy/helm/metrics-collector-config.yaml
+++ b/deploy/helm/metrics-collector-config.yaml
@@ -5,6 +5,7 @@ exporters:
       insecure: ${OTEL_ENVOY_ADDRESS_TLS_INSECURE}
     headers:
       "Authorization": "Bearer ${SOLARWINDS_API_TOKEN}"
+      "swi-reporter": "k8s swo-k8s-collector/{{ .Chart.Version }}"
     retry_on_failure:
       enabled: {{ .Values.otel.metrics.retry_on_failure.enabled }}
       initial_interval: {{ .Values.otel.metrics.retry_on_failure.initial_interval }}

--- a/deploy/helm/metrics-discovery-config.yaml
+++ b/deploy/helm/metrics-discovery-config.yaml
@@ -5,6 +5,7 @@ exporters:
       insecure: ${OTEL_ENVOY_ADDRESS_TLS_INSECURE}
     headers:
       "Authorization": "Bearer ${SOLARWINDS_API_TOKEN}"
+      "swi-reporter": "k8s swo-k8s-collector/{{ .Chart.Version }}"
     retry_on_failure:
       enabled: {{ .Values.aws_fargate.metrics.autodiscovery.retry_on_failure.enabled }}
       initial_interval: {{ .Values.aws_fargate.metrics.autodiscovery.retry_on_failure.initial_interval }}

--- a/deploy/helm/node-collector-config.yaml
+++ b/deploy/helm/node-collector-config.yaml
@@ -5,6 +5,7 @@ exporters:
       insecure: ${OTEL_ENVOY_ADDRESS_TLS_INSECURE}
     headers:
       "Authorization": "Bearer ${SOLARWINDS_API_TOKEN}"
+      "swi-reporter": "k8s swo-k8s-collector/{{ .Chart.Version }}"
     retry_on_failure:
       enabled: {{ .Values.otel.node_collector.retry_on_failure.enabled }}
       initial_interval: {{ .Values.otel.node_collector.retry_on_failure.initial_interval }}

--- a/deploy/helm/templates/operator/discovery-collector.yaml
+++ b/deploy/helm/templates/operator/discovery-collector.yaml
@@ -295,6 +295,7 @@ spec:
           insecure: ${OTEL_ENVOY_ADDRESS_TLS_INSECURE}
         headers:
           "Authorization": "Bearer ${SOLARWINDS_API_TOKEN}"
+          "swi-reporter": "k8s swo-k8s-collector/{{ .Chart.Version }}"
         retry_on_failure:
           enabled: {{ .Values.otel.metrics.autodiscovery.discovery_collector.retry_on_failure.enabled }}
           initial_interval: {{ .Values.otel.metrics.autodiscovery.discovery_collector.retry_on_failure.initial_interval }}

--- a/deploy/helm/tests/__snapshot__/discovery-collector_test.yaml.snap
+++ b/deploy/helm/tests/__snapshot__/discovery-collector_test.yaml.snap
@@ -352,6 +352,7 @@ Discovery collector spec should match snapshot when using default values:
           endpoint: ${OTEL_ENVOY_ADDRESS}
           headers:
             Authorization: Bearer ${SOLARWINDS_API_TOKEN}
+            swi-reporter: k8s swo-k8s-collector/1.0.0
           retry_on_failure:
             enabled: true
             initial_interval: 10s

--- a/deploy/helm/tests/__snapshot__/events-collector-config-map_test.yaml.snap
+++ b/deploy/helm/tests/__snapshot__/events-collector-config-map_test.yaml.snap
@@ -79,6 +79,7 @@ Custom events filter with new syntax:
           endpoint: ${OTEL_ENVOY_ADDRESS}
           headers:
             Authorization: Bearer ${SOLARWINDS_API_TOKEN}
+            swi-reporter: k8s swo-k8s-collector/1.0.0
           retry_on_failure:
             enabled: true
             initial_interval: 10s
@@ -835,6 +836,7 @@ Custom events filter with old syntax:
           endpoint: ${OTEL_ENVOY_ADDRESS}
           headers:
             Authorization: Bearer ${SOLARWINDS_API_TOKEN}
+            swi-reporter: k8s swo-k8s-collector/1.0.0
           retry_on_failure:
             enabled: true
             initial_interval: 10s
@@ -1594,6 +1596,7 @@ Events config should match snapshot when using default values:
           endpoint: ${OTEL_ENVOY_ADDRESS}
           headers:
             Authorization: Bearer ${SOLARWINDS_API_TOKEN}
+            swi-reporter: k8s swo-k8s-collector/1.0.0
           retry_on_failure:
             enabled: true
             initial_interval: 10s
@@ -2273,6 +2276,7 @@ Events config should not contain manifest collection pipeline when disabled:
           endpoint: ${OTEL_ENVOY_ADDRESS}
           headers:
             Authorization: Bearer ${SOLARWINDS_API_TOKEN}
+            swi-reporter: k8s swo-k8s-collector/1.0.0
           retry_on_failure:
             enabled: true
             initial_interval: 10s

--- a/deploy/helm/tests/__snapshot__/gateway-config-map_test.yaml.snap
+++ b/deploy/helm/tests/__snapshot__/gateway-config-map_test.yaml.snap
@@ -388,6 +388,7 @@ Gateway config should match snapshot when using default values:
           endpoint: ${OTEL_ENVOY_ADDRESS}
           headers:
             Authorization: Bearer ${SOLARWINDS_API_TOKEN}
+            swi-reporter: k8s swo-k8s-collector/1.0.0
           retry_on_failure:
             enabled: true
             initial_interval: 10s

--- a/deploy/helm/tests/__snapshot__/metrics-collector-config-map-fargate_test.yaml.snap
+++ b/deploy/helm/tests/__snapshot__/metrics-collector-config-map-fargate_test.yaml.snap
@@ -9,6 +9,7 @@ Metrics config should match snapshot when using default values:
           endpoint: ${OTEL_ENVOY_ADDRESS}
           headers:
             Authorization: Bearer ${SOLARWINDS_API_TOKEN}
+            swi-reporter: k8s swo-k8s-collector/1.0.0
           retry_on_failure:
             enabled: true
             initial_interval: 10s

--- a/deploy/helm/tests/__snapshot__/metrics-collector-config-map_test.yaml.snap
+++ b/deploy/helm/tests/__snapshot__/metrics-collector-config-map_test.yaml.snap
@@ -9,6 +9,7 @@ Metrics config should match snapshot when fargate is enabled:
           endpoint: ${OTEL_ENVOY_ADDRESS}
           headers:
             Authorization: Bearer ${SOLARWINDS_API_TOKEN}
+            swi-reporter: k8s swo-k8s-collector/1.0.0
           retry_on_failure:
             enabled: true
             initial_interval: 10s
@@ -1706,6 +1707,7 @@ Metrics config should match snapshot when using Prometheus url with extra_scrape
           endpoint: ${OTEL_ENVOY_ADDRESS}
           headers:
             Authorization: Bearer ${SOLARWINDS_API_TOKEN}
+            swi-reporter: k8s swo-k8s-collector/1.0.0
           retry_on_failure:
             enabled: true
             initial_interval: 10s
@@ -3348,6 +3350,7 @@ Metrics config should match snapshot when using default values:
           endpoint: ${OTEL_ENVOY_ADDRESS}
           headers:
             Authorization: Bearer ${SOLARWINDS_API_TOKEN}
+            swi-reporter: k8s swo-k8s-collector/1.0.0
           retry_on_failure:
             enabled: true
             initial_interval: 10s

--- a/deploy/helm/tests/__snapshot__/metrics-discovery-config-map_test.yaml.snap
+++ b/deploy/helm/tests/__snapshot__/metrics-discovery-config-map_test.yaml.snap
@@ -329,6 +329,7 @@ Metrics discovery config should match snapshot when Fargate is enabled:
           endpoint: ${OTEL_ENVOY_ADDRESS}
           headers:
             Authorization: Bearer ${SOLARWINDS_API_TOKEN}
+            swi-reporter: k8s swo-k8s-collector/1.0.0
           retry_on_failure:
             enabled: true
             initial_interval: 10s

--- a/deploy/helm/tests/__snapshot__/node-collector-config-map-windows_test.yaml.snap
+++ b/deploy/helm/tests/__snapshot__/node-collector-config-map-windows_test.yaml.snap
@@ -330,6 +330,7 @@ Node collector config for windows nodes should match snapshot when using default
           endpoint: ${OTEL_ENVOY_ADDRESS}
           headers:
             Authorization: Bearer ${SOLARWINDS_API_TOKEN}
+            swi-reporter: k8s swo-k8s-collector/1.0.0
           retry_on_failure:
             enabled: true
             initial_interval: 10s
@@ -2098,6 +2099,7 @@ Node collector config for windows nodes should match snapshot when using legacy 
           endpoint: ${OTEL_ENVOY_ADDRESS}
           headers:
             Authorization: Bearer ${SOLARWINDS_API_TOKEN}
+            swi-reporter: k8s swo-k8s-collector/1.0.0
           retry_on_failure:
             enabled: true
             initial_interval: 10s

--- a/deploy/helm/tests/__snapshot__/node-collector-config-map_test.yaml.snap
+++ b/deploy/helm/tests/__snapshot__/node-collector-config-map_test.yaml.snap
@@ -330,6 +330,7 @@ Custom logs filter with new syntax:
           endpoint: ${OTEL_ENVOY_ADDRESS}
           headers:
             Authorization: Bearer ${SOLARWINDS_API_TOKEN}
+            swi-reporter: k8s swo-k8s-collector/1.0.0
           retry_on_failure:
             enabled: true
             initial_interval: 10s
@@ -2139,6 +2140,7 @@ Custom logs filter with old syntax:
           endpoint: ${OTEL_ENVOY_ADDRESS}
           headers:
             Authorization: Bearer ${SOLARWINDS_API_TOKEN}
+            swi-reporter: k8s swo-k8s-collector/1.0.0
           retry_on_failure:
             enabled: true
             initial_interval: 10s
@@ -4032,6 +4034,7 @@ Node collector config should match snapshot when autodiscovery is disabled:
           endpoint: ${OTEL_ENVOY_ADDRESS}
           headers:
             Authorization: Bearer ${SOLARWINDS_API_TOKEN}
+            swi-reporter: k8s swo-k8s-collector/1.0.0
           retry_on_failure:
             enabled: true
             initial_interval: 10s
@@ -5776,6 +5779,7 @@ Node collector config should match snapshot when fargate is enabled:
           endpoint: ${OTEL_ENVOY_ADDRESS}
           headers:
             Authorization: Bearer ${SOLARWINDS_API_TOKEN}
+            swi-reporter: k8s swo-k8s-collector/1.0.0
           retry_on_failure:
             enabled: true
             initial_interval: 10s
@@ -7498,6 +7502,7 @@ Node collector config should match snapshot when fargate is enabled and autodisc
           endpoint: ${OTEL_ENVOY_ADDRESS}
           headers:
             Authorization: Bearer ${SOLARWINDS_API_TOKEN}
+            swi-reporter: k8s swo-k8s-collector/1.0.0
           retry_on_failure:
             enabled: true
             initial_interval: 10s
@@ -9143,6 +9148,7 @@ Node collector config should match snapshot when using default values:
           endpoint: ${OTEL_ENVOY_ADDRESS}
           headers:
             Authorization: Bearer ${SOLARWINDS_API_TOKEN}
+            swi-reporter: k8s swo-k8s-collector/1.0.0
           retry_on_failure:
             enabled: true
             initial_interval: 10s

--- a/deploy/helm/tests/discovery-collector_test.yaml
+++ b/deploy/helm/tests/discovery-collector_test.yaml
@@ -3,11 +3,12 @@ suite: Test for discovery_collector
 templates:
   - operator/discovery-collector.yaml
   - common-env-config-map.yaml
+chart:
+  appVersion: 1.0.0
+  version: 1.0.0
 release:
   name: swi-k8s-opentelemetry-collector
   namespace: test-namespace
-chart:
-  appVersion: 1.0.0
 tests:
   - it: Discovery collector spec should match snapshot when using default values
     template: operator/discovery-collector.yaml

--- a/deploy/helm/tests/events-collector-config-map_test.yaml
+++ b/deploy/helm/tests/events-collector-config-map_test.yaml
@@ -2,6 +2,8 @@
 suite: Test for events-collector-config-map
 templates:
   - events-collector-config-map.yaml
+chart:
+  version: 1.0.0
 tests:
   - it: Events config should match snapshot when using default values
     template: events-collector-config-map.yaml

--- a/deploy/helm/tests/gateway-config-map_test.yaml
+++ b/deploy/helm/tests/gateway-config-map_test.yaml
@@ -2,6 +2,8 @@ suite: Test for gateway-config-map
 templates:
   - gateway/gateway-config-map.yaml
   - common-env-config-map.yaml
+chart:
+  version: 1.0.0
 tests:
   - it: Gateway config should match snapshot when using default values
     template: gateway/gateway-config-map.yaml

--- a/deploy/helm/tests/metrics-collector-config-map-fargate_test.yaml
+++ b/deploy/helm/tests/metrics-collector-config-map-fargate_test.yaml
@@ -2,6 +2,8 @@
 suite: Test for metrics-collector-config-map
 templates:
   - metrics-collector-config-map.yaml
+chart:
+  version: 1.0.0
 tests:
   - it: Metrics config should match snapshot when using default values
     template: metrics-collector-config-map.yaml

--- a/deploy/helm/tests/metrics-collector-config-map_test.yaml
+++ b/deploy/helm/tests/metrics-collector-config-map_test.yaml
@@ -2,6 +2,8 @@
 suite: Test for metrics-collector-config-map
 templates:
   - metrics-collector-config-map.yaml
+chart:
+  version: 1.0.0
 tests:
   - it: Metrics config should match snapshot when using default values
     template: metrics-collector-config-map.yaml

--- a/deploy/helm/tests/metrics-discovery-config-map_test.yaml
+++ b/deploy/helm/tests/metrics-discovery-config-map_test.yaml
@@ -2,6 +2,8 @@
 suite: Test for metrics-discovery-config-map
 templates:
   - metrics-discovery-config-map.yaml
+chart:
+  version: 1.0.0
 tests:
   - it: Metrics discovery config should match snapshot when Fargate is enabled
     template: metrics-discovery-config-map.yaml

--- a/deploy/helm/tests/node-collector-config-map-windows_test.yaml
+++ b/deploy/helm/tests/node-collector-config-map-windows_test.yaml
@@ -2,6 +2,8 @@
 suite: Test for node-collector-config-map-windows
 templates:
   - node-collector-config-map-windows.yaml
+chart:
+  version: 1.0.0
 tests:
   - it: Node collector config for windows nodes should match snapshot when using default values
     template: node-collector-config-map-windows.yaml

--- a/deploy/helm/tests/node-collector-config-map_test.yaml
+++ b/deploy/helm/tests/node-collector-config-map_test.yaml
@@ -2,6 +2,8 @@
 suite: Test for node-collector-config-map
 templates:
   - node-collector-config-map.yaml
+chart:
+  version: 1.0.0
 tests:
   - it: Node collector config should match snapshot when using default values
     template: node-collector-config-map.yaml


### PR DESCRIPTION
This solves mandatory SWO platform self-identification requirement

since chart version now appears in the config I updated snapshot tests to mock the version to not have to update snapshot tests with every released