### PR TITLE
Setting `max_staleness` property of cumulativetodelta to avoid memory leaks

### DIFF
--- a/deploy/helm/Chart.yaml
+++ b/deploy/helm/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: swo-k8s-collector
-version: 4.7.1
+version: 4.7.2
 appVersion: 0.127.4
 description: SolarWinds Kubernetes Integration
 keywords:

--- a/deploy/helm/metrics-collector-config.yaml
+++ b/deploy/helm/metrics-collector-config.yaml
@@ -571,6 +571,7 @@ processors:
         - 'metric.name == "k8s.kube_job_status_start_time" and value_double == 0'
 
   cumulativetodelta:
+    max_staleness: {{ include "common.maxStaleness" . }}
     include:
       metrics:
         {{- include "common-config.cumulativetorate-cadvisor" . | nindent 8 }}

--- a/deploy/helm/node-collector-config.yaml
+++ b/deploy/helm/node-collector-config.yaml
@@ -81,6 +81,7 @@ processors:
   {{- include "common-config.attributes-remove-temp" . | nindent 2 }}
 
   cumulativetodelta/cadvisor:
+    max_staleness: {{ include "common.maxStaleness" . }}
     include:
       metrics:
         {{- include "common-config.cumulativetorate-cadvisor" . | nindent 8 }}

--- a/deploy/helm/templates/_common-discovery-config.tpl
+++ b/deploy/helm/templates/_common-discovery-config.tpl
@@ -61,6 +61,7 @@ metricstransform/copy-required-metrics:
 
 {{- if .Values.otel.metrics.autodiscovery.prometheusEndpoints.customTransformations.counterToRate }}
 cumulativetodelta/discovery:
+  max_staleness: {{ include "common.maxStaleness" . }}
   include:
     metrics:
 {{- range .Values.otel.metrics.autodiscovery.prometheusEndpoints.customTransformations.counterToRate }}
@@ -108,6 +109,7 @@ metricstransform/istio-metrics:
       new_name: k8s.istio_tcp_received_bytes.delta
 
 cumulativetodelta/istio-metrics:
+  max_staleness: {{ include "common.maxStaleness" . }}
   include:
     metrics:
       - k8s.istio_request_bytes.rate

--- a/deploy/helm/templates/_helpers.tpl
+++ b/deploy/helm/templates/_helpers.tpl
@@ -380,7 +380,7 @@ Usage:
 
 {{/*
 Calculate max_staleness for cumulativetodelta processor
-If max_staleness is explicitly set, use it. Otherwise, default to twice the scrape_interval
+If max_staleness is explicitly set, use it. Otherwise, default to thrice the scrape_interval
 Input should be the Values object with prometheus configuration
 Output will be a duration string like "120s", "4m", etc.
 */}}

--- a/deploy/helm/templates/_helpers.tpl
+++ b/deploy/helm/templates/_helpers.tpl
@@ -378,6 +378,43 @@ Usage:
 {{- end -}}
 {{- end -}}
 
+{{/*
+Calculate max_staleness for cumulativetodelta processor
+If max_staleness is explicitly set, use it. Otherwise, default to twice the scrape_interval
+Input should be the Values object with prometheus configuration
+Output will be a duration string like "120s", "4m", etc.
+*/}}
+{{- define "common.maxStaleness" -}}
+{{- if .Values.otel.metrics.prometheus.max_staleness -}}
+  {{- .Values.otel.metrics.prometheus.max_staleness -}}
+{{- else -}}
+  {{- include "common.doubleInterval" .Values.otel.metrics.prometheus.scrape_interval -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Calculate max_staleness as twice the scrape_interval
+Input should be a duration string like "60s", "5m", etc.
+Output will be the same format but doubled
+*/}}
+{{- define "common.doubleInterval" -}}
+{{- $interval := . -}}
+{{- if hasSuffix "s" $interval -}}
+  {{- $num := $interval | trimSuffix "s" | int -}}
+  {{- printf "%ds" (mul $num 2) -}}
+{{- else if hasSuffix "m" $interval -}}
+  {{- $num := $interval | trimSuffix "m" | int -}}
+  {{- printf "%dm" (mul $num 2) -}}
+{{- else if hasSuffix "h" $interval -}}
+  {{- $num := $interval | trimSuffix "h" | int -}}
+  {{- printf "%dh" (mul $num 2) -}}
+{{- else -}}
+  {{- /* Default case - assume seconds if no suffix */ -}}
+  {{- $num := $interval | int -}}
+  {{- printf "%ds" (mul $num 2) -}}
+{{- end -}}
+{{- end -}}
+
 {{- define "common.prometheus.relabelconfigs" -}}
 metric_relabel_configs:
   - source_labels: [service_name]

--- a/deploy/helm/templates/_helpers.tpl
+++ b/deploy/helm/templates/_helpers.tpl
@@ -388,30 +388,30 @@ Output will be a duration string like "120s", "4m", etc.
 {{- if .Values.otel.metrics.prometheus.max_staleness -}}
   {{- .Values.otel.metrics.prometheus.max_staleness -}}
 {{- else -}}
-  {{- include "common.doubleInterval" .Values.otel.metrics.prometheus.scrape_interval -}}
+  {{- include "common.tripleInterval" .Values.otel.metrics.prometheus.scrape_interval -}}
 {{- end -}}
 {{- end -}}
 
 {{/*
 Calculate max_staleness as twice the scrape_interval
 Input should be a duration string like "60s", "5m", etc.
-Output will be the same format but doubled
+Output will be the same format but tripled
 */}}
-{{- define "common.doubleInterval" -}}
+{{- define "common.tripleInterval" -}}
 {{- $interval := . -}}
 {{- if hasSuffix "s" $interval -}}
   {{- $num := $interval | trimSuffix "s" | int -}}
-  {{- printf "%ds" (mul $num 2) -}}
+  {{- printf "%ds" (mul $num 3) -}}
 {{- else if hasSuffix "m" $interval -}}
   {{- $num := $interval | trimSuffix "m" | int -}}
-  {{- printf "%dm" (mul $num 2) -}}
+  {{- printf "%dm" (mul $num 3) -}}
 {{- else if hasSuffix "h" $interval -}}
   {{- $num := $interval | trimSuffix "h" | int -}}
-  {{- printf "%dh" (mul $num 2) -}}
+  {{- printf "%dh" (mul $num 3) -}}
 {{- else -}}
   {{- /* Default case - assume seconds if no suffix */ -}}
   {{- $num := $interval | int -}}
-  {{- printf "%ds" (mul $num 2) -}}
+  {{- printf "%ds" (mul $num 3) -}}
 {{- end -}}
 {{- end -}}
 

--- a/deploy/helm/templates/_helpers.tpl
+++ b/deploy/helm/templates/_helpers.tpl
@@ -393,7 +393,7 @@ Output will be a duration string like "120s", "4m", etc.
 {{- end -}}
 
 {{/*
-Calculate max_staleness as twice the scrape_interval
+Calculate max_staleness as thrice the scrape_interval
 Input should be a duration string like "60s", "5m", etc.
 Output will be the same format but tripled
 */}}

--- a/deploy/helm/tests/__snapshot__/discovery-collector_test.yaml.snap
+++ b/deploy/helm/tests/__snapshot__/discovery-collector_test.yaml.snap
@@ -253,7 +253,7 @@ Discovery collector spec should match snapshot when using default values:
               - k8s.istio_requests.delta
               - k8s.istio_tcp_sent_bytes.delta
               - k8s.istio_tcp_received_bytes.delta
-          max_staleness: 120s
+          max_staleness: 180s
         deltatorate/istio-metrics:
           metrics:
             - k8s.istio_request_bytes.rate

--- a/deploy/helm/tests/__snapshot__/discovery-collector_test.yaml.snap
+++ b/deploy/helm/tests/__snapshot__/discovery-collector_test.yaml.snap
@@ -253,6 +253,7 @@ Discovery collector spec should match snapshot when using default values:
               - k8s.istio_requests.delta
               - k8s.istio_tcp_sent_bytes.delta
               - k8s.istio_tcp_received_bytes.delta
+          max_staleness: 120s
         deltatorate/istio-metrics:
           metrics:
             - k8s.istio_request_bytes.rate

--- a/deploy/helm/tests/__snapshot__/metrics-collector-config-map-fargate_test.yaml.snap
+++ b/deploy/helm/tests/__snapshot__/metrics-collector-config-map-fargate_test.yaml.snap
@@ -194,6 +194,7 @@ Metrics config should match snapshot when using default values:
             - k8s.node.network.transmit_packets_dropped
             - apiserver_request_not_failed_temp
             - apiserver_request_total_temp
+          max_staleness: 120s
         deltatorate:
           metrics:
           - k8s.node.cpu.usage.seconds.rate

--- a/deploy/helm/tests/__snapshot__/metrics-collector-config-map-fargate_test.yaml.snap
+++ b/deploy/helm/tests/__snapshot__/metrics-collector-config-map-fargate_test.yaml.snap
@@ -194,7 +194,7 @@ Metrics config should match snapshot when using default values:
             - k8s.node.network.transmit_packets_dropped
             - apiserver_request_not_failed_temp
             - apiserver_request_total_temp
-          max_staleness: 120s
+          max_staleness: 180s
         deltatorate:
           metrics:
           - k8s.node.cpu.usage.seconds.rate

--- a/deploy/helm/tests/__snapshot__/metrics-collector-config-map_test.yaml.snap
+++ b/deploy/helm/tests/__snapshot__/metrics-collector-config-map_test.yaml.snap
@@ -194,7 +194,7 @@ Metrics config should match snapshot when fargate is enabled:
             - k8s.node.network.transmit_packets_dropped
             - apiserver_request_not_failed_temp
             - apiserver_request_total_temp
-          max_staleness: 120s
+          max_staleness: 180s
         deltatorate:
           metrics:
           - k8s.node.cpu.usage.seconds.rate
@@ -1895,7 +1895,7 @@ Metrics config should match snapshot when using Prometheus url with extra_scrape
             - k8s.node.network.transmit_packets_dropped
             - apiserver_request_not_failed_temp
             - apiserver_request_total_temp
-          max_staleness: 120s
+          max_staleness: 180s
         deltatorate:
           metrics:
           - k8s.node.cpu.usage.seconds.rate
@@ -3538,7 +3538,7 @@ Metrics config should match snapshot when using default values:
             - k8s.node.network.transmit_packets_dropped
             - apiserver_request_not_failed_temp
             - apiserver_request_total_temp
-          max_staleness: 120s
+          max_staleness: 180s
         deltatorate:
           metrics:
           - k8s.node.cpu.usage.seconds.rate

--- a/deploy/helm/tests/__snapshot__/metrics-collector-config-map_test.yaml.snap
+++ b/deploy/helm/tests/__snapshot__/metrics-collector-config-map_test.yaml.snap
@@ -194,6 +194,7 @@ Metrics config should match snapshot when fargate is enabled:
             - k8s.node.network.transmit_packets_dropped
             - apiserver_request_not_failed_temp
             - apiserver_request_total_temp
+          max_staleness: 120s
         deltatorate:
           metrics:
           - k8s.node.cpu.usage.seconds.rate
@@ -1894,6 +1895,7 @@ Metrics config should match snapshot when using Prometheus url with extra_scrape
             - k8s.node.network.transmit_packets_dropped
             - apiserver_request_not_failed_temp
             - apiserver_request_total_temp
+          max_staleness: 120s
         deltatorate:
           metrics:
           - k8s.node.cpu.usage.seconds.rate
@@ -3536,6 +3538,7 @@ Metrics config should match snapshot when using default values:
             - k8s.node.network.transmit_packets_dropped
             - apiserver_request_not_failed_temp
             - apiserver_request_total_temp
+          max_staleness: 120s
         deltatorate:
           metrics:
           - k8s.node.cpu.usage.seconds.rate

--- a/deploy/helm/tests/__snapshot__/metrics-discovery-config-map_test.yaml.snap
+++ b/deploy/helm/tests/__snapshot__/metrics-discovery-config-map_test.yaml.snap
@@ -233,7 +233,7 @@ Metrics discovery config should match snapshot when Fargate is enabled:
             - k8s.istio_requests.delta
             - k8s.istio_tcp_sent_bytes.delta
             - k8s.istio_tcp_received_bytes.delta
-          max_staleness: 120s
+          max_staleness: 180s
         deltatorate/istio-metrics:
           metrics:
           - k8s.istio_request_bytes.rate

--- a/deploy/helm/tests/__snapshot__/metrics-discovery-config-map_test.yaml.snap
+++ b/deploy/helm/tests/__snapshot__/metrics-discovery-config-map_test.yaml.snap
@@ -233,6 +233,7 @@ Metrics discovery config should match snapshot when Fargate is enabled:
             - k8s.istio_requests.delta
             - k8s.istio_tcp_sent_bytes.delta
             - k8s.istio_tcp_received_bytes.delta
+          max_staleness: 120s
         deltatorate/istio-metrics:
           metrics:
           - k8s.istio_request_bytes.rate

--- a/deploy/helm/tests/__snapshot__/node-collector-config-map-windows_test.yaml.snap
+++ b/deploy/helm/tests/__snapshot__/node-collector-config-map-windows_test.yaml.snap
@@ -286,6 +286,7 @@ Node collector config for windows nodes should match snapshot when using default
             - k8s.node.network.packets_transmitted
             - k8s.node.network.receive_packets_dropped
             - k8s.node.network.transmit_packets_dropped
+          max_staleness: 120s
         cumulativetodelta/istio-metrics:
           include:
             match_type: strict
@@ -302,6 +303,7 @@ Node collector config for windows nodes should match snapshot when using default
             - k8s.istio_requests.delta
             - k8s.istio_tcp_sent_bytes.delta
             - k8s.istio_tcp_received_bytes.delta
+          max_staleness: 120s
         deltatorate/cadvisor:
           metrics:
           - k8s.node.cpu.usage.seconds.rate
@@ -1855,6 +1857,7 @@ Node collector config for windows nodes should match snapshot when using legacy 
             - k8s.node.network.packets_transmitted
             - k8s.node.network.receive_packets_dropped
             - k8s.node.network.transmit_packets_dropped
+          max_staleness: 120s
         cumulativetodelta/istio-metrics:
           include:
             match_type: strict
@@ -1871,6 +1874,7 @@ Node collector config for windows nodes should match snapshot when using legacy 
             - k8s.istio_requests.delta
             - k8s.istio_tcp_sent_bytes.delta
             - k8s.istio_tcp_received_bytes.delta
+          max_staleness: 120s
         deltatorate/cadvisor:
           metrics:
           - k8s.node.cpu.usage.seconds.rate

--- a/deploy/helm/tests/__snapshot__/node-collector-config-map-windows_test.yaml.snap
+++ b/deploy/helm/tests/__snapshot__/node-collector-config-map-windows_test.yaml.snap
@@ -286,7 +286,7 @@ Node collector config for windows nodes should match snapshot when using default
             - k8s.node.network.packets_transmitted
             - k8s.node.network.receive_packets_dropped
             - k8s.node.network.transmit_packets_dropped
-          max_staleness: 120s
+          max_staleness: 180s
         cumulativetodelta/istio-metrics:
           include:
             match_type: strict
@@ -303,7 +303,7 @@ Node collector config for windows nodes should match snapshot when using default
             - k8s.istio_requests.delta
             - k8s.istio_tcp_sent_bytes.delta
             - k8s.istio_tcp_received_bytes.delta
-          max_staleness: 120s
+          max_staleness: 180s
         deltatorate/cadvisor:
           metrics:
           - k8s.node.cpu.usage.seconds.rate
@@ -1857,7 +1857,7 @@ Node collector config for windows nodes should match snapshot when using legacy 
             - k8s.node.network.packets_transmitted
             - k8s.node.network.receive_packets_dropped
             - k8s.node.network.transmit_packets_dropped
-          max_staleness: 120s
+          max_staleness: 180s
         cumulativetodelta/istio-metrics:
           include:
             match_type: strict
@@ -1874,7 +1874,7 @@ Node collector config for windows nodes should match snapshot when using legacy 
             - k8s.istio_requests.delta
             - k8s.istio_tcp_sent_bytes.delta
             - k8s.istio_tcp_received_bytes.delta
-          max_staleness: 120s
+          max_staleness: 180s
         deltatorate/cadvisor:
           metrics:
           - k8s.node.cpu.usage.seconds.rate

--- a/deploy/helm/tests/__snapshot__/node-collector-config-map_test.yaml.snap
+++ b/deploy/helm/tests/__snapshot__/node-collector-config-map_test.yaml.snap
@@ -286,7 +286,7 @@ Custom logs filter with new syntax:
             - k8s.node.network.packets_transmitted
             - k8s.node.network.receive_packets_dropped
             - k8s.node.network.transmit_packets_dropped
-          max_staleness: 120s
+          max_staleness: 180s
         cumulativetodelta/istio-metrics:
           include:
             match_type: strict
@@ -303,7 +303,7 @@ Custom logs filter with new syntax:
             - k8s.istio_requests.delta
             - k8s.istio_tcp_sent_bytes.delta
             - k8s.istio_tcp_received_bytes.delta
-          max_staleness: 120s
+          max_staleness: 180s
         deltatorate/cadvisor:
           metrics:
           - k8s.node.cpu.usage.seconds.rate
@@ -1898,7 +1898,7 @@ Custom logs filter with old syntax:
             - k8s.node.network.packets_transmitted
             - k8s.node.network.receive_packets_dropped
             - k8s.node.network.transmit_packets_dropped
-          max_staleness: 120s
+          max_staleness: 180s
         cumulativetodelta/istio-metrics:
           include:
             match_type: strict
@@ -1915,7 +1915,7 @@ Custom logs filter with old syntax:
             - k8s.istio_requests.delta
             - k8s.istio_tcp_sent_bytes.delta
             - k8s.istio_tcp_received_bytes.delta
-          max_staleness: 120s
+          max_staleness: 180s
         deltatorate/cadvisor:
           metrics:
           - k8s.node.cpu.usage.seconds.rate
@@ -3594,7 +3594,7 @@ Node collector config should match snapshot when autodiscovery is disabled:
             - k8s.node.network.packets_transmitted
             - k8s.node.network.receive_packets_dropped
             - k8s.node.network.transmit_packets_dropped
-          max_staleness: 120s
+          max_staleness: 180s
         cumulativetodelta/istio-metrics:
           include:
             match_type: strict
@@ -3611,7 +3611,7 @@ Node collector config should match snapshot when autodiscovery is disabled:
             - k8s.istio_requests.delta
             - k8s.istio_tcp_sent_bytes.delta
             - k8s.istio_tcp_received_bytes.delta
-          max_staleness: 120s
+          max_staleness: 180s
         deltatorate/cadvisor:
           metrics:
           - k8s.node.cpu.usage.seconds.rate
@@ -5138,7 +5138,7 @@ Node collector config should match snapshot when fargate is enabled:
             - k8s.node.network.packets_transmitted
             - k8s.node.network.receive_packets_dropped
             - k8s.node.network.transmit_packets_dropped
-          max_staleness: 120s
+          max_staleness: 180s
         cumulativetodelta/istio-metrics:
           include:
             match_type: strict
@@ -5155,7 +5155,7 @@ Node collector config should match snapshot when fargate is enabled:
             - k8s.istio_requests.delta
             - k8s.istio_tcp_sent_bytes.delta
             - k8s.istio_tcp_received_bytes.delta
-          max_staleness: 120s
+          max_staleness: 180s
         deltatorate/cadvisor:
           metrics:
           - k8s.node.cpu.usage.seconds.rate
@@ -6658,7 +6658,7 @@ Node collector config should match snapshot when fargate is enabled and autodisc
             - k8s.node.network.packets_transmitted
             - k8s.node.network.receive_packets_dropped
             - k8s.node.network.transmit_packets_dropped
-          max_staleness: 120s
+          max_staleness: 180s
         cumulativetodelta/istio-metrics:
           include:
             match_type: strict
@@ -6675,7 +6675,7 @@ Node collector config should match snapshot when fargate is enabled and autodisc
             - k8s.istio_requests.delta
             - k8s.istio_tcp_sent_bytes.delta
             - k8s.istio_tcp_received_bytes.delta
-          max_staleness: 120s
+          max_staleness: 180s
         deltatorate/cadvisor:
           metrics:
           - k8s.node.cpu.usage.seconds.rate
@@ -8114,7 +8114,7 @@ Node collector config should match snapshot when using default values:
             - k8s.node.network.packets_transmitted
             - k8s.node.network.receive_packets_dropped
             - k8s.node.network.transmit_packets_dropped
-          max_staleness: 120s
+          max_staleness: 180s
         cumulativetodelta/istio-metrics:
           include:
             match_type: strict
@@ -8131,7 +8131,7 @@ Node collector config should match snapshot when using default values:
             - k8s.istio_requests.delta
             - k8s.istio_tcp_sent_bytes.delta
             - k8s.istio_tcp_received_bytes.delta
-          max_staleness: 120s
+          max_staleness: 180s
         deltatorate/cadvisor:
           metrics:
           - k8s.node.cpu.usage.seconds.rate

--- a/deploy/helm/tests/__snapshot__/node-collector-config-map_test.yaml.snap
+++ b/deploy/helm/tests/__snapshot__/node-collector-config-map_test.yaml.snap
@@ -286,6 +286,7 @@ Custom logs filter with new syntax:
             - k8s.node.network.packets_transmitted
             - k8s.node.network.receive_packets_dropped
             - k8s.node.network.transmit_packets_dropped
+          max_staleness: 120s
         cumulativetodelta/istio-metrics:
           include:
             match_type: strict
@@ -302,6 +303,7 @@ Custom logs filter with new syntax:
             - k8s.istio_requests.delta
             - k8s.istio_tcp_sent_bytes.delta
             - k8s.istio_tcp_received_bytes.delta
+          max_staleness: 120s
         deltatorate/cadvisor:
           metrics:
           - k8s.node.cpu.usage.seconds.rate
@@ -1896,6 +1898,7 @@ Custom logs filter with old syntax:
             - k8s.node.network.packets_transmitted
             - k8s.node.network.receive_packets_dropped
             - k8s.node.network.transmit_packets_dropped
+          max_staleness: 120s
         cumulativetodelta/istio-metrics:
           include:
             match_type: strict
@@ -1912,6 +1915,7 @@ Custom logs filter with old syntax:
             - k8s.istio_requests.delta
             - k8s.istio_tcp_sent_bytes.delta
             - k8s.istio_tcp_received_bytes.delta
+          max_staleness: 120s
         deltatorate/cadvisor:
           metrics:
           - k8s.node.cpu.usage.seconds.rate
@@ -3590,6 +3594,7 @@ Node collector config should match snapshot when autodiscovery is disabled:
             - k8s.node.network.packets_transmitted
             - k8s.node.network.receive_packets_dropped
             - k8s.node.network.transmit_packets_dropped
+          max_staleness: 120s
         cumulativetodelta/istio-metrics:
           include:
             match_type: strict
@@ -3606,6 +3611,7 @@ Node collector config should match snapshot when autodiscovery is disabled:
             - k8s.istio_requests.delta
             - k8s.istio_tcp_sent_bytes.delta
             - k8s.istio_tcp_received_bytes.delta
+          max_staleness: 120s
         deltatorate/cadvisor:
           metrics:
           - k8s.node.cpu.usage.seconds.rate
@@ -5132,6 +5138,7 @@ Node collector config should match snapshot when fargate is enabled:
             - k8s.node.network.packets_transmitted
             - k8s.node.network.receive_packets_dropped
             - k8s.node.network.transmit_packets_dropped
+          max_staleness: 120s
         cumulativetodelta/istio-metrics:
           include:
             match_type: strict
@@ -5148,6 +5155,7 @@ Node collector config should match snapshot when fargate is enabled:
             - k8s.istio_requests.delta
             - k8s.istio_tcp_sent_bytes.delta
             - k8s.istio_tcp_received_bytes.delta
+          max_staleness: 120s
         deltatorate/cadvisor:
           metrics:
           - k8s.node.cpu.usage.seconds.rate
@@ -6650,6 +6658,7 @@ Node collector config should match snapshot when fargate is enabled and autodisc
             - k8s.node.network.packets_transmitted
             - k8s.node.network.receive_packets_dropped
             - k8s.node.network.transmit_packets_dropped
+          max_staleness: 120s
         cumulativetodelta/istio-metrics:
           include:
             match_type: strict
@@ -6666,6 +6675,7 @@ Node collector config should match snapshot when fargate is enabled and autodisc
             - k8s.istio_requests.delta
             - k8s.istio_tcp_sent_bytes.delta
             - k8s.istio_tcp_received_bytes.delta
+          max_staleness: 120s
         deltatorate/cadvisor:
           metrics:
           - k8s.node.cpu.usage.seconds.rate
@@ -8104,6 +8114,7 @@ Node collector config should match snapshot when using default values:
             - k8s.node.network.packets_transmitted
             - k8s.node.network.receive_packets_dropped
             - k8s.node.network.transmit_packets_dropped
+          max_staleness: 120s
         cumulativetodelta/istio-metrics:
           include:
             match_type: strict
@@ -8120,6 +8131,7 @@ Node collector config should match snapshot when using default values:
             - k8s.istio_requests.delta
             - k8s.istio_tcp_sent_bytes.delta
             - k8s.istio_tcp_received_bytes.delta
+          max_staleness: 120s
         deltatorate/cadvisor:
           metrics:
           - k8s.node.cpu.usage.seconds.rate

--- a/deploy/helm/values.schema.json
+++ b/deploy/helm/values.schema.json
@@ -1243,6 +1243,9 @@
                                 "scrape_interval": {
                                     "type": "string"
                                 },
+                                "max_staleness": {
+                                    "type": "string"
+                                },
                                 "url": {
                                     "type": "string"
                                 }

--- a/deploy/helm/values.yaml
+++ b/deploy/helm/values.yaml
@@ -272,7 +272,7 @@ otel:
       # How often the metrics are scraped from Prometheus
       scrape_interval: 60s
 
-      # Maximum staleness for cumulativetodelta processor. If not specified, defaults to twice the scrape_interval
+      # Maximum staleness for cumulativetodelta processor. If not specified, defaults to thrice the scrape_interval
       # This determines how long state entries will live past the time they were last seen
       max_staleness: ""
 

--- a/deploy/helm/values.yaml
+++ b/deploy/helm/values.yaml
@@ -272,6 +272,10 @@ otel:
       # How often the metrics are scraped from Prometheus
       scrape_interval: 60s
 
+      # Maximum staleness for cumulativetodelta processor. If not specified, defaults to twice the scrape_interval
+      # This determines how long state entries will live past the time they were last seen
+      max_staleness: ""
+
     # Time to wait per individual attempt to send data to SWO
     timeout: 15s
 


### PR DESCRIPTION
* This is the result of analysis of `heap.out` of one of our customer. It turned out that cumulativetodelta is eating huge amount of memory, probably due to leak of cardinality and that it is keeping old cardinality in memory indefinitely. This should be avoided by setting `max_staleness` - see https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/processor/cumulativetodeltaprocessor
> max_staleness: The total time a state entry will live past the time it was last seen. Set to 0 to retain state indefinitely. Default: 0

* setting max_staleness by default to triple of scrape_interval, making it configurable.
* bumping as bugfix release as 4.7.2