### PR TITLE
Making the repo a bit more copilot friendly

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -75,7 +75,3 @@ The SWO K8s Collector consists of five main components, each with specific pipel
 # Coding conventions 
 1. Maintain backward compatibility when updating chart configurations.  
 2. Follow JSON schema validation for Helm values through `values.schema.json`.  
-
-# Testing rules
-- Use Helm unit tests for verifying chart rendering.  
-- Update snapshot tests with `helm unittest -u deploy/helm`.

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 skaffold.env
 deploy/helm/charts/*.tgz
 operator/swo-otel-operator/**/*
+pod-logs/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,125 @@
+## Development Workflow
+
+### Local iteration with Skaffold
+
+1. Start the default stack:
+
+```bash
+skaffold dev
+```
+
+   This deploys the collector, Prometheus, and the OTLP mock endpoints into your active
+   Kubernetes context.
+
+2. Adjust behaviour with Skaffold profiles. Common combinations:
+   - `operator`: install cert-manager, OTEL operator, and discovery collectors.
+   - `auto-instrumentation`: enable Beyla auto-instrumentation (requires `operator`).
+   - `no-logs`, `no-metrics`, `no-events`, `no-prometheus`: exclude individual subsystems.
+   - `swo`: forward data to SolarWinds Observability. Requires
+     `SOLARWINDS_OTEL_ENDPOINT` and `SOLARWINDS_API_TOKEN` in environment or `skaffold.env`.
+
+```bash
+skaffold dev -p operator,beyla
+```
+
+3. To redeploy quickly after manifest or values changes, interrupt Skaffold and rerun the
+   command; it will rebuild only the modified artifacts.
+
+### Helm chart maintenance
+
+- Update chart dependencies after modifying `deploy/helm/Chart.yaml`:
+
+```bash
+helm dependency update deploy/helm
+```
+
+- Keep `deploy/helm/values.yaml` backwards compatible and validate against
+  `values.schema.json` using your editor or `helm lint`.
+
+## Testing Instructions
+
+### Helm unit tests
+
+- Run the assertions:
+
+```bash
+helm unittest deploy/helm
+```
+
+- Refresh golden snapshots when chart output intentionally changes:
+
+```bash
+helm unittest -u deploy/helm
+```
+
+### Integration tests
+
+- The fastest, fully automated path is the Makefile wrapper:
+
+```bash
+make integration-test
+```
+
+  This target builds images with Skaffold, deploys the test stack, triggers the
+  `integration-test` CronJob, tails pod logs, and tears everything down. Failures export
+  pod logs and mock JSON payloads into the `pod-logs/` folder for analysis.
+
+### Performance profiling
+
+- Enable profiling by setting `diagnostics.profiling.enabled=true` in Helm values, port
+  forward a collector pod (`kubectl port-forward ... 1777:pprof`), and run
+  `go tool pprof http://localhost:1777/debug/pprof/<profile>`.
+
+## Build and Deployment
+
+- Use Skaffold for repeatable builds:
+
+```bash
+skaffold build --file-output=/tmp/tags.json
+```
+
+- Delete the stack and images when finished:
+
+```bash
+skaffold delete
+```
+
+- For chart releases, bump `version` (and `appVersion` if images change) in
+  `deploy/helm/Chart.yaml`, run `helm dependency update deploy/helm`, and commit the updated
+  `Chart.lock`.
+
+## Pull Request Guidelines
+
+- Branch from `master` and keep your feature branch up to date with upstream changes.
+- Document chart-visible changes in the `Unreleased` section of `deploy/helm/CHANGELOG.md`.
+- Run the relevant checks locally (at minimum `helm unittest deploy/helm` and
+  `make integration-test`) before requesting review.
+- Keep test framework updates (Python tooling, mock services) separate from functional
+  chart or collector changes.
+
+## Debugging and Troubleshooting
+
+- Missing CRDs during Skaffold deploy often indicate a stale Helm repository cache. Repair
+  with `helm repo update` and rerun the deploy.
+- If chart downloads fail with `no cached repo found`, add the legacy stable repository:
+
+```bash
+helm repo add stable https://charts.helm.sh/stable --force-update
+```
+
+- Integration test failures:
+  - Inspect streamed pod logs in the terminal; the Makefile background log tail stops when
+    the job finishes.
+  - Review artifacts in `pod-logs/` (collector pods, mock JSON exports) for regression
+    analysis.
+  - Reproduce individual CronJob executions with
+    `kubectl create job --from=cronjob/integration-test debug-run -n test-namespace`.
+- To inspect exported telemetry manually, curl the mock endpoints:
+
+```bash
+curl http://localhost:8088/logs.json
+curl http://localhost:8088/metrics.json
+```
+
+- When working against remote clusters, ensure the registry login has not expired and the
+  namespace referenced by `TEST_CLUSTER_NAMESPACE` exists before deploying.

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,121 @@
+.PHONY: integration-test integration-test-run integration-test-cleanup help
+
+# Variables
+TAGS_FILE := /tmp/tags.json
+TEST_NAMESPACE := test-namespace
+TEST_JOB_NAME := integration-test-manual
+KUBECTL_TIMEOUT := 60s
+POLL_INTERVAL := 3
+SKAFFOLD_ENV := CLUSTER_NAME="cluster name" TEST_CLUSTER_NAMESPACE=$(TEST_NAMESPACE)
+
+help: ## Show this help message
+	@echo 'Usage: make [target]'
+	@echo ''
+	@echo 'Available targets:'
+	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "  \033[36m%-20s\033[0m %s\n", $$1, $$2}'
+
+integration-test: ## Run integration tests (build, deploy, test, cleanup)
+	@echo "========================================="
+	@echo "Starting Integration Test Suite"
+	@echo "========================================="
+	@$(MAKE) integration-test-run; \
+	TEST_RESULT=$$?; \
+	$(MAKE) integration-test-cleanup; \
+	exit $$TEST_RESULT
+
+integration-test-run: ## Internal target: Build, deploy and run tests
+	@echo ""
+	@echo "Step 1/3: Building images with Skaffold..."
+	@echo "-----------------------------------------"
+	$(SKAFFOLD_ENV) skaffold build --file-output=$(TAGS_FILE) -v info
+	@echo ""
+	@echo "Step 2/3: Deploying with Skaffold..."
+	@echo "-----------------------------------------"
+	$(SKAFFOLD_ENV) skaffold deploy --build-artifacts $(TAGS_FILE) -v info
+	@echo ""
+	@echo "Step 3/3: Running integration tests..."
+	@echo "-----------------------------------------"
+	@echo "Waiting for timeseries-mock-service to be ready..."
+	kubectl wait --for=condition=ready --timeout=$(KUBECTL_TIMEOUT) pod -l app=timeseries-mock-service -n $(TEST_NAMESPACE)
+	@echo ""
+	@echo "Cleaning up any previous integration test jobs or pods..."
+	@kubectl delete job $(TEST_JOB_NAME) -n $(TEST_NAMESPACE) --ignore-not-found=true >/dev/null 2>&1 || true
+	@kubectl delete pod -l job-name=$(TEST_JOB_NAME) -n $(TEST_NAMESPACE) --ignore-not-found=true >/dev/null 2>&1 || true
+	@echo ""
+	@echo "Creating integration test job from CronJob..."
+	kubectl create job --from=cronjob/integration-test $(TEST_JOB_NAME) -n $(TEST_NAMESPACE)
+	@echo ""
+	@echo "Waiting for test pod to be ready..."
+	kubectl wait --for=condition=ready --timeout=$(KUBECTL_TIMEOUT) pod -l job-name=$(TEST_JOB_NAME) -n $(TEST_NAMESPACE)
+	@echo ""
+	@echo "Test pod is ready. Starting log streaming in background..."
+	@LOG_PID=$$(kubectl logs -f -l job-name=$(TEST_JOB_NAME) -n $(TEST_NAMESPACE) 2>/dev/null & echo $$!); \
+	echo ""; \
+	echo "Waiting for tests to complete..."; \
+	job_result=0; \
+	while true; do \
+		if kubectl wait --for=condition=complete --timeout=0 jobs/$(TEST_JOB_NAME) -n $(TEST_NAMESPACE) 2>/dev/null; then \
+			job_result=0; \
+			break; \
+		fi; \
+		if kubectl wait --for=condition=failed --timeout=0 jobs/$(TEST_JOB_NAME) -n $(TEST_NAMESPACE) 2>/dev/null; then \
+			job_result=1; \
+			break; \
+		fi; \
+		echo -n "."; \
+		sleep $(POLL_INTERVAL); \
+	done; \
+	kill $$LOG_PID >/dev/null 2>&1 || true; \
+	echo ""; \
+	echo ""; \
+	if [ $$job_result -eq 1 ]; then \
+		echo "========================================"; \
+		echo "Tests FAILED"; \
+		echo "========================================"; \
+		echo ""; \
+		echo "Collecting pod logs for debugging..."; \
+		mkdir -p pod-logs; \
+		pods=$$(kubectl get pods -n $(TEST_NAMESPACE) -o=jsonpath='{.items[*].metadata.name}'); \
+		for pod in $$pods; do \
+			containers=$$(kubectl get pod $$pod -n $(TEST_NAMESPACE) -o=jsonpath='{.spec.containers[*].name}'); \
+			for container in $$containers; do \
+				echo "Saving logs for pod $$pod, container $$container..."; \
+				kubectl logs -n $(TEST_NAMESPACE) $$pod -c $$container > pod-logs/$$pod-$$container.txt 2>&1 || true; \
+			done; \
+		done; \
+		echo "Pod logs saved to pod-logs/ directory"; \
+		echo ""; \
+		echo "Collecting timeseries-mock-service JSON outputs..."; \
+		mock_pods=$$(kubectl get pods -l app=timeseries-mock-service -n $(TEST_NAMESPACE) -o=jsonpath='{.items[*].metadata.name}'); \
+		if [ -z "$$mock_pods" ]; then \
+			echo "No timeseries-mock-service pods found."; \
+		else \
+			for mock_pod in $$mock_pods; do \
+				for json_file in logs metrics events manifests traces entitystateevents; do \
+					target_file=pod-logs/timeseries-mock-service-$$mock_pod-$$json_file.json; \
+					echo "Saving $$json_file.json from $$mock_pod..."; \
+					kubectl exec -n $(TEST_NAMESPACE) $$mock_pod -c file-provider -- cat /usr/share/nginx/html/$$json_file.json > $$target_file 2>/dev/null || \
+					kubectl cp $(TEST_NAMESPACE)/$$mock_pod:/usr/share/nginx/html/$$json_file.json $$target_file >/dev/null 2>&1 || \
+					echo "Failed to retrieve $$json_file.json from $$mock_pod"; \
+				done; \
+			done; \
+		fi; \
+		exit 1; \
+	else \
+		echo "========================================"; \
+		echo "Tests SUCCEEDED"; \
+		echo "========================================"; \
+	fi
+
+integration-test-cleanup: ## Cleanup Skaffold deployment
+	@echo ""
+	@echo "========================================="
+	@echo "Cleaning up Skaffold deployment..."
+	@echo "========================================="
+	@$(SKAFFOLD_ENV) skaffold delete -v info || true
+	@if [ -f $(TAGS_FILE) ]; then \
+		echo "Removing tags file: $(TAGS_FILE)"; \
+		rm -f $(TAGS_FILE); \
+	fi
+	@echo "Cleanup complete"
+	@echo ""

--- a/tests/deploy/tests/templates/integrationTestCronJob.yaml
+++ b/tests/deploy/tests/templates/integrationTestCronJob.yaml
@@ -20,5 +20,5 @@ spec:
               image: integration-test
               env:
                 - name: TIMESERIES_MOCK_ENDPOINT
-                  value: timeseries-mock-service.test-namespace.svc.cluster.local:8088
+                  value: {{ printf "timeseries-mock-service.%s.svc.cluster.local:8088" .Release.Namespace | quote }}
           restartPolicy: Never

--- a/tests/integration/test_log_collection.py
+++ b/tests/integration/test_log_collection.py
@@ -19,7 +19,11 @@ def test_logs_generated():
 
 def assert_test_log_found(content):
     raw_bodies = get_all_bodies_for_all_sent_content(content)
-    test_log_found = any(f'{tested_log}' in body for body in raw_bodies)
+    test_log_found = any(
+        f'{tested_log}' in entry
+        for body in raw_bodies
+        for entry in body
+    )
     return test_log_found
 
 def print_failure(content):


### PR DESCRIPTION
* Making integration tests runnable by Copilot Agent (adding `Makefile` and having that covered under single command `make integration-test` which will deploy environment and run tests)
* adding AGENTS.md with useful commands and instructions for agent