### PR TITLE
Update kube-state-metrics Helm subchart to 6.3.0

### DIFF
--- a/deploy/helm/Chart.lock
+++ b/deploy/helm/Chart.lock
@@ -1,7 +1,7 @@
 dependencies:
 - name: kube-state-metrics
   repository: https://prometheus-community.github.io/helm-charts
-  version: 6.1.0
+  version: 6.3.0
 - name: opentelemetry-operator
   repository: https://open-telemetry.github.io/opentelemetry-helm-charts
   version: 0.93.0
@@ -11,5 +11,5 @@ dependencies:
 - name: trivy-operator
   repository: https://aquasecurity.github.io/helm-charts
   version: 0.29.0
-digest: sha256:a9dab4b2f059c6da1e1e92a9890af0436af761a57039bf6ef9d74dcc413fb42b
-generated: "2025-10-14T16:05:26.1547329+02:00"
+digest: sha256:469090b48ea498c999414a8f12b71be5024d5b61252d1dcec251bb14f737c63d
+generated: "2025-10-23T12:49:03.2451645+02:00"

--- a/deploy/helm/Chart.yaml
+++ b/deploy/helm/Chart.yaml
@@ -20,7 +20,7 @@ maintainers:
 dependencies:
   - name: kube-state-metrics
     repository: https://prometheus-community.github.io/helm-charts
-    version: 6.1.0
+    version: 6.3.0
     condition: kube-state-metrics.enabled
   - name: opentelemetry-operator
     repository: https://open-telemetry.github.io/opentelemetry-helm-charts


### PR DESCRIPTION
No significant changes, mostly bugfixes. Of the relevant ones:
* metric `kube_deployment_status_condition` now has a new label `reason`
* this is the last version that prefers reporting data about `endpoints` instead of `endpointslices`