### PR TITLE
Watch Kustomize FluxCD CRDs

### DIFF
--- a/deploy/helm/Chart.yaml
+++ b/deploy/helm/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: swo-k8s-collector
-version: 4.8.0-alpha.6
+version: 4.8.0-alpha.7
 appVersion: 0.127.7
 description: SolarWinds Kubernetes Integration
 keywords:

--- a/deploy/helm/events-collector-config.yaml
+++ b/deploy/helm/events-collector-config.yaml
@@ -22,6 +22,9 @@
     "endpointslices" "EndpointSlice"
 
 }}
+{{- if or (.Capabilities.APIVersions.Has "kustomize.toolkit.fluxcd.io/v1") (.Capabilities.APIVersions.Has "kustomize.toolkit.fluxcd.io/v1beta2") }}
+{{- $_ := set $resourceMap "kustomizations" "Kustomization" }}
+{{- end }}
 {{- $arrayOfWatchedResources := keys $resourceMap | sortAlpha }}
 exporters:
   otlp:
@@ -424,6 +427,9 @@ processors:
       - k8s.serviceaccount.name
       - k8s.endpoint.name
       - k8s.endpointslice.name
+{{- if or (.Capabilities.APIVersions.Has "kustomize.toolkit.fluxcd.io/v1") (.Capabilities.APIVersions.Has "kustomize.toolkit.fluxcd.io/v1beta2") }}
+      - k8s.kustomization.name
+{{- end }}
 
   resource/events:
     attributes:

--- a/deploy/helm/templates/cluster-role.yaml
+++ b/deploy/helm/templates/cluster-role.yaml
@@ -105,6 +105,14 @@ rules:
       - get
       - list
       - watch
+  - apiGroups:
+      - "kustomize.toolkit.fluxcd.io"
+    resources:
+      - kustomizations
+    verbs:
+      - get
+      - list
+      - watch
   - nonResourceURLs:
       - /metrics
     verbs:

--- a/deploy/helm/templates/cluster-role.yaml
+++ b/deploy/helm/templates/cluster-role.yaml
@@ -105,6 +105,7 @@ rules:
       - get
       - list
       - watch
+{{- if or (.Capabilities.APIVersions.Has "kustomize.toolkit.fluxcd.io/v1") (.Capabilities.APIVersions.Has "kustomize.toolkit.fluxcd.io/v1beta2") }}
   - apiGroups:
       - "kustomize.toolkit.fluxcd.io"
     resources:
@@ -113,6 +114,7 @@ rules:
       - get
       - list
       - watch
+{{- end }}
   - nonResourceURLs:
       - /metrics
     verbs:


### PR DESCRIPTION
This PR allows us to watch Kustomize FluxCD CRDs needed for mapping manifests to Git repos