### PR TITLE
Enable Trivy secret scanner

### DIFF
--- a/deploy/helm/values.yaml
+++ b/deploy/helm/values.yaml
@@ -1381,7 +1381,7 @@ trivy-operator:
     rbacAssessmentScannerEnabled: false
     infraAssessmentScannerEnabled: false
     clusterComplianceEnabled: false
-    exposedSecretScannerEnabled: false
+    exposedSecretScannerEnabled: true
     sbomGenerationEnabled: false
 
     # Access to global secrets and service account tokens is disabled by default


### PR DESCRIPTION
Enable exposedSecretScannerEnabled in the Trivy Operator subchart to generate ExposedSecretReport CRDs. 