### PR TITLE
Update swotelcol image to 0.150.0

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -76,7 +76,7 @@ The SWO K8s Collector consists of multiple components, each with specific pipeli
 
 ### NodeCollector DaemonSet
 - **logs pipeline**: Main pipeline for logs that exports them via OTLP
-- **logs/container pipeline**: Collects container logs from files using the filelog receiver
+- **logs/container pipeline**: Collects container logs from files using the file_log receiver
 - **logs/journal pipeline**: Collects system logs from journald
 - **metrics pipeline**: Main pipeline for node-level metrics that exports them via OTLP
 - **metrics/discovery pipeline**: Uses receiver_creator to discover and collect metrics from discoverable endpoints

--- a/deploy/helm/Chart.yaml
+++ b/deploy/helm/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: swo-k8s-collector
 version: 5.3.0-alpha.1
-appVersion: 0.145.10
+appVersion: 0.150.0
 description: SolarWinds Kubernetes Integration
 keywords:
   - monitoring

--- a/deploy/helm/README.md
+++ b/deploy/helm/README.md
@@ -571,7 +571,7 @@ In case you want to send data from your own [OpenTelemetry Collector](https://gi
 ```yaml
 config:
   exporters:
-    otlp:
+    otlp_grpc:
       endpoint: <chart-name>-metrics-collector.<namespace>.svc.cluster.local:4317
 ```
 

--- a/deploy/helm/discovery-collector-config.yaml
+++ b/deploy/helm/discovery-collector-config.yaml
@@ -1,5 +1,5 @@
 exporters:
-  otlp:
+  otlp_grpc:
     endpoint: ${OTEL_ENVOY_ADDRESS}
     tls:
       insecure: ${OTEL_ENVOY_ADDRESS_TLS_INSECURE}
@@ -26,7 +26,7 @@ extensions:
 {{- end }}
 
 processors:
-  k8sattributes:
+  k8s_attributes:
 {{ include "common.k8s-instrumentation" . | indent 4 }}
 
   memory_limiter:
@@ -130,7 +130,7 @@ service:
 {{- if .Values.otel.metrics.filter_histograms }}
         - filter/histograms
 {{- end }}
-        - k8sattributes
+        - k8s_attributes
 {{- if eq (include "isNamespacesFilterEnabled" .) "true" }}
         - filter/namespaces
 {{- end }}             
@@ -141,7 +141,7 @@ service:
         - transform/scope
         - batch/metrics
       exporters:
-        - otlp
+        - otlp_grpc
     
   telemetry:
 {{- if .Values.otel.metrics.autodiscovery.discovery_collector.telemetry.logs.enabled }}

--- a/deploy/helm/events-collector-config.yaml
+++ b/deploy/helm/events-collector-config.yaml
@@ -34,7 +34,7 @@
 {{- end }}
 {{- $arrayOfWatchedResources := keys $resourceMap | sortAlpha }}
 exporters:
-  otlp:
+  otlp_grpc:
     endpoint: ${OTEL_ENVOY_ADDRESS}
     tls:
       insecure: ${OTEL_ENVOY_ADDRESS_TLS_INSECURE}
@@ -685,7 +685,7 @@ processors:
 
   batch:
 {{ toYaml .Values.otel.events.batch | indent 4 }}
-  k8sattributes:
+  k8s_attributes:
 {{ include "common.k8s-instrumentation" . | indent 4 }}
 
 
@@ -769,7 +769,7 @@ service:
         - transform/namespace
         - transform/entity_attributes
         - resource/events
-        - k8sattributes
+        - k8s_attributes
 {{- if eq (include "isNamespacesFilterEnabled" .) "true" }}
         - filter/namespaces
 {{- end }}          
@@ -779,7 +779,7 @@ service:
         - transform/scope
         - batch
       exporters:
-        - otlp
+        - otlp_grpc
 {{- end }}
 
     logs/manifests:
@@ -803,7 +803,7 @@ service:
         - transform/remove_deployed_by_collector_label_if_from_different_namespace
         - groupbyattrs/serviceendpointsmapping
         - transform/serviceendpointsmapping-renamepodip
-        - k8sattributes
+        - k8s_attributes
 {{- if eq (include "isNamespacesFilterEnabled" .) "true" }}
         - filter/namespaces_manifests
 {{- end }}
@@ -831,7 +831,7 @@ service:
         - transform/scope
         - batch
       exporters:
-        - otlp
+        - otlp_grpc
 
 {{- if and .Values.otel.manifests.enabled .Values.otel.manifests.keepalive_events.enabled }}
     logs/manifests-keepalive:
@@ -845,7 +845,7 @@ service:
         - filter/k8s_collector_config_include
 {{- end }}
         - resource/manifest
-        - k8sattributes
+        - k8s_attributes
         - k8seventgeneration
         - transform/remove_deployed_by_collector_label_if_from_different_namespace
 {{- if eq (include "isNamespacesFilterEnabled" .) "true" }}
@@ -872,7 +872,7 @@ service:
         - transform/scope
         - batch
       exporters:
-        - otlp
+        - otlp_grpc
 {{- end }}
 
   telemetry:

--- a/deploy/helm/gateway-collector-config.yaml
+++ b/deploy/helm/gateway-collector-config.yaml
@@ -1,5 +1,5 @@
 exporters:
-  otlp:
+  otlp_grpc:
     endpoint: ${OTEL_ENVOY_ADDRESS}
     tls:
       insecure: ${OTEL_ENVOY_ADDRESS_TLS_INSECURE}
@@ -40,7 +40,7 @@ processors:
   memory_limiter:
 {{ toYaml .Values.otel.gateway.memory_limiter | indent 4 }}
 
-  k8sattributes:
+  k8s_attributes:
 {{ include "common.k8s-instrumentation" . | indent 4 }}
 
   metricstransform/rename-following-otel-semantics:
@@ -685,7 +685,7 @@ service:
         - forward/metrics_common
       processors:
         - memory_limiter
-        - k8sattributes
+        - k8s_attributes
 {{- if .Values.otel.gateway.prefix }}
         - metricstransform/rename-following-otel-semantics
 {{- end }}
@@ -695,29 +695,29 @@ service:
         - transform/scope
         - batch
       exporters:
-        - otlp
+        - otlp_grpc
     logs:
       receivers:
         - otlp
       processors:
         - memory_limiter
-        - k8sattributes
+        - k8s_attributes
         - resource
         - transform/scope
         - batch
       exporters:
-        - otlp
+        - otlp_grpc
     traces:
       receivers:
         - otlp
       processors:
         - memory_limiter
-        - k8sattributes
+        - k8s_attributes
         - resource
         - transform/scope
         - batch
       exporters:
-        - otlp
+        - otlp_grpc
 
     # Current SWO pipeline cannot process state events and relationships events together,
     # so we need to split them into two separate pipelines.
@@ -759,7 +759,7 @@ service:
         - logdedup/solarwindsentity
         - batch
       exporters:
-        - otlp
+        - otlp_grpc
     logs/obi-stateevents-relationships:
       receivers:
         - solarwindsentity/obi-relationships
@@ -769,7 +769,7 @@ service:
         - logdedup/solarwindsentity
         - batch
       exporters:
-        - otlp
+        - otlp_grpc
 
   telemetry:
 {{- if .Values.otel.gateway.telemetry.logs.enabled }}

--- a/deploy/helm/metrics-collector-config.yaml
+++ b/deploy/helm/metrics-collector-config.yaml
@@ -1,5 +1,5 @@
 exporters:
-  otlp:
+  otlp_grpc:
     endpoint: ${OTEL_ENVOY_ADDRESS}
     tls:
       insecure: ${OTEL_ENVOY_ADDRESS_TLS_INSECURE}
@@ -33,7 +33,7 @@ extensions:
 {{- end }}
 
 processors:
-  k8sattributes:
+  k8s_attributes:
     auth_type: "serviceAccount"
     passthrough: false
     extract:
@@ -762,7 +762,7 @@ processors:
       - context: metric
         statements:
           # adds severity to metric name (metrics are grouped by severity)
-          - set(name, Format("%s_%s", [name, ToLowerCase(resource.attributes["severity"])])) where resource.attributes["severity"] != nil
+          - set(name, Format("%s_%s", [metric.name, ToLowerCase(resource.attributes["severity"])])) where resource.attributes["severity"] != nil
 
   metricstransform/trivy-operator-metrics-aggregation-by-image:
     transforms:
@@ -1233,7 +1233,7 @@ service:
         - metricstransform/aggregate_pod_level
         - groupbyattrs/all
         - resource/metrics
-        - k8sattributes
+        - k8s_attributes
         - transform/remove_deployed_by_collector_label_if_from_different_namespace
 {{- if eq (include "isNamespacesFilterEnabled" .) "true" }}
         - filter/namespaces
@@ -1256,7 +1256,7 @@ service:
         - transform/scope
         - batch
       exporters:
-        - otlp
+        - otlp_grpc
     
   telemetry:
 {{- if .Values.otel.metrics.telemetry.logs.enabled }}

--- a/deploy/helm/metrics-discovery-config.yaml
+++ b/deploy/helm/metrics-discovery-config.yaml
@@ -1,5 +1,5 @@
 exporters:
-  otlp:
+  otlp_grpc:
     endpoint: ${OTEL_ENVOY_ADDRESS}
     tls:
       insecure: ${OTEL_ENVOY_ADDRESS_TLS_INSECURE}
@@ -36,7 +36,7 @@ extensions:
 {{- end }}
 
 processors:
-  k8sattributes:
+  k8s_attributes:
 {{ include "common.k8s-instrumentation" . | indent 4 }}
 
   memory_limiter:
@@ -186,7 +186,7 @@ service:
 {{- if .Values.otel.metrics.filter_histograms }}
         - filter/histograms
 {{- end }}
-        - k8sattributes
+        - k8s_attributes
 {{- if eq (include "isNamespacesFilterEnabled" .) "true" }}
         - filter/namespaces
 {{- end }}             
@@ -197,7 +197,7 @@ service:
         - transform/scope
         - batch/metrics
       exporters:
-        - otlp
+        - otlp_grpc
     
   telemetry:
 {{- if .Values.aws_fargate.metrics.autodiscovery.telemetry.logs.enabled }}

--- a/deploy/helm/node-collector-config.yaml
+++ b/deploy/helm/node-collector-config.yaml
@@ -1,5 +1,5 @@
 exporters:
-  otlp:
+  otlp_grpc:
     endpoint: ${OTEL_ENVOY_ADDRESS}
     tls:
       insecure: ${OTEL_ENVOY_ADDRESS_TLS_INSECURE}
@@ -231,7 +231,7 @@ processors:
   batch/metrics:
 {{ toYaml .Values.otel.metrics.batch | indent 4 }}
 
-  k8sattributes:
+  k8s_attributes:
     auth_type: "serviceAccount"
     passthrough: false
     filter:
@@ -293,7 +293,7 @@ receivers:
       - docker
       - containerd
 {{- end}}
-  filelog:
+  file_log:
 {{- if (.isWindows) }}
     include: [ "\\var\\log\\pods\\*\\*\\*.log" ]
     exclude: [ "\\var\\log\\pods\\${POD_NAMESPACE}_${POD_NAME}*_*\\swi-opentelemetry-collector\\*.log" ]
@@ -623,7 +623,7 @@ service:
 {{- if .Values.otel.logs.container }}
     logs/container:
       receivers:
-        - filelog
+        - file_log
       processors:
         - memory_limiter
 {{- if eq (include "isDeprecatedFilterSyntax" .Values.otel.logs.filter) "true" }}
@@ -632,7 +632,7 @@ service:
         - transform/syslogify
         - groupbyattrs/common-all
         - resource/container
-        - k8sattributes
+        - k8s_attributes
 {{- if eq (include "isNamespacesFilterEnabled" .) "true" }}
         - filter/namespaces_logs
 {{- end }}           
@@ -664,7 +664,7 @@ service:
         - transform/scope
         - batch/logs
       exporters:
-        - otlp
+        - otlp_grpc
 {{- end }}
 
 {{- if .Values.otel.metrics.enabled }}
@@ -705,7 +705,7 @@ service:
 {{- if .Values.otel.metrics.filter_histograms }}
         - filter/histograms
 {{- end }}
-        - k8sattributes
+        - k8s_attributes
 {{- if eq (include "isNamespacesFilterEnabled" .) "true" }}
         - filter/namespaces
 {{- end }}             
@@ -716,7 +716,7 @@ service:
         - transform/scope
         - batch/metrics
       exporters:
-        - otlp
+        - otlp_grpc
 {{- end }}
   telemetry:
 {{- if .Values.otel.logs.telemetry.logs.enabled }}

--- a/deploy/helm/templates/_common-discovery-config.tpl
+++ b/deploy/helm/templates/_common-discovery-config.tpl
@@ -694,7 +694,7 @@ logs/stateevents-entities:
     - logdedup/solarwindsentity
     - batch/stateevents
   exporters:
-    - otlp
+    - otlp_grpc
 
 logs/stateevents-relationships:
   receivers:
@@ -707,7 +707,7 @@ logs/stateevents-relationships:
     - logdedup/solarwindsentity
     - batch/stateevents
   exporters:
-    - otlp
+    - otlp_grpc
 
 metrics/discovery-custom:
   receivers:

--- a/deploy/helm/tests/__snapshot__/events-collector-config-map_test.yaml.snap
+++ b/deploy/helm/tests/__snapshot__/events-collector-config-map_test.yaml.snap
@@ -204,7 +204,7 @@ Cluster filter should match snapshot with combined exclude filters:
                 type: KubernetesServiceRoutesTo
           source_prefix: source.
       exporters:
-        otlp:
+        otlp_grpc:
           endpoint: ${OTEL_ENVOY_ADDRESS}
           headers:
             Authorization: Bearer ${SOLARWINDS_API_TOKEN}
@@ -288,7 +288,7 @@ Cluster filter should match snapshot with combined exclude filters:
           - sw.k8s.deployment.status
           - sw.k8s.statefulset.status
           - sw.k8s.daemonset.status
-        k8sattributes:
+        k8s_attributes:
           auth_type: serviceAccount
           extract:
             metadata:
@@ -945,14 +945,14 @@ Cluster filter should match snapshot with combined exclude filters:
         pipelines:
           logs:
             exporters:
-            - otlp
+            - otlp_grpc
             processors:
             - memory_limiter
             - transform/severity
             - transform/namespace
             - transform/entity_attributes
             - resource/events
-            - k8sattributes
+            - k8s_attributes
             - filter/namespaces
             - transform/scope
             - batch
@@ -976,13 +976,13 @@ Cluster filter should match snapshot with combined exclude filters:
             - transform/remove_deployed_by_collector_label_if_from_different_namespace
             - groupbyattrs/serviceendpointsmapping
             - transform/serviceendpointsmapping-renamepodip
-            - k8sattributes
+            - k8s_attributes
             - filter/namespaces_manifests
             receivers:
             - swok8sobjects
           logs/manifests-export:
             exporters:
-            - otlp
+            - otlp_grpc
             processors:
             - memory_limiter
             - transform/scope
@@ -998,7 +998,7 @@ Cluster filter should match snapshot with combined exclude filters:
             - transform/manifest
             - groupbyattrs/manifest
             - resource/manifest
-            - k8sattributes
+            - k8s_attributes
             - k8seventgeneration
             - transform/remove_deployed_by_collector_label_if_from_different_namespace
             - filter/namespaces_manifests
@@ -1019,7 +1019,7 @@ Cluster filter should match snapshot with combined exclude filters:
             - routing/bypass-keepalive-for-entitystateevents
           logs/stateevents:
             exporters:
-            - otlp
+            - otlp_grpc
             processors:
             - memory_limiter
             - transform/scope
@@ -1243,7 +1243,7 @@ Cluster filter should match snapshot with combined include filters:
                 type: KubernetesServiceRoutesTo
           source_prefix: source.
       exporters:
-        otlp:
+        otlp_grpc:
           endpoint: ${OTEL_ENVOY_ADDRESS}
           headers:
             Authorization: Bearer ${SOLARWINDS_API_TOKEN}
@@ -1323,7 +1323,7 @@ Cluster filter should match snapshot with combined include filters:
           - sw.k8s.deployment.status
           - sw.k8s.statefulset.status
           - sw.k8s.daemonset.status
-        k8sattributes:
+        k8s_attributes:
           auth_type: serviceAccount
           extract:
             metadata:
@@ -1980,14 +1980,14 @@ Cluster filter should match snapshot with combined include filters:
         pipelines:
           logs:
             exporters:
-            - otlp
+            - otlp_grpc
             processors:
             - memory_limiter
             - transform/severity
             - transform/namespace
             - transform/entity_attributes
             - resource/events
-            - k8sattributes
+            - k8s_attributes
             - filter/namespaces
             - transform/scope
             - batch
@@ -2011,13 +2011,13 @@ Cluster filter should match snapshot with combined include filters:
             - transform/remove_deployed_by_collector_label_if_from_different_namespace
             - groupbyattrs/serviceendpointsmapping
             - transform/serviceendpointsmapping-renamepodip
-            - k8sattributes
+            - k8s_attributes
             - filter/namespaces_manifests
             receivers:
             - swok8sobjects
           logs/manifests-export:
             exporters:
-            - otlp
+            - otlp_grpc
             processors:
             - memory_limiter
             - transform/scope
@@ -2033,7 +2033,7 @@ Cluster filter should match snapshot with combined include filters:
             - transform/manifest
             - groupbyattrs/manifest
             - resource/manifest
-            - k8sattributes
+            - k8s_attributes
             - k8seventgeneration
             - transform/remove_deployed_by_collector_label_if_from_different_namespace
             - filter/namespaces_manifests
@@ -2054,7 +2054,7 @@ Cluster filter should match snapshot with combined include filters:
             - routing/bypass-keepalive-for-entitystateevents
           logs/stateevents:
             exporters:
-            - otlp
+            - otlp_grpc
             processors:
             - memory_limiter
             - transform/scope
@@ -2278,7 +2278,7 @@ Cluster filter should match snapshot with exclude_namespaces:
                 type: KubernetesServiceRoutesTo
           source_prefix: source.
       exporters:
-        otlp:
+        otlp_grpc:
           endpoint: ${OTEL_ENVOY_ADDRESS}
           headers:
             Authorization: Bearer ${SOLARWINDS_API_TOKEN}
@@ -2358,7 +2358,7 @@ Cluster filter should match snapshot with exclude_namespaces:
           - sw.k8s.deployment.status
           - sw.k8s.statefulset.status
           - sw.k8s.daemonset.status
-        k8sattributes:
+        k8s_attributes:
           auth_type: serviceAccount
           extract:
             metadata:
@@ -3015,14 +3015,14 @@ Cluster filter should match snapshot with exclude_namespaces:
         pipelines:
           logs:
             exporters:
-            - otlp
+            - otlp_grpc
             processors:
             - memory_limiter
             - transform/severity
             - transform/namespace
             - transform/entity_attributes
             - resource/events
-            - k8sattributes
+            - k8s_attributes
             - filter/namespaces
             - transform/scope
             - batch
@@ -3046,13 +3046,13 @@ Cluster filter should match snapshot with exclude_namespaces:
             - transform/remove_deployed_by_collector_label_if_from_different_namespace
             - groupbyattrs/serviceendpointsmapping
             - transform/serviceendpointsmapping-renamepodip
-            - k8sattributes
+            - k8s_attributes
             - filter/namespaces_manifests
             receivers:
             - swok8sobjects
           logs/manifests-export:
             exporters:
-            - otlp
+            - otlp_grpc
             processors:
             - memory_limiter
             - transform/scope
@@ -3068,7 +3068,7 @@ Cluster filter should match snapshot with exclude_namespaces:
             - transform/manifest
             - groupbyattrs/manifest
             - resource/manifest
-            - k8sattributes
+            - k8s_attributes
             - k8seventgeneration
             - transform/remove_deployed_by_collector_label_if_from_different_namespace
             - filter/namespaces_manifests
@@ -3089,7 +3089,7 @@ Cluster filter should match snapshot with exclude_namespaces:
             - routing/bypass-keepalive-for-entitystateevents
           logs/stateevents:
             exporters:
-            - otlp
+            - otlp_grpc
             processors:
             - memory_limiter
             - transform/scope
@@ -3313,7 +3313,7 @@ Cluster filter should match snapshot with exclude_namespaces_regex:
                 type: KubernetesServiceRoutesTo
           source_prefix: source.
       exporters:
-        otlp:
+        otlp_grpc:
           endpoint: ${OTEL_ENVOY_ADDRESS}
           headers:
             Authorization: Bearer ${SOLARWINDS_API_TOKEN}
@@ -3397,7 +3397,7 @@ Cluster filter should match snapshot with exclude_namespaces_regex:
           - sw.k8s.deployment.status
           - sw.k8s.statefulset.status
           - sw.k8s.daemonset.status
-        k8sattributes:
+        k8s_attributes:
           auth_type: serviceAccount
           extract:
             metadata:
@@ -4054,14 +4054,14 @@ Cluster filter should match snapshot with exclude_namespaces_regex:
         pipelines:
           logs:
             exporters:
-            - otlp
+            - otlp_grpc
             processors:
             - memory_limiter
             - transform/severity
             - transform/namespace
             - transform/entity_attributes
             - resource/events
-            - k8sattributes
+            - k8s_attributes
             - filter/namespaces
             - transform/scope
             - batch
@@ -4085,13 +4085,13 @@ Cluster filter should match snapshot with exclude_namespaces_regex:
             - transform/remove_deployed_by_collector_label_if_from_different_namespace
             - groupbyattrs/serviceendpointsmapping
             - transform/serviceendpointsmapping-renamepodip
-            - k8sattributes
+            - k8s_attributes
             - filter/namespaces_manifests
             receivers:
             - swok8sobjects
           logs/manifests-export:
             exporters:
-            - otlp
+            - otlp_grpc
             processors:
             - memory_limiter
             - transform/scope
@@ -4107,7 +4107,7 @@ Cluster filter should match snapshot with exclude_namespaces_regex:
             - transform/manifest
             - groupbyattrs/manifest
             - resource/manifest
-            - k8sattributes
+            - k8s_attributes
             - k8seventgeneration
             - transform/remove_deployed_by_collector_label_if_from_different_namespace
             - filter/namespaces_manifests
@@ -4128,7 +4128,7 @@ Cluster filter should match snapshot with exclude_namespaces_regex:
             - routing/bypass-keepalive-for-entitystateevents
           logs/stateevents:
             exporters:
-            - otlp
+            - otlp_grpc
             processors:
             - memory_limiter
             - transform/scope
@@ -4352,7 +4352,7 @@ Cluster filter should match snapshot with include_namespaces:
                 type: KubernetesServiceRoutesTo
           source_prefix: source.
       exporters:
-        otlp:
+        otlp_grpc:
           endpoint: ${OTEL_ENVOY_ADDRESS}
           headers:
             Authorization: Bearer ${SOLARWINDS_API_TOKEN}
@@ -4432,7 +4432,7 @@ Cluster filter should match snapshot with include_namespaces:
           - sw.k8s.deployment.status
           - sw.k8s.statefulset.status
           - sw.k8s.daemonset.status
-        k8sattributes:
+        k8s_attributes:
           auth_type: serviceAccount
           extract:
             metadata:
@@ -5089,14 +5089,14 @@ Cluster filter should match snapshot with include_namespaces:
         pipelines:
           logs:
             exporters:
-            - otlp
+            - otlp_grpc
             processors:
             - memory_limiter
             - transform/severity
             - transform/namespace
             - transform/entity_attributes
             - resource/events
-            - k8sattributes
+            - k8s_attributes
             - filter/namespaces
             - transform/scope
             - batch
@@ -5120,13 +5120,13 @@ Cluster filter should match snapshot with include_namespaces:
             - transform/remove_deployed_by_collector_label_if_from_different_namespace
             - groupbyattrs/serviceendpointsmapping
             - transform/serviceendpointsmapping-renamepodip
-            - k8sattributes
+            - k8s_attributes
             - filter/namespaces_manifests
             receivers:
             - swok8sobjects
           logs/manifests-export:
             exporters:
-            - otlp
+            - otlp_grpc
             processors:
             - memory_limiter
             - transform/scope
@@ -5142,7 +5142,7 @@ Cluster filter should match snapshot with include_namespaces:
             - transform/manifest
             - groupbyattrs/manifest
             - resource/manifest
-            - k8sattributes
+            - k8s_attributes
             - k8seventgeneration
             - transform/remove_deployed_by_collector_label_if_from_different_namespace
             - filter/namespaces_manifests
@@ -5163,7 +5163,7 @@ Cluster filter should match snapshot with include_namespaces:
             - routing/bypass-keepalive-for-entitystateevents
           logs/stateevents:
             exporters:
-            - otlp
+            - otlp_grpc
             processors:
             - memory_limiter
             - transform/scope
@@ -5387,7 +5387,7 @@ Cluster filter should match snapshot with include_namespaces_regex:
                 type: KubernetesServiceRoutesTo
           source_prefix: source.
       exporters:
-        otlp:
+        otlp_grpc:
           endpoint: ${OTEL_ENVOY_ADDRESS}
           headers:
             Authorization: Bearer ${SOLARWINDS_API_TOKEN}
@@ -5468,7 +5468,7 @@ Cluster filter should match snapshot with include_namespaces_regex:
           - sw.k8s.deployment.status
           - sw.k8s.statefulset.status
           - sw.k8s.daemonset.status
-        k8sattributes:
+        k8s_attributes:
           auth_type: serviceAccount
           extract:
             metadata:
@@ -6125,14 +6125,14 @@ Cluster filter should match snapshot with include_namespaces_regex:
         pipelines:
           logs:
             exporters:
-            - otlp
+            - otlp_grpc
             processors:
             - memory_limiter
             - transform/severity
             - transform/namespace
             - transform/entity_attributes
             - resource/events
-            - k8sattributes
+            - k8s_attributes
             - filter/namespaces
             - transform/scope
             - batch
@@ -6156,13 +6156,13 @@ Cluster filter should match snapshot with include_namespaces_regex:
             - transform/remove_deployed_by_collector_label_if_from_different_namespace
             - groupbyattrs/serviceendpointsmapping
             - transform/serviceendpointsmapping-renamepodip
-            - k8sattributes
+            - k8s_attributes
             - filter/namespaces_manifests
             receivers:
             - swok8sobjects
           logs/manifests-export:
             exporters:
-            - otlp
+            - otlp_grpc
             processors:
             - memory_limiter
             - transform/scope
@@ -6178,7 +6178,7 @@ Cluster filter should match snapshot with include_namespaces_regex:
             - transform/manifest
             - groupbyattrs/manifest
             - resource/manifest
-            - k8sattributes
+            - k8s_attributes
             - k8seventgeneration
             - transform/remove_deployed_by_collector_label_if_from_different_namespace
             - filter/namespaces_manifests
@@ -6199,7 +6199,7 @@ Cluster filter should match snapshot with include_namespaces_regex:
             - routing/bypass-keepalive-for-entitystateevents
           logs/stateevents:
             exporters:
-            - otlp
+            - otlp_grpc
             processors:
             - memory_limiter
             - transform/scope
@@ -6423,7 +6423,7 @@ Custom events filter with new syntax:
                 type: KubernetesServiceRoutesTo
           source_prefix: source.
       exporters:
-        otlp:
+        otlp_grpc:
           endpoint: ${OTEL_ENVOY_ADDRESS}
           headers:
             Authorization: Bearer ${SOLARWINDS_API_TOKEN}
@@ -6493,7 +6493,7 @@ Custom events filter with new syntax:
           - sw.k8s.deployment.status
           - sw.k8s.statefulset.status
           - sw.k8s.daemonset.status
-        k8sattributes:
+        k8s_attributes:
           auth_type: serviceAccount
           extract:
             metadata:
@@ -7150,14 +7150,14 @@ Custom events filter with new syntax:
         pipelines:
           logs:
             exporters:
-            - otlp
+            - otlp_grpc
             processors:
             - memory_limiter
             - transform/severity
             - transform/namespace
             - transform/entity_attributes
             - resource/events
-            - k8sattributes
+            - k8s_attributes
             - filter
             - transform/scope
             - batch
@@ -7181,12 +7181,12 @@ Custom events filter with new syntax:
             - transform/remove_deployed_by_collector_label_if_from_different_namespace
             - groupbyattrs/serviceendpointsmapping
             - transform/serviceendpointsmapping-renamepodip
-            - k8sattributes
+            - k8s_attributes
             receivers:
             - swok8sobjects
           logs/manifests-export:
             exporters:
-            - otlp
+            - otlp_grpc
             processors:
             - memory_limiter
             - transform/scope
@@ -7202,7 +7202,7 @@ Custom events filter with new syntax:
             - transform/manifest
             - groupbyattrs/manifest
             - resource/manifest
-            - k8sattributes
+            - k8s_attributes
             - k8seventgeneration
             - transform/remove_deployed_by_collector_label_if_from_different_namespace
             receivers:
@@ -7222,7 +7222,7 @@ Custom events filter with new syntax:
             - routing/bypass-keepalive-for-entitystateevents
           logs/stateevents:
             exporters:
-            - otlp
+            - otlp_grpc
             processors:
             - memory_limiter
             - transform/scope
@@ -7446,7 +7446,7 @@ Custom events filter with old syntax:
                 type: KubernetesServiceRoutesTo
           source_prefix: source.
       exporters:
-        otlp:
+        otlp_grpc:
           endpoint: ${OTEL_ENVOY_ADDRESS}
           headers:
             Authorization: Bearer ${SOLARWINDS_API_TOKEN}
@@ -7519,7 +7519,7 @@ Custom events filter with old syntax:
           - sw.k8s.deployment.status
           - sw.k8s.statefulset.status
           - sw.k8s.daemonset.status
-        k8sattributes:
+        k8s_attributes:
           auth_type: serviceAccount
           extract:
             metadata:
@@ -8176,7 +8176,7 @@ Custom events filter with old syntax:
         pipelines:
           logs:
             exporters:
-            - otlp
+            - otlp_grpc
             processors:
             - memory_limiter
             - filter
@@ -8184,7 +8184,7 @@ Custom events filter with old syntax:
             - transform/namespace
             - transform/entity_attributes
             - resource/events
-            - k8sattributes
+            - k8s_attributes
             - transform/scope
             - batch
             receivers:
@@ -8207,12 +8207,12 @@ Custom events filter with old syntax:
             - transform/remove_deployed_by_collector_label_if_from_different_namespace
             - groupbyattrs/serviceendpointsmapping
             - transform/serviceendpointsmapping-renamepodip
-            - k8sattributes
+            - k8s_attributes
             receivers:
             - swok8sobjects
           logs/manifests-export:
             exporters:
-            - otlp
+            - otlp_grpc
             processors:
             - memory_limiter
             - transform/scope
@@ -8228,7 +8228,7 @@ Custom events filter with old syntax:
             - transform/manifest
             - groupbyattrs/manifest
             - resource/manifest
-            - k8sattributes
+            - k8s_attributes
             - k8seventgeneration
             - transform/remove_deployed_by_collector_label_if_from_different_namespace
             receivers:
@@ -8248,7 +8248,7 @@ Custom events filter with old syntax:
             - routing/bypass-keepalive-for-entitystateevents
           logs/stateevents:
             exporters:
-            - otlp
+            - otlp_grpc
             processors:
             - memory_limiter
             - transform/scope
@@ -8472,7 +8472,7 @@ Events config should match snapshot when using default values:
                 type: KubernetesServiceRoutesTo
           source_prefix: source.
       exporters:
-        otlp:
+        otlp_grpc:
           endpoint: ${OTEL_ENVOY_ADDRESS}
           headers:
             Authorization: Bearer ${SOLARWINDS_API_TOKEN}
@@ -8538,7 +8538,7 @@ Events config should match snapshot when using default values:
           - sw.k8s.deployment.status
           - sw.k8s.statefulset.status
           - sw.k8s.daemonset.status
-        k8sattributes:
+        k8s_attributes:
           auth_type: serviceAccount
           extract:
             metadata:
@@ -9195,14 +9195,14 @@ Events config should match snapshot when using default values:
         pipelines:
           logs:
             exporters:
-            - otlp
+            - otlp_grpc
             processors:
             - memory_limiter
             - transform/severity
             - transform/namespace
             - transform/entity_attributes
             - resource/events
-            - k8sattributes
+            - k8s_attributes
             - transform/scope
             - batch
             receivers:
@@ -9225,12 +9225,12 @@ Events config should match snapshot when using default values:
             - transform/remove_deployed_by_collector_label_if_from_different_namespace
             - groupbyattrs/serviceendpointsmapping
             - transform/serviceendpointsmapping-renamepodip
-            - k8sattributes
+            - k8s_attributes
             receivers:
             - swok8sobjects
           logs/manifests-export:
             exporters:
-            - otlp
+            - otlp_grpc
             processors:
             - memory_limiter
             - transform/scope
@@ -9246,7 +9246,7 @@ Events config should match snapshot when using default values:
             - transform/manifest
             - groupbyattrs/manifest
             - resource/manifest
-            - k8sattributes
+            - k8s_attributes
             - k8seventgeneration
             - transform/remove_deployed_by_collector_label_if_from_different_namespace
             receivers:
@@ -9266,7 +9266,7 @@ Events config should match snapshot when using default values:
             - routing/bypass-keepalive-for-entitystateevents
           logs/stateevents:
             exporters:
-            - otlp
+            - otlp_grpc
             processors:
             - memory_limiter
             - transform/scope
@@ -9358,7 +9358,7 @@ Events config should not contain manifest collection pipeline when disabled:
                 type: KubernetesServiceRoutesTo
           source_prefix: source.
       exporters:
-        otlp:
+        otlp_grpc:
           endpoint: ${OTEL_ENVOY_ADDRESS}
           headers:
             Authorization: Bearer ${SOLARWINDS_API_TOKEN}
@@ -9424,7 +9424,7 @@ Events config should not contain manifest collection pipeline when disabled:
           - sw.k8s.deployment.status
           - sw.k8s.statefulset.status
           - sw.k8s.daemonset.status
-        k8sattributes:
+        k8s_attributes:
           auth_type: serviceAccount
           extract:
             metadata:
@@ -9915,14 +9915,14 @@ Events config should not contain manifest collection pipeline when disabled:
         pipelines:
           logs:
             exporters:
-            - otlp
+            - otlp_grpc
             processors:
             - memory_limiter
             - transform/severity
             - transform/namespace
             - transform/entity_attributes
             - resource/events
-            - k8sattributes
+            - k8s_attributes
             - transform/scope
             - batch
             receivers:
@@ -9946,12 +9946,12 @@ Events config should not contain manifest collection pipeline when disabled:
             - transform/remove_deployed_by_collector_label_if_from_different_namespace
             - groupbyattrs/serviceendpointsmapping
             - transform/serviceendpointsmapping-renamepodip
-            - k8sattributes
+            - k8s_attributes
             receivers:
             - swok8sobjects
           logs/manifests-export:
             exporters:
-            - otlp
+            - otlp_grpc
             processors:
             - memory_limiter
             - transform/scope

--- a/deploy/helm/tests/__snapshot__/gateway-config-map_test.yaml.snap
+++ b/deploy/helm/tests/__snapshot__/gateway-config-map_test.yaml.snap
@@ -385,7 +385,7 @@ Gateway config should match snapshot when using default values:
                 type: KubernetesCommunicatesWith
           source_prefix: source.
       exporters:
-        otlp:
+        otlp_grpc:
           endpoint: ${OTEL_ENVOY_ADDRESS}
           headers:
             Authorization: Bearer ${SOLARWINDS_API_TOKEN}
@@ -472,7 +472,7 @@ Gateway config should match snapshot when using default values:
           - tcp
           - http
           - grpc
-        k8sattributes:
+        k8s_attributes:
           auth_type: serviceAccount
           extract:
             metadata:
@@ -788,10 +788,10 @@ Gateway config should match snapshot when using default values:
         pipelines:
           logs:
             exporters:
-            - otlp
+            - otlp_grpc
             processors:
             - memory_limiter
-            - k8sattributes
+            - k8s_attributes
             - resource
             - transform/scope
             - batch
@@ -799,7 +799,7 @@ Gateway config should match snapshot when using default values:
             - otlp
           logs/obi-stateevents-entities:
             exporters:
-            - otlp
+            - otlp_grpc
             processors:
             - memory_limiter
             - transform/scope
@@ -809,7 +809,7 @@ Gateway config should match snapshot when using default values:
             - solarwindsentity/obi-entities
           logs/obi-stateevents-relationships:
             exporters:
-            - otlp
+            - otlp_grpc
             processors:
             - memory_limiter
             - transform/scope
@@ -834,10 +834,10 @@ Gateway config should match snapshot when using default values:
             - otlp
           metrics/common_out:
             exporters:
-            - otlp
+            - otlp_grpc
             processors:
             - memory_limiter
-            - k8sattributes
+            - k8s_attributes
             - metricstransform/rename-following-otel-semantics
             - attributes/clean-attributes-otlp-metrics
             - resource/clean-temporary-attributes
@@ -873,10 +873,10 @@ Gateway config should match snapshot when using default values:
             - forward/obi-relationships
           traces:
             exporters:
-            - otlp
+            - otlp_grpc
             processors:
             - memory_limiter
-            - k8sattributes
+            - k8s_attributes
             - resource
             - transform/scope
             - batch

--- a/deploy/helm/tests/__snapshot__/metrics-collector-config-map-fargate_test.yaml.snap
+++ b/deploy/helm/tests/__snapshot__/metrics-collector-config-map-fargate_test.yaml.snap
@@ -5,7 +5,7 @@ Metrics config should match snapshot when using default values:
         forward/metric-exporter: {}
         forward/prometheus: {}
       exporters:
-        otlp:
+        otlp_grpc:
           endpoint: ${OTEL_ENVOY_ADDRESS}
           headers:
             Authorization: Bearer ${SOLARWINDS_API_TOKEN}
@@ -396,7 +396,7 @@ Metrics config should match snapshot when using default values:
           - k8s.daemonset.name
           - k8s.replicaset.name
           - severity
-        k8sattributes:
+        k8s_attributes:
           auth_type: serviceAccount
           extract:
             labels:
@@ -1472,7 +1472,7 @@ Metrics config should match snapshot when using default values:
           metric_statements:
           - context: metric
             statements:
-            - set(name, Format("%s_%s", [name, ToLowerCase(resource.attributes["severity"])]))
+            - set(name, Format("%s_%s", [metric.name, ToLowerCase(resource.attributes["severity"])]))
               where resource.attributes["severity"] != nil
         transform/unify_node_attribute:
           metric_statements:
@@ -1666,7 +1666,7 @@ Metrics config should match snapshot when using default values:
         pipelines:
           metrics:
             exporters:
-            - otlp
+            - otlp_grpc
             processors:
             - memory_limiter
             - filter/histograms
@@ -1715,7 +1715,7 @@ Metrics config should match snapshot when using default values:
             - metricstransform/aggregate_pod_level
             - groupbyattrs/all
             - resource/metrics
-            - k8sattributes
+            - k8s_attributes
             - transform/remove_deployed_by_collector_label_if_from_different_namespace
             - filter/remove_temporary_metrics
             receivers:

--- a/deploy/helm/tests/__snapshot__/metrics-collector-config-map_test.yaml.snap
+++ b/deploy/helm/tests/__snapshot__/metrics-collector-config-map_test.yaml.snap
@@ -5,7 +5,7 @@ Cluster filter should match snapshot with combined exclude filters:
         forward/metric-exporter: {}
         forward/prometheus: {}
       exporters:
-        otlp:
+        otlp_grpc:
           endpoint: ${OTEL_ENVOY_ADDRESS}
           headers:
             Authorization: Bearer ${SOLARWINDS_API_TOKEN}
@@ -406,7 +406,7 @@ Cluster filter should match snapshot with combined exclude filters:
           - k8s.daemonset.name
           - k8s.replicaset.name
           - severity
-        k8sattributes:
+        k8s_attributes:
           auth_type: serviceAccount
           extract:
             labels:
@@ -1482,7 +1482,7 @@ Cluster filter should match snapshot with combined exclude filters:
           metric_statements:
           - context: metric
             statements:
-            - set(name, Format("%s_%s", [name, ToLowerCase(resource.attributes["severity"])]))
+            - set(name, Format("%s_%s", [metric.name, ToLowerCase(resource.attributes["severity"])]))
               where resource.attributes["severity"] != nil
         transform/unify_node_attribute:
           metric_statements:
@@ -1596,7 +1596,7 @@ Cluster filter should match snapshot with combined exclude filters:
         pipelines:
           metrics:
             exporters:
-            - otlp
+            - otlp_grpc
             processors:
             - memory_limiter
             - filter/histograms
@@ -1645,7 +1645,7 @@ Cluster filter should match snapshot with combined exclude filters:
             - metricstransform/aggregate_pod_level
             - groupbyattrs/all
             - resource/metrics
-            - k8sattributes
+            - k8s_attributes
             - transform/remove_deployed_by_collector_label_if_from_different_namespace
             - filter/namespaces
             - filter/remove_temporary_metrics
@@ -1691,7 +1691,7 @@ Cluster filter should match snapshot with combined include filters:
         forward/metric-exporter: {}
         forward/prometheus: {}
       exporters:
-        otlp:
+        otlp_grpc:
           endpoint: ${OTEL_ENVOY_ADDRESS}
           headers:
             Authorization: Bearer ${SOLARWINDS_API_TOKEN}
@@ -2090,7 +2090,7 @@ Cluster filter should match snapshot with combined include filters:
           - k8s.daemonset.name
           - k8s.replicaset.name
           - severity
-        k8sattributes:
+        k8s_attributes:
           auth_type: serviceAccount
           extract:
             labels:
@@ -3166,7 +3166,7 @@ Cluster filter should match snapshot with combined include filters:
           metric_statements:
           - context: metric
             statements:
-            - set(name, Format("%s_%s", [name, ToLowerCase(resource.attributes["severity"])]))
+            - set(name, Format("%s_%s", [metric.name, ToLowerCase(resource.attributes["severity"])]))
               where resource.attributes["severity"] != nil
         transform/unify_node_attribute:
           metric_statements:
@@ -3280,7 +3280,7 @@ Cluster filter should match snapshot with combined include filters:
         pipelines:
           metrics:
             exporters:
-            - otlp
+            - otlp_grpc
             processors:
             - memory_limiter
             - filter/histograms
@@ -3329,7 +3329,7 @@ Cluster filter should match snapshot with combined include filters:
             - metricstransform/aggregate_pod_level
             - groupbyattrs/all
             - resource/metrics
-            - k8sattributes
+            - k8s_attributes
             - transform/remove_deployed_by_collector_label_if_from_different_namespace
             - filter/namespaces
             - filter/remove_temporary_metrics
@@ -3375,7 +3375,7 @@ Cluster filter should match snapshot with exclude_namespaces:
         forward/metric-exporter: {}
         forward/prometheus: {}
       exporters:
-        otlp:
+        otlp_grpc:
           endpoint: ${OTEL_ENVOY_ADDRESS}
           headers:
             Authorization: Bearer ${SOLARWINDS_API_TOKEN}
@@ -3775,7 +3775,7 @@ Cluster filter should match snapshot with exclude_namespaces:
           - k8s.daemonset.name
           - k8s.replicaset.name
           - severity
-        k8sattributes:
+        k8s_attributes:
           auth_type: serviceAccount
           extract:
             labels:
@@ -4851,7 +4851,7 @@ Cluster filter should match snapshot with exclude_namespaces:
           metric_statements:
           - context: metric
             statements:
-            - set(name, Format("%s_%s", [name, ToLowerCase(resource.attributes["severity"])]))
+            - set(name, Format("%s_%s", [metric.name, ToLowerCase(resource.attributes["severity"])]))
               where resource.attributes["severity"] != nil
         transform/unify_node_attribute:
           metric_statements:
@@ -4965,7 +4965,7 @@ Cluster filter should match snapshot with exclude_namespaces:
         pipelines:
           metrics:
             exporters:
-            - otlp
+            - otlp_grpc
             processors:
             - memory_limiter
             - filter/histograms
@@ -5014,7 +5014,7 @@ Cluster filter should match snapshot with exclude_namespaces:
             - metricstransform/aggregate_pod_level
             - groupbyattrs/all
             - resource/metrics
-            - k8sattributes
+            - k8s_attributes
             - transform/remove_deployed_by_collector_label_if_from_different_namespace
             - filter/namespaces
             - filter/remove_temporary_metrics
@@ -5060,7 +5060,7 @@ Cluster filter should match snapshot with exclude_namespaces_regex:
         forward/metric-exporter: {}
         forward/prometheus: {}
       exporters:
-        otlp:
+        otlp_grpc:
           endpoint: ${OTEL_ENVOY_ADDRESS}
           headers:
             Authorization: Bearer ${SOLARWINDS_API_TOKEN}
@@ -5460,7 +5460,7 @@ Cluster filter should match snapshot with exclude_namespaces_regex:
           - k8s.daemonset.name
           - k8s.replicaset.name
           - severity
-        k8sattributes:
+        k8s_attributes:
           auth_type: serviceAccount
           extract:
             labels:
@@ -6536,7 +6536,7 @@ Cluster filter should match snapshot with exclude_namespaces_regex:
           metric_statements:
           - context: metric
             statements:
-            - set(name, Format("%s_%s", [name, ToLowerCase(resource.attributes["severity"])]))
+            - set(name, Format("%s_%s", [metric.name, ToLowerCase(resource.attributes["severity"])]))
               where resource.attributes["severity"] != nil
         transform/unify_node_attribute:
           metric_statements:
@@ -6650,7 +6650,7 @@ Cluster filter should match snapshot with exclude_namespaces_regex:
         pipelines:
           metrics:
             exporters:
-            - otlp
+            - otlp_grpc
             processors:
             - memory_limiter
             - filter/histograms
@@ -6699,7 +6699,7 @@ Cluster filter should match snapshot with exclude_namespaces_regex:
             - metricstransform/aggregate_pod_level
             - groupbyattrs/all
             - resource/metrics
-            - k8sattributes
+            - k8s_attributes
             - transform/remove_deployed_by_collector_label_if_from_different_namespace
             - filter/namespaces
             - filter/remove_temporary_metrics
@@ -6745,7 +6745,7 @@ Cluster filter should match snapshot with include_namespaces:
         forward/metric-exporter: {}
         forward/prometheus: {}
       exporters:
-        otlp:
+        otlp_grpc:
           endpoint: ${OTEL_ENVOY_ADDRESS}
           headers:
             Authorization: Bearer ${SOLARWINDS_API_TOKEN}
@@ -7144,7 +7144,7 @@ Cluster filter should match snapshot with include_namespaces:
           - k8s.daemonset.name
           - k8s.replicaset.name
           - severity
-        k8sattributes:
+        k8s_attributes:
           auth_type: serviceAccount
           extract:
             labels:
@@ -8220,7 +8220,7 @@ Cluster filter should match snapshot with include_namespaces:
           metric_statements:
           - context: metric
             statements:
-            - set(name, Format("%s_%s", [name, ToLowerCase(resource.attributes["severity"])]))
+            - set(name, Format("%s_%s", [metric.name, ToLowerCase(resource.attributes["severity"])]))
               where resource.attributes["severity"] != nil
         transform/unify_node_attribute:
           metric_statements:
@@ -8334,7 +8334,7 @@ Cluster filter should match snapshot with include_namespaces:
         pipelines:
           metrics:
             exporters:
-            - otlp
+            - otlp_grpc
             processors:
             - memory_limiter
             - filter/histograms
@@ -8383,7 +8383,7 @@ Cluster filter should match snapshot with include_namespaces:
             - metricstransform/aggregate_pod_level
             - groupbyattrs/all
             - resource/metrics
-            - k8sattributes
+            - k8s_attributes
             - transform/remove_deployed_by_collector_label_if_from_different_namespace
             - filter/namespaces
             - filter/remove_temporary_metrics
@@ -8429,7 +8429,7 @@ Cluster filter should match snapshot with include_namespaces_regex:
         forward/metric-exporter: {}
         forward/prometheus: {}
       exporters:
-        otlp:
+        otlp_grpc:
           endpoint: ${OTEL_ENVOY_ADDRESS}
           headers:
             Authorization: Bearer ${SOLARWINDS_API_TOKEN}
@@ -8828,7 +8828,7 @@ Cluster filter should match snapshot with include_namespaces_regex:
           - k8s.daemonset.name
           - k8s.replicaset.name
           - severity
-        k8sattributes:
+        k8s_attributes:
           auth_type: serviceAccount
           extract:
             labels:
@@ -9904,7 +9904,7 @@ Cluster filter should match snapshot with include_namespaces_regex:
           metric_statements:
           - context: metric
             statements:
-            - set(name, Format("%s_%s", [name, ToLowerCase(resource.attributes["severity"])]))
+            - set(name, Format("%s_%s", [metric.name, ToLowerCase(resource.attributes["severity"])]))
               where resource.attributes["severity"] != nil
         transform/unify_node_attribute:
           metric_statements:
@@ -10018,7 +10018,7 @@ Cluster filter should match snapshot with include_namespaces_regex:
         pipelines:
           metrics:
             exporters:
-            - otlp
+            - otlp_grpc
             processors:
             - memory_limiter
             - filter/histograms
@@ -10067,7 +10067,7 @@ Cluster filter should match snapshot with include_namespaces_regex:
             - metricstransform/aggregate_pod_level
             - groupbyattrs/all
             - resource/metrics
-            - k8sattributes
+            - k8s_attributes
             - transform/remove_deployed_by_collector_label_if_from_different_namespace
             - filter/namespaces
             - filter/remove_temporary_metrics
@@ -10113,7 +10113,7 @@ Metrics config should match snapshot when fargate is enabled:
         forward/metric-exporter: {}
         forward/prometheus: {}
       exporters:
-        otlp:
+        otlp_grpc:
           endpoint: ${OTEL_ENVOY_ADDRESS}
           headers:
             Authorization: Bearer ${SOLARWINDS_API_TOKEN}
@@ -10504,7 +10504,7 @@ Metrics config should match snapshot when fargate is enabled:
           - k8s.daemonset.name
           - k8s.replicaset.name
           - severity
-        k8sattributes:
+        k8s_attributes:
           auth_type: serviceAccount
           extract:
             labels:
@@ -11580,7 +11580,7 @@ Metrics config should match snapshot when fargate is enabled:
           metric_statements:
           - context: metric
             statements:
-            - set(name, Format("%s_%s", [name, ToLowerCase(resource.attributes["severity"])]))
+            - set(name, Format("%s_%s", [metric.name, ToLowerCase(resource.attributes["severity"])]))
               where resource.attributes["severity"] != nil
         transform/unify_node_attribute:
           metric_statements:
@@ -11774,7 +11774,7 @@ Metrics config should match snapshot when fargate is enabled:
         pipelines:
           metrics:
             exporters:
-            - otlp
+            - otlp_grpc
             processors:
             - memory_limiter
             - filter/histograms
@@ -11823,7 +11823,7 @@ Metrics config should match snapshot when fargate is enabled:
             - metricstransform/aggregate_pod_level
             - groupbyattrs/all
             - resource/metrics
-            - k8sattributes
+            - k8s_attributes
             - transform/remove_deployed_by_collector_label_if_from_different_namespace
             - filter/remove_temporary_metrics
             receivers:
@@ -11875,7 +11875,7 @@ Metrics config should match snapshot when using Prometheus url with extra_scrape
             pipelines:
             - metrics/prometheus-passthrough
       exporters:
-        otlp:
+        otlp_grpc:
           endpoint: ${OTEL_ENVOY_ADDRESS}
           headers:
             Authorization: Bearer ${SOLARWINDS_API_TOKEN}
@@ -12269,7 +12269,7 @@ Metrics config should match snapshot when using Prometheus url with extra_scrape
           - k8s.daemonset.name
           - k8s.replicaset.name
           - severity
-        k8sattributes:
+        k8s_attributes:
           auth_type: serviceAccount
           extract:
             labels:
@@ -13369,7 +13369,7 @@ Metrics config should match snapshot when using Prometheus url with extra_scrape
           metric_statements:
           - context: metric
             statements:
-            - set(name, Format("%s_%s", [name, ToLowerCase(resource.attributes["severity"])]))
+            - set(name, Format("%s_%s", [metric.name, ToLowerCase(resource.attributes["severity"])]))
               where resource.attributes["severity"] != nil
         transform/unify_node_attribute:
           metric_statements:
@@ -13498,7 +13498,7 @@ Metrics config should match snapshot when using Prometheus url with extra_scrape
         pipelines:
           metrics:
             exporters:
-            - otlp
+            - otlp_grpc
             processors:
             - memory_limiter
             - filter/histograms
@@ -13547,7 +13547,7 @@ Metrics config should match snapshot when using Prometheus url with extra_scrape
             - metricstransform/aggregate_pod_level
             - groupbyattrs/all
             - resource/metrics
-            - k8sattributes
+            - k8s_attributes
             - transform/remove_deployed_by_collector_label_if_from_different_namespace
             - filter/remove_temporary_metrics
             receivers:
@@ -13611,7 +13611,7 @@ Metrics config should match snapshot when using default values:
         forward/metric-exporter: {}
         forward/prometheus: {}
       exporters:
-        otlp:
+        otlp_grpc:
           endpoint: ${OTEL_ENVOY_ADDRESS}
           headers:
             Authorization: Bearer ${SOLARWINDS_API_TOKEN}
@@ -14005,7 +14005,7 @@ Metrics config should match snapshot when using default values:
           - k8s.daemonset.name
           - k8s.replicaset.name
           - severity
-        k8sattributes:
+        k8s_attributes:
           auth_type: serviceAccount
           extract:
             labels:
@@ -15081,7 +15081,7 @@ Metrics config should match snapshot when using default values:
           metric_statements:
           - context: metric
             statements:
-            - set(name, Format("%s_%s", [name, ToLowerCase(resource.attributes["severity"])]))
+            - set(name, Format("%s_%s", [metric.name, ToLowerCase(resource.attributes["severity"])]))
               where resource.attributes["severity"] != nil
         transform/unify_node_attribute:
           metric_statements:
@@ -15195,7 +15195,7 @@ Metrics config should match snapshot when using default values:
         pipelines:
           metrics:
             exporters:
-            - otlp
+            - otlp_grpc
             processors:
             - memory_limiter
             - filter/histograms
@@ -15244,7 +15244,7 @@ Metrics config should match snapshot when using default values:
             - metricstransform/aggregate_pod_level
             - groupbyattrs/all
             - resource/metrics
-            - k8sattributes
+            - k8s_attributes
             - transform/remove_deployed_by_collector_label_if_from_different_namespace
             - filter/remove_temporary_metrics
             receivers:

--- a/deploy/helm/tests/__snapshot__/metrics-discovery-config-map_test.yaml.snap
+++ b/deploy/helm/tests/__snapshot__/metrics-discovery-config-map_test.yaml.snap
@@ -325,7 +325,7 @@ Metrics discovery config should match snapshot when Fargate is enabled:
                 type: KubernetesCommunicatesWith
           source_prefix: source.
       exporters:
-        otlp:
+        otlp_grpc:
           endpoint: ${OTEL_ENVOY_ADDRESS}
           headers:
             Authorization: Bearer ${SOLARWINDS_API_TOKEN}
@@ -462,7 +462,7 @@ Metrics discovery config should match snapshot when Fargate is enabled:
           - dest.k8s.namespace.name
           - dest.k8s.service.name
           - dest.sw.server.address.fqdn
-        k8sattributes:
+        k8s_attributes:
           auth_type: serviceAccount
           extract:
             metadata:
@@ -763,7 +763,7 @@ Metrics discovery config should match snapshot when Fargate is enabled:
         pipelines:
           logs/stateevents-entities:
             exporters:
-            - otlp
+            - otlp_grpc
             processors:
             - memory_limiter
             - filter/keep-entity-state-events
@@ -775,7 +775,7 @@ Metrics discovery config should match snapshot when Fargate is enabled:
             - solarwindsentity/istio-workload-service
           logs/stateevents-relationships:
             exporters:
-            - otlp
+            - otlp_grpc
             processors:
             - memory_limiter
             - filter/keep-relationship-state-events
@@ -787,11 +787,11 @@ Metrics discovery config should match snapshot when Fargate is enabled:
             - solarwindsentity/istio-workload-service
           metrics:
             exporters:
-            - otlp
+            - otlp_grpc
             processors:
             - memory_limiter
             - filter/histograms
-            - k8sattributes
+            - k8s_attributes
             - filter/remove_temporary_metrics
             - transform/scope
             - batch/metrics

--- a/deploy/helm/tests/__snapshot__/node-collector-config-map-windows_test.yaml.snap
+++ b/deploy/helm/tests/__snapshot__/node-collector-config-map-windows_test.yaml.snap
@@ -326,7 +326,7 @@ Node collector config for windows nodes should match snapshot when using default
                 type: KubernetesCommunicatesWith
           source_prefix: source.
       exporters:
-        otlp:
+        otlp_grpc:
           endpoint: ${OTEL_ENVOY_ADDRESS}
           headers:
             Authorization: Bearer ${SOLARWINDS_API_TOKEN}
@@ -628,7 +628,7 @@ Node collector config for windows nodes should match snapshot when using default
           keys:
           - namespace
           - pod
-        k8sattributes:
+        k8s_attributes:
           auth_type: serviceAccount
           extract:
             metadata:
@@ -1448,7 +1448,7 @@ Node collector config for windows nodes should match snapshot when using default
               where IsMatch(metric.name, "^(container_.*)$") == true and datapoint.attributes["k8s.node.name"]
               == nil
       receivers:
-        filelog:
+        file_log:
           encoding: utf-8
           exclude:
           - \var\log\pods\${POD_NAMESPACE}_${POD_NAME}*_*\swi-opentelemetry-collector\*.log
@@ -1650,7 +1650,7 @@ Node collector config for windows nodes should match snapshot when using default
         pipelines:
           logs:
             exporters:
-            - otlp
+            - otlp_grpc
             processors:
             - memory_limiter
             - transform/scope
@@ -1665,12 +1665,12 @@ Node collector config for windows nodes should match snapshot when using default
             - transform/syslogify
             - groupbyattrs/common-all
             - resource/container
-            - k8sattributes
+            - k8s_attributes
             receivers:
-            - filelog
+            - file_log
           logs/stateevents-entities:
             exporters:
-            - otlp
+            - otlp_grpc
             processors:
             - memory_limiter
             - filter/keep-entity-state-events
@@ -1682,7 +1682,7 @@ Node collector config for windows nodes should match snapshot when using default
             - solarwindsentity/istio-workload-service
           logs/stateevents-relationships:
             exporters:
-            - otlp
+            - otlp_grpc
             processors:
             - memory_limiter
             - filter/keep-relationship-state-events
@@ -1694,11 +1694,11 @@ Node collector config for windows nodes should match snapshot when using default
             - solarwindsentity/istio-workload-service
           metrics:
             exporters:
-            - otlp
+            - otlp_grpc
             processors:
             - memory_limiter
             - filter/histograms
-            - k8sattributes
+            - k8s_attributes
             - filter/remove_temporary_metrics
             - transform/scope
             - batch/metrics
@@ -2162,7 +2162,7 @@ Node collector config for windows nodes should match snapshot when using legacy 
                 type: KubernetesCommunicatesWith
           source_prefix: source.
       exporters:
-        otlp:
+        otlp_grpc:
           endpoint: ${OTEL_ENVOY_ADDRESS}
           headers:
             Authorization: Bearer ${SOLARWINDS_API_TOKEN}
@@ -2471,7 +2471,7 @@ Node collector config for windows nodes should match snapshot when using legacy 
           keys:
           - namespace
           - pod
-        k8sattributes:
+        k8s_attributes:
           auth_type: serviceAccount
           extract:
             metadata:
@@ -3291,7 +3291,7 @@ Node collector config for windows nodes should match snapshot when using legacy 
               where IsMatch(metric.name, "^(container_.*)$") == true and datapoint.attributes["k8s.node.name"]
               == nil
       receivers:
-        filelog:
+        file_log:
           encoding: utf-8
           exclude:
           - \var\log\pods\${POD_NAMESPACE}_${POD_NAME}*_*\swi-opentelemetry-collector\*.log
@@ -3574,7 +3574,7 @@ Node collector config for windows nodes should match snapshot when using legacy 
         pipelines:
           logs:
             exporters:
-            - otlp
+            - otlp_grpc
             processors:
             - memory_limiter
             - transform/scope
@@ -3590,12 +3590,12 @@ Node collector config for windows nodes should match snapshot when using legacy 
             - transform/syslogify
             - groupbyattrs/common-all
             - resource/container
-            - k8sattributes
+            - k8s_attributes
             receivers:
-            - filelog
+            - file_log
           logs/stateevents-entities:
             exporters:
-            - otlp
+            - otlp_grpc
             processors:
             - memory_limiter
             - filter/keep-entity-state-events
@@ -3607,7 +3607,7 @@ Node collector config for windows nodes should match snapshot when using legacy 
             - solarwindsentity/istio-workload-service
           logs/stateevents-relationships:
             exporters:
-            - otlp
+            - otlp_grpc
             processors:
             - memory_limiter
             - filter/keep-relationship-state-events
@@ -3619,11 +3619,11 @@ Node collector config for windows nodes should match snapshot when using legacy 
             - solarwindsentity/istio-workload-service
           metrics:
             exporters:
-            - otlp
+            - otlp_grpc
             processors:
             - memory_limiter
             - filter/histograms
-            - k8sattributes
+            - k8s_attributes
             - filter/remove_temporary_metrics
             - transform/scope
             - batch/metrics

--- a/deploy/helm/tests/__snapshot__/node-collector-config-map_test.yaml.snap
+++ b/deploy/helm/tests/__snapshot__/node-collector-config-map_test.yaml.snap
@@ -326,7 +326,7 @@ Cluster filter should match snapshot with combined exclude filters:
                 type: KubernetesCommunicatesWith
           source_prefix: source.
       exporters:
-        otlp:
+        otlp_grpc:
           endpoint: ${OTEL_ENVOY_ADDRESS}
           headers:
             Authorization: Bearer ${SOLARWINDS_API_TOKEN}
@@ -642,7 +642,7 @@ Cluster filter should match snapshot with combined exclude filters:
           keys:
           - namespace
           - pod
-        k8sattributes:
+        k8s_attributes:
           auth_type: serviceAccount
           extract:
             metadata:
@@ -1482,7 +1482,7 @@ Cluster filter should match snapshot with combined exclude filters:
               where IsMatch(metric.name, "^(container_.*)$") == true and datapoint.attributes["k8s.node.name"]
               == nil
       receivers:
-        filelog:
+        file_log:
           encoding: utf-8
           exclude:
           - /var/log/pods/${POD_NAMESPACE}_${POD_NAME}*_*/swi-opentelemetry-collector/*.log
@@ -1691,7 +1691,7 @@ Cluster filter should match snapshot with combined exclude filters:
         pipelines:
           logs:
             exporters:
-            - otlp
+            - otlp_grpc
             processors:
             - memory_limiter
             - transform/scope
@@ -1706,10 +1706,10 @@ Cluster filter should match snapshot with combined exclude filters:
             - transform/syslogify
             - groupbyattrs/common-all
             - resource/container
-            - k8sattributes
+            - k8s_attributes
             - filter/namespaces_logs
             receivers:
-            - filelog
+            - file_log
           logs/journal:
             exporters:
             - forward/logs-exporter
@@ -1721,7 +1721,7 @@ Cluster filter should match snapshot with combined exclude filters:
             - journald
           logs/stateevents-entities:
             exporters:
-            - otlp
+            - otlp_grpc
             processors:
             - memory_limiter
             - filter/keep-entity-state-events
@@ -1733,7 +1733,7 @@ Cluster filter should match snapshot with combined exclude filters:
             - solarwindsentity/istio-workload-service
           logs/stateevents-relationships:
             exporters:
-            - otlp
+            - otlp_grpc
             processors:
             - memory_limiter
             - filter/keep-relationship-state-events
@@ -1745,11 +1745,11 @@ Cluster filter should match snapshot with combined exclude filters:
             - solarwindsentity/istio-workload-service
           metrics:
             exporters:
-            - otlp
+            - otlp_grpc
             processors:
             - memory_limiter
             - filter/histograms
-            - k8sattributes
+            - k8s_attributes
             - filter/namespaces
             - filter/remove_temporary_metrics
             - transform/scope
@@ -2214,7 +2214,7 @@ Cluster filter should match snapshot with combined include filters:
                 type: KubernetesCommunicatesWith
           source_prefix: source.
       exporters:
-        otlp:
+        otlp_grpc:
           endpoint: ${OTEL_ENVOY_ADDRESS}
           headers:
             Authorization: Bearer ${SOLARWINDS_API_TOKEN}
@@ -2526,7 +2526,7 @@ Cluster filter should match snapshot with combined include filters:
           keys:
           - namespace
           - pod
-        k8sattributes:
+        k8s_attributes:
           auth_type: serviceAccount
           extract:
             metadata:
@@ -3366,7 +3366,7 @@ Cluster filter should match snapshot with combined include filters:
               where IsMatch(metric.name, "^(container_.*)$") == true and datapoint.attributes["k8s.node.name"]
               == nil
       receivers:
-        filelog:
+        file_log:
           encoding: utf-8
           exclude:
           - /var/log/pods/${POD_NAMESPACE}_${POD_NAME}*_*/swi-opentelemetry-collector/*.log
@@ -3575,7 +3575,7 @@ Cluster filter should match snapshot with combined include filters:
         pipelines:
           logs:
             exporters:
-            - otlp
+            - otlp_grpc
             processors:
             - memory_limiter
             - transform/scope
@@ -3590,10 +3590,10 @@ Cluster filter should match snapshot with combined include filters:
             - transform/syslogify
             - groupbyattrs/common-all
             - resource/container
-            - k8sattributes
+            - k8s_attributes
             - filter/namespaces_logs
             receivers:
-            - filelog
+            - file_log
           logs/journal:
             exporters:
             - forward/logs-exporter
@@ -3605,7 +3605,7 @@ Cluster filter should match snapshot with combined include filters:
             - journald
           logs/stateevents-entities:
             exporters:
-            - otlp
+            - otlp_grpc
             processors:
             - memory_limiter
             - filter/keep-entity-state-events
@@ -3617,7 +3617,7 @@ Cluster filter should match snapshot with combined include filters:
             - solarwindsentity/istio-workload-service
           logs/stateevents-relationships:
             exporters:
-            - otlp
+            - otlp_grpc
             processors:
             - memory_limiter
             - filter/keep-relationship-state-events
@@ -3629,11 +3629,11 @@ Cluster filter should match snapshot with combined include filters:
             - solarwindsentity/istio-workload-service
           metrics:
             exporters:
-            - otlp
+            - otlp_grpc
             processors:
             - memory_limiter
             - filter/histograms
-            - k8sattributes
+            - k8s_attributes
             - filter/namespaces
             - filter/remove_temporary_metrics
             - transform/scope
@@ -4098,7 +4098,7 @@ Cluster filter should match snapshot with exclude_namespaces:
                 type: KubernetesCommunicatesWith
           source_prefix: source.
       exporters:
-        otlp:
+        otlp_grpc:
           endpoint: ${OTEL_ENVOY_ADDRESS}
           headers:
             Authorization: Bearer ${SOLARWINDS_API_TOKEN}
@@ -4412,7 +4412,7 @@ Cluster filter should match snapshot with exclude_namespaces:
           keys:
           - namespace
           - pod
-        k8sattributes:
+        k8s_attributes:
           auth_type: serviceAccount
           extract:
             metadata:
@@ -5252,7 +5252,7 @@ Cluster filter should match snapshot with exclude_namespaces:
               where IsMatch(metric.name, "^(container_.*)$") == true and datapoint.attributes["k8s.node.name"]
               == nil
       receivers:
-        filelog:
+        file_log:
           encoding: utf-8
           exclude:
           - /var/log/pods/${POD_NAMESPACE}_${POD_NAME}*_*/swi-opentelemetry-collector/*.log
@@ -5461,7 +5461,7 @@ Cluster filter should match snapshot with exclude_namespaces:
         pipelines:
           logs:
             exporters:
-            - otlp
+            - otlp_grpc
             processors:
             - memory_limiter
             - transform/scope
@@ -5476,10 +5476,10 @@ Cluster filter should match snapshot with exclude_namespaces:
             - transform/syslogify
             - groupbyattrs/common-all
             - resource/container
-            - k8sattributes
+            - k8s_attributes
             - filter/namespaces_logs
             receivers:
-            - filelog
+            - file_log
           logs/journal:
             exporters:
             - forward/logs-exporter
@@ -5491,7 +5491,7 @@ Cluster filter should match snapshot with exclude_namespaces:
             - journald
           logs/stateevents-entities:
             exporters:
-            - otlp
+            - otlp_grpc
             processors:
             - memory_limiter
             - filter/keep-entity-state-events
@@ -5503,7 +5503,7 @@ Cluster filter should match snapshot with exclude_namespaces:
             - solarwindsentity/istio-workload-service
           logs/stateevents-relationships:
             exporters:
-            - otlp
+            - otlp_grpc
             processors:
             - memory_limiter
             - filter/keep-relationship-state-events
@@ -5515,11 +5515,11 @@ Cluster filter should match snapshot with exclude_namespaces:
             - solarwindsentity/istio-workload-service
           metrics:
             exporters:
-            - otlp
+            - otlp_grpc
             processors:
             - memory_limiter
             - filter/histograms
-            - k8sattributes
+            - k8s_attributes
             - filter/namespaces
             - filter/remove_temporary_metrics
             - transform/scope
@@ -5984,7 +5984,7 @@ Cluster filter should match snapshot with exclude_namespaces_regex:
                 type: KubernetesCommunicatesWith
           source_prefix: source.
       exporters:
-        otlp:
+        otlp_grpc:
           endpoint: ${OTEL_ENVOY_ADDRESS}
           headers:
             Authorization: Bearer ${SOLARWINDS_API_TOKEN}
@@ -6298,7 +6298,7 @@ Cluster filter should match snapshot with exclude_namespaces_regex:
           keys:
           - namespace
           - pod
-        k8sattributes:
+        k8s_attributes:
           auth_type: serviceAccount
           extract:
             metadata:
@@ -7138,7 +7138,7 @@ Cluster filter should match snapshot with exclude_namespaces_regex:
               where IsMatch(metric.name, "^(container_.*)$") == true and datapoint.attributes["k8s.node.name"]
               == nil
       receivers:
-        filelog:
+        file_log:
           encoding: utf-8
           exclude:
           - /var/log/pods/${POD_NAMESPACE}_${POD_NAME}*_*/swi-opentelemetry-collector/*.log
@@ -7347,7 +7347,7 @@ Cluster filter should match snapshot with exclude_namespaces_regex:
         pipelines:
           logs:
             exporters:
-            - otlp
+            - otlp_grpc
             processors:
             - memory_limiter
             - transform/scope
@@ -7362,10 +7362,10 @@ Cluster filter should match snapshot with exclude_namespaces_regex:
             - transform/syslogify
             - groupbyattrs/common-all
             - resource/container
-            - k8sattributes
+            - k8s_attributes
             - filter/namespaces_logs
             receivers:
-            - filelog
+            - file_log
           logs/journal:
             exporters:
             - forward/logs-exporter
@@ -7377,7 +7377,7 @@ Cluster filter should match snapshot with exclude_namespaces_regex:
             - journald
           logs/stateevents-entities:
             exporters:
-            - otlp
+            - otlp_grpc
             processors:
             - memory_limiter
             - filter/keep-entity-state-events
@@ -7389,7 +7389,7 @@ Cluster filter should match snapshot with exclude_namespaces_regex:
             - solarwindsentity/istio-workload-service
           logs/stateevents-relationships:
             exporters:
-            - otlp
+            - otlp_grpc
             processors:
             - memory_limiter
             - filter/keep-relationship-state-events
@@ -7401,11 +7401,11 @@ Cluster filter should match snapshot with exclude_namespaces_regex:
             - solarwindsentity/istio-workload-service
           metrics:
             exporters:
-            - otlp
+            - otlp_grpc
             processors:
             - memory_limiter
             - filter/histograms
-            - k8sattributes
+            - k8s_attributes
             - filter/namespaces
             - filter/remove_temporary_metrics
             - transform/scope
@@ -7870,7 +7870,7 @@ Cluster filter should match snapshot with include_namespaces:
                 type: KubernetesCommunicatesWith
           source_prefix: source.
       exporters:
-        otlp:
+        otlp_grpc:
           endpoint: ${OTEL_ENVOY_ADDRESS}
           headers:
             Authorization: Bearer ${SOLARWINDS_API_TOKEN}
@@ -8182,7 +8182,7 @@ Cluster filter should match snapshot with include_namespaces:
           keys:
           - namespace
           - pod
-        k8sattributes:
+        k8s_attributes:
           auth_type: serviceAccount
           extract:
             metadata:
@@ -9022,7 +9022,7 @@ Cluster filter should match snapshot with include_namespaces:
               where IsMatch(metric.name, "^(container_.*)$") == true and datapoint.attributes["k8s.node.name"]
               == nil
       receivers:
-        filelog:
+        file_log:
           encoding: utf-8
           exclude:
           - /var/log/pods/${POD_NAMESPACE}_${POD_NAME}*_*/swi-opentelemetry-collector/*.log
@@ -9231,7 +9231,7 @@ Cluster filter should match snapshot with include_namespaces:
         pipelines:
           logs:
             exporters:
-            - otlp
+            - otlp_grpc
             processors:
             - memory_limiter
             - transform/scope
@@ -9246,10 +9246,10 @@ Cluster filter should match snapshot with include_namespaces:
             - transform/syslogify
             - groupbyattrs/common-all
             - resource/container
-            - k8sattributes
+            - k8s_attributes
             - filter/namespaces_logs
             receivers:
-            - filelog
+            - file_log
           logs/journal:
             exporters:
             - forward/logs-exporter
@@ -9261,7 +9261,7 @@ Cluster filter should match snapshot with include_namespaces:
             - journald
           logs/stateevents-entities:
             exporters:
-            - otlp
+            - otlp_grpc
             processors:
             - memory_limiter
             - filter/keep-entity-state-events
@@ -9273,7 +9273,7 @@ Cluster filter should match snapshot with include_namespaces:
             - solarwindsentity/istio-workload-service
           logs/stateevents-relationships:
             exporters:
-            - otlp
+            - otlp_grpc
             processors:
             - memory_limiter
             - filter/keep-relationship-state-events
@@ -9285,11 +9285,11 @@ Cluster filter should match snapshot with include_namespaces:
             - solarwindsentity/istio-workload-service
           metrics:
             exporters:
-            - otlp
+            - otlp_grpc
             processors:
             - memory_limiter
             - filter/histograms
-            - k8sattributes
+            - k8s_attributes
             - filter/namespaces
             - filter/remove_temporary_metrics
             - transform/scope
@@ -9754,7 +9754,7 @@ Cluster filter should match snapshot with include_namespaces_regex:
                 type: KubernetesCommunicatesWith
           source_prefix: source.
       exporters:
-        otlp:
+        otlp_grpc:
           endpoint: ${OTEL_ENVOY_ADDRESS}
           headers:
             Authorization: Bearer ${SOLARWINDS_API_TOKEN}
@@ -10068,7 +10068,7 @@ Cluster filter should match snapshot with include_namespaces_regex:
           keys:
           - namespace
           - pod
-        k8sattributes:
+        k8s_attributes:
           auth_type: serviceAccount
           extract:
             metadata:
@@ -10908,7 +10908,7 @@ Cluster filter should match snapshot with include_namespaces_regex:
               where IsMatch(metric.name, "^(container_.*)$") == true and datapoint.attributes["k8s.node.name"]
               == nil
       receivers:
-        filelog:
+        file_log:
           encoding: utf-8
           exclude:
           - /var/log/pods/${POD_NAMESPACE}_${POD_NAME}*_*/swi-opentelemetry-collector/*.log
@@ -11117,7 +11117,7 @@ Cluster filter should match snapshot with include_namespaces_regex:
         pipelines:
           logs:
             exporters:
-            - otlp
+            - otlp_grpc
             processors:
             - memory_limiter
             - transform/scope
@@ -11132,10 +11132,10 @@ Cluster filter should match snapshot with include_namespaces_regex:
             - transform/syslogify
             - groupbyattrs/common-all
             - resource/container
-            - k8sattributes
+            - k8s_attributes
             - filter/namespaces_logs
             receivers:
-            - filelog
+            - file_log
           logs/journal:
             exporters:
             - forward/logs-exporter
@@ -11147,7 +11147,7 @@ Cluster filter should match snapshot with include_namespaces_regex:
             - journald
           logs/stateevents-entities:
             exporters:
-            - otlp
+            - otlp_grpc
             processors:
             - memory_limiter
             - filter/keep-entity-state-events
@@ -11159,7 +11159,7 @@ Cluster filter should match snapshot with include_namespaces_regex:
             - solarwindsentity/istio-workload-service
           logs/stateevents-relationships:
             exporters:
-            - otlp
+            - otlp_grpc
             processors:
             - memory_limiter
             - filter/keep-relationship-state-events
@@ -11171,11 +11171,11 @@ Cluster filter should match snapshot with include_namespaces_regex:
             - solarwindsentity/istio-workload-service
           metrics:
             exporters:
-            - otlp
+            - otlp_grpc
             processors:
             - memory_limiter
             - filter/histograms
-            - k8sattributes
+            - k8s_attributes
             - filter/namespaces
             - filter/remove_temporary_metrics
             - transform/scope
@@ -11640,7 +11640,7 @@ Custom logs filter with new syntax:
                 type: KubernetesCommunicatesWith
           source_prefix: source.
       exporters:
-        otlp:
+        otlp_grpc:
           endpoint: ${OTEL_ENVOY_ADDRESS}
           headers:
             Authorization: Bearer ${SOLARWINDS_API_TOKEN}
@@ -11946,7 +11946,7 @@ Custom logs filter with new syntax:
           keys:
           - namespace
           - pod
-        k8sattributes:
+        k8s_attributes:
           auth_type: serviceAccount
           extract:
             metadata:
@@ -12786,7 +12786,7 @@ Custom logs filter with new syntax:
               where IsMatch(metric.name, "^(container_.*)$") == true and datapoint.attributes["k8s.node.name"]
               == nil
       receivers:
-        filelog:
+        file_log:
           encoding: utf-8
           exclude:
           - /var/log/pods/${POD_NAMESPACE}_${POD_NAME}*_*/swi-opentelemetry-collector/*.log
@@ -12995,7 +12995,7 @@ Custom logs filter with new syntax:
         pipelines:
           logs:
             exporters:
-            - otlp
+            - otlp_grpc
             processors:
             - memory_limiter
             - transform/scope
@@ -13010,10 +13010,10 @@ Custom logs filter with new syntax:
             - transform/syslogify
             - groupbyattrs/common-all
             - resource/container
-            - k8sattributes
+            - k8s_attributes
             - filter/logs
             receivers:
-            - filelog
+            - file_log
           logs/journal:
             exporters:
             - forward/logs-exporter
@@ -13025,7 +13025,7 @@ Custom logs filter with new syntax:
             - journald
           logs/stateevents-entities:
             exporters:
-            - otlp
+            - otlp_grpc
             processors:
             - memory_limiter
             - filter/keep-entity-state-events
@@ -13037,7 +13037,7 @@ Custom logs filter with new syntax:
             - solarwindsentity/istio-workload-service
           logs/stateevents-relationships:
             exporters:
-            - otlp
+            - otlp_grpc
             processors:
             - memory_limiter
             - filter/keep-relationship-state-events
@@ -13049,11 +13049,11 @@ Custom logs filter with new syntax:
             - solarwindsentity/istio-workload-service
           metrics:
             exporters:
-            - otlp
+            - otlp_grpc
             processors:
             - memory_limiter
             - filter/histograms
-            - k8sattributes
+            - k8s_attributes
             - filter/remove_temporary_metrics
             - transform/scope
             - batch/metrics
@@ -13517,7 +13517,7 @@ Custom logs filter with old syntax:
                 type: KubernetesCommunicatesWith
           source_prefix: source.
       exporters:
-        otlp:
+        otlp_grpc:
           endpoint: ${OTEL_ENVOY_ADDRESS}
           headers:
             Authorization: Bearer ${SOLARWINDS_API_TOKEN}
@@ -13826,7 +13826,7 @@ Custom logs filter with old syntax:
           keys:
           - namespace
           - pod
-        k8sattributes:
+        k8s_attributes:
           auth_type: serviceAccount
           extract:
             metadata:
@@ -14666,7 +14666,7 @@ Custom logs filter with old syntax:
               where IsMatch(metric.name, "^(container_.*)$") == true and datapoint.attributes["k8s.node.name"]
               == nil
       receivers:
-        filelog:
+        file_log:
           encoding: utf-8
           exclude:
           - /var/log/pods/${POD_NAMESPACE}_${POD_NAME}*_*/swi-opentelemetry-collector/*.log
@@ -14956,7 +14956,7 @@ Custom logs filter with old syntax:
         pipelines:
           logs:
             exporters:
-            - otlp
+            - otlp_grpc
             processors:
             - memory_limiter
             - transform/scope
@@ -14972,9 +14972,9 @@ Custom logs filter with old syntax:
             - transform/syslogify
             - groupbyattrs/common-all
             - resource/container
-            - k8sattributes
+            - k8s_attributes
             receivers:
-            - filelog
+            - file_log
           logs/journal:
             exporters:
             - forward/logs-exporter
@@ -14986,7 +14986,7 @@ Custom logs filter with old syntax:
             - journald
           logs/stateevents-entities:
             exporters:
-            - otlp
+            - otlp_grpc
             processors:
             - memory_limiter
             - filter/keep-entity-state-events
@@ -14998,7 +14998,7 @@ Custom logs filter with old syntax:
             - solarwindsentity/istio-workload-service
           logs/stateevents-relationships:
             exporters:
-            - otlp
+            - otlp_grpc
             processors:
             - memory_limiter
             - filter/keep-relationship-state-events
@@ -15010,11 +15010,11 @@ Custom logs filter with old syntax:
             - solarwindsentity/istio-workload-service
           metrics:
             exporters:
-            - otlp
+            - otlp_grpc
             processors:
             - memory_limiter
             - filter/histograms
-            - k8sattributes
+            - k8s_attributes
             - filter/remove_temporary_metrics
             - transform/scope
             - batch/metrics
@@ -15478,7 +15478,7 @@ Node collector config should match snapshot when autodiscovery is disabled:
                 type: KubernetesCommunicatesWith
           source_prefix: source.
       exporters:
-        otlp:
+        otlp_grpc:
           endpoint: ${OTEL_ENVOY_ADDRESS}
           headers:
             Authorization: Bearer ${SOLARWINDS_API_TOKEN}
@@ -15780,7 +15780,7 @@ Node collector config should match snapshot when autodiscovery is disabled:
           keys:
           - namespace
           - pod
-        k8sattributes:
+        k8s_attributes:
           auth_type: serviceAccount
           extract:
             metadata:
@@ -16620,7 +16620,7 @@ Node collector config should match snapshot when autodiscovery is disabled:
               where IsMatch(metric.name, "^(container_.*)$") == true and datapoint.attributes["k8s.node.name"]
               == nil
       receivers:
-        filelog:
+        file_log:
           encoding: utf-8
           exclude:
           - /var/log/pods/${POD_NAMESPACE}_${POD_NAME}*_*/swi-opentelemetry-collector/*.log
@@ -16769,7 +16769,7 @@ Node collector config should match snapshot when autodiscovery is disabled:
         pipelines:
           logs:
             exporters:
-            - otlp
+            - otlp_grpc
             processors:
             - memory_limiter
             - transform/scope
@@ -16784,9 +16784,9 @@ Node collector config should match snapshot when autodiscovery is disabled:
             - transform/syslogify
             - groupbyattrs/common-all
             - resource/container
-            - k8sattributes
+            - k8s_attributes
             receivers:
-            - filelog
+            - file_log
           logs/journal:
             exporters:
             - forward/logs-exporter
@@ -16798,7 +16798,7 @@ Node collector config should match snapshot when autodiscovery is disabled:
             - journald
           logs/stateevents-entities:
             exporters:
-            - otlp
+            - otlp_grpc
             processors:
             - memory_limiter
             - filter/keep-entity-state-events
@@ -16810,7 +16810,7 @@ Node collector config should match snapshot when autodiscovery is disabled:
             - solarwindsentity/istio-workload-service
           logs/stateevents-relationships:
             exporters:
-            - otlp
+            - otlp_grpc
             processors:
             - memory_limiter
             - filter/keep-relationship-state-events
@@ -16822,11 +16822,11 @@ Node collector config should match snapshot when autodiscovery is disabled:
             - solarwindsentity/istio-workload-service
           metrics:
             exporters:
-            - otlp
+            - otlp_grpc
             processors:
             - memory_limiter
             - filter/histograms
-            - k8sattributes
+            - k8s_attributes
             - filter/remove_temporary_metrics
             - transform/scope
             - batch/metrics
@@ -17290,7 +17290,7 @@ Node collector config should match snapshot when fargate is enabled:
                 type: KubernetesCommunicatesWith
           source_prefix: source.
       exporters:
-        otlp:
+        otlp_grpc:
           endpoint: ${OTEL_ENVOY_ADDRESS}
           headers:
             Authorization: Bearer ${SOLARWINDS_API_TOKEN}
@@ -17589,7 +17589,7 @@ Node collector config should match snapshot when fargate is enabled:
           keys:
           - namespace
           - pod
-        k8sattributes:
+        k8s_attributes:
           auth_type: serviceAccount
           extract:
             metadata:
@@ -18429,7 +18429,7 @@ Node collector config should match snapshot when fargate is enabled:
               where IsMatch(metric.name, "^(container_.*)$") == true and datapoint.attributes["k8s.node.name"]
               == nil
       receivers:
-        filelog:
+        file_log:
           encoding: utf-8
           exclude:
           - /var/log/pods/${POD_NAMESPACE}_${POD_NAME}*_*/swi-opentelemetry-collector/*.log
@@ -18583,7 +18583,7 @@ Node collector config should match snapshot when fargate is enabled:
         pipelines:
           logs:
             exporters:
-            - otlp
+            - otlp_grpc
             processors:
             - memory_limiter
             - transform/scope
@@ -18598,9 +18598,9 @@ Node collector config should match snapshot when fargate is enabled:
             - transform/syslogify
             - groupbyattrs/common-all
             - resource/container
-            - k8sattributes
+            - k8s_attributes
             receivers:
-            - filelog
+            - file_log
           logs/journal:
             exporters:
             - forward/logs-exporter
@@ -18612,7 +18612,7 @@ Node collector config should match snapshot when fargate is enabled:
             - journald
           logs/stateevents-entities:
             exporters:
-            - otlp
+            - otlp_grpc
             processors:
             - memory_limiter
             - filter/keep-entity-state-events
@@ -18624,7 +18624,7 @@ Node collector config should match snapshot when fargate is enabled:
             - solarwindsentity/istio-workload-service
           logs/stateevents-relationships:
             exporters:
-            - otlp
+            - otlp_grpc
             processors:
             - memory_limiter
             - filter/keep-relationship-state-events
@@ -18636,11 +18636,11 @@ Node collector config should match snapshot when fargate is enabled:
             - solarwindsentity/istio-workload-service
           metrics:
             exporters:
-            - otlp
+            - otlp_grpc
             processors:
             - memory_limiter
             - filter/histograms
-            - k8sattributes
+            - k8s_attributes
             - filter/remove_temporary_metrics
             - transform/scope
             - batch/metrics
@@ -19080,7 +19080,7 @@ Node collector config should match snapshot when fargate is enabled and autodisc
                 type: KubernetesCommunicatesWith
           source_prefix: source.
       exporters:
-        otlp:
+        otlp_grpc:
           endpoint: ${OTEL_ENVOY_ADDRESS}
           headers:
             Authorization: Bearer ${SOLARWINDS_API_TOKEN}
@@ -19374,7 +19374,7 @@ Node collector config should match snapshot when fargate is enabled and autodisc
           keys:
           - namespace
           - pod
-        k8sattributes:
+        k8s_attributes:
           auth_type: serviceAccount
           extract:
             metadata:
@@ -20214,7 +20214,7 @@ Node collector config should match snapshot when fargate is enabled and autodisc
               where IsMatch(metric.name, "^(container_.*)$") == true and datapoint.attributes["k8s.node.name"]
               == nil
       receivers:
-        filelog:
+        file_log:
           encoding: utf-8
           exclude:
           - /var/log/pods/${POD_NAMESPACE}_${POD_NAME}*_*/swi-opentelemetry-collector/*.log
@@ -20307,7 +20307,7 @@ Node collector config should match snapshot when fargate is enabled and autodisc
         pipelines:
           logs:
             exporters:
-            - otlp
+            - otlp_grpc
             processors:
             - memory_limiter
             - transform/scope
@@ -20322,9 +20322,9 @@ Node collector config should match snapshot when fargate is enabled and autodisc
             - transform/syslogify
             - groupbyattrs/common-all
             - resource/container
-            - k8sattributes
+            - k8s_attributes
             receivers:
-            - filelog
+            - file_log
           logs/journal:
             exporters:
             - forward/logs-exporter
@@ -20336,7 +20336,7 @@ Node collector config should match snapshot when fargate is enabled and autodisc
             - journald
           logs/stateevents-entities:
             exporters:
-            - otlp
+            - otlp_grpc
             processors:
             - memory_limiter
             - filter/keep-entity-state-events
@@ -20348,7 +20348,7 @@ Node collector config should match snapshot when fargate is enabled and autodisc
             - solarwindsentity/istio-workload-service
           logs/stateevents-relationships:
             exporters:
-            - otlp
+            - otlp_grpc
             processors:
             - memory_limiter
             - filter/keep-relationship-state-events
@@ -20793,7 +20793,7 @@ Node collector config should match snapshot when using default values:
                 type: KubernetesCommunicatesWith
           source_prefix: source.
       exporters:
-        otlp:
+        otlp_grpc:
           endpoint: ${OTEL_ENVOY_ADDRESS}
           headers:
             Authorization: Bearer ${SOLARWINDS_API_TOKEN}
@@ -21095,7 +21095,7 @@ Node collector config should match snapshot when using default values:
           keys:
           - namespace
           - pod
-        k8sattributes:
+        k8s_attributes:
           auth_type: serviceAccount
           extract:
             metadata:
@@ -21935,7 +21935,7 @@ Node collector config should match snapshot when using default values:
               where IsMatch(metric.name, "^(container_.*)$") == true and datapoint.attributes["k8s.node.name"]
               == nil
       receivers:
-        filelog:
+        file_log:
           encoding: utf-8
           exclude:
           - /var/log/pods/${POD_NAMESPACE}_${POD_NAME}*_*/swi-opentelemetry-collector/*.log
@@ -22144,7 +22144,7 @@ Node collector config should match snapshot when using default values:
         pipelines:
           logs:
             exporters:
-            - otlp
+            - otlp_grpc
             processors:
             - memory_limiter
             - transform/scope
@@ -22159,9 +22159,9 @@ Node collector config should match snapshot when using default values:
             - transform/syslogify
             - groupbyattrs/common-all
             - resource/container
-            - k8sattributes
+            - k8s_attributes
             receivers:
-            - filelog
+            - file_log
           logs/journal:
             exporters:
             - forward/logs-exporter
@@ -22173,7 +22173,7 @@ Node collector config should match snapshot when using default values:
             - journald
           logs/stateevents-entities:
             exporters:
-            - otlp
+            - otlp_grpc
             processors:
             - memory_limiter
             - filter/keep-entity-state-events
@@ -22185,7 +22185,7 @@ Node collector config should match snapshot when using default values:
             - solarwindsentity/istio-workload-service
           logs/stateevents-relationships:
             exporters:
-            - otlp
+            - otlp_grpc
             processors:
             - memory_limiter
             - filter/keep-relationship-state-events
@@ -22197,11 +22197,11 @@ Node collector config should match snapshot when using default values:
             - solarwindsentity/istio-workload-service
           metrics:
             exporters:
-            - otlp
+            - otlp_grpc
             processors:
             - memory_limiter
             - filter/histograms
-            - k8sattributes
+            - k8s_attributes
             - filter/remove_temporary_metrics
             - transform/scope
             - batch/metrics

--- a/deploy/helm/values.yaml
+++ b/deploy/helm/values.yaml
@@ -609,7 +609,7 @@ otel:
     journal: true
 
     # If true, the container logs will be collected
-    # Log collection uses `filelog` OTEL receiver under the hood
+    # Log collection uses `file_log` OTEL receiver under the hood
     # https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/filelogreceiver
     # Each log has following attributes so they can be filtered out by them using filter configuration:
     #   * sw.k8s.log.type=container
@@ -728,7 +728,7 @@ otel:
     # By default: affinity is set to run the DaemonSet on linux amd64.
     affinity: {}
 
-    # Properties that can be configured on filelog receiver. For full description of properties
+    # Properties that can be configured on file_log receiver. For full description of properties
     # see https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/filelogreceiver
     receiver:
       start_at: end

--- a/doc/collectorPipeline.md
+++ b/doc/collectorPipeline.md
@@ -16,7 +16,7 @@ stateDiagram-v2
     mc_metricsPipeline: 'metrics' pipeline
     state mc_metricsPipeline {
       mc_r1: 'forward/metric-exporter' connector
-      mc_e1: 'otlp' exporter
+      mc_e1: 'otlp_grpc' exporter
       mc_r1 --> mc_e1 : processors
     }
 
@@ -114,7 +114,7 @@ stateDiagram-v2
     state md_logsStateEventsEntitiesPipeline {
       md_r7a: 'solarwindsentity/istio-workload-workload' connector
       md_r7b: 'solarwindsentity/istio-workload-service' connector
-      md_e7: 'otlp' exporter
+      md_e7: 'otlp_grpc' exporter
       md_r7a --> md_e7 : processors
       md_r7b --> md_e7 : processors
     }
@@ -123,7 +123,7 @@ stateDiagram-v2
     state md_logsStateEventsRelationshipsPipeline {
       md_r8a: 'solarwindsentity/istio-workload-workload' connector
       md_r8b: 'solarwindsentity/istio-workload-service' connector
-      md_e8: 'otlp' exporter
+      md_e8: 'otlp_grpc' exporter
       md_r8a --> md_e8 : processors
       md_r8b --> md_e8 : processors
     }
@@ -138,7 +138,7 @@ stateDiagram-v2
     md_metricsPipeline: 'metrics' pipeline
     state md_metricsPipeline {
       md_r10: 'forward/metric-exporter' connector
-      md_e10: 'otlp' exporter
+      md_e10: 'otlp_grpc' exporter
       md_r10 --> md_e10 : processors
     }
 
@@ -167,7 +167,7 @@ stateDiagram-v2
     ec_logsPipeline: 'logs' pipeline
     state ec_logsPipeline {
       ec_r1: 'k8s_events' receiver
-      ec_e1: 'otlp' exporter
+      ec_e1: 'otlp_grpc' exporter
       ec_r1 --> ec_e1 : processors
     }
 
@@ -182,7 +182,7 @@ stateDiagram-v2
     state ec_manifestsExportPipeline {
       ec_r2b: 'routing/manifests' connector
       ec_r2c: 'solarwindsentity/serviceendpointsmapping' connector
-      ec_e2b: 'otlp' exporter
+      ec_e2b: 'otlp_grpc' exporter
       ec_r2b --> ec_e2b : processors
       ec_r2c --> ec_e2b : processors
     }
@@ -197,7 +197,7 @@ stateDiagram-v2
     ec_stateEventsPipeline: 'logs/stateevents' pipeline
     state ec_stateEventsPipeline {
       ec_r4: 'solarwindsentity/keepalive' connector
-      ec_e4: 'otlp' exporter
+      ec_e4: 'otlp_grpc' exporter
       ec_r4 --> ec_e4 : processors
     }
 
@@ -222,7 +222,7 @@ stateDiagram-v2
 
     gw_metricsCommonInPipeline: 'metrics/common_in' pipeline
     state gw_metricsCommonInPipeline {
-      gw_mr1: 'otlp' receiver
+      gw_mr1: 'otlp_grpc' receiver
       gw_me1: 'routing/metrics' connector
       gw_mr1 --> gw_me1 : processors
     }
@@ -237,7 +237,7 @@ stateDiagram-v2
     gw_metricsCommonOutPipeline: 'metrics/common_out' pipeline
     state gw_metricsCommonOutPipeline {
       gw_mr3: 'forward/metrics_common' connector
-      gw_me3: 'otlp' exporter
+      gw_me3: 'otlp_grpc' exporter
       gw_mr3 --> gw_me3 : processors
     }
 
@@ -255,28 +255,28 @@ stateDiagram-v2
     gw_logsObiStateEventsEntitiesPipeline: 'logs/obi-stateevents-entities' pipeline
     state gw_logsObiStateEventsEntitiesPipeline {
       gw_lr1: 'solarwindsentity/obi-entities' connector
-      gw_le1: 'otlp' exporter
+      gw_le1: 'otlp_grpc' exporter
       gw_lr1 --> gw_le1 : processors
     }
 
     gw_logsObiStateEventsRelationshipsPipeline: 'logs/obi-stateevents-relationships' pipeline
     state gw_logsObiStateEventsRelationshipsPipeline {
       gw_lr2: 'solarwindsentity/obi-relationships' connector
-      gw_le2: 'otlp' exporter
+      gw_le2: 'otlp_grpc' exporter
       gw_lr2 --> gw_le2 : processors
     }
 
     gw_logsPipeline: 'logs' pipeline
     state gw_logsPipeline {
       gw_lr3: 'otlp' receiver
-      gw_le3: 'otlp' exporter
+      gw_le3: 'otlp_grpc' exporter
       gw_lr3 --> gw_le3 : processors
     }
 
     gw_tracesPipeline: 'traces' pipeline
     state gw_tracesPipeline {
       gw_tr: 'otlp' receiver
-      gw_te: 'otlp' exporter
+      gw_te: 'otlp_grpc' exporter
       gw_tr --> gw_te : processors
     }
 
@@ -308,13 +308,13 @@ stateDiagram-v2
     nc_logsPipeline: 'logs' pipeline
     state nc_logsPipeline {
       nc_r1: 'forward/logs-exporter' connector
-      nc_e1: 'otlp' exporter
+      nc_e1: 'otlp_grpc' exporter
       nc_r1 --> nc_e1 : processors
     }
 
     nc_logsContainerPipeline: 'logs/container' pipeline
     state nc_logsContainerPipeline {
-      nc_r2: 'filelog' receiver
+      nc_r2: 'file_log' receiver
       nc_e2: 'forward/logs-exporter' connector
       nc_r2 --> nc_e2 : processors
     }
@@ -329,7 +329,7 @@ stateDiagram-v2
     nc_metricsPipeline: 'metrics' pipeline
     state nc_metricsPipeline {
       nc_r4: 'forward/metric-exporter' connector
-      nc_e4: 'otlp' exporter
+      nc_e4: 'otlp_grpc' exporter
       nc_r4 --> nc_e4 : processors
     }
 
@@ -387,7 +387,7 @@ stateDiagram-v2
     state nc_logsStateEventsEntitiesPipeline {
       nc_r11a: 'solarwindsentity/istio-workload-workload' connector
       nc_r11b: 'solarwindsentity/istio-workload-service' connector
-      nc_e11: 'otlp' exporter
+      nc_e11: 'otlp_grpc' exporter
       nc_r11a --> nc_e11 : processors
       nc_r11b --> nc_e11 : processors
     }
@@ -396,7 +396,7 @@ stateDiagram-v2
     state nc_logsStateEventsRelationshipsPipeline {
       nc_r12a: 'solarwindsentity/istio-workload-workload' connector
       nc_r12b: 'solarwindsentity/istio-workload-service' connector
-      nc_e12: 'otlp' exporter
+      nc_e12: 'otlp_grpc' exporter
       nc_r12a --> nc_e12 : processors
       nc_r12b --> nc_e12 : processors
     }

--- a/tests/deploy/timeseries-mock-service/values.yaml
+++ b/tests/deploy/timeseries-mock-service/values.yaml
@@ -1,6 +1,6 @@
 otel:
   port: 9082
-  image: otel/opentelemetry-collector-contrib:0.139.0
+  image: otel/opentelemetry-collector-contrib:0.150.1
 
 fileProvider:
   # Enable file-based export (deprecated, will be replaced by ClickHouse)


### PR DESCRIPTION
* Most changes are just renames.
* There is one fix for explicitly mentioning a metric context.
* Internal telemetry metrics generated by OTEL Collector now have different names. While a breaking change, it's not clear if this actually affects anyone.