### PR TITLE
fix: use in-memory cache backend for trivy scan jobs

### DIFF
--- a/deploy/helm/values.yaml
+++ b/deploy/helm/values.yaml
@@ -1366,6 +1366,10 @@ trivy-operator:
     configFile:
       scan:
         disable-telemetry: true
+      # Use in-memory cache backend to avoid BoltDB file lock contention
+      # See https://github.com/aquasecurity/trivy-operator/issues/2769
+      cache:
+        backend: memory
   trivyOperator:
     scanJobNodeSelector:
       kubernetes.io/os: linux


### PR DESCRIPTION
## Summary

Use in-memory cache backend for trivy scan jobs to avoid BoltDB file lock contention in multi-container scan pods.

## Problem

When trivy-operator scans a pod with multiple containers, it creates a scan job with one trivy container per image. All containers in the scan pod share a single `/tmp` emptyDir volume. The default BoltDB file-based cache causes lock contention between concurrent trivy processes, resulting in scan failures:

```
unable to initialize cache: unable to initialize fs cache: cache may be in use by another process: timeout
```

## Fix

Set `cache.backend: memory` in the trivy configFile defaults. This avoids the file lock entirely. There is no practical impact since scan jobs are ephemeral and don't benefit from persistent cache.

## References

- https://github.com/aquasecurity/trivy-operator/issues/2769
