### PR TITLE
NH-118849 Upgrade APM Python 5.0.0

### DIFF
--- a/deploy/helm/values.yaml
+++ b/deploy/helm/values.yaml
@@ -1213,7 +1213,7 @@ operator:
         tag: ""
       python:
         repository: "solarwinds/autoinstrumentation-python"
-        tag: "4.3.0"
+        tag: "5.0.0"
       dotnet:
         repository: ""
         tag: ""


### PR DESCRIPTION
Upgrade to APM Python 5.0.0, released Sep 11 2025.