### PR TITLE
Upgrade APM Python 6.0.0

### DIFF
--- a/deploy/helm/values.yaml
+++ b/deploy/helm/values.yaml
@@ -1255,7 +1255,7 @@ operator:
         tag: ""
       python:
         repository: "solarwinds/autoinstrumentation-python"
-        tag: "5.2.1"
+        tag: "6.0.0"
       dotnet:
         repository: ""
         tag: ""


### PR DESCRIPTION
Upgrade APM Python 6.0.0, released Mar 25 2026.