### PR TITLE
fix: '_temp' metric deletion

### DIFF
--- a/deploy/helm/metrics-collector-config.yaml
+++ b/deploy/helm/metrics-collector-config.yaml
@@ -239,21 +239,21 @@ processors:
       - include: k8s.kube_pod_container_resource_limits
         experimental_match_labels: { "resource": "cpu" }
         action: insert
-        new_name: k8s.container.spec.cpu.limit_temp
+        new_name: k8s.container.spec.cpu.limit__swo_temp
       - include: k8s.kube_pod_init_container_resource_limits
         experimental_match_labels: { "resource": "cpu" }
         action: insert
-        new_name: k8s.initcontainer.spec.cpu.limit_temp
+        new_name: k8s.initcontainer.spec.cpu.limit__swo_temp
 
       - include: k8s.kube_pod_container_resource_requests
         experimental_match_labels: { "resource": "cpu" }
         action: insert
-        new_name: k8s.container.spec.cpu.requests_temp
+        new_name: k8s.container.spec.cpu.requests__swo_temp
       - include: k8s.kube_pod_init_container_resource_requests
         experimental_match_labels: { "resource": "cpu" }
         action: insert
-        new_name: k8s.initcontainer.spec.cpu.requests_temp
-      - include: (k8s.container.spec.cpu.requests_temp|k8s.initcontainer.spec.cpu.requests_temp)
+        new_name: k8s.initcontainer.spec.cpu.requests__swo_temp
+      - include: (k8s.container.spec.cpu.requests__swo_temp|k8s.initcontainer.spec.cpu.requests__swo_temp)
         match_type: regexp
         action: combine
         new_name: k8s.container.spec.cpu.requests
@@ -261,12 +261,12 @@ processors:
       - include: k8s.kube_pod_container_resource_requests
         experimental_match_labels: { "resource": "memory" }
         action: insert
-        new_name: k8s.container.spec.memory.requests_temp
+        new_name: k8s.container.spec.memory.requests__swo_temp
       - include: k8s.kube_pod_init_container_resource_requests
         experimental_match_labels: { "resource": "memory" }
         action: insert
-        new_name: k8s.initcontainer.spec.memory.requests_temp
-      - include: (k8s.container.spec.memory.requests_temp|k8s.initcontainer.spec.memory.requests_temp)
+        new_name: k8s.initcontainer.spec.memory.requests__swo_temp
+      - include: (k8s.container.spec.memory.requests__swo_temp|k8s.initcontainer.spec.memory.requests__swo_temp)
         match_type: regexp
         action: combine
         new_name: k8s.container.spec.memory.requests
@@ -275,33 +275,33 @@ processors:
         action: insert
         match_type: regexp
         experimental_match_labels: { "resource": "memory" }
-        new_name: k8s.container.spec.memory.limit_temp
+        new_name: k8s.container.spec.memory.limit__swo_temp
       - include: k8s.kube_pod_init_container_resource_limits
         action: insert
         match_type: regexp
         experimental_match_labels: { "resource": "memory" }
-        new_name: k8s.initcontainer.spec.memory.limit_temp
+        new_name: k8s.initcontainer.spec.memory.limit__swo_temp
 
       # Pod resource metrics
-      - include: k8s.container.spec.cpu.limit_temp
+      - include: k8s.container.spec.cpu.limit__swo_temp
         action: insert
         new_name: k8s.pod.spec.cpu.limit
         operations:
           - action: aggregate_labels
             label_set: [pod, namespace, k8s.node.name]
             aggregation_type: sum
-      - include: (k8s.container.spec.cpu.limit_temp|k8s.initcontainer.spec.cpu.limit_temp)
+      - include: (k8s.container.spec.cpu.limit__swo_temp|k8s.initcontainer.spec.cpu.limit__swo_temp)
         match_type: regexp
         action: combine
         new_name: k8s.container.spec.cpu.limit
-      - include: k8s.container.spec.memory.limit_temp
+      - include: k8s.container.spec.memory.limit__swo_temp
         action: insert
         new_name: k8s.pod.spec.memory.limit
         operations:
           - action: aggregate_labels
             label_set: [pod, namespace, k8s.node.name]
             aggregation_type: sum
-      - include: (k8s.container.spec.memory.limit_temp|k8s.initcontainer.spec.memory.limit_temp)
+      - include: (k8s.container.spec.memory.limit__swo_temp|k8s.initcontainer.spec.memory.limit__swo_temp)
         match_type: regexp
         action: combine
         new_name: k8s.container.spec.memory.limit
@@ -406,7 +406,7 @@ processors:
       - include: k8s.kube_pod_status_phase
         experimental_match_labels: { "phase": "Running" }
         action: insert
-        new_name: k8s.pod.status.phase.running_temp
+        new_name: k8s.pod.status.phase.running__swo_temp
       
       # Cluster metrics
       - include: k8s.kube_pod_info
@@ -457,7 +457,7 @@ processors:
             # use [dummy_label_workaround] instead of [] as a workaround for a bug introduced in metricstransform 0.106
             label_set: [dummy_label_workaround]
             aggregation_type: sum
-      - include: k8s.pod.status.phase.running_temp
+      - include: k8s.pod.status.phase.running__swo_temp
         action: insert
         new_name: k8s.cluster.pods.running
         operations:
@@ -511,17 +511,17 @@ processors:
             aggregation_type: sum
       - include: k8s.kubernetes_build_info
         action: update
-        new_name: k8s.kubernetes_build_info_temp
+        new_name: k8s.kubernetes_build_info__swo_temp
       # Prometheus metrics
       - include: k8s.apiserver_request_total
         action: insert
         match_type: regexp
         # Alternative to (?!5\d\d|429) - Go regex does not support negative lookahead
         experimental_match_labels: { "code": '^(([0-3]|[6-9])\d\d)|(4([0-1]|[3-9])\d)|(42[0-8])$' }
-        new_name: apiserver_request_not_failed_temp
-      - include: apiserver_request_not_failed_temp
+        new_name: apiserver_request_not_failed__swo_temp
+      - include: apiserver_request_not_failed__swo_temp
         action: update
-        new_name: apiserver_request_not_failed_temp
+        new_name: apiserver_request_not_failed__swo_temp
         operations:
           - action: aggregate_labels
             # use [dummy_label_workaround] instead of [] as a workaround for a bug introduced in metricstransform 0.106
@@ -529,7 +529,7 @@ processors:
             aggregation_type: sum
       - include: k8s.apiserver_request_total
         action: insert
-        new_name: apiserver_request_total_temp
+        new_name: apiserver_request_total__swo_temp
         operations:
           - action: aggregate_labels
             # use [dummy_label_workaround] instead of [] as a workaround for a bug introduced in metricstransform 0.106
@@ -576,8 +576,8 @@ processors:
     include:
       metrics:
         {{- include "common-config.cumulativetorate-cadvisor" . | nindent 8 }}
-        - apiserver_request_not_failed_temp
-        - apiserver_request_total_temp
+        - apiserver_request_not_failed__swo_temp
+        - apiserver_request_total__swo_temp
       match_type: strict
 
   deltatorate:
@@ -589,8 +589,8 @@ processors:
       - name: k8s.apiserver.request.successrate
         unit: Percent
         type: calculate
-        metric1: apiserver_request_not_failed_temp
-        metric2: apiserver_request_total_temp
+        metric1: apiserver_request_not_failed__swo_temp
+        metric2: apiserver_request_total__swo_temp
         operation: percent
   
   groupbyattrs/node:

--- a/deploy/helm/templates/_common-config.tpl
+++ b/deploy/helm/templates/_common-config.tpl
@@ -39,11 +39,11 @@ transform/unify_node_attribute:
 {{- define "common-config.metricstransform-preprocessing-cadvisor" -}}
 - include: k8s.container_fs_reads_total
   action: insert
-  new_name: k8s.container_fs_reads_total_temp
+  new_name: k8s.container_fs_reads_total__swo_temp
 - include: k8s.container_fs_writes_total
   action: insert
-  new_name: k8s.container_fs_writes_total_temp
-- include: (k8s.container_fs_reads_total_temp|k8s.container_fs_writes_total_temp)
+  new_name: k8s.container_fs_writes_total__swo_temp
+- include: (k8s.container_fs_reads_total__swo_temp|k8s.container_fs_writes_total__swo_temp)
   match_type: regexp
   action: combine
   submatch_case: lower
@@ -56,11 +56,11 @@ transform/unify_node_attribute:
 
 - include: k8s.container_fs_reads_bytes_total
   action: insert
-  new_name: k8s.container_fs_reads_bytes_total_temp
+  new_name: k8s.container_fs_reads_bytes_total__swo_temp
 - include: k8s.container_fs_writes_bytes_total
   action: insert
-  new_name: k8s.container_fs_writes_bytes_total_temp
-- include: (k8s.container_fs_reads_bytes_total_temp|k8s.container_fs_writes_bytes_total_temp)
+  new_name: k8s.container_fs_writes_bytes_total__swo_temp
+- include: (k8s.container_fs_reads_bytes_total__swo_temp|k8s.container_fs_writes_bytes_total__swo_temp)
   match_type: regexp
   action: combine
   submatch_case: lower
@@ -190,11 +190,11 @@ transform/unify_node_attribute:
   new_name: k8s.pod.fs.writes.bytes.rate
 - include: k8s.pod.fs.reads.rate
   action: insert
-  new_name: k8s.pod.fs.reads.rate_temp
+  new_name: k8s.pod.fs.reads.rate__swo_temp
 - include: k8s.pod.fs.writes.rate
   action: insert
-  new_name: k8s.pod.fs.writes.rate_temp
-- include: (k8s.pod.fs.reads.rate_temp|k8s.pod.fs.writes.rate_temp)
+  new_name: k8s.pod.fs.writes.rate__swo_temp
+- include: (k8s.pod.fs.reads.rate__swo_temp|k8s.pod.fs.writes.rate__swo_temp)
   match_type: regexp
   action: combine
   submatch_case: lower
@@ -205,11 +205,11 @@ transform/unify_node_attribute:
   new_name: k8s.pod.fs.iops
 - include: k8s.pod.fs.reads.bytes.rate
   action: insert
-  new_name: k8s.pod.fs.reads.bytes.rate_temp
+  new_name: k8s.pod.fs.reads.bytes.rate__swo_temp
 - include: k8s.pod.fs.writes.bytes.rate
   action: insert
-  new_name: k8s.pod.fs.writes.bytes.rate_temp
-- include: (k8s.pod.fs.reads.bytes.rate_temp|k8s.pod.fs.writes.bytes.rate_temp)
+  new_name: k8s.pod.fs.writes.bytes.rate__swo_temp
+- include: (k8s.pod.fs.reads.bytes.rate__swo_temp|k8s.pod.fs.writes.bytes.rate__swo_temp)
   match_type: regexp
   action: combine
   submatch_case: lower
@@ -296,29 +296,29 @@ transform/unify_node_attribute:
     - action: aggregate_labels
       label_set: [k8s.node.name]
       aggregation_type: sum
-  new_name: k8s.node.fs.reads.rate_temp
+  new_name: k8s.node.fs.reads.rate__swo_temp
 - include: k8s.pod.fs.writes.rate
   action: insert
   operations:
     - action: aggregate_labels
       label_set: [k8s.node.name]
       aggregation_type: sum
-  new_name: k8s.node.fs.writes.rate_temp
+  new_name: k8s.node.fs.writes.rate__swo_temp
 - include: k8s.pod.fs.reads.bytes.rate
   action: insert
   operations:
     - action: aggregate_labels
       label_set: [k8s.node.name]
       aggregation_type: sum
-  new_name: k8s.node.fs.reads.bytes.rate_temp
+  new_name: k8s.node.fs.reads.bytes.rate__swo_temp
 - include: k8s.pod.fs.writes.bytes.rate
   action: insert
   operations:
     - action: aggregate_labels
       label_set: [k8s.node.name]
       aggregation_type: sum
-  new_name: k8s.node.fs.writes.bytes.rate_temp
-- include: (k8s.node.fs.reads.rate_temp|k8s.node.fs.writes.rate_temp)
+  new_name: k8s.node.fs.writes.bytes.rate__swo_temp
+- include: (k8s.node.fs.reads.rate__swo_temp|k8s.node.fs.writes.rate__swo_temp)
   match_type: regexp
   action: combine
   submatch_case: lower
@@ -327,7 +327,7 @@ transform/unify_node_attribute:
       label_set:  [k8s.node.name]
       aggregation_type: sum
   new_name: k8s.node.fs.iops
-- include: (k8s.node.fs.reads.bytes.rate_temp|k8s.node.fs.writes.bytes.rate_temp)
+- include: (k8s.node.fs.reads.bytes.rate__swo_temp|k8s.node.fs.writes.bytes.rate__swo_temp)
   match_type: regexp
   action: combine
   submatch_case: lower
@@ -364,7 +364,7 @@ attributes/remove_temp:
       - .*
   actions:
     - key: temp
-      pattern: (.*_temp$)|(^\$.*) # attributes starting with $ are result of `combine` operations
+      pattern: (.*__swo_temp$)|(^\$.*) # attributes starting with $ are result of `combine` operations
       action: delete
 {{- end }}
 
@@ -620,5 +620,5 @@ resource/metrics:
 filter/remove_temporary_metrics:
   metrics:
     metric:            
-      - 'IsMatch(name , ".*_temp")'
+      - 'IsMatch(name , ".*__swo_temp$")'
 {{- end }}

--- a/deploy/helm/templates/_common-discovery-config.tpl
+++ b/deploy/helm/templates/_common-discovery-config.tpl
@@ -116,8 +116,8 @@ cumulativetodelta/istio-metrics:
     metrics:
       - k8s.istio_request_bytes.rate
       - k8s.istio_response_bytes.rate
-      - k8s.istio_request_duration_milliseconds_sum_temp
-      - k8s.istio_request_duration_milliseconds_count_temp
+      - k8s.istio_request_duration_milliseconds_sum__swo_temp
+      - k8s.istio_request_duration_milliseconds_count__swo_temp
       - k8s.istio_requests.rate
       - k8s.istio_tcp_sent_bytes.rate
       - k8s.istio_tcp_received_bytes.rate
@@ -132,8 +132,8 @@ deltatorate/istio-metrics:
   metrics:
     - k8s.istio_request_bytes.rate
     - k8s.istio_response_bytes.rate
-    - k8s.istio_request_duration_milliseconds_sum_temp
-    - k8s.istio_request_duration_milliseconds_count_temp
+    - k8s.istio_request_duration_milliseconds_sum__swo_temp
+    - k8s.istio_request_duration_milliseconds_count__swo_temp
     - k8s.istio_requests.rate
     - k8s.istio_tcp_sent_bytes.rate
     - k8s.istio_tcp_received_bytes.rate
@@ -142,8 +142,8 @@ metricsgeneration/istio-metrics:
   rules:
     - name: k8s.istio_request_duration_milliseconds.rate
       type: calculate
-      metric1: k8s.istio_request_duration_milliseconds_sum_temp
-      metric2: k8s.istio_request_duration_milliseconds_count_temp
+      metric1: k8s.istio_request_duration_milliseconds_sum__swo_temp
+      metric2: k8s.istio_request_duration_milliseconds_count__swo_temp
       operation: divide
 
 transform/istio-metrics:
@@ -151,8 +151,8 @@ transform/istio-metrics:
     - statements:
         - extract_sum_metric(true) where (metric.name == "{{ .Values.otel.metrics.autodiscovery.prefix }}istio_request_bytes" or metric.name == "{{ .Values.otel.metrics.autodiscovery.prefix }}istio_response_bytes" or metric.name == "{{ .Values.otel.metrics.autodiscovery.prefix }}istio_request_duration_milliseconds")
         - extract_count_metric(true) where (metric.name == "{{ .Values.otel.metrics.autodiscovery.prefix }}istio_request_duration_milliseconds")
-        - set(metric.name, "k8s.istio_request_duration_milliseconds_sum_temp") where metric.name == "{{ .Values.otel.metrics.autodiscovery.prefix }}istio_request_duration_milliseconds_sum"
-        - set(metric.name, "k8s.istio_request_duration_milliseconds_count_temp") where metric.name == "{{ .Values.otel.metrics.autodiscovery.prefix }}istio_request_duration_milliseconds_count"
+        - set(metric.name, "k8s.istio_request_duration_milliseconds_sum__swo_temp") where metric.name == "{{ .Values.otel.metrics.autodiscovery.prefix }}istio_request_duration_milliseconds_sum"
+        - set(metric.name, "k8s.istio_request_duration_milliseconds_count__swo_temp") where metric.name == "{{ .Values.otel.metrics.autodiscovery.prefix }}istio_request_duration_milliseconds_count"
         - set(resource.attributes["istio"], "true")
 
 transform/istio-metric-datapoints:

--- a/deploy/helm/tests/__snapshot__/discovery-collector_test.yaml.snap
+++ b/deploy/helm/tests/__snapshot__/discovery-collector_test.yaml.snap
@@ -383,8 +383,8 @@ Discovery collector spec should match snapshot when using default values:
             metrics:
               - k8s.istio_request_bytes.rate
               - k8s.istio_response_bytes.rate
-              - k8s.istio_request_duration_milliseconds_sum_temp
-              - k8s.istio_request_duration_milliseconds_count_temp
+              - k8s.istio_request_duration_milliseconds_sum__swo_temp
+              - k8s.istio_request_duration_milliseconds_count__swo_temp
               - k8s.istio_requests.rate
               - k8s.istio_tcp_sent_bytes.rate
               - k8s.istio_tcp_received_bytes.rate
@@ -398,8 +398,8 @@ Discovery collector spec should match snapshot when using default values:
           metrics:
             - k8s.istio_request_bytes.rate
             - k8s.istio_response_bytes.rate
-            - k8s.istio_request_duration_milliseconds_sum_temp
-            - k8s.istio_request_duration_milliseconds_count_temp
+            - k8s.istio_request_duration_milliseconds_sum__swo_temp
+            - k8s.istio_request_duration_milliseconds_count__swo_temp
             - k8s.istio_requests.rate
             - k8s.istio_tcp_sent_bytes.rate
             - k8s.istio_tcp_received_bytes.rate
@@ -433,7 +433,7 @@ Discovery collector spec should match snapshot when using default values:
         filter/remove_temporary_metrics:
           metrics:
             metric:
-              - IsMatch(name , ".*_temp")
+              - IsMatch(name , ".*__swo_temp$")
         filter/zero-delta-values:
           error_mode: ignore
           metrics:
@@ -484,8 +484,8 @@ Discovery collector spec should match snapshot when using default values:
           spike_limit_mib: 300
         metricsgeneration/istio-metrics:
           rules:
-            - metric1: k8s.istio_request_duration_milliseconds_sum_temp
-              metric2: k8s.istio_request_duration_milliseconds_count_temp
+            - metric1: k8s.istio_request_duration_milliseconds_sum__swo_temp
+              metric2: k8s.istio_request_duration_milliseconds_count__swo_temp
               name: k8s.istio_request_duration_milliseconds.rate
               operation: divide
               type: calculate
@@ -581,8 +581,8 @@ Discovery collector spec should match snapshot when using default values:
             - statements:
                 - extract_sum_metric(true) where (metric.name == "k8s.istio_request_bytes" or metric.name == "k8s.istio_response_bytes" or metric.name == "k8s.istio_request_duration_milliseconds")
                 - extract_count_metric(true) where (metric.name == "k8s.istio_request_duration_milliseconds")
-                - set(metric.name, "k8s.istio_request_duration_milliseconds_sum_temp") where metric.name == "k8s.istio_request_duration_milliseconds_sum"
-                - set(metric.name, "k8s.istio_request_duration_milliseconds_count_temp") where metric.name == "k8s.istio_request_duration_milliseconds_count"
+                - set(metric.name, "k8s.istio_request_duration_milliseconds_sum__swo_temp") where metric.name == "k8s.istio_request_duration_milliseconds_sum"
+                - set(metric.name, "k8s.istio_request_duration_milliseconds_count__swo_temp") where metric.name == "k8s.istio_request_duration_milliseconds_count"
                 - set(resource.attributes["istio"], "true")
         transform/istio-relationship-types:
           metric_statements:

--- a/deploy/helm/tests/__snapshot__/events-collector-config-map_test.yaml.snap
+++ b/deploy/helm/tests/__snapshot__/events-collector-config-map_test.yaml.snap
@@ -84,6 +84,16 @@ Custom events filter with new syntax:
               - sw.k8s.cluster.uid
               - k8s.namespace.name
               - k8s.statefulset.name
+            - entity: KubernetesGitRepository
+              id:
+              - sw.k8s.cluster.uid
+              - k8s.namespace.name
+              - k8s.gitrepository.name
+            - entity: KubernetesKustomization
+              id:
+              - sw.k8s.cluster.uid
+              - k8s.namespace.name
+              - k8s.kustomization.name
         solarwindsentity/serviceendpointsmapping:
           destination_prefix: dest.
           schema:
@@ -357,6 +367,10 @@ Custom events filter with new syntax:
               where resource.attributes["k8s.object.kind"] == "CronJob"
             - set(resource.attributes["k8s.node.name"], resource.attributes["k8s.object.name"])
               where resource.attributes["k8s.object.kind"] == "Node"
+            - set(resource.attributes["k8s.gitrepository.name"], resource.attributes["k8s.object.name"])
+              where resource.attributes["k8s.object.kind"] == "GitRepository"
+            - set(resource.attributes["k8s.kustomization.name"], resource.attributes["k8s.object.name"])
+              where resource.attributes["k8s.object.kind"] == "Kustomization"
             - set(resource.attributes["k8s.namespace.name"], log.attributes["k8s.namespace.name"])
               where log.attributes["k8s.namespace.name"] != nil
             - delete_key(log.attributes, "k8s.namespace.name") where log.attributes["k8s.namespace.name"]
@@ -1024,6 +1038,16 @@ Custom events filter with old syntax:
               - sw.k8s.cluster.uid
               - k8s.namespace.name
               - k8s.statefulset.name
+            - entity: KubernetesGitRepository
+              id:
+              - sw.k8s.cluster.uid
+              - k8s.namespace.name
+              - k8s.gitrepository.name
+            - entity: KubernetesKustomization
+              id:
+              - sw.k8s.cluster.uid
+              - k8s.namespace.name
+              - k8s.kustomization.name
         solarwindsentity/serviceendpointsmapping:
           destination_prefix: dest.
           schema:
@@ -1300,6 +1324,10 @@ Custom events filter with old syntax:
               where resource.attributes["k8s.object.kind"] == "CronJob"
             - set(resource.attributes["k8s.node.name"], resource.attributes["k8s.object.name"])
               where resource.attributes["k8s.object.kind"] == "Node"
+            - set(resource.attributes["k8s.gitrepository.name"], resource.attributes["k8s.object.name"])
+              where resource.attributes["k8s.object.kind"] == "GitRepository"
+            - set(resource.attributes["k8s.kustomization.name"], resource.attributes["k8s.object.name"])
+              where resource.attributes["k8s.object.kind"] == "Kustomization"
             - set(resource.attributes["k8s.namespace.name"], log.attributes["k8s.namespace.name"])
               where log.attributes["k8s.namespace.name"] != nil
             - delete_key(log.attributes, "k8s.namespace.name") where log.attributes["k8s.namespace.name"]
@@ -1967,6 +1995,16 @@ Events config should match snapshot when using default values:
               - sw.k8s.cluster.uid
               - k8s.namespace.name
               - k8s.statefulset.name
+            - entity: KubernetesGitRepository
+              id:
+              - sw.k8s.cluster.uid
+              - k8s.namespace.name
+              - k8s.gitrepository.name
+            - entity: KubernetesKustomization
+              id:
+              - sw.k8s.cluster.uid
+              - k8s.namespace.name
+              - k8s.kustomization.name
         solarwindsentity/serviceendpointsmapping:
           destination_prefix: dest.
           schema:
@@ -2236,6 +2274,10 @@ Events config should match snapshot when using default values:
               where resource.attributes["k8s.object.kind"] == "CronJob"
             - set(resource.attributes["k8s.node.name"], resource.attributes["k8s.object.name"])
               where resource.attributes["k8s.object.kind"] == "Node"
+            - set(resource.attributes["k8s.gitrepository.name"], resource.attributes["k8s.object.name"])
+              where resource.attributes["k8s.object.kind"] == "GitRepository"
+            - set(resource.attributes["k8s.kustomization.name"], resource.attributes["k8s.object.name"])
+              where resource.attributes["k8s.object.kind"] == "Kustomization"
             - set(resource.attributes["k8s.namespace.name"], log.attributes["k8s.namespace.name"])
               where log.attributes["k8s.namespace.name"] != nil
             - delete_key(log.attributes, "k8s.namespace.name") where log.attributes["k8s.namespace.name"]
@@ -3099,6 +3141,10 @@ Events config should not contain manifest collection pipeline when disabled:
               where resource.attributes["k8s.object.kind"] == "CronJob"
             - set(resource.attributes["k8s.node.name"], resource.attributes["k8s.object.name"])
               where resource.attributes["k8s.object.kind"] == "Node"
+            - set(resource.attributes["k8s.gitrepository.name"], resource.attributes["k8s.object.name"])
+              where resource.attributes["k8s.object.kind"] == "GitRepository"
+            - set(resource.attributes["k8s.kustomization.name"], resource.attributes["k8s.object.name"])
+              where resource.attributes["k8s.object.kind"] == "Kustomization"
             - set(resource.attributes["k8s.namespace.name"], log.attributes["k8s.namespace.name"])
               where log.attributes["k8s.namespace.name"] != nil
             - delete_key(log.attributes, "k8s.namespace.name") where log.attributes["k8s.namespace.name"]

--- a/deploy/helm/tests/__snapshot__/metrics-collector-config-map-fargate_test.yaml.snap
+++ b/deploy/helm/tests/__snapshot__/metrics-collector-config-map-fargate_test.yaml.snap
@@ -71,7 +71,7 @@ Metrics config should match snapshot when using default values:
           actions:
           - action: delete
             key: temp
-            pattern: (.*_temp$)|(^\$.*)
+            pattern: (.*__swo_temp$)|(^\$.*)
           include:
             match_type: regexp
             metric_names:
@@ -193,8 +193,8 @@ Metrics config should match snapshot when using default values:
             - k8s.node.network.packets_transmitted
             - k8s.node.network.receive_packets_dropped
             - k8s.node.network.transmit_packets_dropped
-            - apiserver_request_not_failed_temp
-            - apiserver_request_total_temp
+            - apiserver_request_not_failed__swo_temp
+            - apiserver_request_total__swo_temp
           max_staleness: 180s
         deltatorate:
           metrics:
@@ -373,7 +373,7 @@ Metrics config should match snapshot when using default values:
         filter/remove_temporary_metrics:
           metrics:
             metric:
-            - IsMatch(name , ".*_temp")
+            - IsMatch(name , ".*__swo_temp$")
         groupbyattrs/all:
           keys:
           - kubelet_version
@@ -454,8 +454,8 @@ Metrics config should match snapshot when using default values:
           spike_limit_mib: 512
         metricsgeneration/cluster:
           rules:
-          - metric1: apiserver_request_not_failed_temp
-            metric2: apiserver_request_total_temp
+          - metric1: apiserver_request_not_failed__swo_temp
+            metric2: apiserver_request_total__swo_temp
             name: k8s.apiserver.request.successrate
             operation: percent
             type: calculate
@@ -543,16 +543,16 @@ Metrics config should match snapshot when using default values:
               new_label: sw.k8s.persistentvolumeclaim.status
           - action: insert
             include: k8s.container_fs_reads_total
-            new_name: k8s.container_fs_reads_total_temp
+            new_name: k8s.container_fs_reads_total__swo_temp
           - action: insert
             include: k8s.container_fs_writes_total
-            new_name: k8s.container_fs_writes_total_temp
+            new_name: k8s.container_fs_writes_total__swo_temp
           - action: combine
             experimental_match_labels:
               container: \S+
               namespace: \S+
               pod: \S+
-            include: (k8s.container_fs_reads_total_temp|k8s.container_fs_writes_total_temp)
+            include: (k8s.container_fs_reads_total__swo_temp|k8s.container_fs_writes_total__swo_temp)
             match_type: regexp
             new_name: k8s.container.fs.iops
             operations:
@@ -565,16 +565,16 @@ Metrics config should match snapshot when using default values:
             submatch_case: lower
           - action: insert
             include: k8s.container_fs_reads_bytes_total
-            new_name: k8s.container_fs_reads_bytes_total_temp
+            new_name: k8s.container_fs_reads_bytes_total__swo_temp
           - action: insert
             include: k8s.container_fs_writes_bytes_total
-            new_name: k8s.container_fs_writes_bytes_total_temp
+            new_name: k8s.container_fs_writes_bytes_total__swo_temp
           - action: combine
             experimental_match_labels:
               container: \S+
               namespace: \S+
               pod: \S+
-            include: (k8s.container_fs_reads_bytes_total_temp|k8s.container_fs_writes_bytes_total_temp)
+            include: (k8s.container_fs_reads_bytes_total__swo_temp|k8s.container_fs_writes_bytes_total__swo_temp)
             match_type: regexp
             new_name: k8s.container.fs.throughput
             operations:
@@ -776,12 +776,12 @@ Metrics config should match snapshot when using default values:
               - k8s.node.name
           - action: insert
             include: k8s.pod.fs.reads.rate
-            new_name: k8s.pod.fs.reads.rate_temp
+            new_name: k8s.pod.fs.reads.rate__swo_temp
           - action: insert
             include: k8s.pod.fs.writes.rate
-            new_name: k8s.pod.fs.writes.rate_temp
+            new_name: k8s.pod.fs.writes.rate__swo_temp
           - action: combine
-            include: (k8s.pod.fs.reads.rate_temp|k8s.pod.fs.writes.rate_temp)
+            include: (k8s.pod.fs.reads.rate__swo_temp|k8s.pod.fs.writes.rate__swo_temp)
             match_type: regexp
             new_name: k8s.pod.fs.iops
             operations:
@@ -794,12 +794,12 @@ Metrics config should match snapshot when using default values:
             submatch_case: lower
           - action: insert
             include: k8s.pod.fs.reads.bytes.rate
-            new_name: k8s.pod.fs.reads.bytes.rate_temp
+            new_name: k8s.pod.fs.reads.bytes.rate__swo_temp
           - action: insert
             include: k8s.pod.fs.writes.bytes.rate
-            new_name: k8s.pod.fs.writes.bytes.rate_temp
+            new_name: k8s.pod.fs.writes.bytes.rate__swo_temp
           - action: combine
-            include: (k8s.pod.fs.reads.bytes.rate_temp|k8s.pod.fs.writes.bytes.rate_temp)
+            include: (k8s.pod.fs.reads.bytes.rate__swo_temp|k8s.pod.fs.writes.bytes.rate__swo_temp)
             match_type: regexp
             new_name: k8s.pod.fs.throughput
             operations:
@@ -909,7 +909,7 @@ Metrics config should match snapshot when using default values:
               - k8s.node.name
           - action: insert
             include: k8s.pod.fs.reads.rate
-            new_name: k8s.node.fs.reads.rate_temp
+            new_name: k8s.node.fs.reads.rate__swo_temp
             operations:
             - action: aggregate_labels
               aggregation_type: sum
@@ -917,7 +917,7 @@ Metrics config should match snapshot when using default values:
               - k8s.node.name
           - action: insert
             include: k8s.pod.fs.writes.rate
-            new_name: k8s.node.fs.writes.rate_temp
+            new_name: k8s.node.fs.writes.rate__swo_temp
             operations:
             - action: aggregate_labels
               aggregation_type: sum
@@ -925,7 +925,7 @@ Metrics config should match snapshot when using default values:
               - k8s.node.name
           - action: insert
             include: k8s.pod.fs.reads.bytes.rate
-            new_name: k8s.node.fs.reads.bytes.rate_temp
+            new_name: k8s.node.fs.reads.bytes.rate__swo_temp
             operations:
             - action: aggregate_labels
               aggregation_type: sum
@@ -933,14 +933,14 @@ Metrics config should match snapshot when using default values:
               - k8s.node.name
           - action: insert
             include: k8s.pod.fs.writes.bytes.rate
-            new_name: k8s.node.fs.writes.bytes.rate_temp
+            new_name: k8s.node.fs.writes.bytes.rate__swo_temp
             operations:
             - action: aggregate_labels
               aggregation_type: sum
               label_set:
               - k8s.node.name
           - action: combine
-            include: (k8s.node.fs.reads.rate_temp|k8s.node.fs.writes.rate_temp)
+            include: (k8s.node.fs.reads.rate__swo_temp|k8s.node.fs.writes.rate__swo_temp)
             match_type: regexp
             new_name: k8s.node.fs.iops
             operations:
@@ -950,7 +950,7 @@ Metrics config should match snapshot when using default values:
               - k8s.node.name
             submatch_case: lower
           - action: combine
-            include: (k8s.node.fs.reads.bytes.rate_temp|k8s.node.fs.writes.bytes.rate_temp)
+            include: (k8s.node.fs.reads.bytes.rate__swo_temp|k8s.node.fs.writes.bytes.rate__swo_temp)
             match_type: regexp
             new_name: k8s.node.fs.throughput
             operations:
@@ -977,38 +977,38 @@ Metrics config should match snapshot when using default values:
             experimental_match_labels:
               resource: cpu
             include: k8s.kube_pod_container_resource_limits
-            new_name: k8s.container.spec.cpu.limit_temp
+            new_name: k8s.container.spec.cpu.limit__swo_temp
           - action: insert
             experimental_match_labels:
               resource: cpu
             include: k8s.kube_pod_init_container_resource_limits
-            new_name: k8s.initcontainer.spec.cpu.limit_temp
+            new_name: k8s.initcontainer.spec.cpu.limit__swo_temp
           - action: insert
             experimental_match_labels:
               resource: cpu
             include: k8s.kube_pod_container_resource_requests
-            new_name: k8s.container.spec.cpu.requests_temp
+            new_name: k8s.container.spec.cpu.requests__swo_temp
           - action: insert
             experimental_match_labels:
               resource: cpu
             include: k8s.kube_pod_init_container_resource_requests
-            new_name: k8s.initcontainer.spec.cpu.requests_temp
+            new_name: k8s.initcontainer.spec.cpu.requests__swo_temp
           - action: combine
-            include: (k8s.container.spec.cpu.requests_temp|k8s.initcontainer.spec.cpu.requests_temp)
+            include: (k8s.container.spec.cpu.requests__swo_temp|k8s.initcontainer.spec.cpu.requests__swo_temp)
             match_type: regexp
             new_name: k8s.container.spec.cpu.requests
           - action: insert
             experimental_match_labels:
               resource: memory
             include: k8s.kube_pod_container_resource_requests
-            new_name: k8s.container.spec.memory.requests_temp
+            new_name: k8s.container.spec.memory.requests__swo_temp
           - action: insert
             experimental_match_labels:
               resource: memory
             include: k8s.kube_pod_init_container_resource_requests
-            new_name: k8s.initcontainer.spec.memory.requests_temp
+            new_name: k8s.initcontainer.spec.memory.requests__swo_temp
           - action: combine
-            include: (k8s.container.spec.memory.requests_temp|k8s.initcontainer.spec.memory.requests_temp)
+            include: (k8s.container.spec.memory.requests__swo_temp|k8s.initcontainer.spec.memory.requests__swo_temp)
             match_type: regexp
             new_name: k8s.container.spec.memory.requests
           - action: insert
@@ -1016,15 +1016,15 @@ Metrics config should match snapshot when using default values:
               resource: memory
             include: k8s.kube_pod_container_resource_limits
             match_type: regexp
-            new_name: k8s.container.spec.memory.limit_temp
+            new_name: k8s.container.spec.memory.limit__swo_temp
           - action: insert
             experimental_match_labels:
               resource: memory
             include: k8s.kube_pod_init_container_resource_limits
             match_type: regexp
-            new_name: k8s.initcontainer.spec.memory.limit_temp
+            new_name: k8s.initcontainer.spec.memory.limit__swo_temp
           - action: insert
-            include: k8s.container.spec.cpu.limit_temp
+            include: k8s.container.spec.cpu.limit__swo_temp
             new_name: k8s.pod.spec.cpu.limit
             operations:
             - action: aggregate_labels
@@ -1034,11 +1034,11 @@ Metrics config should match snapshot when using default values:
               - namespace
               - k8s.node.name
           - action: combine
-            include: (k8s.container.spec.cpu.limit_temp|k8s.initcontainer.spec.cpu.limit_temp)
+            include: (k8s.container.spec.cpu.limit__swo_temp|k8s.initcontainer.spec.cpu.limit__swo_temp)
             match_type: regexp
             new_name: k8s.container.spec.cpu.limit
           - action: insert
-            include: k8s.container.spec.memory.limit_temp
+            include: k8s.container.spec.memory.limit__swo_temp
             new_name: k8s.pod.spec.memory.limit
             operations:
             - action: aggregate_labels
@@ -1048,7 +1048,7 @@ Metrics config should match snapshot when using default values:
               - namespace
               - k8s.node.name
           - action: combine
-            include: (k8s.container.spec.memory.limit_temp|k8s.initcontainer.spec.memory.limit_temp)
+            include: (k8s.container.spec.memory.limit__swo_temp|k8s.initcontainer.spec.memory.limit__swo_temp)
             match_type: regexp
             new_name: k8s.container.spec.memory.limit
           - action: insert
@@ -1184,7 +1184,7 @@ Metrics config should match snapshot when using default values:
             experimental_match_labels:
               phase: Running
             include: k8s.kube_pod_status_phase
-            new_name: k8s.pod.status.phase.running_temp
+            new_name: k8s.pod.status.phase.running__swo_temp
           - action: insert
             include: k8s.kube_pod_info
             new_name: k8s.cluster.pods
@@ -1234,7 +1234,7 @@ Metrics config should match snapshot when using default values:
               label_set:
               - dummy_label_workaround
           - action: insert
-            include: k8s.pod.status.phase.running_temp
+            include: k8s.pod.status.phase.running__swo_temp
             new_name: k8s.cluster.pods.running
             operations:
             - action: aggregate_labels
@@ -1289,16 +1289,16 @@ Metrics config should match snapshot when using default values:
               - sw.k8s.cluster.version
           - action: update
             include: k8s.kubernetes_build_info
-            new_name: k8s.kubernetes_build_info_temp
+            new_name: k8s.kubernetes_build_info__swo_temp
           - action: insert
             experimental_match_labels:
               code: ^(([0-3]|[6-9])\d\d)|(4([0-1]|[3-9])\d)|(42[0-8])$
             include: k8s.apiserver_request_total
             match_type: regexp
-            new_name: apiserver_request_not_failed_temp
+            new_name: apiserver_request_not_failed__swo_temp
           - action: update
-            include: apiserver_request_not_failed_temp
-            new_name: apiserver_request_not_failed_temp
+            include: apiserver_request_not_failed__swo_temp
+            new_name: apiserver_request_not_failed__swo_temp
             operations:
             - action: aggregate_labels
               aggregation_type: sum
@@ -1306,7 +1306,7 @@ Metrics config should match snapshot when using default values:
               - dummy_label_workaround
           - action: insert
             include: k8s.apiserver_request_total
-            new_name: apiserver_request_total_temp
+            new_name: apiserver_request_total__swo_temp
             operations:
             - action: aggregate_labels
               aggregation_type: sum

--- a/deploy/helm/tests/__snapshot__/metrics-collector-config-map_test.yaml.snap
+++ b/deploy/helm/tests/__snapshot__/metrics-collector-config-map_test.yaml.snap
@@ -71,7 +71,7 @@ Metrics config should match snapshot when fargate is enabled:
           actions:
           - action: delete
             key: temp
-            pattern: (.*_temp$)|(^\$.*)
+            pattern: (.*__swo_temp$)|(^\$.*)
           include:
             match_type: regexp
             metric_names:
@@ -193,8 +193,8 @@ Metrics config should match snapshot when fargate is enabled:
             - k8s.node.network.packets_transmitted
             - k8s.node.network.receive_packets_dropped
             - k8s.node.network.transmit_packets_dropped
-            - apiserver_request_not_failed_temp
-            - apiserver_request_total_temp
+            - apiserver_request_not_failed__swo_temp
+            - apiserver_request_total__swo_temp
           max_staleness: 180s
         deltatorate:
           metrics:
@@ -373,7 +373,7 @@ Metrics config should match snapshot when fargate is enabled:
         filter/remove_temporary_metrics:
           metrics:
             metric:
-            - IsMatch(name , ".*_temp")
+            - IsMatch(name , ".*__swo_temp$")
         groupbyattrs/all:
           keys:
           - kubelet_version
@@ -454,8 +454,8 @@ Metrics config should match snapshot when fargate is enabled:
           spike_limit_mib: 512
         metricsgeneration/cluster:
           rules:
-          - metric1: apiserver_request_not_failed_temp
-            metric2: apiserver_request_total_temp
+          - metric1: apiserver_request_not_failed__swo_temp
+            metric2: apiserver_request_total__swo_temp
             name: k8s.apiserver.request.successrate
             operation: percent
             type: calculate
@@ -543,16 +543,16 @@ Metrics config should match snapshot when fargate is enabled:
               new_label: sw.k8s.persistentvolumeclaim.status
           - action: insert
             include: k8s.container_fs_reads_total
-            new_name: k8s.container_fs_reads_total_temp
+            new_name: k8s.container_fs_reads_total__swo_temp
           - action: insert
             include: k8s.container_fs_writes_total
-            new_name: k8s.container_fs_writes_total_temp
+            new_name: k8s.container_fs_writes_total__swo_temp
           - action: combine
             experimental_match_labels:
               container: \S+
               namespace: \S+
               pod: \S+
-            include: (k8s.container_fs_reads_total_temp|k8s.container_fs_writes_total_temp)
+            include: (k8s.container_fs_reads_total__swo_temp|k8s.container_fs_writes_total__swo_temp)
             match_type: regexp
             new_name: k8s.container.fs.iops
             operations:
@@ -565,16 +565,16 @@ Metrics config should match snapshot when fargate is enabled:
             submatch_case: lower
           - action: insert
             include: k8s.container_fs_reads_bytes_total
-            new_name: k8s.container_fs_reads_bytes_total_temp
+            new_name: k8s.container_fs_reads_bytes_total__swo_temp
           - action: insert
             include: k8s.container_fs_writes_bytes_total
-            new_name: k8s.container_fs_writes_bytes_total_temp
+            new_name: k8s.container_fs_writes_bytes_total__swo_temp
           - action: combine
             experimental_match_labels:
               container: \S+
               namespace: \S+
               pod: \S+
-            include: (k8s.container_fs_reads_bytes_total_temp|k8s.container_fs_writes_bytes_total_temp)
+            include: (k8s.container_fs_reads_bytes_total__swo_temp|k8s.container_fs_writes_bytes_total__swo_temp)
             match_type: regexp
             new_name: k8s.container.fs.throughput
             operations:
@@ -776,12 +776,12 @@ Metrics config should match snapshot when fargate is enabled:
               - k8s.node.name
           - action: insert
             include: k8s.pod.fs.reads.rate
-            new_name: k8s.pod.fs.reads.rate_temp
+            new_name: k8s.pod.fs.reads.rate__swo_temp
           - action: insert
             include: k8s.pod.fs.writes.rate
-            new_name: k8s.pod.fs.writes.rate_temp
+            new_name: k8s.pod.fs.writes.rate__swo_temp
           - action: combine
-            include: (k8s.pod.fs.reads.rate_temp|k8s.pod.fs.writes.rate_temp)
+            include: (k8s.pod.fs.reads.rate__swo_temp|k8s.pod.fs.writes.rate__swo_temp)
             match_type: regexp
             new_name: k8s.pod.fs.iops
             operations:
@@ -794,12 +794,12 @@ Metrics config should match snapshot when fargate is enabled:
             submatch_case: lower
           - action: insert
             include: k8s.pod.fs.reads.bytes.rate
-            new_name: k8s.pod.fs.reads.bytes.rate_temp
+            new_name: k8s.pod.fs.reads.bytes.rate__swo_temp
           - action: insert
             include: k8s.pod.fs.writes.bytes.rate
-            new_name: k8s.pod.fs.writes.bytes.rate_temp
+            new_name: k8s.pod.fs.writes.bytes.rate__swo_temp
           - action: combine
-            include: (k8s.pod.fs.reads.bytes.rate_temp|k8s.pod.fs.writes.bytes.rate_temp)
+            include: (k8s.pod.fs.reads.bytes.rate__swo_temp|k8s.pod.fs.writes.bytes.rate__swo_temp)
             match_type: regexp
             new_name: k8s.pod.fs.throughput
             operations:
@@ -909,7 +909,7 @@ Metrics config should match snapshot when fargate is enabled:
               - k8s.node.name
           - action: insert
             include: k8s.pod.fs.reads.rate
-            new_name: k8s.node.fs.reads.rate_temp
+            new_name: k8s.node.fs.reads.rate__swo_temp
             operations:
             - action: aggregate_labels
               aggregation_type: sum
@@ -917,7 +917,7 @@ Metrics config should match snapshot when fargate is enabled:
               - k8s.node.name
           - action: insert
             include: k8s.pod.fs.writes.rate
-            new_name: k8s.node.fs.writes.rate_temp
+            new_name: k8s.node.fs.writes.rate__swo_temp
             operations:
             - action: aggregate_labels
               aggregation_type: sum
@@ -925,7 +925,7 @@ Metrics config should match snapshot when fargate is enabled:
               - k8s.node.name
           - action: insert
             include: k8s.pod.fs.reads.bytes.rate
-            new_name: k8s.node.fs.reads.bytes.rate_temp
+            new_name: k8s.node.fs.reads.bytes.rate__swo_temp
             operations:
             - action: aggregate_labels
               aggregation_type: sum
@@ -933,14 +933,14 @@ Metrics config should match snapshot when fargate is enabled:
               - k8s.node.name
           - action: insert
             include: k8s.pod.fs.writes.bytes.rate
-            new_name: k8s.node.fs.writes.bytes.rate_temp
+            new_name: k8s.node.fs.writes.bytes.rate__swo_temp
             operations:
             - action: aggregate_labels
               aggregation_type: sum
               label_set:
               - k8s.node.name
           - action: combine
-            include: (k8s.node.fs.reads.rate_temp|k8s.node.fs.writes.rate_temp)
+            include: (k8s.node.fs.reads.rate__swo_temp|k8s.node.fs.writes.rate__swo_temp)
             match_type: regexp
             new_name: k8s.node.fs.iops
             operations:
@@ -950,7 +950,7 @@ Metrics config should match snapshot when fargate is enabled:
               - k8s.node.name
             submatch_case: lower
           - action: combine
-            include: (k8s.node.fs.reads.bytes.rate_temp|k8s.node.fs.writes.bytes.rate_temp)
+            include: (k8s.node.fs.reads.bytes.rate__swo_temp|k8s.node.fs.writes.bytes.rate__swo_temp)
             match_type: regexp
             new_name: k8s.node.fs.throughput
             operations:
@@ -977,38 +977,38 @@ Metrics config should match snapshot when fargate is enabled:
             experimental_match_labels:
               resource: cpu
             include: k8s.kube_pod_container_resource_limits
-            new_name: k8s.container.spec.cpu.limit_temp
+            new_name: k8s.container.spec.cpu.limit__swo_temp
           - action: insert
             experimental_match_labels:
               resource: cpu
             include: k8s.kube_pod_init_container_resource_limits
-            new_name: k8s.initcontainer.spec.cpu.limit_temp
+            new_name: k8s.initcontainer.spec.cpu.limit__swo_temp
           - action: insert
             experimental_match_labels:
               resource: cpu
             include: k8s.kube_pod_container_resource_requests
-            new_name: k8s.container.spec.cpu.requests_temp
+            new_name: k8s.container.spec.cpu.requests__swo_temp
           - action: insert
             experimental_match_labels:
               resource: cpu
             include: k8s.kube_pod_init_container_resource_requests
-            new_name: k8s.initcontainer.spec.cpu.requests_temp
+            new_name: k8s.initcontainer.spec.cpu.requests__swo_temp
           - action: combine
-            include: (k8s.container.spec.cpu.requests_temp|k8s.initcontainer.spec.cpu.requests_temp)
+            include: (k8s.container.spec.cpu.requests__swo_temp|k8s.initcontainer.spec.cpu.requests__swo_temp)
             match_type: regexp
             new_name: k8s.container.spec.cpu.requests
           - action: insert
             experimental_match_labels:
               resource: memory
             include: k8s.kube_pod_container_resource_requests
-            new_name: k8s.container.spec.memory.requests_temp
+            new_name: k8s.container.spec.memory.requests__swo_temp
           - action: insert
             experimental_match_labels:
               resource: memory
             include: k8s.kube_pod_init_container_resource_requests
-            new_name: k8s.initcontainer.spec.memory.requests_temp
+            new_name: k8s.initcontainer.spec.memory.requests__swo_temp
           - action: combine
-            include: (k8s.container.spec.memory.requests_temp|k8s.initcontainer.spec.memory.requests_temp)
+            include: (k8s.container.spec.memory.requests__swo_temp|k8s.initcontainer.spec.memory.requests__swo_temp)
             match_type: regexp
             new_name: k8s.container.spec.memory.requests
           - action: insert
@@ -1016,15 +1016,15 @@ Metrics config should match snapshot when fargate is enabled:
               resource: memory
             include: k8s.kube_pod_container_resource_limits
             match_type: regexp
-            new_name: k8s.container.spec.memory.limit_temp
+            new_name: k8s.container.spec.memory.limit__swo_temp
           - action: insert
             experimental_match_labels:
               resource: memory
             include: k8s.kube_pod_init_container_resource_limits
             match_type: regexp
-            new_name: k8s.initcontainer.spec.memory.limit_temp
+            new_name: k8s.initcontainer.spec.memory.limit__swo_temp
           - action: insert
-            include: k8s.container.spec.cpu.limit_temp
+            include: k8s.container.spec.cpu.limit__swo_temp
             new_name: k8s.pod.spec.cpu.limit
             operations:
             - action: aggregate_labels
@@ -1034,11 +1034,11 @@ Metrics config should match snapshot when fargate is enabled:
               - namespace
               - k8s.node.name
           - action: combine
-            include: (k8s.container.spec.cpu.limit_temp|k8s.initcontainer.spec.cpu.limit_temp)
+            include: (k8s.container.spec.cpu.limit__swo_temp|k8s.initcontainer.spec.cpu.limit__swo_temp)
             match_type: regexp
             new_name: k8s.container.spec.cpu.limit
           - action: insert
-            include: k8s.container.spec.memory.limit_temp
+            include: k8s.container.spec.memory.limit__swo_temp
             new_name: k8s.pod.spec.memory.limit
             operations:
             - action: aggregate_labels
@@ -1048,7 +1048,7 @@ Metrics config should match snapshot when fargate is enabled:
               - namespace
               - k8s.node.name
           - action: combine
-            include: (k8s.container.spec.memory.limit_temp|k8s.initcontainer.spec.memory.limit_temp)
+            include: (k8s.container.spec.memory.limit__swo_temp|k8s.initcontainer.spec.memory.limit__swo_temp)
             match_type: regexp
             new_name: k8s.container.spec.memory.limit
           - action: insert
@@ -1184,7 +1184,7 @@ Metrics config should match snapshot when fargate is enabled:
             experimental_match_labels:
               phase: Running
             include: k8s.kube_pod_status_phase
-            new_name: k8s.pod.status.phase.running_temp
+            new_name: k8s.pod.status.phase.running__swo_temp
           - action: insert
             include: k8s.kube_pod_info
             new_name: k8s.cluster.pods
@@ -1234,7 +1234,7 @@ Metrics config should match snapshot when fargate is enabled:
               label_set:
               - dummy_label_workaround
           - action: insert
-            include: k8s.pod.status.phase.running_temp
+            include: k8s.pod.status.phase.running__swo_temp
             new_name: k8s.cluster.pods.running
             operations:
             - action: aggregate_labels
@@ -1289,16 +1289,16 @@ Metrics config should match snapshot when fargate is enabled:
               - sw.k8s.cluster.version
           - action: update
             include: k8s.kubernetes_build_info
-            new_name: k8s.kubernetes_build_info_temp
+            new_name: k8s.kubernetes_build_info__swo_temp
           - action: insert
             experimental_match_labels:
               code: ^(([0-3]|[6-9])\d\d)|(4([0-1]|[3-9])\d)|(42[0-8])$
             include: k8s.apiserver_request_total
             match_type: regexp
-            new_name: apiserver_request_not_failed_temp
+            new_name: apiserver_request_not_failed__swo_temp
           - action: update
-            include: apiserver_request_not_failed_temp
-            new_name: apiserver_request_not_failed_temp
+            include: apiserver_request_not_failed__swo_temp
+            new_name: apiserver_request_not_failed__swo_temp
             operations:
             - action: aggregate_labels
               aggregation_type: sum
@@ -1306,7 +1306,7 @@ Metrics config should match snapshot when fargate is enabled:
               - dummy_label_workaround
           - action: insert
             include: k8s.apiserver_request_total
-            new_name: apiserver_request_total_temp
+            new_name: apiserver_request_total__swo_temp
             operations:
             - action: aggregate_labels
               aggregation_type: sum
@@ -1776,7 +1776,7 @@ Metrics config should match snapshot when using Prometheus url with extra_scrape
           actions:
           - action: delete
             key: temp
-            pattern: (.*_temp$)|(^\$.*)
+            pattern: (.*__swo_temp$)|(^\$.*)
           include:
             match_type: regexp
             metric_names:
@@ -1901,8 +1901,8 @@ Metrics config should match snapshot when using Prometheus url with extra_scrape
             - k8s.node.network.packets_transmitted
             - k8s.node.network.receive_packets_dropped
             - k8s.node.network.transmit_packets_dropped
-            - apiserver_request_not_failed_temp
-            - apiserver_request_total_temp
+            - apiserver_request_not_failed__swo_temp
+            - apiserver_request_total__swo_temp
           max_staleness: 180s
         deltatorate:
           metrics:
@@ -2081,7 +2081,7 @@ Metrics config should match snapshot when using Prometheus url with extra_scrape
         filter/remove_temporary_metrics:
           metrics:
             metric:
-            - IsMatch(name , ".*_temp")
+            - IsMatch(name , ".*__swo_temp$")
         groupbyattrs/all:
           keys:
           - kubelet_version
@@ -2162,8 +2162,8 @@ Metrics config should match snapshot when using Prometheus url with extra_scrape
           spike_limit_mib: 512
         metricsgeneration/cluster:
           rules:
-          - metric1: apiserver_request_not_failed_temp
-            metric2: apiserver_request_total_temp
+          - metric1: apiserver_request_not_failed__swo_temp
+            metric2: apiserver_request_total__swo_temp
             name: k8s.apiserver.request.successrate
             operation: percent
             type: calculate
@@ -2251,16 +2251,16 @@ Metrics config should match snapshot when using Prometheus url with extra_scrape
               new_label: sw.k8s.persistentvolumeclaim.status
           - action: insert
             include: k8s.container_fs_reads_total
-            new_name: k8s.container_fs_reads_total_temp
+            new_name: k8s.container_fs_reads_total__swo_temp
           - action: insert
             include: k8s.container_fs_writes_total
-            new_name: k8s.container_fs_writes_total_temp
+            new_name: k8s.container_fs_writes_total__swo_temp
           - action: combine
             experimental_match_labels:
               container: \S+
               namespace: \S+
               pod: \S+
-            include: (k8s.container_fs_reads_total_temp|k8s.container_fs_writes_total_temp)
+            include: (k8s.container_fs_reads_total__swo_temp|k8s.container_fs_writes_total__swo_temp)
             match_type: regexp
             new_name: k8s.container.fs.iops
             operations:
@@ -2273,16 +2273,16 @@ Metrics config should match snapshot when using Prometheus url with extra_scrape
             submatch_case: lower
           - action: insert
             include: k8s.container_fs_reads_bytes_total
-            new_name: k8s.container_fs_reads_bytes_total_temp
+            new_name: k8s.container_fs_reads_bytes_total__swo_temp
           - action: insert
             include: k8s.container_fs_writes_bytes_total
-            new_name: k8s.container_fs_writes_bytes_total_temp
+            new_name: k8s.container_fs_writes_bytes_total__swo_temp
           - action: combine
             experimental_match_labels:
               container: \S+
               namespace: \S+
               pod: \S+
-            include: (k8s.container_fs_reads_bytes_total_temp|k8s.container_fs_writes_bytes_total_temp)
+            include: (k8s.container_fs_reads_bytes_total__swo_temp|k8s.container_fs_writes_bytes_total__swo_temp)
             match_type: regexp
             new_name: k8s.container.fs.throughput
             operations:
@@ -2484,12 +2484,12 @@ Metrics config should match snapshot when using Prometheus url with extra_scrape
               - k8s.node.name
           - action: insert
             include: k8s.pod.fs.reads.rate
-            new_name: k8s.pod.fs.reads.rate_temp
+            new_name: k8s.pod.fs.reads.rate__swo_temp
           - action: insert
             include: k8s.pod.fs.writes.rate
-            new_name: k8s.pod.fs.writes.rate_temp
+            new_name: k8s.pod.fs.writes.rate__swo_temp
           - action: combine
-            include: (k8s.pod.fs.reads.rate_temp|k8s.pod.fs.writes.rate_temp)
+            include: (k8s.pod.fs.reads.rate__swo_temp|k8s.pod.fs.writes.rate__swo_temp)
             match_type: regexp
             new_name: k8s.pod.fs.iops
             operations:
@@ -2502,12 +2502,12 @@ Metrics config should match snapshot when using Prometheus url with extra_scrape
             submatch_case: lower
           - action: insert
             include: k8s.pod.fs.reads.bytes.rate
-            new_name: k8s.pod.fs.reads.bytes.rate_temp
+            new_name: k8s.pod.fs.reads.bytes.rate__swo_temp
           - action: insert
             include: k8s.pod.fs.writes.bytes.rate
-            new_name: k8s.pod.fs.writes.bytes.rate_temp
+            new_name: k8s.pod.fs.writes.bytes.rate__swo_temp
           - action: combine
-            include: (k8s.pod.fs.reads.bytes.rate_temp|k8s.pod.fs.writes.bytes.rate_temp)
+            include: (k8s.pod.fs.reads.bytes.rate__swo_temp|k8s.pod.fs.writes.bytes.rate__swo_temp)
             match_type: regexp
             new_name: k8s.pod.fs.throughput
             operations:
@@ -2617,7 +2617,7 @@ Metrics config should match snapshot when using Prometheus url with extra_scrape
               - k8s.node.name
           - action: insert
             include: k8s.pod.fs.reads.rate
-            new_name: k8s.node.fs.reads.rate_temp
+            new_name: k8s.node.fs.reads.rate__swo_temp
             operations:
             - action: aggregate_labels
               aggregation_type: sum
@@ -2625,7 +2625,7 @@ Metrics config should match snapshot when using Prometheus url with extra_scrape
               - k8s.node.name
           - action: insert
             include: k8s.pod.fs.writes.rate
-            new_name: k8s.node.fs.writes.rate_temp
+            new_name: k8s.node.fs.writes.rate__swo_temp
             operations:
             - action: aggregate_labels
               aggregation_type: sum
@@ -2633,7 +2633,7 @@ Metrics config should match snapshot when using Prometheus url with extra_scrape
               - k8s.node.name
           - action: insert
             include: k8s.pod.fs.reads.bytes.rate
-            new_name: k8s.node.fs.reads.bytes.rate_temp
+            new_name: k8s.node.fs.reads.bytes.rate__swo_temp
             operations:
             - action: aggregate_labels
               aggregation_type: sum
@@ -2641,14 +2641,14 @@ Metrics config should match snapshot when using Prometheus url with extra_scrape
               - k8s.node.name
           - action: insert
             include: k8s.pod.fs.writes.bytes.rate
-            new_name: k8s.node.fs.writes.bytes.rate_temp
+            new_name: k8s.node.fs.writes.bytes.rate__swo_temp
             operations:
             - action: aggregate_labels
               aggregation_type: sum
               label_set:
               - k8s.node.name
           - action: combine
-            include: (k8s.node.fs.reads.rate_temp|k8s.node.fs.writes.rate_temp)
+            include: (k8s.node.fs.reads.rate__swo_temp|k8s.node.fs.writes.rate__swo_temp)
             match_type: regexp
             new_name: k8s.node.fs.iops
             operations:
@@ -2658,7 +2658,7 @@ Metrics config should match snapshot when using Prometheus url with extra_scrape
               - k8s.node.name
             submatch_case: lower
           - action: combine
-            include: (k8s.node.fs.reads.bytes.rate_temp|k8s.node.fs.writes.bytes.rate_temp)
+            include: (k8s.node.fs.reads.bytes.rate__swo_temp|k8s.node.fs.writes.bytes.rate__swo_temp)
             match_type: regexp
             new_name: k8s.node.fs.throughput
             operations:
@@ -2685,38 +2685,38 @@ Metrics config should match snapshot when using Prometheus url with extra_scrape
             experimental_match_labels:
               resource: cpu
             include: k8s.kube_pod_container_resource_limits
-            new_name: k8s.container.spec.cpu.limit_temp
+            new_name: k8s.container.spec.cpu.limit__swo_temp
           - action: insert
             experimental_match_labels:
               resource: cpu
             include: k8s.kube_pod_init_container_resource_limits
-            new_name: k8s.initcontainer.spec.cpu.limit_temp
+            new_name: k8s.initcontainer.spec.cpu.limit__swo_temp
           - action: insert
             experimental_match_labels:
               resource: cpu
             include: k8s.kube_pod_container_resource_requests
-            new_name: k8s.container.spec.cpu.requests_temp
+            new_name: k8s.container.spec.cpu.requests__swo_temp
           - action: insert
             experimental_match_labels:
               resource: cpu
             include: k8s.kube_pod_init_container_resource_requests
-            new_name: k8s.initcontainer.spec.cpu.requests_temp
+            new_name: k8s.initcontainer.spec.cpu.requests__swo_temp
           - action: combine
-            include: (k8s.container.spec.cpu.requests_temp|k8s.initcontainer.spec.cpu.requests_temp)
+            include: (k8s.container.spec.cpu.requests__swo_temp|k8s.initcontainer.spec.cpu.requests__swo_temp)
             match_type: regexp
             new_name: k8s.container.spec.cpu.requests
           - action: insert
             experimental_match_labels:
               resource: memory
             include: k8s.kube_pod_container_resource_requests
-            new_name: k8s.container.spec.memory.requests_temp
+            new_name: k8s.container.spec.memory.requests__swo_temp
           - action: insert
             experimental_match_labels:
               resource: memory
             include: k8s.kube_pod_init_container_resource_requests
-            new_name: k8s.initcontainer.spec.memory.requests_temp
+            new_name: k8s.initcontainer.spec.memory.requests__swo_temp
           - action: combine
-            include: (k8s.container.spec.memory.requests_temp|k8s.initcontainer.spec.memory.requests_temp)
+            include: (k8s.container.spec.memory.requests__swo_temp|k8s.initcontainer.spec.memory.requests__swo_temp)
             match_type: regexp
             new_name: k8s.container.spec.memory.requests
           - action: insert
@@ -2724,15 +2724,15 @@ Metrics config should match snapshot when using Prometheus url with extra_scrape
               resource: memory
             include: k8s.kube_pod_container_resource_limits
             match_type: regexp
-            new_name: k8s.container.spec.memory.limit_temp
+            new_name: k8s.container.spec.memory.limit__swo_temp
           - action: insert
             experimental_match_labels:
               resource: memory
             include: k8s.kube_pod_init_container_resource_limits
             match_type: regexp
-            new_name: k8s.initcontainer.spec.memory.limit_temp
+            new_name: k8s.initcontainer.spec.memory.limit__swo_temp
           - action: insert
-            include: k8s.container.spec.cpu.limit_temp
+            include: k8s.container.spec.cpu.limit__swo_temp
             new_name: k8s.pod.spec.cpu.limit
             operations:
             - action: aggregate_labels
@@ -2742,11 +2742,11 @@ Metrics config should match snapshot when using Prometheus url with extra_scrape
               - namespace
               - k8s.node.name
           - action: combine
-            include: (k8s.container.spec.cpu.limit_temp|k8s.initcontainer.spec.cpu.limit_temp)
+            include: (k8s.container.spec.cpu.limit__swo_temp|k8s.initcontainer.spec.cpu.limit__swo_temp)
             match_type: regexp
             new_name: k8s.container.spec.cpu.limit
           - action: insert
-            include: k8s.container.spec.memory.limit_temp
+            include: k8s.container.spec.memory.limit__swo_temp
             new_name: k8s.pod.spec.memory.limit
             operations:
             - action: aggregate_labels
@@ -2756,7 +2756,7 @@ Metrics config should match snapshot when using Prometheus url with extra_scrape
               - namespace
               - k8s.node.name
           - action: combine
-            include: (k8s.container.spec.memory.limit_temp|k8s.initcontainer.spec.memory.limit_temp)
+            include: (k8s.container.spec.memory.limit__swo_temp|k8s.initcontainer.spec.memory.limit__swo_temp)
             match_type: regexp
             new_name: k8s.container.spec.memory.limit
           - action: insert
@@ -2892,7 +2892,7 @@ Metrics config should match snapshot when using Prometheus url with extra_scrape
             experimental_match_labels:
               phase: Running
             include: k8s.kube_pod_status_phase
-            new_name: k8s.pod.status.phase.running_temp
+            new_name: k8s.pod.status.phase.running__swo_temp
           - action: insert
             include: k8s.kube_pod_info
             new_name: k8s.cluster.pods
@@ -2942,7 +2942,7 @@ Metrics config should match snapshot when using Prometheus url with extra_scrape
               label_set:
               - dummy_label_workaround
           - action: insert
-            include: k8s.pod.status.phase.running_temp
+            include: k8s.pod.status.phase.running__swo_temp
             new_name: k8s.cluster.pods.running
             operations:
             - action: aggregate_labels
@@ -2997,16 +2997,16 @@ Metrics config should match snapshot when using Prometheus url with extra_scrape
               - sw.k8s.cluster.version
           - action: update
             include: k8s.kubernetes_build_info
-            new_name: k8s.kubernetes_build_info_temp
+            new_name: k8s.kubernetes_build_info__swo_temp
           - action: insert
             experimental_match_labels:
               code: ^(([0-3]|[6-9])\d\d)|(4([0-1]|[3-9])\d)|(42[0-8])$
             include: k8s.apiserver_request_total
             match_type: regexp
-            new_name: apiserver_request_not_failed_temp
+            new_name: apiserver_request_not_failed__swo_temp
           - action: update
-            include: apiserver_request_not_failed_temp
-            new_name: apiserver_request_not_failed_temp
+            include: apiserver_request_not_failed__swo_temp
+            new_name: apiserver_request_not_failed__swo_temp
             operations:
             - action: aggregate_labels
               aggregation_type: sum
@@ -3014,7 +3014,7 @@ Metrics config should match snapshot when using Prometheus url with extra_scrape
               - dummy_label_workaround
           - action: insert
             include: k8s.apiserver_request_total
-            new_name: apiserver_request_total_temp
+            new_name: apiserver_request_total__swo_temp
             operations:
             - action: aggregate_labels
               aggregation_type: sum
@@ -3426,7 +3426,7 @@ Metrics config should match snapshot when using default values:
           actions:
           - action: delete
             key: temp
-            pattern: (.*_temp$)|(^\$.*)
+            pattern: (.*__swo_temp$)|(^\$.*)
           include:
             match_type: regexp
             metric_names:
@@ -3551,8 +3551,8 @@ Metrics config should match snapshot when using default values:
             - k8s.node.network.packets_transmitted
             - k8s.node.network.receive_packets_dropped
             - k8s.node.network.transmit_packets_dropped
-            - apiserver_request_not_failed_temp
-            - apiserver_request_total_temp
+            - apiserver_request_not_failed__swo_temp
+            - apiserver_request_total__swo_temp
           max_staleness: 180s
         deltatorate:
           metrics:
@@ -3731,7 +3731,7 @@ Metrics config should match snapshot when using default values:
         filter/remove_temporary_metrics:
           metrics:
             metric:
-            - IsMatch(name , ".*_temp")
+            - IsMatch(name , ".*__swo_temp$")
         groupbyattrs/all:
           keys:
           - kubelet_version
@@ -3812,8 +3812,8 @@ Metrics config should match snapshot when using default values:
           spike_limit_mib: 512
         metricsgeneration/cluster:
           rules:
-          - metric1: apiserver_request_not_failed_temp
-            metric2: apiserver_request_total_temp
+          - metric1: apiserver_request_not_failed__swo_temp
+            metric2: apiserver_request_total__swo_temp
             name: k8s.apiserver.request.successrate
             operation: percent
             type: calculate
@@ -3901,16 +3901,16 @@ Metrics config should match snapshot when using default values:
               new_label: sw.k8s.persistentvolumeclaim.status
           - action: insert
             include: k8s.container_fs_reads_total
-            new_name: k8s.container_fs_reads_total_temp
+            new_name: k8s.container_fs_reads_total__swo_temp
           - action: insert
             include: k8s.container_fs_writes_total
-            new_name: k8s.container_fs_writes_total_temp
+            new_name: k8s.container_fs_writes_total__swo_temp
           - action: combine
             experimental_match_labels:
               container: \S+
               namespace: \S+
               pod: \S+
-            include: (k8s.container_fs_reads_total_temp|k8s.container_fs_writes_total_temp)
+            include: (k8s.container_fs_reads_total__swo_temp|k8s.container_fs_writes_total__swo_temp)
             match_type: regexp
             new_name: k8s.container.fs.iops
             operations:
@@ -3923,16 +3923,16 @@ Metrics config should match snapshot when using default values:
             submatch_case: lower
           - action: insert
             include: k8s.container_fs_reads_bytes_total
-            new_name: k8s.container_fs_reads_bytes_total_temp
+            new_name: k8s.container_fs_reads_bytes_total__swo_temp
           - action: insert
             include: k8s.container_fs_writes_bytes_total
-            new_name: k8s.container_fs_writes_bytes_total_temp
+            new_name: k8s.container_fs_writes_bytes_total__swo_temp
           - action: combine
             experimental_match_labels:
               container: \S+
               namespace: \S+
               pod: \S+
-            include: (k8s.container_fs_reads_bytes_total_temp|k8s.container_fs_writes_bytes_total_temp)
+            include: (k8s.container_fs_reads_bytes_total__swo_temp|k8s.container_fs_writes_bytes_total__swo_temp)
             match_type: regexp
             new_name: k8s.container.fs.throughput
             operations:
@@ -4134,12 +4134,12 @@ Metrics config should match snapshot when using default values:
               - k8s.node.name
           - action: insert
             include: k8s.pod.fs.reads.rate
-            new_name: k8s.pod.fs.reads.rate_temp
+            new_name: k8s.pod.fs.reads.rate__swo_temp
           - action: insert
             include: k8s.pod.fs.writes.rate
-            new_name: k8s.pod.fs.writes.rate_temp
+            new_name: k8s.pod.fs.writes.rate__swo_temp
           - action: combine
-            include: (k8s.pod.fs.reads.rate_temp|k8s.pod.fs.writes.rate_temp)
+            include: (k8s.pod.fs.reads.rate__swo_temp|k8s.pod.fs.writes.rate__swo_temp)
             match_type: regexp
             new_name: k8s.pod.fs.iops
             operations:
@@ -4152,12 +4152,12 @@ Metrics config should match snapshot when using default values:
             submatch_case: lower
           - action: insert
             include: k8s.pod.fs.reads.bytes.rate
-            new_name: k8s.pod.fs.reads.bytes.rate_temp
+            new_name: k8s.pod.fs.reads.bytes.rate__swo_temp
           - action: insert
             include: k8s.pod.fs.writes.bytes.rate
-            new_name: k8s.pod.fs.writes.bytes.rate_temp
+            new_name: k8s.pod.fs.writes.bytes.rate__swo_temp
           - action: combine
-            include: (k8s.pod.fs.reads.bytes.rate_temp|k8s.pod.fs.writes.bytes.rate_temp)
+            include: (k8s.pod.fs.reads.bytes.rate__swo_temp|k8s.pod.fs.writes.bytes.rate__swo_temp)
             match_type: regexp
             new_name: k8s.pod.fs.throughput
             operations:
@@ -4267,7 +4267,7 @@ Metrics config should match snapshot when using default values:
               - k8s.node.name
           - action: insert
             include: k8s.pod.fs.reads.rate
-            new_name: k8s.node.fs.reads.rate_temp
+            new_name: k8s.node.fs.reads.rate__swo_temp
             operations:
             - action: aggregate_labels
               aggregation_type: sum
@@ -4275,7 +4275,7 @@ Metrics config should match snapshot when using default values:
               - k8s.node.name
           - action: insert
             include: k8s.pod.fs.writes.rate
-            new_name: k8s.node.fs.writes.rate_temp
+            new_name: k8s.node.fs.writes.rate__swo_temp
             operations:
             - action: aggregate_labels
               aggregation_type: sum
@@ -4283,7 +4283,7 @@ Metrics config should match snapshot when using default values:
               - k8s.node.name
           - action: insert
             include: k8s.pod.fs.reads.bytes.rate
-            new_name: k8s.node.fs.reads.bytes.rate_temp
+            new_name: k8s.node.fs.reads.bytes.rate__swo_temp
             operations:
             - action: aggregate_labels
               aggregation_type: sum
@@ -4291,14 +4291,14 @@ Metrics config should match snapshot when using default values:
               - k8s.node.name
           - action: insert
             include: k8s.pod.fs.writes.bytes.rate
-            new_name: k8s.node.fs.writes.bytes.rate_temp
+            new_name: k8s.node.fs.writes.bytes.rate__swo_temp
             operations:
             - action: aggregate_labels
               aggregation_type: sum
               label_set:
               - k8s.node.name
           - action: combine
-            include: (k8s.node.fs.reads.rate_temp|k8s.node.fs.writes.rate_temp)
+            include: (k8s.node.fs.reads.rate__swo_temp|k8s.node.fs.writes.rate__swo_temp)
             match_type: regexp
             new_name: k8s.node.fs.iops
             operations:
@@ -4308,7 +4308,7 @@ Metrics config should match snapshot when using default values:
               - k8s.node.name
             submatch_case: lower
           - action: combine
-            include: (k8s.node.fs.reads.bytes.rate_temp|k8s.node.fs.writes.bytes.rate_temp)
+            include: (k8s.node.fs.reads.bytes.rate__swo_temp|k8s.node.fs.writes.bytes.rate__swo_temp)
             match_type: regexp
             new_name: k8s.node.fs.throughput
             operations:
@@ -4335,38 +4335,38 @@ Metrics config should match snapshot when using default values:
             experimental_match_labels:
               resource: cpu
             include: k8s.kube_pod_container_resource_limits
-            new_name: k8s.container.spec.cpu.limit_temp
+            new_name: k8s.container.spec.cpu.limit__swo_temp
           - action: insert
             experimental_match_labels:
               resource: cpu
             include: k8s.kube_pod_init_container_resource_limits
-            new_name: k8s.initcontainer.spec.cpu.limit_temp
+            new_name: k8s.initcontainer.spec.cpu.limit__swo_temp
           - action: insert
             experimental_match_labels:
               resource: cpu
             include: k8s.kube_pod_container_resource_requests
-            new_name: k8s.container.spec.cpu.requests_temp
+            new_name: k8s.container.spec.cpu.requests__swo_temp
           - action: insert
             experimental_match_labels:
               resource: cpu
             include: k8s.kube_pod_init_container_resource_requests
-            new_name: k8s.initcontainer.spec.cpu.requests_temp
+            new_name: k8s.initcontainer.spec.cpu.requests__swo_temp
           - action: combine
-            include: (k8s.container.spec.cpu.requests_temp|k8s.initcontainer.spec.cpu.requests_temp)
+            include: (k8s.container.spec.cpu.requests__swo_temp|k8s.initcontainer.spec.cpu.requests__swo_temp)
             match_type: regexp
             new_name: k8s.container.spec.cpu.requests
           - action: insert
             experimental_match_labels:
               resource: memory
             include: k8s.kube_pod_container_resource_requests
-            new_name: k8s.container.spec.memory.requests_temp
+            new_name: k8s.container.spec.memory.requests__swo_temp
           - action: insert
             experimental_match_labels:
               resource: memory
             include: k8s.kube_pod_init_container_resource_requests
-            new_name: k8s.initcontainer.spec.memory.requests_temp
+            new_name: k8s.initcontainer.spec.memory.requests__swo_temp
           - action: combine
-            include: (k8s.container.spec.memory.requests_temp|k8s.initcontainer.spec.memory.requests_temp)
+            include: (k8s.container.spec.memory.requests__swo_temp|k8s.initcontainer.spec.memory.requests__swo_temp)
             match_type: regexp
             new_name: k8s.container.spec.memory.requests
           - action: insert
@@ -4374,15 +4374,15 @@ Metrics config should match snapshot when using default values:
               resource: memory
             include: k8s.kube_pod_container_resource_limits
             match_type: regexp
-            new_name: k8s.container.spec.memory.limit_temp
+            new_name: k8s.container.spec.memory.limit__swo_temp
           - action: insert
             experimental_match_labels:
               resource: memory
             include: k8s.kube_pod_init_container_resource_limits
             match_type: regexp
-            new_name: k8s.initcontainer.spec.memory.limit_temp
+            new_name: k8s.initcontainer.spec.memory.limit__swo_temp
           - action: insert
-            include: k8s.container.spec.cpu.limit_temp
+            include: k8s.container.spec.cpu.limit__swo_temp
             new_name: k8s.pod.spec.cpu.limit
             operations:
             - action: aggregate_labels
@@ -4392,11 +4392,11 @@ Metrics config should match snapshot when using default values:
               - namespace
               - k8s.node.name
           - action: combine
-            include: (k8s.container.spec.cpu.limit_temp|k8s.initcontainer.spec.cpu.limit_temp)
+            include: (k8s.container.spec.cpu.limit__swo_temp|k8s.initcontainer.spec.cpu.limit__swo_temp)
             match_type: regexp
             new_name: k8s.container.spec.cpu.limit
           - action: insert
-            include: k8s.container.spec.memory.limit_temp
+            include: k8s.container.spec.memory.limit__swo_temp
             new_name: k8s.pod.spec.memory.limit
             operations:
             - action: aggregate_labels
@@ -4406,7 +4406,7 @@ Metrics config should match snapshot when using default values:
               - namespace
               - k8s.node.name
           - action: combine
-            include: (k8s.container.spec.memory.limit_temp|k8s.initcontainer.spec.memory.limit_temp)
+            include: (k8s.container.spec.memory.limit__swo_temp|k8s.initcontainer.spec.memory.limit__swo_temp)
             match_type: regexp
             new_name: k8s.container.spec.memory.limit
           - action: insert
@@ -4542,7 +4542,7 @@ Metrics config should match snapshot when using default values:
             experimental_match_labels:
               phase: Running
             include: k8s.kube_pod_status_phase
-            new_name: k8s.pod.status.phase.running_temp
+            new_name: k8s.pod.status.phase.running__swo_temp
           - action: insert
             include: k8s.kube_pod_info
             new_name: k8s.cluster.pods
@@ -4592,7 +4592,7 @@ Metrics config should match snapshot when using default values:
               label_set:
               - dummy_label_workaround
           - action: insert
-            include: k8s.pod.status.phase.running_temp
+            include: k8s.pod.status.phase.running__swo_temp
             new_name: k8s.cluster.pods.running
             operations:
             - action: aggregate_labels
@@ -4647,16 +4647,16 @@ Metrics config should match snapshot when using default values:
               - sw.k8s.cluster.version
           - action: update
             include: k8s.kubernetes_build_info
-            new_name: k8s.kubernetes_build_info_temp
+            new_name: k8s.kubernetes_build_info__swo_temp
           - action: insert
             experimental_match_labels:
               code: ^(([0-3]|[6-9])\d\d)|(4([0-1]|[3-9])\d)|(42[0-8])$
             include: k8s.apiserver_request_total
             match_type: regexp
-            new_name: apiserver_request_not_failed_temp
+            new_name: apiserver_request_not_failed__swo_temp
           - action: update
-            include: apiserver_request_not_failed_temp
-            new_name: apiserver_request_not_failed_temp
+            include: apiserver_request_not_failed__swo_temp
+            new_name: apiserver_request_not_failed__swo_temp
             operations:
             - action: aggregate_labels
               aggregation_type: sum
@@ -4664,7 +4664,7 @@ Metrics config should match snapshot when using default values:
               - dummy_label_workaround
           - action: insert
             include: k8s.apiserver_request_total
-            new_name: apiserver_request_total_temp
+            new_name: apiserver_request_total__swo_temp
             operations:
             - action: aggregate_labels
               aggregation_type: sum

--- a/deploy/helm/tests/__snapshot__/metrics-discovery-config-map_test.yaml.snap
+++ b/deploy/helm/tests/__snapshot__/metrics-discovery-config-map_test.yaml.snap
@@ -363,8 +363,8 @@ Metrics discovery config should match snapshot when Fargate is enabled:
             metrics:
             - k8s.istio_request_bytes.rate
             - k8s.istio_response_bytes.rate
-            - k8s.istio_request_duration_milliseconds_sum_temp
-            - k8s.istio_request_duration_milliseconds_count_temp
+            - k8s.istio_request_duration_milliseconds_sum__swo_temp
+            - k8s.istio_request_duration_milliseconds_count__swo_temp
             - k8s.istio_requests.rate
             - k8s.istio_tcp_sent_bytes.rate
             - k8s.istio_tcp_received_bytes.rate
@@ -378,8 +378,8 @@ Metrics discovery config should match snapshot when Fargate is enabled:
           metrics:
           - k8s.istio_request_bytes.rate
           - k8s.istio_response_bytes.rate
-          - k8s.istio_request_duration_milliseconds_sum_temp
-          - k8s.istio_request_duration_milliseconds_count_temp
+          - k8s.istio_request_duration_milliseconds_sum__swo_temp
+          - k8s.istio_request_duration_milliseconds_count__swo_temp
           - k8s.istio_requests.rate
           - k8s.istio_tcp_sent_bytes.rate
           - k8s.istio_tcp_received_bytes.rate
@@ -423,7 +423,7 @@ Metrics discovery config should match snapshot when Fargate is enabled:
         filter/remove_temporary_metrics:
           metrics:
             metric:
-            - IsMatch(name , ".*_temp")
+            - IsMatch(name , ".*__swo_temp$")
         filter/zero-delta-values:
           error_mode: ignore
           metrics:
@@ -482,8 +482,8 @@ Metrics discovery config should match snapshot when Fargate is enabled:
           spike_limit_mib: 512
         metricsgeneration/istio-metrics:
           rules:
-          - metric1: k8s.istio_request_duration_milliseconds_sum_temp
-            metric2: k8s.istio_request_duration_milliseconds_count_temp
+          - metric1: k8s.istio_request_duration_milliseconds_sum__swo_temp
+            metric2: k8s.istio_request_duration_milliseconds_count__swo_temp
             name: k8s.istio_request_duration_milliseconds.rate
             operation: divide
             type: calculate
@@ -584,10 +584,10 @@ Metrics discovery config should match snapshot when Fargate is enabled:
             - extract_sum_metric(true) where (metric.name == "k8s.istio_request_bytes" or
               metric.name == "k8s.istio_response_bytes" or metric.name == "k8s.istio_request_duration_milliseconds")
             - extract_count_metric(true) where (metric.name == "k8s.istio_request_duration_milliseconds")
-            - set(metric.name, "k8s.istio_request_duration_milliseconds_sum_temp") where
-              metric.name == "k8s.istio_request_duration_milliseconds_sum"
-            - set(metric.name, "k8s.istio_request_duration_milliseconds_count_temp") where
-              metric.name == "k8s.istio_request_duration_milliseconds_count"
+            - set(metric.name, "k8s.istio_request_duration_milliseconds_sum__swo_temp")
+              where metric.name == "k8s.istio_request_duration_milliseconds_sum"
+            - set(metric.name, "k8s.istio_request_duration_milliseconds_count__swo_temp")
+              where metric.name == "k8s.istio_request_duration_milliseconds_count"
             - set(resource.attributes["istio"], "true")
         transform/istio-relationship-types:
           metric_statements:

--- a/deploy/helm/tests/__snapshot__/node-collector-config-map-windows_test.yaml.snap
+++ b/deploy/helm/tests/__snapshot__/node-collector-config-map-windows_test.yaml.snap
@@ -366,7 +366,7 @@ Node collector config for windows nodes should match snapshot when using default
           actions:
           - action: delete
             key: temp
-            pattern: (.*_temp$)|(^\$.*)
+            pattern: (.*__swo_temp$)|(^\$.*)
           include:
             match_type: regexp
             metric_names:
@@ -433,8 +433,8 @@ Node collector config for windows nodes should match snapshot when using default
             metrics:
             - k8s.istio_request_bytes.rate
             - k8s.istio_response_bytes.rate
-            - k8s.istio_request_duration_milliseconds_sum_temp
-            - k8s.istio_request_duration_milliseconds_count_temp
+            - k8s.istio_request_duration_milliseconds_sum__swo_temp
+            - k8s.istio_request_duration_milliseconds_count__swo_temp
             - k8s.istio_requests.rate
             - k8s.istio_tcp_sent_bytes.rate
             - k8s.istio_tcp_received_bytes.rate
@@ -477,8 +477,8 @@ Node collector config for windows nodes should match snapshot when using default
           metrics:
           - k8s.istio_request_bytes.rate
           - k8s.istio_response_bytes.rate
-          - k8s.istio_request_duration_milliseconds_sum_temp
-          - k8s.istio_request_duration_milliseconds_count_temp
+          - k8s.istio_request_duration_milliseconds_sum__swo_temp
+          - k8s.istio_request_duration_milliseconds_count__swo_temp
           - k8s.istio_requests.rate
           - k8s.istio_tcp_sent_bytes.rate
           - k8s.istio_tcp_received_bytes.rate
@@ -541,7 +541,7 @@ Node collector config for windows nodes should match snapshot when using default
         filter/remove_temporary_metrics:
           metrics:
             metric:
-            - IsMatch(name , ".*_temp")
+            - IsMatch(name , ".*__swo_temp$")
         filter/zero-delta-values:
           error_mode: ignore
           metrics:
@@ -643,8 +643,8 @@ Node collector config for windows nodes should match snapshot when using default
           spike_limit_mib: 300
         metricsgeneration/istio-metrics:
           rules:
-          - metric1: k8s.istio_request_duration_milliseconds_sum_temp
-            metric2: k8s.istio_request_duration_milliseconds_count_temp
+          - metric1: k8s.istio_request_duration_milliseconds_sum__swo_temp
+            metric2: k8s.istio_request_duration_milliseconds_count__swo_temp
             name: k8s.istio_request_duration_milliseconds.rate
             operation: divide
             type: calculate
@@ -684,16 +684,16 @@ Node collector config for windows nodes should match snapshot when using default
           transforms:
           - action: insert
             include: k8s.container_fs_reads_total
-            new_name: k8s.container_fs_reads_total_temp
+            new_name: k8s.container_fs_reads_total__swo_temp
           - action: insert
             include: k8s.container_fs_writes_total
-            new_name: k8s.container_fs_writes_total_temp
+            new_name: k8s.container_fs_writes_total__swo_temp
           - action: combine
             experimental_match_labels:
               container: \S+
               namespace: \S+
               pod: \S+
-            include: (k8s.container_fs_reads_total_temp|k8s.container_fs_writes_total_temp)
+            include: (k8s.container_fs_reads_total__swo_temp|k8s.container_fs_writes_total__swo_temp)
             match_type: regexp
             new_name: k8s.container.fs.iops
             operations:
@@ -706,16 +706,16 @@ Node collector config for windows nodes should match snapshot when using default
             submatch_case: lower
           - action: insert
             include: k8s.container_fs_reads_bytes_total
-            new_name: k8s.container_fs_reads_bytes_total_temp
+            new_name: k8s.container_fs_reads_bytes_total__swo_temp
           - action: insert
             include: k8s.container_fs_writes_bytes_total
-            new_name: k8s.container_fs_writes_bytes_total_temp
+            new_name: k8s.container_fs_writes_bytes_total__swo_temp
           - action: combine
             experimental_match_labels:
               container: \S+
               namespace: \S+
               pod: \S+
-            include: (k8s.container_fs_reads_bytes_total_temp|k8s.container_fs_writes_bytes_total_temp)
+            include: (k8s.container_fs_reads_bytes_total__swo_temp|k8s.container_fs_writes_bytes_total__swo_temp)
             match_type: regexp
             new_name: k8s.container.fs.throughput
             operations:
@@ -917,12 +917,12 @@ Node collector config for windows nodes should match snapshot when using default
               - k8s.node.name
           - action: insert
             include: k8s.pod.fs.reads.rate
-            new_name: k8s.pod.fs.reads.rate_temp
+            new_name: k8s.pod.fs.reads.rate__swo_temp
           - action: insert
             include: k8s.pod.fs.writes.rate
-            new_name: k8s.pod.fs.writes.rate_temp
+            new_name: k8s.pod.fs.writes.rate__swo_temp
           - action: combine
-            include: (k8s.pod.fs.reads.rate_temp|k8s.pod.fs.writes.rate_temp)
+            include: (k8s.pod.fs.reads.rate__swo_temp|k8s.pod.fs.writes.rate__swo_temp)
             match_type: regexp
             new_name: k8s.pod.fs.iops
             operations:
@@ -935,12 +935,12 @@ Node collector config for windows nodes should match snapshot when using default
             submatch_case: lower
           - action: insert
             include: k8s.pod.fs.reads.bytes.rate
-            new_name: k8s.pod.fs.reads.bytes.rate_temp
+            new_name: k8s.pod.fs.reads.bytes.rate__swo_temp
           - action: insert
             include: k8s.pod.fs.writes.bytes.rate
-            new_name: k8s.pod.fs.writes.bytes.rate_temp
+            new_name: k8s.pod.fs.writes.bytes.rate__swo_temp
           - action: combine
-            include: (k8s.pod.fs.reads.bytes.rate_temp|k8s.pod.fs.writes.bytes.rate_temp)
+            include: (k8s.pod.fs.reads.bytes.rate__swo_temp|k8s.pod.fs.writes.bytes.rate__swo_temp)
             match_type: regexp
             new_name: k8s.pod.fs.throughput
             operations:
@@ -1050,7 +1050,7 @@ Node collector config for windows nodes should match snapshot when using default
               - k8s.node.name
           - action: insert
             include: k8s.pod.fs.reads.rate
-            new_name: k8s.node.fs.reads.rate_temp
+            new_name: k8s.node.fs.reads.rate__swo_temp
             operations:
             - action: aggregate_labels
               aggregation_type: sum
@@ -1058,7 +1058,7 @@ Node collector config for windows nodes should match snapshot when using default
               - k8s.node.name
           - action: insert
             include: k8s.pod.fs.writes.rate
-            new_name: k8s.node.fs.writes.rate_temp
+            new_name: k8s.node.fs.writes.rate__swo_temp
             operations:
             - action: aggregate_labels
               aggregation_type: sum
@@ -1066,7 +1066,7 @@ Node collector config for windows nodes should match snapshot when using default
               - k8s.node.name
           - action: insert
             include: k8s.pod.fs.reads.bytes.rate
-            new_name: k8s.node.fs.reads.bytes.rate_temp
+            new_name: k8s.node.fs.reads.bytes.rate__swo_temp
             operations:
             - action: aggregate_labels
               aggregation_type: sum
@@ -1074,14 +1074,14 @@ Node collector config for windows nodes should match snapshot when using default
               - k8s.node.name
           - action: insert
             include: k8s.pod.fs.writes.bytes.rate
-            new_name: k8s.node.fs.writes.bytes.rate_temp
+            new_name: k8s.node.fs.writes.bytes.rate__swo_temp
             operations:
             - action: aggregate_labels
               aggregation_type: sum
               label_set:
               - k8s.node.name
           - action: combine
-            include: (k8s.node.fs.reads.rate_temp|k8s.node.fs.writes.rate_temp)
+            include: (k8s.node.fs.reads.rate__swo_temp|k8s.node.fs.writes.rate__swo_temp)
             match_type: regexp
             new_name: k8s.node.fs.iops
             operations:
@@ -1091,7 +1091,7 @@ Node collector config for windows nodes should match snapshot when using default
               - k8s.node.name
             submatch_case: lower
           - action: combine
-            include: (k8s.node.fs.reads.bytes.rate_temp|k8s.node.fs.writes.bytes.rate_temp)
+            include: (k8s.node.fs.reads.bytes.rate__swo_temp|k8s.node.fs.writes.bytes.rate__swo_temp)
             match_type: regexp
             new_name: k8s.node.fs.throughput
             operations:
@@ -1316,10 +1316,10 @@ Node collector config for windows nodes should match snapshot when using default
             - extract_sum_metric(true) where (metric.name == "k8s.istio_request_bytes" or
               metric.name == "k8s.istio_response_bytes" or metric.name == "k8s.istio_request_duration_milliseconds")
             - extract_count_metric(true) where (metric.name == "k8s.istio_request_duration_milliseconds")
-            - set(metric.name, "k8s.istio_request_duration_milliseconds_sum_temp") where
-              metric.name == "k8s.istio_request_duration_milliseconds_sum"
-            - set(metric.name, "k8s.istio_request_duration_milliseconds_count_temp") where
-              metric.name == "k8s.istio_request_duration_milliseconds_count"
+            - set(metric.name, "k8s.istio_request_duration_milliseconds_sum__swo_temp")
+              where metric.name == "k8s.istio_request_duration_milliseconds_sum"
+            - set(metric.name, "k8s.istio_request_duration_milliseconds_count__swo_temp")
+              where metric.name == "k8s.istio_request_duration_milliseconds_count"
             - set(resource.attributes["istio"], "true")
         transform/istio-relationship-types:
           metric_statements:
@@ -2137,7 +2137,7 @@ Node collector config for windows nodes should match snapshot when using legacy 
           actions:
           - action: delete
             key: temp
-            pattern: (.*_temp$)|(^\$.*)
+            pattern: (.*__swo_temp$)|(^\$.*)
           include:
             match_type: regexp
             metric_names:
@@ -2204,8 +2204,8 @@ Node collector config for windows nodes should match snapshot when using legacy 
             metrics:
             - k8s.istio_request_bytes.rate
             - k8s.istio_response_bytes.rate
-            - k8s.istio_request_duration_milliseconds_sum_temp
-            - k8s.istio_request_duration_milliseconds_count_temp
+            - k8s.istio_request_duration_milliseconds_sum__swo_temp
+            - k8s.istio_request_duration_milliseconds_count__swo_temp
             - k8s.istio_requests.rate
             - k8s.istio_tcp_sent_bytes.rate
             - k8s.istio_tcp_received_bytes.rate
@@ -2248,8 +2248,8 @@ Node collector config for windows nodes should match snapshot when using legacy 
           metrics:
           - k8s.istio_request_bytes.rate
           - k8s.istio_response_bytes.rate
-          - k8s.istio_request_duration_milliseconds_sum_temp
-          - k8s.istio_request_duration_milliseconds_count_temp
+          - k8s.istio_request_duration_milliseconds_sum__swo_temp
+          - k8s.istio_request_duration_milliseconds_count__swo_temp
           - k8s.istio_requests.rate
           - k8s.istio_tcp_sent_bytes.rate
           - k8s.istio_tcp_received_bytes.rate
@@ -2319,7 +2319,7 @@ Node collector config for windows nodes should match snapshot when using legacy 
         filter/remove_temporary_metrics:
           metrics:
             metric:
-            - IsMatch(name , ".*_temp")
+            - IsMatch(name , ".*__swo_temp$")
         filter/zero-delta-values:
           error_mode: ignore
           metrics:
@@ -2421,8 +2421,8 @@ Node collector config for windows nodes should match snapshot when using legacy 
           spike_limit_mib: 300
         metricsgeneration/istio-metrics:
           rules:
-          - metric1: k8s.istio_request_duration_milliseconds_sum_temp
-            metric2: k8s.istio_request_duration_milliseconds_count_temp
+          - metric1: k8s.istio_request_duration_milliseconds_sum__swo_temp
+            metric2: k8s.istio_request_duration_milliseconds_count__swo_temp
             name: k8s.istio_request_duration_milliseconds.rate
             operation: divide
             type: calculate
@@ -2462,16 +2462,16 @@ Node collector config for windows nodes should match snapshot when using legacy 
           transforms:
           - action: insert
             include: k8s.container_fs_reads_total
-            new_name: k8s.container_fs_reads_total_temp
+            new_name: k8s.container_fs_reads_total__swo_temp
           - action: insert
             include: k8s.container_fs_writes_total
-            new_name: k8s.container_fs_writes_total_temp
+            new_name: k8s.container_fs_writes_total__swo_temp
           - action: combine
             experimental_match_labels:
               container: \S+
               namespace: \S+
               pod: \S+
-            include: (k8s.container_fs_reads_total_temp|k8s.container_fs_writes_total_temp)
+            include: (k8s.container_fs_reads_total__swo_temp|k8s.container_fs_writes_total__swo_temp)
             match_type: regexp
             new_name: k8s.container.fs.iops
             operations:
@@ -2484,16 +2484,16 @@ Node collector config for windows nodes should match snapshot when using legacy 
             submatch_case: lower
           - action: insert
             include: k8s.container_fs_reads_bytes_total
-            new_name: k8s.container_fs_reads_bytes_total_temp
+            new_name: k8s.container_fs_reads_bytes_total__swo_temp
           - action: insert
             include: k8s.container_fs_writes_bytes_total
-            new_name: k8s.container_fs_writes_bytes_total_temp
+            new_name: k8s.container_fs_writes_bytes_total__swo_temp
           - action: combine
             experimental_match_labels:
               container: \S+
               namespace: \S+
               pod: \S+
-            include: (k8s.container_fs_reads_bytes_total_temp|k8s.container_fs_writes_bytes_total_temp)
+            include: (k8s.container_fs_reads_bytes_total__swo_temp|k8s.container_fs_writes_bytes_total__swo_temp)
             match_type: regexp
             new_name: k8s.container.fs.throughput
             operations:
@@ -2695,12 +2695,12 @@ Node collector config for windows nodes should match snapshot when using legacy 
               - k8s.node.name
           - action: insert
             include: k8s.pod.fs.reads.rate
-            new_name: k8s.pod.fs.reads.rate_temp
+            new_name: k8s.pod.fs.reads.rate__swo_temp
           - action: insert
             include: k8s.pod.fs.writes.rate
-            new_name: k8s.pod.fs.writes.rate_temp
+            new_name: k8s.pod.fs.writes.rate__swo_temp
           - action: combine
-            include: (k8s.pod.fs.reads.rate_temp|k8s.pod.fs.writes.rate_temp)
+            include: (k8s.pod.fs.reads.rate__swo_temp|k8s.pod.fs.writes.rate__swo_temp)
             match_type: regexp
             new_name: k8s.pod.fs.iops
             operations:
@@ -2713,12 +2713,12 @@ Node collector config for windows nodes should match snapshot when using legacy 
             submatch_case: lower
           - action: insert
             include: k8s.pod.fs.reads.bytes.rate
-            new_name: k8s.pod.fs.reads.bytes.rate_temp
+            new_name: k8s.pod.fs.reads.bytes.rate__swo_temp
           - action: insert
             include: k8s.pod.fs.writes.bytes.rate
-            new_name: k8s.pod.fs.writes.bytes.rate_temp
+            new_name: k8s.pod.fs.writes.bytes.rate__swo_temp
           - action: combine
-            include: (k8s.pod.fs.reads.bytes.rate_temp|k8s.pod.fs.writes.bytes.rate_temp)
+            include: (k8s.pod.fs.reads.bytes.rate__swo_temp|k8s.pod.fs.writes.bytes.rate__swo_temp)
             match_type: regexp
             new_name: k8s.pod.fs.throughput
             operations:
@@ -2828,7 +2828,7 @@ Node collector config for windows nodes should match snapshot when using legacy 
               - k8s.node.name
           - action: insert
             include: k8s.pod.fs.reads.rate
-            new_name: k8s.node.fs.reads.rate_temp
+            new_name: k8s.node.fs.reads.rate__swo_temp
             operations:
             - action: aggregate_labels
               aggregation_type: sum
@@ -2836,7 +2836,7 @@ Node collector config for windows nodes should match snapshot when using legacy 
               - k8s.node.name
           - action: insert
             include: k8s.pod.fs.writes.rate
-            new_name: k8s.node.fs.writes.rate_temp
+            new_name: k8s.node.fs.writes.rate__swo_temp
             operations:
             - action: aggregate_labels
               aggregation_type: sum
@@ -2844,7 +2844,7 @@ Node collector config for windows nodes should match snapshot when using legacy 
               - k8s.node.name
           - action: insert
             include: k8s.pod.fs.reads.bytes.rate
-            new_name: k8s.node.fs.reads.bytes.rate_temp
+            new_name: k8s.node.fs.reads.bytes.rate__swo_temp
             operations:
             - action: aggregate_labels
               aggregation_type: sum
@@ -2852,14 +2852,14 @@ Node collector config for windows nodes should match snapshot when using legacy 
               - k8s.node.name
           - action: insert
             include: k8s.pod.fs.writes.bytes.rate
-            new_name: k8s.node.fs.writes.bytes.rate_temp
+            new_name: k8s.node.fs.writes.bytes.rate__swo_temp
             operations:
             - action: aggregate_labels
               aggregation_type: sum
               label_set:
               - k8s.node.name
           - action: combine
-            include: (k8s.node.fs.reads.rate_temp|k8s.node.fs.writes.rate_temp)
+            include: (k8s.node.fs.reads.rate__swo_temp|k8s.node.fs.writes.rate__swo_temp)
             match_type: regexp
             new_name: k8s.node.fs.iops
             operations:
@@ -2869,7 +2869,7 @@ Node collector config for windows nodes should match snapshot when using legacy 
               - k8s.node.name
             submatch_case: lower
           - action: combine
-            include: (k8s.node.fs.reads.bytes.rate_temp|k8s.node.fs.writes.bytes.rate_temp)
+            include: (k8s.node.fs.reads.bytes.rate__swo_temp|k8s.node.fs.writes.bytes.rate__swo_temp)
             match_type: regexp
             new_name: k8s.node.fs.throughput
             operations:
@@ -3094,10 +3094,10 @@ Node collector config for windows nodes should match snapshot when using legacy 
             - extract_sum_metric(true) where (metric.name == "k8s.istio_request_bytes" or
               metric.name == "k8s.istio_response_bytes" or metric.name == "k8s.istio_request_duration_milliseconds")
             - extract_count_metric(true) where (metric.name == "k8s.istio_request_duration_milliseconds")
-            - set(metric.name, "k8s.istio_request_duration_milliseconds_sum_temp") where
-              metric.name == "k8s.istio_request_duration_milliseconds_sum"
-            - set(metric.name, "k8s.istio_request_duration_milliseconds_count_temp") where
-              metric.name == "k8s.istio_request_duration_milliseconds_count"
+            - set(metric.name, "k8s.istio_request_duration_milliseconds_sum__swo_temp")
+              where metric.name == "k8s.istio_request_duration_milliseconds_sum"
+            - set(metric.name, "k8s.istio_request_duration_milliseconds_count__swo_temp")
+              where metric.name == "k8s.istio_request_duration_milliseconds_count"
             - set(resource.attributes["istio"], "true")
         transform/istio-relationship-types:
           metric_statements:

--- a/deploy/helm/tests/__snapshot__/node-collector-config-map_test.yaml.snap
+++ b/deploy/helm/tests/__snapshot__/node-collector-config-map_test.yaml.snap
@@ -366,7 +366,7 @@ Custom logs filter with new syntax:
           actions:
           - action: delete
             key: temp
-            pattern: (.*_temp$)|(^\$.*)
+            pattern: (.*__swo_temp$)|(^\$.*)
           include:
             match_type: regexp
             metric_names:
@@ -433,8 +433,8 @@ Custom logs filter with new syntax:
             metrics:
             - k8s.istio_request_bytes.rate
             - k8s.istio_response_bytes.rate
-            - k8s.istio_request_duration_milliseconds_sum_temp
-            - k8s.istio_request_duration_milliseconds_count_temp
+            - k8s.istio_request_duration_milliseconds_sum__swo_temp
+            - k8s.istio_request_duration_milliseconds_count__swo_temp
             - k8s.istio_requests.rate
             - k8s.istio_tcp_sent_bytes.rate
             - k8s.istio_tcp_received_bytes.rate
@@ -477,8 +477,8 @@ Custom logs filter with new syntax:
           metrics:
           - k8s.istio_request_bytes.rate
           - k8s.istio_response_bytes.rate
-          - k8s.istio_request_duration_milliseconds_sum_temp
-          - k8s.istio_request_duration_milliseconds_count_temp
+          - k8s.istio_request_duration_milliseconds_sum__swo_temp
+          - k8s.istio_request_duration_milliseconds_count__swo_temp
           - k8s.istio_requests.rate
           - k8s.istio_tcp_sent_bytes.rate
           - k8s.istio_tcp_received_bytes.rate
@@ -545,7 +545,7 @@ Custom logs filter with new syntax:
         filter/remove_temporary_metrics:
           metrics:
             metric:
-            - IsMatch(name , ".*_temp")
+            - IsMatch(name , ".*__swo_temp$")
         filter/zero-delta-values:
           error_mode: ignore
           metrics:
@@ -647,8 +647,8 @@ Custom logs filter with new syntax:
           spike_limit_mib: 300
         metricsgeneration/istio-metrics:
           rules:
-          - metric1: k8s.istio_request_duration_milliseconds_sum_temp
-            metric2: k8s.istio_request_duration_milliseconds_count_temp
+          - metric1: k8s.istio_request_duration_milliseconds_sum__swo_temp
+            metric2: k8s.istio_request_duration_milliseconds_count__swo_temp
             name: k8s.istio_request_duration_milliseconds.rate
             operation: divide
             type: calculate
@@ -688,16 +688,16 @@ Custom logs filter with new syntax:
           transforms:
           - action: insert
             include: k8s.container_fs_reads_total
-            new_name: k8s.container_fs_reads_total_temp
+            new_name: k8s.container_fs_reads_total__swo_temp
           - action: insert
             include: k8s.container_fs_writes_total
-            new_name: k8s.container_fs_writes_total_temp
+            new_name: k8s.container_fs_writes_total__swo_temp
           - action: combine
             experimental_match_labels:
               container: \S+
               namespace: \S+
               pod: \S+
-            include: (k8s.container_fs_reads_total_temp|k8s.container_fs_writes_total_temp)
+            include: (k8s.container_fs_reads_total__swo_temp|k8s.container_fs_writes_total__swo_temp)
             match_type: regexp
             new_name: k8s.container.fs.iops
             operations:
@@ -710,16 +710,16 @@ Custom logs filter with new syntax:
             submatch_case: lower
           - action: insert
             include: k8s.container_fs_reads_bytes_total
-            new_name: k8s.container_fs_reads_bytes_total_temp
+            new_name: k8s.container_fs_reads_bytes_total__swo_temp
           - action: insert
             include: k8s.container_fs_writes_bytes_total
-            new_name: k8s.container_fs_writes_bytes_total_temp
+            new_name: k8s.container_fs_writes_bytes_total__swo_temp
           - action: combine
             experimental_match_labels:
               container: \S+
               namespace: \S+
               pod: \S+
-            include: (k8s.container_fs_reads_bytes_total_temp|k8s.container_fs_writes_bytes_total_temp)
+            include: (k8s.container_fs_reads_bytes_total__swo_temp|k8s.container_fs_writes_bytes_total__swo_temp)
             match_type: regexp
             new_name: k8s.container.fs.throughput
             operations:
@@ -921,12 +921,12 @@ Custom logs filter with new syntax:
               - k8s.node.name
           - action: insert
             include: k8s.pod.fs.reads.rate
-            new_name: k8s.pod.fs.reads.rate_temp
+            new_name: k8s.pod.fs.reads.rate__swo_temp
           - action: insert
             include: k8s.pod.fs.writes.rate
-            new_name: k8s.pod.fs.writes.rate_temp
+            new_name: k8s.pod.fs.writes.rate__swo_temp
           - action: combine
-            include: (k8s.pod.fs.reads.rate_temp|k8s.pod.fs.writes.rate_temp)
+            include: (k8s.pod.fs.reads.rate__swo_temp|k8s.pod.fs.writes.rate__swo_temp)
             match_type: regexp
             new_name: k8s.pod.fs.iops
             operations:
@@ -939,12 +939,12 @@ Custom logs filter with new syntax:
             submatch_case: lower
           - action: insert
             include: k8s.pod.fs.reads.bytes.rate
-            new_name: k8s.pod.fs.reads.bytes.rate_temp
+            new_name: k8s.pod.fs.reads.bytes.rate__swo_temp
           - action: insert
             include: k8s.pod.fs.writes.bytes.rate
-            new_name: k8s.pod.fs.writes.bytes.rate_temp
+            new_name: k8s.pod.fs.writes.bytes.rate__swo_temp
           - action: combine
-            include: (k8s.pod.fs.reads.bytes.rate_temp|k8s.pod.fs.writes.bytes.rate_temp)
+            include: (k8s.pod.fs.reads.bytes.rate__swo_temp|k8s.pod.fs.writes.bytes.rate__swo_temp)
             match_type: regexp
             new_name: k8s.pod.fs.throughput
             operations:
@@ -1054,7 +1054,7 @@ Custom logs filter with new syntax:
               - k8s.node.name
           - action: insert
             include: k8s.pod.fs.reads.rate
-            new_name: k8s.node.fs.reads.rate_temp
+            new_name: k8s.node.fs.reads.rate__swo_temp
             operations:
             - action: aggregate_labels
               aggregation_type: sum
@@ -1062,7 +1062,7 @@ Custom logs filter with new syntax:
               - k8s.node.name
           - action: insert
             include: k8s.pod.fs.writes.rate
-            new_name: k8s.node.fs.writes.rate_temp
+            new_name: k8s.node.fs.writes.rate__swo_temp
             operations:
             - action: aggregate_labels
               aggregation_type: sum
@@ -1070,7 +1070,7 @@ Custom logs filter with new syntax:
               - k8s.node.name
           - action: insert
             include: k8s.pod.fs.reads.bytes.rate
-            new_name: k8s.node.fs.reads.bytes.rate_temp
+            new_name: k8s.node.fs.reads.bytes.rate__swo_temp
             operations:
             - action: aggregate_labels
               aggregation_type: sum
@@ -1078,14 +1078,14 @@ Custom logs filter with new syntax:
               - k8s.node.name
           - action: insert
             include: k8s.pod.fs.writes.bytes.rate
-            new_name: k8s.node.fs.writes.bytes.rate_temp
+            new_name: k8s.node.fs.writes.bytes.rate__swo_temp
             operations:
             - action: aggregate_labels
               aggregation_type: sum
               label_set:
               - k8s.node.name
           - action: combine
-            include: (k8s.node.fs.reads.rate_temp|k8s.node.fs.writes.rate_temp)
+            include: (k8s.node.fs.reads.rate__swo_temp|k8s.node.fs.writes.rate__swo_temp)
             match_type: regexp
             new_name: k8s.node.fs.iops
             operations:
@@ -1095,7 +1095,7 @@ Custom logs filter with new syntax:
               - k8s.node.name
             submatch_case: lower
           - action: combine
-            include: (k8s.node.fs.reads.bytes.rate_temp|k8s.node.fs.writes.bytes.rate_temp)
+            include: (k8s.node.fs.reads.bytes.rate__swo_temp|k8s.node.fs.writes.bytes.rate__swo_temp)
             match_type: regexp
             new_name: k8s.node.fs.throughput
             operations:
@@ -1340,10 +1340,10 @@ Custom logs filter with new syntax:
             - extract_sum_metric(true) where (metric.name == "k8s.istio_request_bytes" or
               metric.name == "k8s.istio_response_bytes" or metric.name == "k8s.istio_request_duration_milliseconds")
             - extract_count_metric(true) where (metric.name == "k8s.istio_request_duration_milliseconds")
-            - set(metric.name, "k8s.istio_request_duration_milliseconds_sum_temp") where
-              metric.name == "k8s.istio_request_duration_milliseconds_sum"
-            - set(metric.name, "k8s.istio_request_duration_milliseconds_count_temp") where
-              metric.name == "k8s.istio_request_duration_milliseconds_count"
+            - set(metric.name, "k8s.istio_request_duration_milliseconds_sum__swo_temp")
+              where metric.name == "k8s.istio_request_duration_milliseconds_sum"
+            - set(metric.name, "k8s.istio_request_duration_milliseconds_count__swo_temp")
+              where metric.name == "k8s.istio_request_duration_milliseconds_count"
             - set(resource.attributes["istio"], "true")
         transform/istio-relationship-types:
           metric_statements:
@@ -2178,7 +2178,7 @@ Custom logs filter with old syntax:
           actions:
           - action: delete
             key: temp
-            pattern: (.*_temp$)|(^\$.*)
+            pattern: (.*__swo_temp$)|(^\$.*)
           include:
             match_type: regexp
             metric_names:
@@ -2245,8 +2245,8 @@ Custom logs filter with old syntax:
             metrics:
             - k8s.istio_request_bytes.rate
             - k8s.istio_response_bytes.rate
-            - k8s.istio_request_duration_milliseconds_sum_temp
-            - k8s.istio_request_duration_milliseconds_count_temp
+            - k8s.istio_request_duration_milliseconds_sum__swo_temp
+            - k8s.istio_request_duration_milliseconds_count__swo_temp
             - k8s.istio_requests.rate
             - k8s.istio_tcp_sent_bytes.rate
             - k8s.istio_tcp_received_bytes.rate
@@ -2289,8 +2289,8 @@ Custom logs filter with old syntax:
           metrics:
           - k8s.istio_request_bytes.rate
           - k8s.istio_response_bytes.rate
-          - k8s.istio_request_duration_milliseconds_sum_temp
-          - k8s.istio_request_duration_milliseconds_count_temp
+          - k8s.istio_request_duration_milliseconds_sum__swo_temp
+          - k8s.istio_request_duration_milliseconds_count__swo_temp
           - k8s.istio_requests.rate
           - k8s.istio_tcp_sent_bytes.rate
           - k8s.istio_tcp_received_bytes.rate
@@ -2360,7 +2360,7 @@ Custom logs filter with old syntax:
         filter/remove_temporary_metrics:
           metrics:
             metric:
-            - IsMatch(name , ".*_temp")
+            - IsMatch(name , ".*__swo_temp$")
         filter/zero-delta-values:
           error_mode: ignore
           metrics:
@@ -2462,8 +2462,8 @@ Custom logs filter with old syntax:
           spike_limit_mib: 300
         metricsgeneration/istio-metrics:
           rules:
-          - metric1: k8s.istio_request_duration_milliseconds_sum_temp
-            metric2: k8s.istio_request_duration_milliseconds_count_temp
+          - metric1: k8s.istio_request_duration_milliseconds_sum__swo_temp
+            metric2: k8s.istio_request_duration_milliseconds_count__swo_temp
             name: k8s.istio_request_duration_milliseconds.rate
             operation: divide
             type: calculate
@@ -2503,16 +2503,16 @@ Custom logs filter with old syntax:
           transforms:
           - action: insert
             include: k8s.container_fs_reads_total
-            new_name: k8s.container_fs_reads_total_temp
+            new_name: k8s.container_fs_reads_total__swo_temp
           - action: insert
             include: k8s.container_fs_writes_total
-            new_name: k8s.container_fs_writes_total_temp
+            new_name: k8s.container_fs_writes_total__swo_temp
           - action: combine
             experimental_match_labels:
               container: \S+
               namespace: \S+
               pod: \S+
-            include: (k8s.container_fs_reads_total_temp|k8s.container_fs_writes_total_temp)
+            include: (k8s.container_fs_reads_total__swo_temp|k8s.container_fs_writes_total__swo_temp)
             match_type: regexp
             new_name: k8s.container.fs.iops
             operations:
@@ -2525,16 +2525,16 @@ Custom logs filter with old syntax:
             submatch_case: lower
           - action: insert
             include: k8s.container_fs_reads_bytes_total
-            new_name: k8s.container_fs_reads_bytes_total_temp
+            new_name: k8s.container_fs_reads_bytes_total__swo_temp
           - action: insert
             include: k8s.container_fs_writes_bytes_total
-            new_name: k8s.container_fs_writes_bytes_total_temp
+            new_name: k8s.container_fs_writes_bytes_total__swo_temp
           - action: combine
             experimental_match_labels:
               container: \S+
               namespace: \S+
               pod: \S+
-            include: (k8s.container_fs_reads_bytes_total_temp|k8s.container_fs_writes_bytes_total_temp)
+            include: (k8s.container_fs_reads_bytes_total__swo_temp|k8s.container_fs_writes_bytes_total__swo_temp)
             match_type: regexp
             new_name: k8s.container.fs.throughput
             operations:
@@ -2736,12 +2736,12 @@ Custom logs filter with old syntax:
               - k8s.node.name
           - action: insert
             include: k8s.pod.fs.reads.rate
-            new_name: k8s.pod.fs.reads.rate_temp
+            new_name: k8s.pod.fs.reads.rate__swo_temp
           - action: insert
             include: k8s.pod.fs.writes.rate
-            new_name: k8s.pod.fs.writes.rate_temp
+            new_name: k8s.pod.fs.writes.rate__swo_temp
           - action: combine
-            include: (k8s.pod.fs.reads.rate_temp|k8s.pod.fs.writes.rate_temp)
+            include: (k8s.pod.fs.reads.rate__swo_temp|k8s.pod.fs.writes.rate__swo_temp)
             match_type: regexp
             new_name: k8s.pod.fs.iops
             operations:
@@ -2754,12 +2754,12 @@ Custom logs filter with old syntax:
             submatch_case: lower
           - action: insert
             include: k8s.pod.fs.reads.bytes.rate
-            new_name: k8s.pod.fs.reads.bytes.rate_temp
+            new_name: k8s.pod.fs.reads.bytes.rate__swo_temp
           - action: insert
             include: k8s.pod.fs.writes.bytes.rate
-            new_name: k8s.pod.fs.writes.bytes.rate_temp
+            new_name: k8s.pod.fs.writes.bytes.rate__swo_temp
           - action: combine
-            include: (k8s.pod.fs.reads.bytes.rate_temp|k8s.pod.fs.writes.bytes.rate_temp)
+            include: (k8s.pod.fs.reads.bytes.rate__swo_temp|k8s.pod.fs.writes.bytes.rate__swo_temp)
             match_type: regexp
             new_name: k8s.pod.fs.throughput
             operations:
@@ -2869,7 +2869,7 @@ Custom logs filter with old syntax:
               - k8s.node.name
           - action: insert
             include: k8s.pod.fs.reads.rate
-            new_name: k8s.node.fs.reads.rate_temp
+            new_name: k8s.node.fs.reads.rate__swo_temp
             operations:
             - action: aggregate_labels
               aggregation_type: sum
@@ -2877,7 +2877,7 @@ Custom logs filter with old syntax:
               - k8s.node.name
           - action: insert
             include: k8s.pod.fs.writes.rate
-            new_name: k8s.node.fs.writes.rate_temp
+            new_name: k8s.node.fs.writes.rate__swo_temp
             operations:
             - action: aggregate_labels
               aggregation_type: sum
@@ -2885,7 +2885,7 @@ Custom logs filter with old syntax:
               - k8s.node.name
           - action: insert
             include: k8s.pod.fs.reads.bytes.rate
-            new_name: k8s.node.fs.reads.bytes.rate_temp
+            new_name: k8s.node.fs.reads.bytes.rate__swo_temp
             operations:
             - action: aggregate_labels
               aggregation_type: sum
@@ -2893,14 +2893,14 @@ Custom logs filter with old syntax:
               - k8s.node.name
           - action: insert
             include: k8s.pod.fs.writes.bytes.rate
-            new_name: k8s.node.fs.writes.bytes.rate_temp
+            new_name: k8s.node.fs.writes.bytes.rate__swo_temp
             operations:
             - action: aggregate_labels
               aggregation_type: sum
               label_set:
               - k8s.node.name
           - action: combine
-            include: (k8s.node.fs.reads.rate_temp|k8s.node.fs.writes.rate_temp)
+            include: (k8s.node.fs.reads.rate__swo_temp|k8s.node.fs.writes.rate__swo_temp)
             match_type: regexp
             new_name: k8s.node.fs.iops
             operations:
@@ -2910,7 +2910,7 @@ Custom logs filter with old syntax:
               - k8s.node.name
             submatch_case: lower
           - action: combine
-            include: (k8s.node.fs.reads.bytes.rate_temp|k8s.node.fs.writes.bytes.rate_temp)
+            include: (k8s.node.fs.reads.bytes.rate__swo_temp|k8s.node.fs.writes.bytes.rate__swo_temp)
             match_type: regexp
             new_name: k8s.node.fs.throughput
             operations:
@@ -3155,10 +3155,10 @@ Custom logs filter with old syntax:
             - extract_sum_metric(true) where (metric.name == "k8s.istio_request_bytes" or
               metric.name == "k8s.istio_response_bytes" or metric.name == "k8s.istio_request_duration_milliseconds")
             - extract_count_metric(true) where (metric.name == "k8s.istio_request_duration_milliseconds")
-            - set(metric.name, "k8s.istio_request_duration_milliseconds_sum_temp") where
-              metric.name == "k8s.istio_request_duration_milliseconds_sum"
-            - set(metric.name, "k8s.istio_request_duration_milliseconds_count_temp") where
-              metric.name == "k8s.istio_request_duration_milliseconds_count"
+            - set(metric.name, "k8s.istio_request_duration_milliseconds_sum__swo_temp")
+              where metric.name == "k8s.istio_request_duration_milliseconds_sum"
+            - set(metric.name, "k8s.istio_request_duration_milliseconds_count__swo_temp")
+              where metric.name == "k8s.istio_request_duration_milliseconds_count"
             - set(resource.attributes["istio"], "true")
         transform/istio-relationship-types:
           metric_statements:
@@ -4074,7 +4074,7 @@ Node collector config should match snapshot when autodiscovery is disabled:
           actions:
           - action: delete
             key: temp
-            pattern: (.*_temp$)|(^\$.*)
+            pattern: (.*__swo_temp$)|(^\$.*)
           include:
             match_type: regexp
             metric_names:
@@ -4141,8 +4141,8 @@ Node collector config should match snapshot when autodiscovery is disabled:
             metrics:
             - k8s.istio_request_bytes.rate
             - k8s.istio_response_bytes.rate
-            - k8s.istio_request_duration_milliseconds_sum_temp
-            - k8s.istio_request_duration_milliseconds_count_temp
+            - k8s.istio_request_duration_milliseconds_sum__swo_temp
+            - k8s.istio_request_duration_milliseconds_count__swo_temp
             - k8s.istio_requests.rate
             - k8s.istio_tcp_sent_bytes.rate
             - k8s.istio_tcp_received_bytes.rate
@@ -4185,8 +4185,8 @@ Node collector config should match snapshot when autodiscovery is disabled:
           metrics:
           - k8s.istio_request_bytes.rate
           - k8s.istio_response_bytes.rate
-          - k8s.istio_request_duration_milliseconds_sum_temp
-          - k8s.istio_request_duration_milliseconds_count_temp
+          - k8s.istio_request_duration_milliseconds_sum__swo_temp
+          - k8s.istio_request_duration_milliseconds_count__swo_temp
           - k8s.istio_requests.rate
           - k8s.istio_tcp_sent_bytes.rate
           - k8s.istio_tcp_received_bytes.rate
@@ -4249,7 +4249,7 @@ Node collector config should match snapshot when autodiscovery is disabled:
         filter/remove_temporary_metrics:
           metrics:
             metric:
-            - IsMatch(name , ".*_temp")
+            - IsMatch(name , ".*__swo_temp$")
         filter/zero-delta-values:
           error_mode: ignore
           metrics:
@@ -4351,8 +4351,8 @@ Node collector config should match snapshot when autodiscovery is disabled:
           spike_limit_mib: 300
         metricsgeneration/istio-metrics:
           rules:
-          - metric1: k8s.istio_request_duration_milliseconds_sum_temp
-            metric2: k8s.istio_request_duration_milliseconds_count_temp
+          - metric1: k8s.istio_request_duration_milliseconds_sum__swo_temp
+            metric2: k8s.istio_request_duration_milliseconds_count__swo_temp
             name: k8s.istio_request_duration_milliseconds.rate
             operation: divide
             type: calculate
@@ -4392,16 +4392,16 @@ Node collector config should match snapshot when autodiscovery is disabled:
           transforms:
           - action: insert
             include: k8s.container_fs_reads_total
-            new_name: k8s.container_fs_reads_total_temp
+            new_name: k8s.container_fs_reads_total__swo_temp
           - action: insert
             include: k8s.container_fs_writes_total
-            new_name: k8s.container_fs_writes_total_temp
+            new_name: k8s.container_fs_writes_total__swo_temp
           - action: combine
             experimental_match_labels:
               container: \S+
               namespace: \S+
               pod: \S+
-            include: (k8s.container_fs_reads_total_temp|k8s.container_fs_writes_total_temp)
+            include: (k8s.container_fs_reads_total__swo_temp|k8s.container_fs_writes_total__swo_temp)
             match_type: regexp
             new_name: k8s.container.fs.iops
             operations:
@@ -4414,16 +4414,16 @@ Node collector config should match snapshot when autodiscovery is disabled:
             submatch_case: lower
           - action: insert
             include: k8s.container_fs_reads_bytes_total
-            new_name: k8s.container_fs_reads_bytes_total_temp
+            new_name: k8s.container_fs_reads_bytes_total__swo_temp
           - action: insert
             include: k8s.container_fs_writes_bytes_total
-            new_name: k8s.container_fs_writes_bytes_total_temp
+            new_name: k8s.container_fs_writes_bytes_total__swo_temp
           - action: combine
             experimental_match_labels:
               container: \S+
               namespace: \S+
               pod: \S+
-            include: (k8s.container_fs_reads_bytes_total_temp|k8s.container_fs_writes_bytes_total_temp)
+            include: (k8s.container_fs_reads_bytes_total__swo_temp|k8s.container_fs_writes_bytes_total__swo_temp)
             match_type: regexp
             new_name: k8s.container.fs.throughput
             operations:
@@ -4625,12 +4625,12 @@ Node collector config should match snapshot when autodiscovery is disabled:
               - k8s.node.name
           - action: insert
             include: k8s.pod.fs.reads.rate
-            new_name: k8s.pod.fs.reads.rate_temp
+            new_name: k8s.pod.fs.reads.rate__swo_temp
           - action: insert
             include: k8s.pod.fs.writes.rate
-            new_name: k8s.pod.fs.writes.rate_temp
+            new_name: k8s.pod.fs.writes.rate__swo_temp
           - action: combine
-            include: (k8s.pod.fs.reads.rate_temp|k8s.pod.fs.writes.rate_temp)
+            include: (k8s.pod.fs.reads.rate__swo_temp|k8s.pod.fs.writes.rate__swo_temp)
             match_type: regexp
             new_name: k8s.pod.fs.iops
             operations:
@@ -4643,12 +4643,12 @@ Node collector config should match snapshot when autodiscovery is disabled:
             submatch_case: lower
           - action: insert
             include: k8s.pod.fs.reads.bytes.rate
-            new_name: k8s.pod.fs.reads.bytes.rate_temp
+            new_name: k8s.pod.fs.reads.bytes.rate__swo_temp
           - action: insert
             include: k8s.pod.fs.writes.bytes.rate
-            new_name: k8s.pod.fs.writes.bytes.rate_temp
+            new_name: k8s.pod.fs.writes.bytes.rate__swo_temp
           - action: combine
-            include: (k8s.pod.fs.reads.bytes.rate_temp|k8s.pod.fs.writes.bytes.rate_temp)
+            include: (k8s.pod.fs.reads.bytes.rate__swo_temp|k8s.pod.fs.writes.bytes.rate__swo_temp)
             match_type: regexp
             new_name: k8s.pod.fs.throughput
             operations:
@@ -4758,7 +4758,7 @@ Node collector config should match snapshot when autodiscovery is disabled:
               - k8s.node.name
           - action: insert
             include: k8s.pod.fs.reads.rate
-            new_name: k8s.node.fs.reads.rate_temp
+            new_name: k8s.node.fs.reads.rate__swo_temp
             operations:
             - action: aggregate_labels
               aggregation_type: sum
@@ -4766,7 +4766,7 @@ Node collector config should match snapshot when autodiscovery is disabled:
               - k8s.node.name
           - action: insert
             include: k8s.pod.fs.writes.rate
-            new_name: k8s.node.fs.writes.rate_temp
+            new_name: k8s.node.fs.writes.rate__swo_temp
             operations:
             - action: aggregate_labels
               aggregation_type: sum
@@ -4774,7 +4774,7 @@ Node collector config should match snapshot when autodiscovery is disabled:
               - k8s.node.name
           - action: insert
             include: k8s.pod.fs.reads.bytes.rate
-            new_name: k8s.node.fs.reads.bytes.rate_temp
+            new_name: k8s.node.fs.reads.bytes.rate__swo_temp
             operations:
             - action: aggregate_labels
               aggregation_type: sum
@@ -4782,14 +4782,14 @@ Node collector config should match snapshot when autodiscovery is disabled:
               - k8s.node.name
           - action: insert
             include: k8s.pod.fs.writes.bytes.rate
-            new_name: k8s.node.fs.writes.bytes.rate_temp
+            new_name: k8s.node.fs.writes.bytes.rate__swo_temp
             operations:
             - action: aggregate_labels
               aggregation_type: sum
               label_set:
               - k8s.node.name
           - action: combine
-            include: (k8s.node.fs.reads.rate_temp|k8s.node.fs.writes.rate_temp)
+            include: (k8s.node.fs.reads.rate__swo_temp|k8s.node.fs.writes.rate__swo_temp)
             match_type: regexp
             new_name: k8s.node.fs.iops
             operations:
@@ -4799,7 +4799,7 @@ Node collector config should match snapshot when autodiscovery is disabled:
               - k8s.node.name
             submatch_case: lower
           - action: combine
-            include: (k8s.node.fs.reads.bytes.rate_temp|k8s.node.fs.writes.bytes.rate_temp)
+            include: (k8s.node.fs.reads.bytes.rate__swo_temp|k8s.node.fs.writes.bytes.rate__swo_temp)
             match_type: regexp
             new_name: k8s.node.fs.throughput
             operations:
@@ -5044,10 +5044,10 @@ Node collector config should match snapshot when autodiscovery is disabled:
             - extract_sum_metric(true) where (metric.name == "k8s.istio_request_bytes" or
               metric.name == "k8s.istio_response_bytes" or metric.name == "k8s.istio_request_duration_milliseconds")
             - extract_count_metric(true) where (metric.name == "k8s.istio_request_duration_milliseconds")
-            - set(metric.name, "k8s.istio_request_duration_milliseconds_sum_temp") where
-              metric.name == "k8s.istio_request_duration_milliseconds_sum"
-            - set(metric.name, "k8s.istio_request_duration_milliseconds_count_temp") where
-              metric.name == "k8s.istio_request_duration_milliseconds_count"
+            - set(metric.name, "k8s.istio_request_duration_milliseconds_sum__swo_temp")
+              where metric.name == "k8s.istio_request_duration_milliseconds_sum"
+            - set(metric.name, "k8s.istio_request_duration_milliseconds_count__swo_temp")
+              where metric.name == "k8s.istio_request_duration_milliseconds_count"
             - set(resource.attributes["istio"], "true")
         transform/istio-relationship-types:
           metric_statements:
@@ -5821,7 +5821,7 @@ Node collector config should match snapshot when fargate is enabled:
           actions:
           - action: delete
             key: temp
-            pattern: (.*_temp$)|(^\$.*)
+            pattern: (.*__swo_temp$)|(^\$.*)
           include:
             match_type: regexp
             metric_names:
@@ -5885,8 +5885,8 @@ Node collector config should match snapshot when fargate is enabled:
             metrics:
             - k8s.istio_request_bytes.rate
             - k8s.istio_response_bytes.rate
-            - k8s.istio_request_duration_milliseconds_sum_temp
-            - k8s.istio_request_duration_milliseconds_count_temp
+            - k8s.istio_request_duration_milliseconds_sum__swo_temp
+            - k8s.istio_request_duration_milliseconds_count__swo_temp
             - k8s.istio_requests.rate
             - k8s.istio_tcp_sent_bytes.rate
             - k8s.istio_tcp_received_bytes.rate
@@ -5929,8 +5929,8 @@ Node collector config should match snapshot when fargate is enabled:
           metrics:
           - k8s.istio_request_bytes.rate
           - k8s.istio_response_bytes.rate
-          - k8s.istio_request_duration_milliseconds_sum_temp
-          - k8s.istio_request_duration_milliseconds_count_temp
+          - k8s.istio_request_duration_milliseconds_sum__swo_temp
+          - k8s.istio_request_duration_milliseconds_count__swo_temp
           - k8s.istio_requests.rate
           - k8s.istio_tcp_sent_bytes.rate
           - k8s.istio_tcp_received_bytes.rate
@@ -5993,7 +5993,7 @@ Node collector config should match snapshot when fargate is enabled:
         filter/remove_temporary_metrics:
           metrics:
             metric:
-            - IsMatch(name , ".*_temp")
+            - IsMatch(name , ".*__swo_temp$")
         filter/zero-delta-values:
           error_mode: ignore
           metrics:
@@ -6095,8 +6095,8 @@ Node collector config should match snapshot when fargate is enabled:
           spike_limit_mib: 300
         metricsgeneration/istio-metrics:
           rules:
-          - metric1: k8s.istio_request_duration_milliseconds_sum_temp
-            metric2: k8s.istio_request_duration_milliseconds_count_temp
+          - metric1: k8s.istio_request_duration_milliseconds_sum__swo_temp
+            metric2: k8s.istio_request_duration_milliseconds_count__swo_temp
             name: k8s.istio_request_duration_milliseconds.rate
             operation: divide
             type: calculate
@@ -6136,16 +6136,16 @@ Node collector config should match snapshot when fargate is enabled:
           transforms:
           - action: insert
             include: k8s.container_fs_reads_total
-            new_name: k8s.container_fs_reads_total_temp
+            new_name: k8s.container_fs_reads_total__swo_temp
           - action: insert
             include: k8s.container_fs_writes_total
-            new_name: k8s.container_fs_writes_total_temp
+            new_name: k8s.container_fs_writes_total__swo_temp
           - action: combine
             experimental_match_labels:
               container: \S+
               namespace: \S+
               pod: \S+
-            include: (k8s.container_fs_reads_total_temp|k8s.container_fs_writes_total_temp)
+            include: (k8s.container_fs_reads_total__swo_temp|k8s.container_fs_writes_total__swo_temp)
             match_type: regexp
             new_name: k8s.container.fs.iops
             operations:
@@ -6158,16 +6158,16 @@ Node collector config should match snapshot when fargate is enabled:
             submatch_case: lower
           - action: insert
             include: k8s.container_fs_reads_bytes_total
-            new_name: k8s.container_fs_reads_bytes_total_temp
+            new_name: k8s.container_fs_reads_bytes_total__swo_temp
           - action: insert
             include: k8s.container_fs_writes_bytes_total
-            new_name: k8s.container_fs_writes_bytes_total_temp
+            new_name: k8s.container_fs_writes_bytes_total__swo_temp
           - action: combine
             experimental_match_labels:
               container: \S+
               namespace: \S+
               pod: \S+
-            include: (k8s.container_fs_reads_bytes_total_temp|k8s.container_fs_writes_bytes_total_temp)
+            include: (k8s.container_fs_reads_bytes_total__swo_temp|k8s.container_fs_writes_bytes_total__swo_temp)
             match_type: regexp
             new_name: k8s.container.fs.throughput
             operations:
@@ -6369,12 +6369,12 @@ Node collector config should match snapshot when fargate is enabled:
               - k8s.node.name
           - action: insert
             include: k8s.pod.fs.reads.rate
-            new_name: k8s.pod.fs.reads.rate_temp
+            new_name: k8s.pod.fs.reads.rate__swo_temp
           - action: insert
             include: k8s.pod.fs.writes.rate
-            new_name: k8s.pod.fs.writes.rate_temp
+            new_name: k8s.pod.fs.writes.rate__swo_temp
           - action: combine
-            include: (k8s.pod.fs.reads.rate_temp|k8s.pod.fs.writes.rate_temp)
+            include: (k8s.pod.fs.reads.rate__swo_temp|k8s.pod.fs.writes.rate__swo_temp)
             match_type: regexp
             new_name: k8s.pod.fs.iops
             operations:
@@ -6387,12 +6387,12 @@ Node collector config should match snapshot when fargate is enabled:
             submatch_case: lower
           - action: insert
             include: k8s.pod.fs.reads.bytes.rate
-            new_name: k8s.pod.fs.reads.bytes.rate_temp
+            new_name: k8s.pod.fs.reads.bytes.rate__swo_temp
           - action: insert
             include: k8s.pod.fs.writes.bytes.rate
-            new_name: k8s.pod.fs.writes.bytes.rate_temp
+            new_name: k8s.pod.fs.writes.bytes.rate__swo_temp
           - action: combine
-            include: (k8s.pod.fs.reads.bytes.rate_temp|k8s.pod.fs.writes.bytes.rate_temp)
+            include: (k8s.pod.fs.reads.bytes.rate__swo_temp|k8s.pod.fs.writes.bytes.rate__swo_temp)
             match_type: regexp
             new_name: k8s.pod.fs.throughput
             operations:
@@ -6502,7 +6502,7 @@ Node collector config should match snapshot when fargate is enabled:
               - k8s.node.name
           - action: insert
             include: k8s.pod.fs.reads.rate
-            new_name: k8s.node.fs.reads.rate_temp
+            new_name: k8s.node.fs.reads.rate__swo_temp
             operations:
             - action: aggregate_labels
               aggregation_type: sum
@@ -6510,7 +6510,7 @@ Node collector config should match snapshot when fargate is enabled:
               - k8s.node.name
           - action: insert
             include: k8s.pod.fs.writes.rate
-            new_name: k8s.node.fs.writes.rate_temp
+            new_name: k8s.node.fs.writes.rate__swo_temp
             operations:
             - action: aggregate_labels
               aggregation_type: sum
@@ -6518,7 +6518,7 @@ Node collector config should match snapshot when fargate is enabled:
               - k8s.node.name
           - action: insert
             include: k8s.pod.fs.reads.bytes.rate
-            new_name: k8s.node.fs.reads.bytes.rate_temp
+            new_name: k8s.node.fs.reads.bytes.rate__swo_temp
             operations:
             - action: aggregate_labels
               aggregation_type: sum
@@ -6526,14 +6526,14 @@ Node collector config should match snapshot when fargate is enabled:
               - k8s.node.name
           - action: insert
             include: k8s.pod.fs.writes.bytes.rate
-            new_name: k8s.node.fs.writes.bytes.rate_temp
+            new_name: k8s.node.fs.writes.bytes.rate__swo_temp
             operations:
             - action: aggregate_labels
               aggregation_type: sum
               label_set:
               - k8s.node.name
           - action: combine
-            include: (k8s.node.fs.reads.rate_temp|k8s.node.fs.writes.rate_temp)
+            include: (k8s.node.fs.reads.rate__swo_temp|k8s.node.fs.writes.rate__swo_temp)
             match_type: regexp
             new_name: k8s.node.fs.iops
             operations:
@@ -6543,7 +6543,7 @@ Node collector config should match snapshot when fargate is enabled:
               - k8s.node.name
             submatch_case: lower
           - action: combine
-            include: (k8s.node.fs.reads.bytes.rate_temp|k8s.node.fs.writes.bytes.rate_temp)
+            include: (k8s.node.fs.reads.bytes.rate__swo_temp|k8s.node.fs.writes.bytes.rate__swo_temp)
             match_type: regexp
             new_name: k8s.node.fs.throughput
             operations:
@@ -6788,10 +6788,10 @@ Node collector config should match snapshot when fargate is enabled:
             - extract_sum_metric(true) where (metric.name == "k8s.istio_request_bytes" or
               metric.name == "k8s.istio_response_bytes" or metric.name == "k8s.istio_request_duration_milliseconds")
             - extract_count_metric(true) where (metric.name == "k8s.istio_request_duration_milliseconds")
-            - set(metric.name, "k8s.istio_request_duration_milliseconds_sum_temp") where
-              metric.name == "k8s.istio_request_duration_milliseconds_sum"
-            - set(metric.name, "k8s.istio_request_duration_milliseconds_count_temp") where
-              metric.name == "k8s.istio_request_duration_milliseconds_count"
+            - set(metric.name, "k8s.istio_request_duration_milliseconds_sum__swo_temp")
+              where metric.name == "k8s.istio_request_duration_milliseconds_sum"
+            - set(metric.name, "k8s.istio_request_duration_milliseconds_count__swo_temp")
+              where metric.name == "k8s.istio_request_duration_milliseconds_count"
             - set(resource.attributes["istio"], "true")
         transform/istio-relationship-types:
           metric_statements:
@@ -7541,7 +7541,7 @@ Node collector config should match snapshot when fargate is enabled and autodisc
           actions:
           - action: delete
             key: temp
-            pattern: (.*_temp$)|(^\$.*)
+            pattern: (.*__swo_temp$)|(^\$.*)
           include:
             match_type: regexp
             metric_names:
@@ -7605,8 +7605,8 @@ Node collector config should match snapshot when fargate is enabled and autodisc
             metrics:
             - k8s.istio_request_bytes.rate
             - k8s.istio_response_bytes.rate
-            - k8s.istio_request_duration_milliseconds_sum_temp
-            - k8s.istio_request_duration_milliseconds_count_temp
+            - k8s.istio_request_duration_milliseconds_sum__swo_temp
+            - k8s.istio_request_duration_milliseconds_count__swo_temp
             - k8s.istio_requests.rate
             - k8s.istio_tcp_sent_bytes.rate
             - k8s.istio_tcp_received_bytes.rate
@@ -7649,8 +7649,8 @@ Node collector config should match snapshot when fargate is enabled and autodisc
           metrics:
           - k8s.istio_request_bytes.rate
           - k8s.istio_response_bytes.rate
-          - k8s.istio_request_duration_milliseconds_sum_temp
-          - k8s.istio_request_duration_milliseconds_count_temp
+          - k8s.istio_request_duration_milliseconds_sum__swo_temp
+          - k8s.istio_request_duration_milliseconds_count__swo_temp
           - k8s.istio_requests.rate
           - k8s.istio_tcp_sent_bytes.rate
           - k8s.istio_tcp_received_bytes.rate
@@ -7713,7 +7713,7 @@ Node collector config should match snapshot when fargate is enabled and autodisc
         filter/remove_temporary_metrics:
           metrics:
             metric:
-            - IsMatch(name , ".*_temp")
+            - IsMatch(name , ".*__swo_temp$")
         filter/zero-delta-values:
           error_mode: ignore
           metrics:
@@ -7815,8 +7815,8 @@ Node collector config should match snapshot when fargate is enabled and autodisc
           spike_limit_mib: 300
         metricsgeneration/istio-metrics:
           rules:
-          - metric1: k8s.istio_request_duration_milliseconds_sum_temp
-            metric2: k8s.istio_request_duration_milliseconds_count_temp
+          - metric1: k8s.istio_request_duration_milliseconds_sum__swo_temp
+            metric2: k8s.istio_request_duration_milliseconds_count__swo_temp
             name: k8s.istio_request_duration_milliseconds.rate
             operation: divide
             type: calculate
@@ -7856,16 +7856,16 @@ Node collector config should match snapshot when fargate is enabled and autodisc
           transforms:
           - action: insert
             include: k8s.container_fs_reads_total
-            new_name: k8s.container_fs_reads_total_temp
+            new_name: k8s.container_fs_reads_total__swo_temp
           - action: insert
             include: k8s.container_fs_writes_total
-            new_name: k8s.container_fs_writes_total_temp
+            new_name: k8s.container_fs_writes_total__swo_temp
           - action: combine
             experimental_match_labels:
               container: \S+
               namespace: \S+
               pod: \S+
-            include: (k8s.container_fs_reads_total_temp|k8s.container_fs_writes_total_temp)
+            include: (k8s.container_fs_reads_total__swo_temp|k8s.container_fs_writes_total__swo_temp)
             match_type: regexp
             new_name: k8s.container.fs.iops
             operations:
@@ -7878,16 +7878,16 @@ Node collector config should match snapshot when fargate is enabled and autodisc
             submatch_case: lower
           - action: insert
             include: k8s.container_fs_reads_bytes_total
-            new_name: k8s.container_fs_reads_bytes_total_temp
+            new_name: k8s.container_fs_reads_bytes_total__swo_temp
           - action: insert
             include: k8s.container_fs_writes_bytes_total
-            new_name: k8s.container_fs_writes_bytes_total_temp
+            new_name: k8s.container_fs_writes_bytes_total__swo_temp
           - action: combine
             experimental_match_labels:
               container: \S+
               namespace: \S+
               pod: \S+
-            include: (k8s.container_fs_reads_bytes_total_temp|k8s.container_fs_writes_bytes_total_temp)
+            include: (k8s.container_fs_reads_bytes_total__swo_temp|k8s.container_fs_writes_bytes_total__swo_temp)
             match_type: regexp
             new_name: k8s.container.fs.throughput
             operations:
@@ -8089,12 +8089,12 @@ Node collector config should match snapshot when fargate is enabled and autodisc
               - k8s.node.name
           - action: insert
             include: k8s.pod.fs.reads.rate
-            new_name: k8s.pod.fs.reads.rate_temp
+            new_name: k8s.pod.fs.reads.rate__swo_temp
           - action: insert
             include: k8s.pod.fs.writes.rate
-            new_name: k8s.pod.fs.writes.rate_temp
+            new_name: k8s.pod.fs.writes.rate__swo_temp
           - action: combine
-            include: (k8s.pod.fs.reads.rate_temp|k8s.pod.fs.writes.rate_temp)
+            include: (k8s.pod.fs.reads.rate__swo_temp|k8s.pod.fs.writes.rate__swo_temp)
             match_type: regexp
             new_name: k8s.pod.fs.iops
             operations:
@@ -8107,12 +8107,12 @@ Node collector config should match snapshot when fargate is enabled and autodisc
             submatch_case: lower
           - action: insert
             include: k8s.pod.fs.reads.bytes.rate
-            new_name: k8s.pod.fs.reads.bytes.rate_temp
+            new_name: k8s.pod.fs.reads.bytes.rate__swo_temp
           - action: insert
             include: k8s.pod.fs.writes.bytes.rate
-            new_name: k8s.pod.fs.writes.bytes.rate_temp
+            new_name: k8s.pod.fs.writes.bytes.rate__swo_temp
           - action: combine
-            include: (k8s.pod.fs.reads.bytes.rate_temp|k8s.pod.fs.writes.bytes.rate_temp)
+            include: (k8s.pod.fs.reads.bytes.rate__swo_temp|k8s.pod.fs.writes.bytes.rate__swo_temp)
             match_type: regexp
             new_name: k8s.pod.fs.throughput
             operations:
@@ -8222,7 +8222,7 @@ Node collector config should match snapshot when fargate is enabled and autodisc
               - k8s.node.name
           - action: insert
             include: k8s.pod.fs.reads.rate
-            new_name: k8s.node.fs.reads.rate_temp
+            new_name: k8s.node.fs.reads.rate__swo_temp
             operations:
             - action: aggregate_labels
               aggregation_type: sum
@@ -8230,7 +8230,7 @@ Node collector config should match snapshot when fargate is enabled and autodisc
               - k8s.node.name
           - action: insert
             include: k8s.pod.fs.writes.rate
-            new_name: k8s.node.fs.writes.rate_temp
+            new_name: k8s.node.fs.writes.rate__swo_temp
             operations:
             - action: aggregate_labels
               aggregation_type: sum
@@ -8238,7 +8238,7 @@ Node collector config should match snapshot when fargate is enabled and autodisc
               - k8s.node.name
           - action: insert
             include: k8s.pod.fs.reads.bytes.rate
-            new_name: k8s.node.fs.reads.bytes.rate_temp
+            new_name: k8s.node.fs.reads.bytes.rate__swo_temp
             operations:
             - action: aggregate_labels
               aggregation_type: sum
@@ -8246,14 +8246,14 @@ Node collector config should match snapshot when fargate is enabled and autodisc
               - k8s.node.name
           - action: insert
             include: k8s.pod.fs.writes.bytes.rate
-            new_name: k8s.node.fs.writes.bytes.rate_temp
+            new_name: k8s.node.fs.writes.bytes.rate__swo_temp
             operations:
             - action: aggregate_labels
               aggregation_type: sum
               label_set:
               - k8s.node.name
           - action: combine
-            include: (k8s.node.fs.reads.rate_temp|k8s.node.fs.writes.rate_temp)
+            include: (k8s.node.fs.reads.rate__swo_temp|k8s.node.fs.writes.rate__swo_temp)
             match_type: regexp
             new_name: k8s.node.fs.iops
             operations:
@@ -8263,7 +8263,7 @@ Node collector config should match snapshot when fargate is enabled and autodisc
               - k8s.node.name
             submatch_case: lower
           - action: combine
-            include: (k8s.node.fs.reads.bytes.rate_temp|k8s.node.fs.writes.bytes.rate_temp)
+            include: (k8s.node.fs.reads.bytes.rate__swo_temp|k8s.node.fs.writes.bytes.rate__swo_temp)
             match_type: regexp
             new_name: k8s.node.fs.throughput
             operations:
@@ -8508,10 +8508,10 @@ Node collector config should match snapshot when fargate is enabled and autodisc
             - extract_sum_metric(true) where (metric.name == "k8s.istio_request_bytes" or
               metric.name == "k8s.istio_response_bytes" or metric.name == "k8s.istio_request_duration_milliseconds")
             - extract_count_metric(true) where (metric.name == "k8s.istio_request_duration_milliseconds")
-            - set(metric.name, "k8s.istio_request_duration_milliseconds_sum_temp") where
-              metric.name == "k8s.istio_request_duration_milliseconds_sum"
-            - set(metric.name, "k8s.istio_request_duration_milliseconds_count_temp") where
-              metric.name == "k8s.istio_request_duration_milliseconds_count"
+            - set(metric.name, "k8s.istio_request_duration_milliseconds_sum__swo_temp")
+              where metric.name == "k8s.istio_request_duration_milliseconds_sum"
+            - set(metric.name, "k8s.istio_request_duration_milliseconds_count__swo_temp")
+              where metric.name == "k8s.istio_request_duration_milliseconds_count"
             - set(resource.attributes["istio"], "true")
         transform/istio-relationship-types:
           metric_statements:
@@ -9194,7 +9194,7 @@ Node collector config should match snapshot when using default values:
           actions:
           - action: delete
             key: temp
-            pattern: (.*_temp$)|(^\$.*)
+            pattern: (.*__swo_temp$)|(^\$.*)
           include:
             match_type: regexp
             metric_names:
@@ -9261,8 +9261,8 @@ Node collector config should match snapshot when using default values:
             metrics:
             - k8s.istio_request_bytes.rate
             - k8s.istio_response_bytes.rate
-            - k8s.istio_request_duration_milliseconds_sum_temp
-            - k8s.istio_request_duration_milliseconds_count_temp
+            - k8s.istio_request_duration_milliseconds_sum__swo_temp
+            - k8s.istio_request_duration_milliseconds_count__swo_temp
             - k8s.istio_requests.rate
             - k8s.istio_tcp_sent_bytes.rate
             - k8s.istio_tcp_received_bytes.rate
@@ -9305,8 +9305,8 @@ Node collector config should match snapshot when using default values:
           metrics:
           - k8s.istio_request_bytes.rate
           - k8s.istio_response_bytes.rate
-          - k8s.istio_request_duration_milliseconds_sum_temp
-          - k8s.istio_request_duration_milliseconds_count_temp
+          - k8s.istio_request_duration_milliseconds_sum__swo_temp
+          - k8s.istio_request_duration_milliseconds_count__swo_temp
           - k8s.istio_requests.rate
           - k8s.istio_tcp_sent_bytes.rate
           - k8s.istio_tcp_received_bytes.rate
@@ -9369,7 +9369,7 @@ Node collector config should match snapshot when using default values:
         filter/remove_temporary_metrics:
           metrics:
             metric:
-            - IsMatch(name , ".*_temp")
+            - IsMatch(name , ".*__swo_temp$")
         filter/zero-delta-values:
           error_mode: ignore
           metrics:
@@ -9471,8 +9471,8 @@ Node collector config should match snapshot when using default values:
           spike_limit_mib: 300
         metricsgeneration/istio-metrics:
           rules:
-          - metric1: k8s.istio_request_duration_milliseconds_sum_temp
-            metric2: k8s.istio_request_duration_milliseconds_count_temp
+          - metric1: k8s.istio_request_duration_milliseconds_sum__swo_temp
+            metric2: k8s.istio_request_duration_milliseconds_count__swo_temp
             name: k8s.istio_request_duration_milliseconds.rate
             operation: divide
             type: calculate
@@ -9512,16 +9512,16 @@ Node collector config should match snapshot when using default values:
           transforms:
           - action: insert
             include: k8s.container_fs_reads_total
-            new_name: k8s.container_fs_reads_total_temp
+            new_name: k8s.container_fs_reads_total__swo_temp
           - action: insert
             include: k8s.container_fs_writes_total
-            new_name: k8s.container_fs_writes_total_temp
+            new_name: k8s.container_fs_writes_total__swo_temp
           - action: combine
             experimental_match_labels:
               container: \S+
               namespace: \S+
               pod: \S+
-            include: (k8s.container_fs_reads_total_temp|k8s.container_fs_writes_total_temp)
+            include: (k8s.container_fs_reads_total__swo_temp|k8s.container_fs_writes_total__swo_temp)
             match_type: regexp
             new_name: k8s.container.fs.iops
             operations:
@@ -9534,16 +9534,16 @@ Node collector config should match snapshot when using default values:
             submatch_case: lower
           - action: insert
             include: k8s.container_fs_reads_bytes_total
-            new_name: k8s.container_fs_reads_bytes_total_temp
+            new_name: k8s.container_fs_reads_bytes_total__swo_temp
           - action: insert
             include: k8s.container_fs_writes_bytes_total
-            new_name: k8s.container_fs_writes_bytes_total_temp
+            new_name: k8s.container_fs_writes_bytes_total__swo_temp
           - action: combine
             experimental_match_labels:
               container: \S+
               namespace: \S+
               pod: \S+
-            include: (k8s.container_fs_reads_bytes_total_temp|k8s.container_fs_writes_bytes_total_temp)
+            include: (k8s.container_fs_reads_bytes_total__swo_temp|k8s.container_fs_writes_bytes_total__swo_temp)
             match_type: regexp
             new_name: k8s.container.fs.throughput
             operations:
@@ -9745,12 +9745,12 @@ Node collector config should match snapshot when using default values:
               - k8s.node.name
           - action: insert
             include: k8s.pod.fs.reads.rate
-            new_name: k8s.pod.fs.reads.rate_temp
+            new_name: k8s.pod.fs.reads.rate__swo_temp
           - action: insert
             include: k8s.pod.fs.writes.rate
-            new_name: k8s.pod.fs.writes.rate_temp
+            new_name: k8s.pod.fs.writes.rate__swo_temp
           - action: combine
-            include: (k8s.pod.fs.reads.rate_temp|k8s.pod.fs.writes.rate_temp)
+            include: (k8s.pod.fs.reads.rate__swo_temp|k8s.pod.fs.writes.rate__swo_temp)
             match_type: regexp
             new_name: k8s.pod.fs.iops
             operations:
@@ -9763,12 +9763,12 @@ Node collector config should match snapshot when using default values:
             submatch_case: lower
           - action: insert
             include: k8s.pod.fs.reads.bytes.rate
-            new_name: k8s.pod.fs.reads.bytes.rate_temp
+            new_name: k8s.pod.fs.reads.bytes.rate__swo_temp
           - action: insert
             include: k8s.pod.fs.writes.bytes.rate
-            new_name: k8s.pod.fs.writes.bytes.rate_temp
+            new_name: k8s.pod.fs.writes.bytes.rate__swo_temp
           - action: combine
-            include: (k8s.pod.fs.reads.bytes.rate_temp|k8s.pod.fs.writes.bytes.rate_temp)
+            include: (k8s.pod.fs.reads.bytes.rate__swo_temp|k8s.pod.fs.writes.bytes.rate__swo_temp)
             match_type: regexp
             new_name: k8s.pod.fs.throughput
             operations:
@@ -9878,7 +9878,7 @@ Node collector config should match snapshot when using default values:
               - k8s.node.name
           - action: insert
             include: k8s.pod.fs.reads.rate
-            new_name: k8s.node.fs.reads.rate_temp
+            new_name: k8s.node.fs.reads.rate__swo_temp
             operations:
             - action: aggregate_labels
               aggregation_type: sum
@@ -9886,7 +9886,7 @@ Node collector config should match snapshot when using default values:
               - k8s.node.name
           - action: insert
             include: k8s.pod.fs.writes.rate
-            new_name: k8s.node.fs.writes.rate_temp
+            new_name: k8s.node.fs.writes.rate__swo_temp
             operations:
             - action: aggregate_labels
               aggregation_type: sum
@@ -9894,7 +9894,7 @@ Node collector config should match snapshot when using default values:
               - k8s.node.name
           - action: insert
             include: k8s.pod.fs.reads.bytes.rate
-            new_name: k8s.node.fs.reads.bytes.rate_temp
+            new_name: k8s.node.fs.reads.bytes.rate__swo_temp
             operations:
             - action: aggregate_labels
               aggregation_type: sum
@@ -9902,14 +9902,14 @@ Node collector config should match snapshot when using default values:
               - k8s.node.name
           - action: insert
             include: k8s.pod.fs.writes.bytes.rate
-            new_name: k8s.node.fs.writes.bytes.rate_temp
+            new_name: k8s.node.fs.writes.bytes.rate__swo_temp
             operations:
             - action: aggregate_labels
               aggregation_type: sum
               label_set:
               - k8s.node.name
           - action: combine
-            include: (k8s.node.fs.reads.rate_temp|k8s.node.fs.writes.rate_temp)
+            include: (k8s.node.fs.reads.rate__swo_temp|k8s.node.fs.writes.rate__swo_temp)
             match_type: regexp
             new_name: k8s.node.fs.iops
             operations:
@@ -9919,7 +9919,7 @@ Node collector config should match snapshot when using default values:
               - k8s.node.name
             submatch_case: lower
           - action: combine
-            include: (k8s.node.fs.reads.bytes.rate_temp|k8s.node.fs.writes.bytes.rate_temp)
+            include: (k8s.node.fs.reads.bytes.rate__swo_temp|k8s.node.fs.writes.bytes.rate__swo_temp)
             match_type: regexp
             new_name: k8s.node.fs.throughput
             operations:
@@ -10164,10 +10164,10 @@ Node collector config should match snapshot when using default values:
             - extract_sum_metric(true) where (metric.name == "k8s.istio_request_bytes" or
               metric.name == "k8s.istio_response_bytes" or metric.name == "k8s.istio_request_duration_milliseconds")
             - extract_count_metric(true) where (metric.name == "k8s.istio_request_duration_milliseconds")
-            - set(metric.name, "k8s.istio_request_duration_milliseconds_sum_temp") where
-              metric.name == "k8s.istio_request_duration_milliseconds_sum"
-            - set(metric.name, "k8s.istio_request_duration_milliseconds_count_temp") where
-              metric.name == "k8s.istio_request_duration_milliseconds_count"
+            - set(metric.name, "k8s.istio_request_duration_milliseconds_sum__swo_temp")
+              where metric.name == "k8s.istio_request_duration_milliseconds_sum"
+            - set(metric.name, "k8s.istio_request_duration_milliseconds_count__swo_temp")
+              where metric.name == "k8s.istio_request_duration_milliseconds_count"
             - set(resource.attributes["istio"], "true")
         transform/istio-relationship-types:
           metric_statements:


### PR DESCRIPTION
Fix '_temp' metric deletion to actually match only temporary metrics