### PR TITLE
fix: drop duplicate OBI flow bytes to fix 2x throughput in Network Topology

### DIFF
--- a/deploy/helm/gateway-collector-config.yaml
+++ b/deploy/helm/gateway-collector-config.yaml
@@ -340,6 +340,17 @@ processors:
       - dest.k8s.pod.name
       - dest.k8s.namespace.name
 
+  filter/obi-direction-dedup:
+    error_mode: ignore
+    metrics:
+      datapoint:
+        # Drop receiver-side (direction=response) obi.network.flow.bytes ONLY when the source is a known
+        # K8s workload (sw.k8s.src.workload.name != nil). In that case, the sender node's OBI also emits
+        # a direction=request datapoint with identical bytes, so the response side is a duplicate.
+        # When the source is external (sw.k8s.src.workload.name == nil), the response side is the only
+        # observation of that flow and must be kept.
+        - metric.name == "obi.network.flow.bytes" and datapoint.attributes["direction"] == "response" and resource.attributes["sw.k8s.src.workload.name"] != nil
+
   filter/obi-self-loop-relationships:
     error_mode: ignore
     metrics:
@@ -731,6 +742,7 @@ service:
         - transform/obi-fqdn-attribute
         - groupbyattrs/obi-entity-ids
         - transform/obi-entity-ids
+        - filter/obi-direction-dedup
         - transform/obi-relationship-types
         - groupbyattrs/obi-relationship-types
         - groupbyattrs/obi-entity-ids-after-transform

--- a/deploy/helm/tests/__snapshot__/gateway-config-map_test.yaml.snap
+++ b/deploy/helm/tests/__snapshot__/gateway-config-map_test.yaml.snap
@@ -418,6 +418,12 @@ Gateway config should match snapshot when using default values:
           metrics:
             metric:
             - type == METRIC_DATA_TYPE_HISTOGRAM
+        filter/obi-direction-dedup:
+          error_mode: ignore
+          metrics:
+            datapoint:
+            - metric.name == "obi.network.flow.bytes" and datapoint.attributes["direction"]
+              == "response" and resource.attributes["sw.k8s.src.workload.name"] != nil
         filter/obi-self-loop-relationships:
           error_mode: ignore
           metrics:
@@ -857,6 +863,7 @@ Gateway config should match snapshot when using default values:
             - transform/obi-fqdn-attribute
             - groupbyattrs/obi-entity-ids
             - transform/obi-entity-ids
+            - filter/obi-direction-dedup
             - transform/obi-relationship-types
             - groupbyattrs/obi-relationship-types
             - groupbyattrs/obi-entity-ids-after-transform


### PR DESCRIPTION
## Summary

OBI (eBPF network observer) runs as a DaemonSet. For cross-node flows, both the sender node (`direction=request`) and the receiver node (`direction=response`) independently observe and emit `obi.network.flow.bytes` for the same flow. Both datapoints are written to Chainsaw via the `metrics/obi-network-entities-and-relationships` pipeline, causing any `sum()` over the metric to return 2x the actual throughput in Network Topology.

## Fix

Add a `filter/obi-direction-dedup` processor that drops `direction=response` datapoints for `obi.network.flow.bytes`, but **only** when `sw.k8s.src.workload.name != nil` (i.e. the source is a known K8s workload, meaning a `direction=request` duplicate from the sender node exists).

External-to-internal flows — where the source is an external IP and OBI on the receiving node is the only observer — are preserved: `sw.k8s.src.workload.name` is nil for those flows, so the filter does not drop them.

The filter is placed **after** `transform/obi-entity-ids` (so direction-based fallback source/dest attribution runs first) and **before** `transform/obi-relationship-types`.

## Changes

- `deploy/helm/gateway-collector-config.yaml` — add `filter/obi-direction-dedup` processor definition and insert it into `metrics/obi-network-entities-and-relationships` pipeline
- `deploy/helm/tests/__snapshot__/gateway-config-map_test.yaml.snap` — updated snapshot

All 172 Helm unit tests pass.
