### PR TITLE
Add database entities discovery

### DIFF
--- a/deploy/helm/Chart.yaml
+++ b/deploy/helm/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: swo-k8s-collector
 version: 5.3.0-alpha.1
-appVersion: 0.145.10
+appVersion: 0.150.0
 description: SolarWinds Kubernetes Integration
 keywords:
   - monitoring

--- a/deploy/helm/events-collector-config.yaml
+++ b/deploy/helm/events-collector-config.yaml
@@ -209,6 +209,20 @@ connectors:
           attributes["sw.k8s.log.type"] == "entitystateevent"
 {{- end }}
 
+{{- if .Values.entityDiscovery.enabled }}
+  # Current SWO pipeline cannot process state events and relationships events together,
+  # so we need to split them into two separate pipelines.
+  # TODO - merge them into one pipeline when SWO supports it.
+  routing/entity-discovery:
+    default_pipelines: [logs/entity-discovery-entities]
+    table:
+      - context: log
+        pipelines:
+          - logs/entity-discovery-relationships
+        condition: |
+          attributes["otel.entity.event.type"] == "entity_relationship_state"
+{{- end }}
+
   solarwindsentity/serviceendpointsmapping:
     source_prefix: "source."
     destination_prefix: "dest."
@@ -574,7 +588,7 @@ processors:
       - k8s.gitrepository.name
 {{- end }}
 
-  resource/events:
+  resource/mandatory:
     attributes:
       # Collector and Manifest version
       - key: sw.k8s.agent.manifest.version
@@ -594,33 +608,25 @@ processors:
         value: ${CLUSTER_NAME}
         action: insert
 
+  resource/events:
+    attributes:
       - key: sw.k8s.log.type
         value: event
         action: insert
 
   resource/manifest:
     attributes:
-      # Collector and Manifest version
-      - key: sw.k8s.agent.manifest.version
-        value: ${MANIFEST_VERSION}
-        action: insert
-
-      - key: sw.k8s.agent.app.version
-        value: ${APP_VERSION}
-        action: insert
-
-      # Cluster
-      - key: sw.k8s.cluster.uid
-        value: ${CLUSTER_UID}
-        action: insert
-
-      - key: k8s.cluster.name
-        value: ${CLUSTER_NAME}
-        action: insert
-
       - key: sw.k8s.log.type
         value: manifest
         action: insert
+
+{{- if .Values.entityDiscovery.enabled }}
+  resource/entity-state-event:
+    attributes:
+      - key: sw.k8s.log.type
+        value: entitystateevent
+        action: insert
+{{- end }}
 
   resourcedetection/providers:
     timeout: 2s
@@ -743,6 +749,11 @@ receivers:
         mode: watch
 {{- end }}
 
+{{- if .Values.entityDiscovery.enabled }}
+  swok8sdiscovery:
+    reporter: "swo-k8s-collector"
+{{- end }}
+
 service:
   extensions:
 {{- if .Values.otel.events.sending_queue.offload_to_disk }}
@@ -768,6 +779,7 @@ service:
         - transform/severity
         - transform/namespace
         - transform/entity_attributes
+        - resource/mandatory
         - resource/events
         - k8sattributes
 {{- if eq (include "isNamespacesFilterEnabled" .) "true" }}
@@ -797,6 +809,7 @@ service:
         - transform/stringify_body
         - swok8sworkloadstatus
         - groupbyattrs/workloadstatus
+        - resource/mandatory
         - resource/manifest
         - resourcedetection/providers
         - k8seventgeneration
@@ -844,6 +857,7 @@ service:
 {{- if not (and .Values.otel.events.enabled .Values.otel.manifests.enabled) }}
         - filter/k8s_collector_config_include
 {{- end }}
+        - resource/mandatory
         - resource/manifest
         - k8sattributes
         - k8seventgeneration
@@ -870,6 +884,35 @@ service:
       processors:
         - memory_limiter
         - transform/scope
+        - batch
+      exporters:
+        - otlp
+{{- end }}
+
+{{- if .Values.entityDiscovery.enabled }}
+    logs/entity-discovery:
+      receivers:
+        - swok8sdiscovery
+      processors:
+        - memory_limiter
+        - resource/mandatory
+        - resource/entity-state-event
+        - transform/scope
+      exporters:
+        - routing/entity-discovery
+
+    logs/entity-discovery-entities:
+      receivers:
+        - routing/entity-discovery
+      processors:
+        - batch
+      exporters:
+        - otlp
+
+    logs/entity-discovery-relationships:
+      receivers:
+        - routing/entity-discovery
+      processors:
         - batch
       exporters:
         - otlp

--- a/deploy/helm/events-collector-config.yaml
+++ b/deploy/helm/events-collector-config.yaml
@@ -751,7 +751,54 @@ receivers:
 
 {{- if .Values.entityDiscovery.enabled }}
   swok8sdiscovery:
-    reporter: "swo-k8s-collector"
+    auth_type: serviceAccount
+    reporter: swo-k8s-collector
+    database:
+      image_rules:
+        - database_type: "redis"
+          patterns: ["(^|/)redis:.+$"]
+          default_port: 6379
+        - database_type: "mysql"
+          patterns: ["(^|/)mysql:.+$", "(^|/)mariadb:.+$", "(^|/)mysql-server:.+$"]
+          default_port: 3306
+        - database_type: "sqlserver"
+          patterns: ["(^|/)mssql:.+$", "(^|/)mssql/server:.+$"]
+          default_port: 1433
+        - database_type: "postgresql"
+          patterns: ["(^|/)postgres:.+$", "(^|/)postgresql:.+$"]
+          default_port: 5432
+        - database_type: "mongodb"
+          patterns: ["(^|/)mongo:.+$"]
+          default_port: 27017
+      domain_rules:
+        - database_type: redis
+          patterns:
+            - "\\.redis\\.cache\\.windows\\.net$"
+            - "\\.elasticache(?:\\.[a-z]{2}(?:-[a-z]+){1,2}-\\d+)?\\.amazonaws\\.com$"
+            - "\\.redis(?:\\.[a-z]{2}(?:-[a-z]+){1,2}-\\d+)?\\.amazonaws\\.com$"
+            - "\\.cache(?:\\.[a-z]{2}(?:-[a-z]+){1,2}-\\d+)?\\.amazonaws\\.com$"
+          default_port: 6379
+        - database_type: mysql
+          patterns:
+            - "\\.mysql\\.database\\.azure\\.com$"
+            - "\\.rds(?:\\.[a-z]{2}(?:-[a-z]+){1,2}-\\d+)?\\.amazonaws\\.com$"
+          default_port: 3306
+        - database_type: sqlserver
+          patterns:
+            - "\\.database\\.windows\\.net$"
+            - "\\.rds(?:\\.[a-z]{2}(?:-[a-z]+){1,2}-\\d+)?\\.amazonaws\\.com$"
+          default_port: 1433
+        - database_type: postgresql
+          patterns:
+            - "\\.postgres\\.database\\.azure\\.com$"
+            - "\\.rds(?:\\.[a-z]{2}(?:-[a-z]+){1,2}-\\d+)?\\.amazonaws\\.com$"
+          default_port: 5432
+        - database_type: mongodb
+          patterns:
+            - "\\.mongo\\.cosmos\\.azure\\.com$"
+            - "\\.docdb(?:\\.[a-z]{2}(?:-[a-z]+){1,2}-\\d+)?\\.amazonaws\\.com$"
+            - "\\.mongodb\\.net$"
+          default_port: 27017
 {{- end }}
 
 service:

--- a/deploy/helm/tests/__snapshot__/events-collector-config-map_test.yaml.snap
+++ b/deploy/helm/tests/__snapshot__/events-collector-config-map_test.yaml.snap
@@ -11,6 +11,15 @@ Cluster filter should match snapshot with combined exclude filters:
             context: resource
             pipelines:
             - logs/stateevents
+        routing/entity-discovery:
+          default_pipelines:
+          - logs/entity-discovery-entities
+          table:
+          - condition: |
+              attributes["otel.entity.event.type"] == "entity_relationship_state"
+            context: log
+            pipelines:
+            - logs/entity-discovery-relationships
         routing/manifests:
           default_pipelines:
           - logs/manifests-export
@@ -317,24 +326,17 @@ Cluster filter should match snapshot with combined exclude filters:
           check_interval: 1s
           limit_mib: 800
           spike_limit_mib: 300
+        resource/entity-state-event:
+          attributes:
+          - action: insert
+            key: sw.k8s.log.type
+            value: entitystateevent
         resource/events:
           attributes:
           - action: insert
-            key: sw.k8s.agent.manifest.version
-            value: ${MANIFEST_VERSION}
-          - action: insert
-            key: sw.k8s.agent.app.version
-            value: ${APP_VERSION}
-          - action: insert
-            key: sw.k8s.cluster.uid
-            value: ${CLUSTER_UID}
-          - action: insert
-            key: k8s.cluster.name
-            value: ${CLUSTER_NAME}
-          - action: insert
             key: sw.k8s.log.type
             value: event
-        resource/manifest:
+        resource/mandatory:
           attributes:
           - action: insert
             key: sw.k8s.agent.manifest.version
@@ -348,6 +350,8 @@ Cluster filter should match snapshot with combined exclude filters:
           - action: insert
             key: k8s.cluster.name
             value: ${CLUSTER_NAME}
+        resource/manifest:
+          attributes:
           - action: insert
             key: sw.k8s.log.type
             value: manifest
@@ -765,6 +769,8 @@ Cluster filter should match snapshot with combined exclude filters:
             - set(log.body, log.body.string)
       receivers:
         k8s_events: null
+        swok8sdiscovery:
+          reporter: swo-k8s-collector
         swok8sobjects:
           auth_type: serviceAccount
           objects:
@@ -951,6 +957,7 @@ Cluster filter should match snapshot with combined exclude filters:
             - transform/severity
             - transform/namespace
             - transform/entity_attributes
+            - resource/mandatory
             - resource/events
             - k8sattributes
             - filter/namespaces
@@ -958,6 +965,30 @@ Cluster filter should match snapshot with combined exclude filters:
             - batch
             receivers:
             - k8s_events
+          logs/entity-discovery:
+            exporters:
+            - routing/entity-discovery
+            processors:
+            - memory_limiter
+            - resource/mandatory
+            - resource/entity-state-event
+            - transform/scope
+            receivers:
+            - swok8sdiscovery
+          logs/entity-discovery-entities:
+            exporters:
+            - otlp
+            processors:
+            - batch
+            receivers:
+            - routing/entity-discovery
+          logs/entity-discovery-relationships:
+            exporters:
+            - otlp
+            processors:
+            - batch
+            receivers:
+            - routing/entity-discovery
           logs/manifests:
             exporters:
             - routing/manifests
@@ -970,6 +1001,7 @@ Cluster filter should match snapshot with combined exclude filters:
             - transform/stringify_body
             - swok8sworkloadstatus
             - groupbyattrs/workloadstatus
+            - resource/mandatory
             - resource/manifest
             - resourcedetection/providers
             - k8seventgeneration
@@ -997,6 +1029,7 @@ Cluster filter should match snapshot with combined exclude filters:
             - memory_limiter
             - transform/manifest
             - groupbyattrs/manifest
+            - resource/mandatory
             - resource/manifest
             - k8sattributes
             - k8seventgeneration
@@ -1050,6 +1083,15 @@ Cluster filter should match snapshot with combined include filters:
             context: resource
             pipelines:
             - logs/stateevents
+        routing/entity-discovery:
+          default_pipelines:
+          - logs/entity-discovery-entities
+          table:
+          - condition: |
+              attributes["otel.entity.event.type"] == "entity_relationship_state"
+            context: log
+            pipelines:
+            - logs/entity-discovery-relationships
         routing/manifests:
           default_pipelines:
           - logs/manifests-export
@@ -1352,24 +1394,17 @@ Cluster filter should match snapshot with combined include filters:
           check_interval: 1s
           limit_mib: 800
           spike_limit_mib: 300
+        resource/entity-state-event:
+          attributes:
+          - action: insert
+            key: sw.k8s.log.type
+            value: entitystateevent
         resource/events:
           attributes:
           - action: insert
-            key: sw.k8s.agent.manifest.version
-            value: ${MANIFEST_VERSION}
-          - action: insert
-            key: sw.k8s.agent.app.version
-            value: ${APP_VERSION}
-          - action: insert
-            key: sw.k8s.cluster.uid
-            value: ${CLUSTER_UID}
-          - action: insert
-            key: k8s.cluster.name
-            value: ${CLUSTER_NAME}
-          - action: insert
             key: sw.k8s.log.type
             value: event
-        resource/manifest:
+        resource/mandatory:
           attributes:
           - action: insert
             key: sw.k8s.agent.manifest.version
@@ -1383,6 +1418,8 @@ Cluster filter should match snapshot with combined include filters:
           - action: insert
             key: k8s.cluster.name
             value: ${CLUSTER_NAME}
+        resource/manifest:
+          attributes:
           - action: insert
             key: sw.k8s.log.type
             value: manifest
@@ -1800,6 +1837,8 @@ Cluster filter should match snapshot with combined include filters:
             - set(log.body, log.body.string)
       receivers:
         k8s_events: null
+        swok8sdiscovery:
+          reporter: swo-k8s-collector
         swok8sobjects:
           auth_type: serviceAccount
           objects:
@@ -1986,6 +2025,7 @@ Cluster filter should match snapshot with combined include filters:
             - transform/severity
             - transform/namespace
             - transform/entity_attributes
+            - resource/mandatory
             - resource/events
             - k8sattributes
             - filter/namespaces
@@ -1993,6 +2033,30 @@ Cluster filter should match snapshot with combined include filters:
             - batch
             receivers:
             - k8s_events
+          logs/entity-discovery:
+            exporters:
+            - routing/entity-discovery
+            processors:
+            - memory_limiter
+            - resource/mandatory
+            - resource/entity-state-event
+            - transform/scope
+            receivers:
+            - swok8sdiscovery
+          logs/entity-discovery-entities:
+            exporters:
+            - otlp
+            processors:
+            - batch
+            receivers:
+            - routing/entity-discovery
+          logs/entity-discovery-relationships:
+            exporters:
+            - otlp
+            processors:
+            - batch
+            receivers:
+            - routing/entity-discovery
           logs/manifests:
             exporters:
             - routing/manifests
@@ -2005,6 +2069,7 @@ Cluster filter should match snapshot with combined include filters:
             - transform/stringify_body
             - swok8sworkloadstatus
             - groupbyattrs/workloadstatus
+            - resource/mandatory
             - resource/manifest
             - resourcedetection/providers
             - k8seventgeneration
@@ -2032,6 +2097,7 @@ Cluster filter should match snapshot with combined include filters:
             - memory_limiter
             - transform/manifest
             - groupbyattrs/manifest
+            - resource/mandatory
             - resource/manifest
             - k8sattributes
             - k8seventgeneration
@@ -2085,6 +2151,15 @@ Cluster filter should match snapshot with exclude_namespaces:
             context: resource
             pipelines:
             - logs/stateevents
+        routing/entity-discovery:
+          default_pipelines:
+          - logs/entity-discovery-entities
+          table:
+          - condition: |
+              attributes["otel.entity.event.type"] == "entity_relationship_state"
+            context: log
+            pipelines:
+            - logs/entity-discovery-relationships
         routing/manifests:
           default_pipelines:
           - logs/manifests-export
@@ -2387,24 +2462,17 @@ Cluster filter should match snapshot with exclude_namespaces:
           check_interval: 1s
           limit_mib: 800
           spike_limit_mib: 300
+        resource/entity-state-event:
+          attributes:
+          - action: insert
+            key: sw.k8s.log.type
+            value: entitystateevent
         resource/events:
           attributes:
           - action: insert
-            key: sw.k8s.agent.manifest.version
-            value: ${MANIFEST_VERSION}
-          - action: insert
-            key: sw.k8s.agent.app.version
-            value: ${APP_VERSION}
-          - action: insert
-            key: sw.k8s.cluster.uid
-            value: ${CLUSTER_UID}
-          - action: insert
-            key: k8s.cluster.name
-            value: ${CLUSTER_NAME}
-          - action: insert
             key: sw.k8s.log.type
             value: event
-        resource/manifest:
+        resource/mandatory:
           attributes:
           - action: insert
             key: sw.k8s.agent.manifest.version
@@ -2418,6 +2486,8 @@ Cluster filter should match snapshot with exclude_namespaces:
           - action: insert
             key: k8s.cluster.name
             value: ${CLUSTER_NAME}
+        resource/manifest:
+          attributes:
           - action: insert
             key: sw.k8s.log.type
             value: manifest
@@ -2835,6 +2905,8 @@ Cluster filter should match snapshot with exclude_namespaces:
             - set(log.body, log.body.string)
       receivers:
         k8s_events: null
+        swok8sdiscovery:
+          reporter: swo-k8s-collector
         swok8sobjects:
           auth_type: serviceAccount
           objects:
@@ -3021,6 +3093,7 @@ Cluster filter should match snapshot with exclude_namespaces:
             - transform/severity
             - transform/namespace
             - transform/entity_attributes
+            - resource/mandatory
             - resource/events
             - k8sattributes
             - filter/namespaces
@@ -3028,6 +3101,30 @@ Cluster filter should match snapshot with exclude_namespaces:
             - batch
             receivers:
             - k8s_events
+          logs/entity-discovery:
+            exporters:
+            - routing/entity-discovery
+            processors:
+            - memory_limiter
+            - resource/mandatory
+            - resource/entity-state-event
+            - transform/scope
+            receivers:
+            - swok8sdiscovery
+          logs/entity-discovery-entities:
+            exporters:
+            - otlp
+            processors:
+            - batch
+            receivers:
+            - routing/entity-discovery
+          logs/entity-discovery-relationships:
+            exporters:
+            - otlp
+            processors:
+            - batch
+            receivers:
+            - routing/entity-discovery
           logs/manifests:
             exporters:
             - routing/manifests
@@ -3040,6 +3137,7 @@ Cluster filter should match snapshot with exclude_namespaces:
             - transform/stringify_body
             - swok8sworkloadstatus
             - groupbyattrs/workloadstatus
+            - resource/mandatory
             - resource/manifest
             - resourcedetection/providers
             - k8seventgeneration
@@ -3067,6 +3165,7 @@ Cluster filter should match snapshot with exclude_namespaces:
             - memory_limiter
             - transform/manifest
             - groupbyattrs/manifest
+            - resource/mandatory
             - resource/manifest
             - k8sattributes
             - k8seventgeneration
@@ -3120,6 +3219,15 @@ Cluster filter should match snapshot with exclude_namespaces_regex:
             context: resource
             pipelines:
             - logs/stateevents
+        routing/entity-discovery:
+          default_pipelines:
+          - logs/entity-discovery-entities
+          table:
+          - condition: |
+              attributes["otel.entity.event.type"] == "entity_relationship_state"
+            context: log
+            pipelines:
+            - logs/entity-discovery-relationships
         routing/manifests:
           default_pipelines:
           - logs/manifests-export
@@ -3426,24 +3534,17 @@ Cluster filter should match snapshot with exclude_namespaces_regex:
           check_interval: 1s
           limit_mib: 800
           spike_limit_mib: 300
+        resource/entity-state-event:
+          attributes:
+          - action: insert
+            key: sw.k8s.log.type
+            value: entitystateevent
         resource/events:
           attributes:
           - action: insert
-            key: sw.k8s.agent.manifest.version
-            value: ${MANIFEST_VERSION}
-          - action: insert
-            key: sw.k8s.agent.app.version
-            value: ${APP_VERSION}
-          - action: insert
-            key: sw.k8s.cluster.uid
-            value: ${CLUSTER_UID}
-          - action: insert
-            key: k8s.cluster.name
-            value: ${CLUSTER_NAME}
-          - action: insert
             key: sw.k8s.log.type
             value: event
-        resource/manifest:
+        resource/mandatory:
           attributes:
           - action: insert
             key: sw.k8s.agent.manifest.version
@@ -3457,6 +3558,8 @@ Cluster filter should match snapshot with exclude_namespaces_regex:
           - action: insert
             key: k8s.cluster.name
             value: ${CLUSTER_NAME}
+        resource/manifest:
+          attributes:
           - action: insert
             key: sw.k8s.log.type
             value: manifest
@@ -3874,6 +3977,8 @@ Cluster filter should match snapshot with exclude_namespaces_regex:
             - set(log.body, log.body.string)
       receivers:
         k8s_events: null
+        swok8sdiscovery:
+          reporter: swo-k8s-collector
         swok8sobjects:
           auth_type: serviceAccount
           objects:
@@ -4060,6 +4165,7 @@ Cluster filter should match snapshot with exclude_namespaces_regex:
             - transform/severity
             - transform/namespace
             - transform/entity_attributes
+            - resource/mandatory
             - resource/events
             - k8sattributes
             - filter/namespaces
@@ -4067,6 +4173,30 @@ Cluster filter should match snapshot with exclude_namespaces_regex:
             - batch
             receivers:
             - k8s_events
+          logs/entity-discovery:
+            exporters:
+            - routing/entity-discovery
+            processors:
+            - memory_limiter
+            - resource/mandatory
+            - resource/entity-state-event
+            - transform/scope
+            receivers:
+            - swok8sdiscovery
+          logs/entity-discovery-entities:
+            exporters:
+            - otlp
+            processors:
+            - batch
+            receivers:
+            - routing/entity-discovery
+          logs/entity-discovery-relationships:
+            exporters:
+            - otlp
+            processors:
+            - batch
+            receivers:
+            - routing/entity-discovery
           logs/manifests:
             exporters:
             - routing/manifests
@@ -4079,6 +4209,7 @@ Cluster filter should match snapshot with exclude_namespaces_regex:
             - transform/stringify_body
             - swok8sworkloadstatus
             - groupbyattrs/workloadstatus
+            - resource/mandatory
             - resource/manifest
             - resourcedetection/providers
             - k8seventgeneration
@@ -4106,6 +4237,7 @@ Cluster filter should match snapshot with exclude_namespaces_regex:
             - memory_limiter
             - transform/manifest
             - groupbyattrs/manifest
+            - resource/mandatory
             - resource/manifest
             - k8sattributes
             - k8seventgeneration
@@ -4159,6 +4291,15 @@ Cluster filter should match snapshot with include_namespaces:
             context: resource
             pipelines:
             - logs/stateevents
+        routing/entity-discovery:
+          default_pipelines:
+          - logs/entity-discovery-entities
+          table:
+          - condition: |
+              attributes["otel.entity.event.type"] == "entity_relationship_state"
+            context: log
+            pipelines:
+            - logs/entity-discovery-relationships
         routing/manifests:
           default_pipelines:
           - logs/manifests-export
@@ -4461,24 +4602,17 @@ Cluster filter should match snapshot with include_namespaces:
           check_interval: 1s
           limit_mib: 800
           spike_limit_mib: 300
+        resource/entity-state-event:
+          attributes:
+          - action: insert
+            key: sw.k8s.log.type
+            value: entitystateevent
         resource/events:
           attributes:
           - action: insert
-            key: sw.k8s.agent.manifest.version
-            value: ${MANIFEST_VERSION}
-          - action: insert
-            key: sw.k8s.agent.app.version
-            value: ${APP_VERSION}
-          - action: insert
-            key: sw.k8s.cluster.uid
-            value: ${CLUSTER_UID}
-          - action: insert
-            key: k8s.cluster.name
-            value: ${CLUSTER_NAME}
-          - action: insert
             key: sw.k8s.log.type
             value: event
-        resource/manifest:
+        resource/mandatory:
           attributes:
           - action: insert
             key: sw.k8s.agent.manifest.version
@@ -4492,6 +4626,8 @@ Cluster filter should match snapshot with include_namespaces:
           - action: insert
             key: k8s.cluster.name
             value: ${CLUSTER_NAME}
+        resource/manifest:
+          attributes:
           - action: insert
             key: sw.k8s.log.type
             value: manifest
@@ -4909,6 +5045,8 @@ Cluster filter should match snapshot with include_namespaces:
             - set(log.body, log.body.string)
       receivers:
         k8s_events: null
+        swok8sdiscovery:
+          reporter: swo-k8s-collector
         swok8sobjects:
           auth_type: serviceAccount
           objects:
@@ -5095,6 +5233,7 @@ Cluster filter should match snapshot with include_namespaces:
             - transform/severity
             - transform/namespace
             - transform/entity_attributes
+            - resource/mandatory
             - resource/events
             - k8sattributes
             - filter/namespaces
@@ -5102,6 +5241,30 @@ Cluster filter should match snapshot with include_namespaces:
             - batch
             receivers:
             - k8s_events
+          logs/entity-discovery:
+            exporters:
+            - routing/entity-discovery
+            processors:
+            - memory_limiter
+            - resource/mandatory
+            - resource/entity-state-event
+            - transform/scope
+            receivers:
+            - swok8sdiscovery
+          logs/entity-discovery-entities:
+            exporters:
+            - otlp
+            processors:
+            - batch
+            receivers:
+            - routing/entity-discovery
+          logs/entity-discovery-relationships:
+            exporters:
+            - otlp
+            processors:
+            - batch
+            receivers:
+            - routing/entity-discovery
           logs/manifests:
             exporters:
             - routing/manifests
@@ -5114,6 +5277,7 @@ Cluster filter should match snapshot with include_namespaces:
             - transform/stringify_body
             - swok8sworkloadstatus
             - groupbyattrs/workloadstatus
+            - resource/mandatory
             - resource/manifest
             - resourcedetection/providers
             - k8seventgeneration
@@ -5141,6 +5305,7 @@ Cluster filter should match snapshot with include_namespaces:
             - memory_limiter
             - transform/manifest
             - groupbyattrs/manifest
+            - resource/mandatory
             - resource/manifest
             - k8sattributes
             - k8seventgeneration
@@ -5194,6 +5359,15 @@ Cluster filter should match snapshot with include_namespaces_regex:
             context: resource
             pipelines:
             - logs/stateevents
+        routing/entity-discovery:
+          default_pipelines:
+          - logs/entity-discovery-entities
+          table:
+          - condition: |
+              attributes["otel.entity.event.type"] == "entity_relationship_state"
+            context: log
+            pipelines:
+            - logs/entity-discovery-relationships
         routing/manifests:
           default_pipelines:
           - logs/manifests-export
@@ -5497,24 +5671,17 @@ Cluster filter should match snapshot with include_namespaces_regex:
           check_interval: 1s
           limit_mib: 800
           spike_limit_mib: 300
+        resource/entity-state-event:
+          attributes:
+          - action: insert
+            key: sw.k8s.log.type
+            value: entitystateevent
         resource/events:
           attributes:
           - action: insert
-            key: sw.k8s.agent.manifest.version
-            value: ${MANIFEST_VERSION}
-          - action: insert
-            key: sw.k8s.agent.app.version
-            value: ${APP_VERSION}
-          - action: insert
-            key: sw.k8s.cluster.uid
-            value: ${CLUSTER_UID}
-          - action: insert
-            key: k8s.cluster.name
-            value: ${CLUSTER_NAME}
-          - action: insert
             key: sw.k8s.log.type
             value: event
-        resource/manifest:
+        resource/mandatory:
           attributes:
           - action: insert
             key: sw.k8s.agent.manifest.version
@@ -5528,6 +5695,8 @@ Cluster filter should match snapshot with include_namespaces_regex:
           - action: insert
             key: k8s.cluster.name
             value: ${CLUSTER_NAME}
+        resource/manifest:
+          attributes:
           - action: insert
             key: sw.k8s.log.type
             value: manifest
@@ -5945,6 +6114,8 @@ Cluster filter should match snapshot with include_namespaces_regex:
             - set(log.body, log.body.string)
       receivers:
         k8s_events: null
+        swok8sdiscovery:
+          reporter: swo-k8s-collector
         swok8sobjects:
           auth_type: serviceAccount
           objects:
@@ -6131,6 +6302,7 @@ Cluster filter should match snapshot with include_namespaces_regex:
             - transform/severity
             - transform/namespace
             - transform/entity_attributes
+            - resource/mandatory
             - resource/events
             - k8sattributes
             - filter/namespaces
@@ -6138,6 +6310,30 @@ Cluster filter should match snapshot with include_namespaces_regex:
             - batch
             receivers:
             - k8s_events
+          logs/entity-discovery:
+            exporters:
+            - routing/entity-discovery
+            processors:
+            - memory_limiter
+            - resource/mandatory
+            - resource/entity-state-event
+            - transform/scope
+            receivers:
+            - swok8sdiscovery
+          logs/entity-discovery-entities:
+            exporters:
+            - otlp
+            processors:
+            - batch
+            receivers:
+            - routing/entity-discovery
+          logs/entity-discovery-relationships:
+            exporters:
+            - otlp
+            processors:
+            - batch
+            receivers:
+            - routing/entity-discovery
           logs/manifests:
             exporters:
             - routing/manifests
@@ -6150,6 +6346,7 @@ Cluster filter should match snapshot with include_namespaces_regex:
             - transform/stringify_body
             - swok8sworkloadstatus
             - groupbyattrs/workloadstatus
+            - resource/mandatory
             - resource/manifest
             - resourcedetection/providers
             - k8seventgeneration
@@ -6177,6 +6374,7 @@ Cluster filter should match snapshot with include_namespaces_regex:
             - memory_limiter
             - transform/manifest
             - groupbyattrs/manifest
+            - resource/mandatory
             - resource/manifest
             - k8sattributes
             - k8seventgeneration
@@ -6230,6 +6428,15 @@ Custom events filter with new syntax:
             context: resource
             pipelines:
             - logs/stateevents
+        routing/entity-discovery:
+          default_pipelines:
+          - logs/entity-discovery-entities
+          table:
+          - condition: |
+              attributes["otel.entity.event.type"] == "entity_relationship_state"
+            context: log
+            pipelines:
+            - logs/entity-discovery-relationships
         routing/manifests:
           default_pipelines:
           - logs/manifests-export
@@ -6522,24 +6729,17 @@ Custom events filter with new syntax:
           check_interval: 1s
           limit_mib: 800
           spike_limit_mib: 300
+        resource/entity-state-event:
+          attributes:
+          - action: insert
+            key: sw.k8s.log.type
+            value: entitystateevent
         resource/events:
           attributes:
           - action: insert
-            key: sw.k8s.agent.manifest.version
-            value: ${MANIFEST_VERSION}
-          - action: insert
-            key: sw.k8s.agent.app.version
-            value: ${APP_VERSION}
-          - action: insert
-            key: sw.k8s.cluster.uid
-            value: ${CLUSTER_UID}
-          - action: insert
-            key: k8s.cluster.name
-            value: ${CLUSTER_NAME}
-          - action: insert
             key: sw.k8s.log.type
             value: event
-        resource/manifest:
+        resource/mandatory:
           attributes:
           - action: insert
             key: sw.k8s.agent.manifest.version
@@ -6553,6 +6753,8 @@ Custom events filter with new syntax:
           - action: insert
             key: k8s.cluster.name
             value: ${CLUSTER_NAME}
+        resource/manifest:
+          attributes:
           - action: insert
             key: sw.k8s.log.type
             value: manifest
@@ -6970,6 +7172,8 @@ Custom events filter with new syntax:
             - set(log.body, log.body.string)
       receivers:
         k8s_events: null
+        swok8sdiscovery:
+          reporter: swo-k8s-collector
         swok8sobjects:
           auth_type: serviceAccount
           objects:
@@ -7156,6 +7360,7 @@ Custom events filter with new syntax:
             - transform/severity
             - transform/namespace
             - transform/entity_attributes
+            - resource/mandatory
             - resource/events
             - k8sattributes
             - filter
@@ -7163,6 +7368,30 @@ Custom events filter with new syntax:
             - batch
             receivers:
             - k8s_events
+          logs/entity-discovery:
+            exporters:
+            - routing/entity-discovery
+            processors:
+            - memory_limiter
+            - resource/mandatory
+            - resource/entity-state-event
+            - transform/scope
+            receivers:
+            - swok8sdiscovery
+          logs/entity-discovery-entities:
+            exporters:
+            - otlp
+            processors:
+            - batch
+            receivers:
+            - routing/entity-discovery
+          logs/entity-discovery-relationships:
+            exporters:
+            - otlp
+            processors:
+            - batch
+            receivers:
+            - routing/entity-discovery
           logs/manifests:
             exporters:
             - routing/manifests
@@ -7175,6 +7404,7 @@ Custom events filter with new syntax:
             - transform/stringify_body
             - swok8sworkloadstatus
             - groupbyattrs/workloadstatus
+            - resource/mandatory
             - resource/manifest
             - resourcedetection/providers
             - k8seventgeneration
@@ -7201,6 +7431,7 @@ Custom events filter with new syntax:
             - memory_limiter
             - transform/manifest
             - groupbyattrs/manifest
+            - resource/mandatory
             - resource/manifest
             - k8sattributes
             - k8seventgeneration
@@ -7253,6 +7484,15 @@ Custom events filter with old syntax:
             context: resource
             pipelines:
             - logs/stateevents
+        routing/entity-discovery:
+          default_pipelines:
+          - logs/entity-discovery-entities
+          table:
+          - condition: |
+              attributes["otel.entity.event.type"] == "entity_relationship_state"
+            context: log
+            pipelines:
+            - logs/entity-discovery-relationships
         routing/manifests:
           default_pipelines:
           - logs/manifests-export
@@ -7548,24 +7788,17 @@ Custom events filter with old syntax:
           check_interval: 1s
           limit_mib: 800
           spike_limit_mib: 300
+        resource/entity-state-event:
+          attributes:
+          - action: insert
+            key: sw.k8s.log.type
+            value: entitystateevent
         resource/events:
           attributes:
           - action: insert
-            key: sw.k8s.agent.manifest.version
-            value: ${MANIFEST_VERSION}
-          - action: insert
-            key: sw.k8s.agent.app.version
-            value: ${APP_VERSION}
-          - action: insert
-            key: sw.k8s.cluster.uid
-            value: ${CLUSTER_UID}
-          - action: insert
-            key: k8s.cluster.name
-            value: ${CLUSTER_NAME}
-          - action: insert
             key: sw.k8s.log.type
             value: event
-        resource/manifest:
+        resource/mandatory:
           attributes:
           - action: insert
             key: sw.k8s.agent.manifest.version
@@ -7579,6 +7812,8 @@ Custom events filter with old syntax:
           - action: insert
             key: k8s.cluster.name
             value: ${CLUSTER_NAME}
+        resource/manifest:
+          attributes:
           - action: insert
             key: sw.k8s.log.type
             value: manifest
@@ -7996,6 +8231,8 @@ Custom events filter with old syntax:
             - set(log.body, log.body.string)
       receivers:
         k8s_events: null
+        swok8sdiscovery:
+          reporter: swo-k8s-collector
         swok8sobjects:
           auth_type: serviceAccount
           objects:
@@ -8183,12 +8420,37 @@ Custom events filter with old syntax:
             - transform/severity
             - transform/namespace
             - transform/entity_attributes
+            - resource/mandatory
             - resource/events
             - k8sattributes
             - transform/scope
             - batch
             receivers:
             - k8s_events
+          logs/entity-discovery:
+            exporters:
+            - routing/entity-discovery
+            processors:
+            - memory_limiter
+            - resource/mandatory
+            - resource/entity-state-event
+            - transform/scope
+            receivers:
+            - swok8sdiscovery
+          logs/entity-discovery-entities:
+            exporters:
+            - otlp
+            processors:
+            - batch
+            receivers:
+            - routing/entity-discovery
+          logs/entity-discovery-relationships:
+            exporters:
+            - otlp
+            processors:
+            - batch
+            receivers:
+            - routing/entity-discovery
           logs/manifests:
             exporters:
             - routing/manifests
@@ -8201,6 +8463,7 @@ Custom events filter with old syntax:
             - transform/stringify_body
             - swok8sworkloadstatus
             - groupbyattrs/workloadstatus
+            - resource/mandatory
             - resource/manifest
             - resourcedetection/providers
             - k8seventgeneration
@@ -8227,6 +8490,7 @@ Custom events filter with old syntax:
             - memory_limiter
             - transform/manifest
             - groupbyattrs/manifest
+            - resource/mandatory
             - resource/manifest
             - k8sattributes
             - k8seventgeneration
@@ -8279,6 +8543,15 @@ Events config should match snapshot when using default values:
             context: resource
             pipelines:
             - logs/stateevents
+        routing/entity-discovery:
+          default_pipelines:
+          - logs/entity-discovery-entities
+          table:
+          - condition: |
+              attributes["otel.entity.event.type"] == "entity_relationship_state"
+            context: log
+            pipelines:
+            - logs/entity-discovery-relationships
         routing/manifests:
           default_pipelines:
           - logs/manifests-export
@@ -8567,24 +8840,17 @@ Events config should match snapshot when using default values:
           check_interval: 1s
           limit_mib: 800
           spike_limit_mib: 300
+        resource/entity-state-event:
+          attributes:
+          - action: insert
+            key: sw.k8s.log.type
+            value: entitystateevent
         resource/events:
           attributes:
           - action: insert
-            key: sw.k8s.agent.manifest.version
-            value: ${MANIFEST_VERSION}
-          - action: insert
-            key: sw.k8s.agent.app.version
-            value: ${APP_VERSION}
-          - action: insert
-            key: sw.k8s.cluster.uid
-            value: ${CLUSTER_UID}
-          - action: insert
-            key: k8s.cluster.name
-            value: ${CLUSTER_NAME}
-          - action: insert
             key: sw.k8s.log.type
             value: event
-        resource/manifest:
+        resource/mandatory:
           attributes:
           - action: insert
             key: sw.k8s.agent.manifest.version
@@ -8598,6 +8864,8 @@ Events config should match snapshot when using default values:
           - action: insert
             key: k8s.cluster.name
             value: ${CLUSTER_NAME}
+        resource/manifest:
+          attributes:
           - action: insert
             key: sw.k8s.log.type
             value: manifest
@@ -9015,6 +9283,8 @@ Events config should match snapshot when using default values:
             - set(log.body, log.body.string)
       receivers:
         k8s_events: null
+        swok8sdiscovery:
+          reporter: swo-k8s-collector
         swok8sobjects:
           auth_type: serviceAccount
           objects:
@@ -9201,12 +9471,37 @@ Events config should match snapshot when using default values:
             - transform/severity
             - transform/namespace
             - transform/entity_attributes
+            - resource/mandatory
             - resource/events
             - k8sattributes
             - transform/scope
             - batch
             receivers:
             - k8s_events
+          logs/entity-discovery:
+            exporters:
+            - routing/entity-discovery
+            processors:
+            - memory_limiter
+            - resource/mandatory
+            - resource/entity-state-event
+            - transform/scope
+            receivers:
+            - swok8sdiscovery
+          logs/entity-discovery-entities:
+            exporters:
+            - otlp
+            processors:
+            - batch
+            receivers:
+            - routing/entity-discovery
+          logs/entity-discovery-relationships:
+            exporters:
+            - otlp
+            processors:
+            - batch
+            receivers:
+            - routing/entity-discovery
           logs/manifests:
             exporters:
             - routing/manifests
@@ -9219,6 +9514,7 @@ Events config should match snapshot when using default values:
             - transform/stringify_body
             - swok8sworkloadstatus
             - groupbyattrs/workloadstatus
+            - resource/mandatory
             - resource/manifest
             - resourcedetection/providers
             - k8seventgeneration
@@ -9245,6 +9541,7 @@ Events config should match snapshot when using default values:
             - memory_limiter
             - transform/manifest
             - groupbyattrs/manifest
+            - resource/mandatory
             - resource/manifest
             - k8sattributes
             - k8seventgeneration
@@ -9288,6 +9585,15 @@ Events config should not contain manifest collection pipeline when disabled:
   1: |
     events.config: |-
       connectors:
+        routing/entity-discovery:
+          default_pipelines:
+          - logs/entity-discovery-entities
+          table:
+          - condition: |
+              attributes["otel.entity.event.type"] == "entity_relationship_state"
+            context: log
+            pipelines:
+            - logs/entity-discovery-relationships
         routing/manifests:
           default_pipelines:
           - logs/manifests-export
@@ -9453,24 +9759,17 @@ Events config should not contain manifest collection pipeline when disabled:
           check_interval: 1s
           limit_mib: 800
           spike_limit_mib: 300
+        resource/entity-state-event:
+          attributes:
+          - action: insert
+            key: sw.k8s.log.type
+            value: entitystateevent
         resource/events:
           attributes:
           - action: insert
-            key: sw.k8s.agent.manifest.version
-            value: ${MANIFEST_VERSION}
-          - action: insert
-            key: sw.k8s.agent.app.version
-            value: ${APP_VERSION}
-          - action: insert
-            key: sw.k8s.cluster.uid
-            value: ${CLUSTER_UID}
-          - action: insert
-            key: k8s.cluster.name
-            value: ${CLUSTER_NAME}
-          - action: insert
             key: sw.k8s.log.type
             value: event
-        resource/manifest:
+        resource/mandatory:
           attributes:
           - action: insert
             key: sw.k8s.agent.manifest.version
@@ -9484,6 +9783,8 @@ Events config should not contain manifest collection pipeline when disabled:
           - action: insert
             key: k8s.cluster.name
             value: ${CLUSTER_NAME}
+        resource/manifest:
+          attributes:
           - action: insert
             key: sw.k8s.log.type
             value: manifest
@@ -9901,6 +10202,8 @@ Events config should not contain manifest collection pipeline when disabled:
             - set(log.body, log.body.string)
       receivers:
         k8s_events: null
+        swok8sdiscovery:
+          reporter: swo-k8s-collector
         swok8sobjects:
           auth_type: serviceAccount
           objects:
@@ -9921,12 +10224,37 @@ Events config should not contain manifest collection pipeline when disabled:
             - transform/severity
             - transform/namespace
             - transform/entity_attributes
+            - resource/mandatory
             - resource/events
             - k8sattributes
             - transform/scope
             - batch
             receivers:
             - k8s_events
+          logs/entity-discovery:
+            exporters:
+            - routing/entity-discovery
+            processors:
+            - memory_limiter
+            - resource/mandatory
+            - resource/entity-state-event
+            - transform/scope
+            receivers:
+            - swok8sdiscovery
+          logs/entity-discovery-entities:
+            exporters:
+            - otlp
+            processors:
+            - batch
+            receivers:
+            - routing/entity-discovery
+          logs/entity-discovery-relationships:
+            exporters:
+            - otlp
+            processors:
+            - batch
+            receivers:
+            - routing/entity-discovery
           logs/manifests:
             exporters:
             - routing/manifests
@@ -9940,6 +10268,7 @@ Events config should not contain manifest collection pipeline when disabled:
             - transform/stringify_body
             - swok8sworkloadstatus
             - groupbyattrs/workloadstatus
+            - resource/mandatory
             - resource/manifest
             - resourcedetection/providers
             - k8seventgeneration

--- a/deploy/helm/tests/__snapshot__/events-collector-config-map_test.yaml.snap
+++ b/deploy/helm/tests/__snapshot__/events-collector-config-map_test.yaml.snap
@@ -770,6 +770,62 @@ Cluster filter should match snapshot with combined exclude filters:
       receivers:
         k8s_events: null
         swok8sdiscovery:
+          auth_type: serviceAccount
+          database:
+            domain_rules:
+            - database_type: redis
+              default_port: 6379
+              patterns:
+              - \.redis\.cache\.windows\.net$
+              - \.elasticache(?:\.[a-z]{2}(?:-[a-z]+){1,2}-\d+)?\.amazonaws\.com$
+              - \.redis(?:\.[a-z]{2}(?:-[a-z]+){1,2}-\d+)?\.amazonaws\.com$
+              - \.cache(?:\.[a-z]{2}(?:-[a-z]+){1,2}-\d+)?\.amazonaws\.com$
+            - database_type: mysql
+              default_port: 3306
+              patterns:
+              - \.mysql\.database\.azure\.com$
+              - \.rds(?:\.[a-z]{2}(?:-[a-z]+){1,2}-\d+)?\.amazonaws\.com$
+            - database_type: sqlserver
+              default_port: 1433
+              patterns:
+              - \.database\.windows\.net$
+              - \.rds(?:\.[a-z]{2}(?:-[a-z]+){1,2}-\d+)?\.amazonaws\.com$
+            - database_type: postgresql
+              default_port: 5432
+              patterns:
+              - \.postgres\.database\.azure\.com$
+              - \.rds(?:\.[a-z]{2}(?:-[a-z]+){1,2}-\d+)?\.amazonaws\.com$
+            - database_type: mongodb
+              default_port: 27017
+              patterns:
+              - \.mongo\.cosmos\.azure\.com$
+              - \.docdb(?:\.[a-z]{2}(?:-[a-z]+){1,2}-\d+)?\.amazonaws\.com$
+              - \.mongodb\.net$
+            image_rules:
+            - database_type: redis
+              default_port: 6379
+              patterns:
+              - (^|/)redis:.+$
+            - database_type: mysql
+              default_port: 3306
+              patterns:
+              - (^|/)mysql:.+$
+              - (^|/)mariadb:.+$
+              - (^|/)mysql-server:.+$
+            - database_type: sqlserver
+              default_port: 1433
+              patterns:
+              - (^|/)mssql:.+$
+              - (^|/)mssql/server:.+$
+            - database_type: postgresql
+              default_port: 5432
+              patterns:
+              - (^|/)postgres:.+$
+              - (^|/)postgresql:.+$
+            - database_type: mongodb
+              default_port: 27017
+              patterns:
+              - (^|/)mongo:.+$
           reporter: swo-k8s-collector
         swok8sobjects:
           auth_type: serviceAccount
@@ -1838,6 +1894,62 @@ Cluster filter should match snapshot with combined include filters:
       receivers:
         k8s_events: null
         swok8sdiscovery:
+          auth_type: serviceAccount
+          database:
+            domain_rules:
+            - database_type: redis
+              default_port: 6379
+              patterns:
+              - \.redis\.cache\.windows\.net$
+              - \.elasticache(?:\.[a-z]{2}(?:-[a-z]+){1,2}-\d+)?\.amazonaws\.com$
+              - \.redis(?:\.[a-z]{2}(?:-[a-z]+){1,2}-\d+)?\.amazonaws\.com$
+              - \.cache(?:\.[a-z]{2}(?:-[a-z]+){1,2}-\d+)?\.amazonaws\.com$
+            - database_type: mysql
+              default_port: 3306
+              patterns:
+              - \.mysql\.database\.azure\.com$
+              - \.rds(?:\.[a-z]{2}(?:-[a-z]+){1,2}-\d+)?\.amazonaws\.com$
+            - database_type: sqlserver
+              default_port: 1433
+              patterns:
+              - \.database\.windows\.net$
+              - \.rds(?:\.[a-z]{2}(?:-[a-z]+){1,2}-\d+)?\.amazonaws\.com$
+            - database_type: postgresql
+              default_port: 5432
+              patterns:
+              - \.postgres\.database\.azure\.com$
+              - \.rds(?:\.[a-z]{2}(?:-[a-z]+){1,2}-\d+)?\.amazonaws\.com$
+            - database_type: mongodb
+              default_port: 27017
+              patterns:
+              - \.mongo\.cosmos\.azure\.com$
+              - \.docdb(?:\.[a-z]{2}(?:-[a-z]+){1,2}-\d+)?\.amazonaws\.com$
+              - \.mongodb\.net$
+            image_rules:
+            - database_type: redis
+              default_port: 6379
+              patterns:
+              - (^|/)redis:.+$
+            - database_type: mysql
+              default_port: 3306
+              patterns:
+              - (^|/)mysql:.+$
+              - (^|/)mariadb:.+$
+              - (^|/)mysql-server:.+$
+            - database_type: sqlserver
+              default_port: 1433
+              patterns:
+              - (^|/)mssql:.+$
+              - (^|/)mssql/server:.+$
+            - database_type: postgresql
+              default_port: 5432
+              patterns:
+              - (^|/)postgres:.+$
+              - (^|/)postgresql:.+$
+            - database_type: mongodb
+              default_port: 27017
+              patterns:
+              - (^|/)mongo:.+$
           reporter: swo-k8s-collector
         swok8sobjects:
           auth_type: serviceAccount
@@ -2906,6 +3018,62 @@ Cluster filter should match snapshot with exclude_namespaces:
       receivers:
         k8s_events: null
         swok8sdiscovery:
+          auth_type: serviceAccount
+          database:
+            domain_rules:
+            - database_type: redis
+              default_port: 6379
+              patterns:
+              - \.redis\.cache\.windows\.net$
+              - \.elasticache(?:\.[a-z]{2}(?:-[a-z]+){1,2}-\d+)?\.amazonaws\.com$
+              - \.redis(?:\.[a-z]{2}(?:-[a-z]+){1,2}-\d+)?\.amazonaws\.com$
+              - \.cache(?:\.[a-z]{2}(?:-[a-z]+){1,2}-\d+)?\.amazonaws\.com$
+            - database_type: mysql
+              default_port: 3306
+              patterns:
+              - \.mysql\.database\.azure\.com$
+              - \.rds(?:\.[a-z]{2}(?:-[a-z]+){1,2}-\d+)?\.amazonaws\.com$
+            - database_type: sqlserver
+              default_port: 1433
+              patterns:
+              - \.database\.windows\.net$
+              - \.rds(?:\.[a-z]{2}(?:-[a-z]+){1,2}-\d+)?\.amazonaws\.com$
+            - database_type: postgresql
+              default_port: 5432
+              patterns:
+              - \.postgres\.database\.azure\.com$
+              - \.rds(?:\.[a-z]{2}(?:-[a-z]+){1,2}-\d+)?\.amazonaws\.com$
+            - database_type: mongodb
+              default_port: 27017
+              patterns:
+              - \.mongo\.cosmos\.azure\.com$
+              - \.docdb(?:\.[a-z]{2}(?:-[a-z]+){1,2}-\d+)?\.amazonaws\.com$
+              - \.mongodb\.net$
+            image_rules:
+            - database_type: redis
+              default_port: 6379
+              patterns:
+              - (^|/)redis:.+$
+            - database_type: mysql
+              default_port: 3306
+              patterns:
+              - (^|/)mysql:.+$
+              - (^|/)mariadb:.+$
+              - (^|/)mysql-server:.+$
+            - database_type: sqlserver
+              default_port: 1433
+              patterns:
+              - (^|/)mssql:.+$
+              - (^|/)mssql/server:.+$
+            - database_type: postgresql
+              default_port: 5432
+              patterns:
+              - (^|/)postgres:.+$
+              - (^|/)postgresql:.+$
+            - database_type: mongodb
+              default_port: 27017
+              patterns:
+              - (^|/)mongo:.+$
           reporter: swo-k8s-collector
         swok8sobjects:
           auth_type: serviceAccount
@@ -3978,6 +4146,62 @@ Cluster filter should match snapshot with exclude_namespaces_regex:
       receivers:
         k8s_events: null
         swok8sdiscovery:
+          auth_type: serviceAccount
+          database:
+            domain_rules:
+            - database_type: redis
+              default_port: 6379
+              patterns:
+              - \.redis\.cache\.windows\.net$
+              - \.elasticache(?:\.[a-z]{2}(?:-[a-z]+){1,2}-\d+)?\.amazonaws\.com$
+              - \.redis(?:\.[a-z]{2}(?:-[a-z]+){1,2}-\d+)?\.amazonaws\.com$
+              - \.cache(?:\.[a-z]{2}(?:-[a-z]+){1,2}-\d+)?\.amazonaws\.com$
+            - database_type: mysql
+              default_port: 3306
+              patterns:
+              - \.mysql\.database\.azure\.com$
+              - \.rds(?:\.[a-z]{2}(?:-[a-z]+){1,2}-\d+)?\.amazonaws\.com$
+            - database_type: sqlserver
+              default_port: 1433
+              patterns:
+              - \.database\.windows\.net$
+              - \.rds(?:\.[a-z]{2}(?:-[a-z]+){1,2}-\d+)?\.amazonaws\.com$
+            - database_type: postgresql
+              default_port: 5432
+              patterns:
+              - \.postgres\.database\.azure\.com$
+              - \.rds(?:\.[a-z]{2}(?:-[a-z]+){1,2}-\d+)?\.amazonaws\.com$
+            - database_type: mongodb
+              default_port: 27017
+              patterns:
+              - \.mongo\.cosmos\.azure\.com$
+              - \.docdb(?:\.[a-z]{2}(?:-[a-z]+){1,2}-\d+)?\.amazonaws\.com$
+              - \.mongodb\.net$
+            image_rules:
+            - database_type: redis
+              default_port: 6379
+              patterns:
+              - (^|/)redis:.+$
+            - database_type: mysql
+              default_port: 3306
+              patterns:
+              - (^|/)mysql:.+$
+              - (^|/)mariadb:.+$
+              - (^|/)mysql-server:.+$
+            - database_type: sqlserver
+              default_port: 1433
+              patterns:
+              - (^|/)mssql:.+$
+              - (^|/)mssql/server:.+$
+            - database_type: postgresql
+              default_port: 5432
+              patterns:
+              - (^|/)postgres:.+$
+              - (^|/)postgresql:.+$
+            - database_type: mongodb
+              default_port: 27017
+              patterns:
+              - (^|/)mongo:.+$
           reporter: swo-k8s-collector
         swok8sobjects:
           auth_type: serviceAccount
@@ -5046,6 +5270,62 @@ Cluster filter should match snapshot with include_namespaces:
       receivers:
         k8s_events: null
         swok8sdiscovery:
+          auth_type: serviceAccount
+          database:
+            domain_rules:
+            - database_type: redis
+              default_port: 6379
+              patterns:
+              - \.redis\.cache\.windows\.net$
+              - \.elasticache(?:\.[a-z]{2}(?:-[a-z]+){1,2}-\d+)?\.amazonaws\.com$
+              - \.redis(?:\.[a-z]{2}(?:-[a-z]+){1,2}-\d+)?\.amazonaws\.com$
+              - \.cache(?:\.[a-z]{2}(?:-[a-z]+){1,2}-\d+)?\.amazonaws\.com$
+            - database_type: mysql
+              default_port: 3306
+              patterns:
+              - \.mysql\.database\.azure\.com$
+              - \.rds(?:\.[a-z]{2}(?:-[a-z]+){1,2}-\d+)?\.amazonaws\.com$
+            - database_type: sqlserver
+              default_port: 1433
+              patterns:
+              - \.database\.windows\.net$
+              - \.rds(?:\.[a-z]{2}(?:-[a-z]+){1,2}-\d+)?\.amazonaws\.com$
+            - database_type: postgresql
+              default_port: 5432
+              patterns:
+              - \.postgres\.database\.azure\.com$
+              - \.rds(?:\.[a-z]{2}(?:-[a-z]+){1,2}-\d+)?\.amazonaws\.com$
+            - database_type: mongodb
+              default_port: 27017
+              patterns:
+              - \.mongo\.cosmos\.azure\.com$
+              - \.docdb(?:\.[a-z]{2}(?:-[a-z]+){1,2}-\d+)?\.amazonaws\.com$
+              - \.mongodb\.net$
+            image_rules:
+            - database_type: redis
+              default_port: 6379
+              patterns:
+              - (^|/)redis:.+$
+            - database_type: mysql
+              default_port: 3306
+              patterns:
+              - (^|/)mysql:.+$
+              - (^|/)mariadb:.+$
+              - (^|/)mysql-server:.+$
+            - database_type: sqlserver
+              default_port: 1433
+              patterns:
+              - (^|/)mssql:.+$
+              - (^|/)mssql/server:.+$
+            - database_type: postgresql
+              default_port: 5432
+              patterns:
+              - (^|/)postgres:.+$
+              - (^|/)postgresql:.+$
+            - database_type: mongodb
+              default_port: 27017
+              patterns:
+              - (^|/)mongo:.+$
           reporter: swo-k8s-collector
         swok8sobjects:
           auth_type: serviceAccount
@@ -6115,6 +6395,62 @@ Cluster filter should match snapshot with include_namespaces_regex:
       receivers:
         k8s_events: null
         swok8sdiscovery:
+          auth_type: serviceAccount
+          database:
+            domain_rules:
+            - database_type: redis
+              default_port: 6379
+              patterns:
+              - \.redis\.cache\.windows\.net$
+              - \.elasticache(?:\.[a-z]{2}(?:-[a-z]+){1,2}-\d+)?\.amazonaws\.com$
+              - \.redis(?:\.[a-z]{2}(?:-[a-z]+){1,2}-\d+)?\.amazonaws\.com$
+              - \.cache(?:\.[a-z]{2}(?:-[a-z]+){1,2}-\d+)?\.amazonaws\.com$
+            - database_type: mysql
+              default_port: 3306
+              patterns:
+              - \.mysql\.database\.azure\.com$
+              - \.rds(?:\.[a-z]{2}(?:-[a-z]+){1,2}-\d+)?\.amazonaws\.com$
+            - database_type: sqlserver
+              default_port: 1433
+              patterns:
+              - \.database\.windows\.net$
+              - \.rds(?:\.[a-z]{2}(?:-[a-z]+){1,2}-\d+)?\.amazonaws\.com$
+            - database_type: postgresql
+              default_port: 5432
+              patterns:
+              - \.postgres\.database\.azure\.com$
+              - \.rds(?:\.[a-z]{2}(?:-[a-z]+){1,2}-\d+)?\.amazonaws\.com$
+            - database_type: mongodb
+              default_port: 27017
+              patterns:
+              - \.mongo\.cosmos\.azure\.com$
+              - \.docdb(?:\.[a-z]{2}(?:-[a-z]+){1,2}-\d+)?\.amazonaws\.com$
+              - \.mongodb\.net$
+            image_rules:
+            - database_type: redis
+              default_port: 6379
+              patterns:
+              - (^|/)redis:.+$
+            - database_type: mysql
+              default_port: 3306
+              patterns:
+              - (^|/)mysql:.+$
+              - (^|/)mariadb:.+$
+              - (^|/)mysql-server:.+$
+            - database_type: sqlserver
+              default_port: 1433
+              patterns:
+              - (^|/)mssql:.+$
+              - (^|/)mssql/server:.+$
+            - database_type: postgresql
+              default_port: 5432
+              patterns:
+              - (^|/)postgres:.+$
+              - (^|/)postgresql:.+$
+            - database_type: mongodb
+              default_port: 27017
+              patterns:
+              - (^|/)mongo:.+$
           reporter: swo-k8s-collector
         swok8sobjects:
           auth_type: serviceAccount
@@ -7173,6 +7509,62 @@ Custom events filter with new syntax:
       receivers:
         k8s_events: null
         swok8sdiscovery:
+          auth_type: serviceAccount
+          database:
+            domain_rules:
+            - database_type: redis
+              default_port: 6379
+              patterns:
+              - \.redis\.cache\.windows\.net$
+              - \.elasticache(?:\.[a-z]{2}(?:-[a-z]+){1,2}-\d+)?\.amazonaws\.com$
+              - \.redis(?:\.[a-z]{2}(?:-[a-z]+){1,2}-\d+)?\.amazonaws\.com$
+              - \.cache(?:\.[a-z]{2}(?:-[a-z]+){1,2}-\d+)?\.amazonaws\.com$
+            - database_type: mysql
+              default_port: 3306
+              patterns:
+              - \.mysql\.database\.azure\.com$
+              - \.rds(?:\.[a-z]{2}(?:-[a-z]+){1,2}-\d+)?\.amazonaws\.com$
+            - database_type: sqlserver
+              default_port: 1433
+              patterns:
+              - \.database\.windows\.net$
+              - \.rds(?:\.[a-z]{2}(?:-[a-z]+){1,2}-\d+)?\.amazonaws\.com$
+            - database_type: postgresql
+              default_port: 5432
+              patterns:
+              - \.postgres\.database\.azure\.com$
+              - \.rds(?:\.[a-z]{2}(?:-[a-z]+){1,2}-\d+)?\.amazonaws\.com$
+            - database_type: mongodb
+              default_port: 27017
+              patterns:
+              - \.mongo\.cosmos\.azure\.com$
+              - \.docdb(?:\.[a-z]{2}(?:-[a-z]+){1,2}-\d+)?\.amazonaws\.com$
+              - \.mongodb\.net$
+            image_rules:
+            - database_type: redis
+              default_port: 6379
+              patterns:
+              - (^|/)redis:.+$
+            - database_type: mysql
+              default_port: 3306
+              patterns:
+              - (^|/)mysql:.+$
+              - (^|/)mariadb:.+$
+              - (^|/)mysql-server:.+$
+            - database_type: sqlserver
+              default_port: 1433
+              patterns:
+              - (^|/)mssql:.+$
+              - (^|/)mssql/server:.+$
+            - database_type: postgresql
+              default_port: 5432
+              patterns:
+              - (^|/)postgres:.+$
+              - (^|/)postgresql:.+$
+            - database_type: mongodb
+              default_port: 27017
+              patterns:
+              - (^|/)mongo:.+$
           reporter: swo-k8s-collector
         swok8sobjects:
           auth_type: serviceAccount
@@ -8232,6 +8624,62 @@ Custom events filter with old syntax:
       receivers:
         k8s_events: null
         swok8sdiscovery:
+          auth_type: serviceAccount
+          database:
+            domain_rules:
+            - database_type: redis
+              default_port: 6379
+              patterns:
+              - \.redis\.cache\.windows\.net$
+              - \.elasticache(?:\.[a-z]{2}(?:-[a-z]+){1,2}-\d+)?\.amazonaws\.com$
+              - \.redis(?:\.[a-z]{2}(?:-[a-z]+){1,2}-\d+)?\.amazonaws\.com$
+              - \.cache(?:\.[a-z]{2}(?:-[a-z]+){1,2}-\d+)?\.amazonaws\.com$
+            - database_type: mysql
+              default_port: 3306
+              patterns:
+              - \.mysql\.database\.azure\.com$
+              - \.rds(?:\.[a-z]{2}(?:-[a-z]+){1,2}-\d+)?\.amazonaws\.com$
+            - database_type: sqlserver
+              default_port: 1433
+              patterns:
+              - \.database\.windows\.net$
+              - \.rds(?:\.[a-z]{2}(?:-[a-z]+){1,2}-\d+)?\.amazonaws\.com$
+            - database_type: postgresql
+              default_port: 5432
+              patterns:
+              - \.postgres\.database\.azure\.com$
+              - \.rds(?:\.[a-z]{2}(?:-[a-z]+){1,2}-\d+)?\.amazonaws\.com$
+            - database_type: mongodb
+              default_port: 27017
+              patterns:
+              - \.mongo\.cosmos\.azure\.com$
+              - \.docdb(?:\.[a-z]{2}(?:-[a-z]+){1,2}-\d+)?\.amazonaws\.com$
+              - \.mongodb\.net$
+            image_rules:
+            - database_type: redis
+              default_port: 6379
+              patterns:
+              - (^|/)redis:.+$
+            - database_type: mysql
+              default_port: 3306
+              patterns:
+              - (^|/)mysql:.+$
+              - (^|/)mariadb:.+$
+              - (^|/)mysql-server:.+$
+            - database_type: sqlserver
+              default_port: 1433
+              patterns:
+              - (^|/)mssql:.+$
+              - (^|/)mssql/server:.+$
+            - database_type: postgresql
+              default_port: 5432
+              patterns:
+              - (^|/)postgres:.+$
+              - (^|/)postgresql:.+$
+            - database_type: mongodb
+              default_port: 27017
+              patterns:
+              - (^|/)mongo:.+$
           reporter: swo-k8s-collector
         swok8sobjects:
           auth_type: serviceAccount
@@ -9284,6 +9732,62 @@ Events config should match snapshot when using default values:
       receivers:
         k8s_events: null
         swok8sdiscovery:
+          auth_type: serviceAccount
+          database:
+            domain_rules:
+            - database_type: redis
+              default_port: 6379
+              patterns:
+              - \.redis\.cache\.windows\.net$
+              - \.elasticache(?:\.[a-z]{2}(?:-[a-z]+){1,2}-\d+)?\.amazonaws\.com$
+              - \.redis(?:\.[a-z]{2}(?:-[a-z]+){1,2}-\d+)?\.amazonaws\.com$
+              - \.cache(?:\.[a-z]{2}(?:-[a-z]+){1,2}-\d+)?\.amazonaws\.com$
+            - database_type: mysql
+              default_port: 3306
+              patterns:
+              - \.mysql\.database\.azure\.com$
+              - \.rds(?:\.[a-z]{2}(?:-[a-z]+){1,2}-\d+)?\.amazonaws\.com$
+            - database_type: sqlserver
+              default_port: 1433
+              patterns:
+              - \.database\.windows\.net$
+              - \.rds(?:\.[a-z]{2}(?:-[a-z]+){1,2}-\d+)?\.amazonaws\.com$
+            - database_type: postgresql
+              default_port: 5432
+              patterns:
+              - \.postgres\.database\.azure\.com$
+              - \.rds(?:\.[a-z]{2}(?:-[a-z]+){1,2}-\d+)?\.amazonaws\.com$
+            - database_type: mongodb
+              default_port: 27017
+              patterns:
+              - \.mongo\.cosmos\.azure\.com$
+              - \.docdb(?:\.[a-z]{2}(?:-[a-z]+){1,2}-\d+)?\.amazonaws\.com$
+              - \.mongodb\.net$
+            image_rules:
+            - database_type: redis
+              default_port: 6379
+              patterns:
+              - (^|/)redis:.+$
+            - database_type: mysql
+              default_port: 3306
+              patterns:
+              - (^|/)mysql:.+$
+              - (^|/)mariadb:.+$
+              - (^|/)mysql-server:.+$
+            - database_type: sqlserver
+              default_port: 1433
+              patterns:
+              - (^|/)mssql:.+$
+              - (^|/)mssql/server:.+$
+            - database_type: postgresql
+              default_port: 5432
+              patterns:
+              - (^|/)postgres:.+$
+              - (^|/)postgresql:.+$
+            - database_type: mongodb
+              default_port: 27017
+              patterns:
+              - (^|/)mongo:.+$
           reporter: swo-k8s-collector
         swok8sobjects:
           auth_type: serviceAccount
@@ -10203,6 +10707,62 @@ Events config should not contain manifest collection pipeline when disabled:
       receivers:
         k8s_events: null
         swok8sdiscovery:
+          auth_type: serviceAccount
+          database:
+            domain_rules:
+            - database_type: redis
+              default_port: 6379
+              patterns:
+              - \.redis\.cache\.windows\.net$
+              - \.elasticache(?:\.[a-z]{2}(?:-[a-z]+){1,2}-\d+)?\.amazonaws\.com$
+              - \.redis(?:\.[a-z]{2}(?:-[a-z]+){1,2}-\d+)?\.amazonaws\.com$
+              - \.cache(?:\.[a-z]{2}(?:-[a-z]+){1,2}-\d+)?\.amazonaws\.com$
+            - database_type: mysql
+              default_port: 3306
+              patterns:
+              - \.mysql\.database\.azure\.com$
+              - \.rds(?:\.[a-z]{2}(?:-[a-z]+){1,2}-\d+)?\.amazonaws\.com$
+            - database_type: sqlserver
+              default_port: 1433
+              patterns:
+              - \.database\.windows\.net$
+              - \.rds(?:\.[a-z]{2}(?:-[a-z]+){1,2}-\d+)?\.amazonaws\.com$
+            - database_type: postgresql
+              default_port: 5432
+              patterns:
+              - \.postgres\.database\.azure\.com$
+              - \.rds(?:\.[a-z]{2}(?:-[a-z]+){1,2}-\d+)?\.amazonaws\.com$
+            - database_type: mongodb
+              default_port: 27017
+              patterns:
+              - \.mongo\.cosmos\.azure\.com$
+              - \.docdb(?:\.[a-z]{2}(?:-[a-z]+){1,2}-\d+)?\.amazonaws\.com$
+              - \.mongodb\.net$
+            image_rules:
+            - database_type: redis
+              default_port: 6379
+              patterns:
+              - (^|/)redis:.+$
+            - database_type: mysql
+              default_port: 3306
+              patterns:
+              - (^|/)mysql:.+$
+              - (^|/)mariadb:.+$
+              - (^|/)mysql-server:.+$
+            - database_type: sqlserver
+              default_port: 1433
+              patterns:
+              - (^|/)mssql:.+$
+              - (^|/)mssql/server:.+$
+            - database_type: postgresql
+              default_port: 5432
+              patterns:
+              - (^|/)postgres:.+$
+              - (^|/)postgresql:.+$
+            - database_type: mongodb
+              default_port: 27017
+              patterns:
+              - (^|/)mongo:.+$
           reporter: swo-k8s-collector
         swok8sobjects:
           auth_type: serviceAccount

--- a/deploy/helm/values.schema.json
+++ b/deploy/helm/values.schema.json
@@ -1807,8 +1807,17 @@
                     "type": "boolean"
                 }
             }
+        },
+        "entityDiscovery": {
+            "description": "If enabled, starts detecting potentially observable entities and their relationships.",
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean"
+                }
+            },
+            "additionalProperties": false
         }
-
     },
     "required": [
         "cluster",

--- a/deploy/helm/values.yaml
+++ b/deploy/helm/values.yaml
@@ -1404,3 +1404,8 @@ migrations:
   # In 5.x.x the discovery collector is no longer managed by OpenTelemetryOperator. To avoid conflicts the old CR has to be removed.
   cleanup_discovery_collector:
     enabled: true
+
+# Configuration for discovery of potential SWO integrations
+entityDiscovery:
+  # Define whether discovery is enabled or not
+  enabled: true


### PR DESCRIPTION
A new setting `entityDiscovery.enabled` (enabled by default) will utilize https://github.com/solarwinds/solarwinds-otel-collector-contrib/pull/154 to send discovered database instances.