### PR TITLE
Upgrade to APM Python 6.1.0

### DIFF
--- a/deploy/helm/values.yaml
+++ b/deploy/helm/values.yaml
@@ -1255,7 +1255,7 @@ operator:
         tag: ""
       python:
         repository: "solarwinds/autoinstrumentation-python"
-        tag: "6.0.0"
+        tag: "6.1.0"
       dotnet:
         repository: ""
         tag: ""


### PR DESCRIPTION
Upgrade to APM Python 6.1.0, released May 1 2026.