### PR TITLE
memory leak fix

### DIFF
--- a/deploy/helm/discovery-collector-config.yaml
+++ b/deploy/helm/discovery-collector-config.yaml
@@ -153,9 +153,6 @@ service:
       level: none
 {{- if .Values.otel.metrics.autodiscovery.discovery_collector.telemetry.metrics.enabled }}
     metrics:
-      exemplars:
-        # Disable exemplars to prevent unbounded cardinality growth in the metric SDK
-        filter: always_off
       readers:
         - pull:
             exporter:

--- a/deploy/helm/discovery-collector-config.yaml
+++ b/deploy/helm/discovery-collector-config.yaml
@@ -148,8 +148,14 @@ service:
     logs:
       level: {{ .Values.otel.metrics.autodiscovery.discovery_collector.telemetry.logs.level }}
 {{- end }}
+    # Disable internal tracing to prevent evictedQueue span event accumulation (memory leak)
+    traces:
+      level: none
 {{- if .Values.otel.metrics.autodiscovery.discovery_collector.telemetry.metrics.enabled }}
     metrics:
+      exemplars:
+        # Disable exemplars to prevent unbounded cardinality growth in the metric SDK
+        filter: always_off
       readers:
         - pull:
             exporter:

--- a/deploy/helm/events-collector-config.yaml
+++ b/deploy/helm/events-collector-config.yaml
@@ -880,8 +880,14 @@ service:
     logs:
       level: {{ .Values.otel.events.telemetry.logs.level }}
 {{- end }}
+    # Disable internal tracing to prevent evictedQueue span event accumulation (memory leak)
+    traces:
+      level: none
 {{- if .Values.otel.events.telemetry.metrics.enabled }}
     metrics:
+      exemplars:
+        # Disable exemplars to prevent unbounded cardinality growth in the metric SDK
+        filter: always_off
       readers:
         - pull:
             exporter:

--- a/deploy/helm/events-collector-config.yaml
+++ b/deploy/helm/events-collector-config.yaml
@@ -885,9 +885,6 @@ service:
       level: none
 {{- if .Values.otel.events.telemetry.metrics.enabled }}
     metrics:
-      exemplars:
-        # Disable exemplars to prevent unbounded cardinality growth in the metric SDK
-        filter: always_off
       readers:
         - pull:
             exporter:

--- a/deploy/helm/gateway-collector-config.yaml
+++ b/deploy/helm/gateway-collector-config.yaml
@@ -781,9 +781,6 @@ service:
       level: none
 {{- if .Values.otel.gateway.telemetry.metrics.enabled }}
     metrics:
-      exemplars:
-        # Disable exemplars to prevent unbounded cardinality growth in the metric SDK
-        filter: always_off
       readers:
         - pull:
             exporter:

--- a/deploy/helm/gateway-collector-config.yaml
+++ b/deploy/helm/gateway-collector-config.yaml
@@ -776,8 +776,14 @@ service:
     logs:
       level: {{ .Values.otel.gateway.telemetry.logs.level }}
 {{- end }}
+    # Disable internal tracing to prevent evictedQueue span event accumulation (memory leak)
+    traces:
+      level: none
 {{- if .Values.otel.gateway.telemetry.metrics.enabled }}
     metrics:
+      exemplars:
+        # Disable exemplars to prevent unbounded cardinality growth in the metric SDK
+        filter: always_off
       readers:
         - pull:
             exporter:

--- a/deploy/helm/metrics-collector-config.yaml
+++ b/deploy/helm/metrics-collector-config.yaml
@@ -1263,8 +1263,14 @@ service:
     logs:
       level: {{ .Values.otel.metrics.telemetry.logs.level }}
 {{- end }}
+    # Disable internal tracing to prevent evictedQueue span event accumulation (memory leak)
+    traces:
+      level: none
 {{- if .Values.otel.metrics.telemetry.metrics.enabled }}
     metrics:
+      exemplars:
+        # Disable exemplars to prevent unbounded cardinality growth in the metric SDK
+        filter: always_off
       readers:
         - pull:
             exporter:

--- a/deploy/helm/metrics-collector-config.yaml
+++ b/deploy/helm/metrics-collector-config.yaml
@@ -1268,9 +1268,6 @@ service:
       level: none
 {{- if .Values.otel.metrics.telemetry.metrics.enabled }}
     metrics:
-      exemplars:
-        # Disable exemplars to prevent unbounded cardinality growth in the metric SDK
-        filter: always_off
       readers:
         - pull:
             exporter:

--- a/deploy/helm/metrics-discovery-config.yaml
+++ b/deploy/helm/metrics-discovery-config.yaml
@@ -209,9 +209,6 @@ service:
       level: none
 {{- if .Values.aws_fargate.metrics.autodiscovery.telemetry.metrics.enabled }}
     metrics:
-      exemplars:
-        # Disable exemplars to prevent unbounded cardinality growth in the metric SDK
-        filter: always_off
       readers:
         - pull:
             exporter:

--- a/deploy/helm/metrics-discovery-config.yaml
+++ b/deploy/helm/metrics-discovery-config.yaml
@@ -204,8 +204,14 @@ service:
     logs:
       level: {{ .Values.aws_fargate.metrics.autodiscovery.telemetry.logs.level }}
 {{- end }}
+    # Disable internal tracing to prevent evictedQueue span event accumulation (memory leak)
+    traces:
+      level: none
 {{- if .Values.aws_fargate.metrics.autodiscovery.telemetry.metrics.enabled }}
     metrics:
+      exemplars:
+        # Disable exemplars to prevent unbounded cardinality growth in the metric SDK
+        filter: always_off
       readers:
         - pull:
             exporter:

--- a/deploy/helm/node-collector-config.yaml
+++ b/deploy/helm/node-collector-config.yaml
@@ -723,8 +723,14 @@ service:
     logs:
       level: {{ .Values.otel.logs.telemetry.logs.level }}
 {{- end }}
+    # Disable internal tracing to prevent evictedQueue span event accumulation (memory leak)
+    traces:
+      level: none
 {{- if .Values.otel.logs.telemetry.metrics.enabled }}
     metrics:
+      exemplars:
+        # Disable exemplars to prevent unbounded cardinality growth in the metric SDK
+        filter: always_off
       readers:
         - pull:
             exporter:

--- a/deploy/helm/node-collector-config.yaml
+++ b/deploy/helm/node-collector-config.yaml
@@ -728,9 +728,6 @@ service:
       level: none
 {{- if .Values.otel.logs.telemetry.metrics.enabled }}
     metrics:
-      exemplars:
-        # Disable exemplars to prevent unbounded cardinality growth in the metric SDK
-        filter: always_off
       readers:
         - pull:
             exporter:

--- a/deploy/helm/tests/__snapshot__/events-collector-config-map_test.yaml.snap
+++ b/deploy/helm/tests/__snapshot__/events-collector-config-map_test.yaml.snap
@@ -1031,8 +1031,6 @@ Cluster filter should match snapshot with combined exclude filters:
           logs:
             level: error
           metrics:
-            exemplars:
-              filter: always_off
             readers:
             - pull:
                 exporter:
@@ -2070,8 +2068,6 @@ Cluster filter should match snapshot with combined include filters:
           logs:
             level: error
           metrics:
-            exemplars:
-              filter: always_off
             readers:
             - pull:
                 exporter:
@@ -3109,8 +3105,6 @@ Cluster filter should match snapshot with exclude_namespaces:
           logs:
             level: error
           metrics:
-            exemplars:
-              filter: always_off
             readers:
             - pull:
                 exporter:
@@ -4152,8 +4146,6 @@ Cluster filter should match snapshot with exclude_namespaces_regex:
           logs:
             level: error
           metrics:
-            exemplars:
-              filter: always_off
             readers:
             - pull:
                 exporter:
@@ -5191,8 +5183,6 @@ Cluster filter should match snapshot with include_namespaces:
           logs:
             level: error
           metrics:
-            exemplars:
-              filter: always_off
             readers:
             - pull:
                 exporter:
@@ -6231,8 +6221,6 @@ Cluster filter should match snapshot with include_namespaces_regex:
           logs:
             level: error
           metrics:
-            exemplars:
-              filter: always_off
             readers:
             - pull:
                 exporter:
@@ -7258,8 +7246,6 @@ Custom events filter with new syntax:
           logs:
             level: error
           metrics:
-            exemplars:
-              filter: always_off
             readers:
             - pull:
                 exporter:
@@ -8288,8 +8274,6 @@ Custom events filter with old syntax:
           logs:
             level: error
           metrics:
-            exemplars:
-              filter: always_off
             readers:
             - pull:
                 exporter:
@@ -9310,8 +9294,6 @@ Events config should match snapshot when using default values:
           logs:
             level: error
           metrics:
-            exemplars:
-              filter: always_off
             readers:
             - pull:
                 exporter:
@@ -10007,8 +9989,6 @@ Events config should not contain manifest collection pipeline when disabled:
           logs:
             level: error
           metrics:
-            exemplars:
-              filter: always_off
             readers:
             - pull:
                 exporter:

--- a/deploy/helm/tests/__snapshot__/events-collector-config-map_test.yaml.snap
+++ b/deploy/helm/tests/__snapshot__/events-collector-config-map_test.yaml.snap
@@ -1031,12 +1031,16 @@ Cluster filter should match snapshot with combined exclude filters:
           logs:
             level: error
           metrics:
+            exemplars:
+              filter: always_off
             readers:
             - pull:
                 exporter:
                   prometheus:
                     host: 0.0.0.0
                     port: 8888
+          traces:
+            level: none
 Cluster filter should match snapshot with combined include filters:
   1: |
     events.config: |-
@@ -2066,12 +2070,16 @@ Cluster filter should match snapshot with combined include filters:
           logs:
             level: error
           metrics:
+            exemplars:
+              filter: always_off
             readers:
             - pull:
                 exporter:
                   prometheus:
                     host: 0.0.0.0
                     port: 8888
+          traces:
+            level: none
 Cluster filter should match snapshot with exclude_namespaces:
   1: |
     events.config: |-
@@ -3101,12 +3109,16 @@ Cluster filter should match snapshot with exclude_namespaces:
           logs:
             level: error
           metrics:
+            exemplars:
+              filter: always_off
             readers:
             - pull:
                 exporter:
                   prometheus:
                     host: 0.0.0.0
                     port: 8888
+          traces:
+            level: none
 Cluster filter should match snapshot with exclude_namespaces_regex:
   1: |
     events.config: |-
@@ -4140,12 +4152,16 @@ Cluster filter should match snapshot with exclude_namespaces_regex:
           logs:
             level: error
           metrics:
+            exemplars:
+              filter: always_off
             readers:
             - pull:
                 exporter:
                   prometheus:
                     host: 0.0.0.0
                     port: 8888
+          traces:
+            level: none
 Cluster filter should match snapshot with include_namespaces:
   1: |
     events.config: |-
@@ -5175,12 +5191,16 @@ Cluster filter should match snapshot with include_namespaces:
           logs:
             level: error
           metrics:
+            exemplars:
+              filter: always_off
             readers:
             - pull:
                 exporter:
                   prometheus:
                     host: 0.0.0.0
                     port: 8888
+          traces:
+            level: none
 Cluster filter should match snapshot with include_namespaces_regex:
   1: |
     events.config: |-
@@ -6211,12 +6231,16 @@ Cluster filter should match snapshot with include_namespaces_regex:
           logs:
             level: error
           metrics:
+            exemplars:
+              filter: always_off
             readers:
             - pull:
                 exporter:
                   prometheus:
                     host: 0.0.0.0
                     port: 8888
+          traces:
+            level: none
 Custom events filter with new syntax:
   1: |
     events.config: |-
@@ -7234,12 +7258,16 @@ Custom events filter with new syntax:
           logs:
             level: error
           metrics:
+            exemplars:
+              filter: always_off
             readers:
             - pull:
                 exporter:
                   prometheus:
                     host: 0.0.0.0
                     port: 8888
+          traces:
+            level: none
 Custom events filter with old syntax:
   1: |
     events.config: |-
@@ -8260,12 +8288,16 @@ Custom events filter with old syntax:
           logs:
             level: error
           metrics:
+            exemplars:
+              filter: always_off
             readers:
             - pull:
                 exporter:
                   prometheus:
                     host: 0.0.0.0
                     port: 8888
+          traces:
+            level: none
 Events config should match snapshot when using default values:
   1: |
     events.config: |-
@@ -9278,12 +9310,16 @@ Events config should match snapshot when using default values:
           logs:
             level: error
           metrics:
+            exemplars:
+              filter: always_off
             readers:
             - pull:
                 exporter:
                   prometheus:
                     host: 0.0.0.0
                     port: 8888
+          traces:
+            level: none
 Events config should not contain manifest collection pipeline when disabled:
   1: |
     events.config: |-
@@ -9971,9 +10007,13 @@ Events config should not contain manifest collection pipeline when disabled:
           logs:
             level: error
           metrics:
+            exemplars:
+              filter: always_off
             readers:
             - pull:
                 exporter:
                   prometheus:
                     host: 0.0.0.0
                     port: 8888
+          traces:
+            level: none

--- a/deploy/helm/tests/__snapshot__/gateway-config-map_test.yaml.snap
+++ b/deploy/helm/tests/__snapshot__/gateway-config-map_test.yaml.snap
@@ -886,8 +886,6 @@ Gateway config should match snapshot when using default values:
           logs:
             level: error
           metrics:
-            exemplars:
-              filter: always_off
             readers:
             - pull:
                 exporter:

--- a/deploy/helm/tests/__snapshot__/gateway-config-map_test.yaml.snap
+++ b/deploy/helm/tests/__snapshot__/gateway-config-map_test.yaml.snap
@@ -886,9 +886,13 @@ Gateway config should match snapshot when using default values:
           logs:
             level: error
           metrics:
+            exemplars:
+              filter: always_off
             readers:
             - pull:
                 exporter:
                   prometheus:
                     host: 0.0.0.0
                     port: 8888
+          traces:
+            level: none

--- a/deploy/helm/tests/__snapshot__/metrics-collector-config-map-fargate_test.yaml.snap
+++ b/deploy/helm/tests/__snapshot__/metrics-collector-config-map-fargate_test.yaml.snap
@@ -1746,8 +1746,6 @@ Metrics config should match snapshot when using default values:
           logs:
             level: error
           metrics:
-            exemplars:
-              filter: always_off
             readers:
             - pull:
                 exporter:

--- a/deploy/helm/tests/__snapshot__/metrics-collector-config-map-fargate_test.yaml.snap
+++ b/deploy/helm/tests/__snapshot__/metrics-collector-config-map-fargate_test.yaml.snap
@@ -1746,9 +1746,13 @@ Metrics config should match snapshot when using default values:
           logs:
             level: error
           metrics:
+            exemplars:
+              filter: always_off
             readers:
             - pull:
                 exporter:
                   prometheus:
                     host: 0.0.0.0
                     port: 8888
+          traces:
+            level: none

--- a/deploy/helm/tests/__snapshot__/metrics-collector-config-map_test.yaml.snap
+++ b/deploy/helm/tests/__snapshot__/metrics-collector-config-map_test.yaml.snap
@@ -1678,8 +1678,6 @@ Cluster filter should match snapshot with combined exclude filters:
           logs:
             level: error
           metrics:
-            exemplars:
-              filter: always_off
             readers:
             - pull:
                 exporter:
@@ -3366,8 +3364,6 @@ Cluster filter should match snapshot with combined include filters:
           logs:
             level: error
           metrics:
-            exemplars:
-              filter: always_off
             readers:
             - pull:
                 exporter:
@@ -5055,8 +5051,6 @@ Cluster filter should match snapshot with exclude_namespaces:
           logs:
             level: error
           metrics:
-            exemplars:
-              filter: always_off
             readers:
             - pull:
                 exporter:
@@ -6744,8 +6738,6 @@ Cluster filter should match snapshot with exclude_namespaces_regex:
           logs:
             level: error
           metrics:
-            exemplars:
-              filter: always_off
             readers:
             - pull:
                 exporter:
@@ -8432,8 +8424,6 @@ Cluster filter should match snapshot with include_namespaces:
           logs:
             level: error
           metrics:
-            exemplars:
-              filter: always_off
             readers:
             - pull:
                 exporter:
@@ -10120,8 +10110,6 @@ Cluster filter should match snapshot with include_namespaces_regex:
           logs:
             level: error
           metrics:
-            exemplars:
-              filter: always_off
             readers:
             - pull:
                 exporter:
@@ -11878,8 +11866,6 @@ Metrics config should match snapshot when fargate is enabled:
           logs:
             level: error
           metrics:
-            exemplars:
-              filter: always_off
             readers:
             - pull:
                 exporter:
@@ -13626,8 +13612,6 @@ Metrics config should match snapshot when using Prometheus url with extra_scrape
           logs:
             level: error
           metrics:
-            exemplars:
-              filter: always_off
             readers:
             - pull:
                 exporter:
@@ -15307,8 +15291,6 @@ Metrics config should match snapshot when using default values:
           logs:
             level: error
           metrics:
-            exemplars:
-              filter: always_off
             readers:
             - pull:
                 exporter:

--- a/deploy/helm/tests/__snapshot__/metrics-collector-config-map_test.yaml.snap
+++ b/deploy/helm/tests/__snapshot__/metrics-collector-config-map_test.yaml.snap
@@ -1678,12 +1678,16 @@ Cluster filter should match snapshot with combined exclude filters:
           logs:
             level: error
           metrics:
+            exemplars:
+              filter: always_off
             readers:
             - pull:
                 exporter:
                   prometheus:
                     host: 0.0.0.0
                     port: 8888
+          traces:
+            level: none
 Cluster filter should match snapshot with combined include filters:
   1: |
     metrics.config: |-
@@ -3362,12 +3366,16 @@ Cluster filter should match snapshot with combined include filters:
           logs:
             level: error
           metrics:
+            exemplars:
+              filter: always_off
             readers:
             - pull:
                 exporter:
                   prometheus:
                     host: 0.0.0.0
                     port: 8888
+          traces:
+            level: none
 Cluster filter should match snapshot with exclude_namespaces:
   1: |
     metrics.config: |-
@@ -5047,12 +5055,16 @@ Cluster filter should match snapshot with exclude_namespaces:
           logs:
             level: error
           metrics:
+            exemplars:
+              filter: always_off
             readers:
             - pull:
                 exporter:
                   prometheus:
                     host: 0.0.0.0
                     port: 8888
+          traces:
+            level: none
 Cluster filter should match snapshot with exclude_namespaces_regex:
   1: |
     metrics.config: |-
@@ -6732,12 +6744,16 @@ Cluster filter should match snapshot with exclude_namespaces_regex:
           logs:
             level: error
           metrics:
+            exemplars:
+              filter: always_off
             readers:
             - pull:
                 exporter:
                   prometheus:
                     host: 0.0.0.0
                     port: 8888
+          traces:
+            level: none
 Cluster filter should match snapshot with include_namespaces:
   1: |
     metrics.config: |-
@@ -8416,12 +8432,16 @@ Cluster filter should match snapshot with include_namespaces:
           logs:
             level: error
           metrics:
+            exemplars:
+              filter: always_off
             readers:
             - pull:
                 exporter:
                   prometheus:
                     host: 0.0.0.0
                     port: 8888
+          traces:
+            level: none
 Cluster filter should match snapshot with include_namespaces_regex:
   1: |
     metrics.config: |-
@@ -10100,12 +10120,16 @@ Cluster filter should match snapshot with include_namespaces_regex:
           logs:
             level: error
           metrics:
+            exemplars:
+              filter: always_off
             readers:
             - pull:
                 exporter:
                   prometheus:
                     host: 0.0.0.0
                     port: 8888
+          traces:
+            level: none
 Metrics config should match snapshot when fargate is enabled:
   1: |
     metrics.config: |-
@@ -11854,12 +11878,16 @@ Metrics config should match snapshot when fargate is enabled:
           logs:
             level: error
           metrics:
+            exemplars:
+              filter: always_off
             readers:
             - pull:
                 exporter:
                   prometheus:
                     host: 0.0.0.0
                     port: 8888
+          traces:
+            level: none
 Metrics config should match snapshot when using Prometheus url with extra_scrape_metrics:
   1: |
     metrics.config: |-
@@ -13598,12 +13626,16 @@ Metrics config should match snapshot when using Prometheus url with extra_scrape
           logs:
             level: error
           metrics:
+            exemplars:
+              filter: always_off
             readers:
             - pull:
                 exporter:
                   prometheus:
                     host: 0.0.0.0
                     port: 8888
+          traces:
+            level: none
 Metrics config should match snapshot when using default values:
   1: |
     metrics.config: |-
@@ -15275,9 +15307,13 @@ Metrics config should match snapshot when using default values:
           logs:
             level: error
           metrics:
+            exemplars:
+              filter: always_off
             readers:
             - pull:
                 exporter:
                   prometheus:
                     host: 0.0.0.0
                     port: 8888
+          traces:
+            level: none

--- a/deploy/helm/tests/__snapshot__/metrics-discovery-config-map_test.yaml.snap
+++ b/deploy/helm/tests/__snapshot__/metrics-discovery-config-map_test.yaml.snap
@@ -898,8 +898,6 @@ Metrics discovery config should match snapshot when Fargate is enabled:
           logs:
             level: error
           metrics:
-            exemplars:
-              filter: always_off
             readers:
             - pull:
                 exporter:

--- a/deploy/helm/tests/__snapshot__/metrics-discovery-config-map_test.yaml.snap
+++ b/deploy/helm/tests/__snapshot__/metrics-discovery-config-map_test.yaml.snap
@@ -898,9 +898,13 @@ Metrics discovery config should match snapshot when Fargate is enabled:
           logs:
             level: error
           metrics:
+            exemplars:
+              filter: always_off
             readers:
             - pull:
                 exporter:
                   prometheus:
                     host: 0.0.0.0
                     port: 8888
+          traces:
+            level: none

--- a/deploy/helm/tests/__snapshot__/node-collector-config-map-windows_test.yaml.snap
+++ b/deploy/helm/tests/__snapshot__/node-collector-config-map-windows_test.yaml.snap
@@ -1828,12 +1828,16 @@ Node collector config for windows nodes should match snapshot when using default
           logs:
             level: error
           metrics:
+            exemplars:
+              filter: always_off
             readers:
             - pull:
                 exporter:
                   prometheus:
                     host: 0.0.0.0
                     port: 8888
+          traces:
+            level: none
 Node collector config for windows nodes should match snapshot when using legacy filter:
   1: |
     logs.config: |
@@ -3753,9 +3757,13 @@ Node collector config for windows nodes should match snapshot when using legacy 
           logs:
             level: error
           metrics:
+            exemplars:
+              filter: always_off
             readers:
             - pull:
                 exporter:
                   prometheus:
                     host: 0.0.0.0
                     port: 8888
+          traces:
+            level: none

--- a/deploy/helm/tests/__snapshot__/node-collector-config-map-windows_test.yaml.snap
+++ b/deploy/helm/tests/__snapshot__/node-collector-config-map-windows_test.yaml.snap
@@ -1828,8 +1828,6 @@ Node collector config for windows nodes should match snapshot when using default
           logs:
             level: error
           metrics:
-            exemplars:
-              filter: always_off
             readers:
             - pull:
                 exporter:
@@ -3757,8 +3755,6 @@ Node collector config for windows nodes should match snapshot when using legacy 
           logs:
             level: error
           metrics:
-            exemplars:
-              filter: always_off
             readers:
             - pull:
                 exporter:

--- a/deploy/helm/tests/__snapshot__/node-collector-config-map_test.yaml.snap
+++ b/deploy/helm/tests/__snapshot__/node-collector-config-map_test.yaml.snap
@@ -1880,8 +1880,6 @@ Cluster filter should match snapshot with combined exclude filters:
           logs:
             level: error
           metrics:
-            exemplars:
-              filter: always_off
             readers:
             - pull:
                 exporter:
@@ -3768,8 +3766,6 @@ Cluster filter should match snapshot with combined include filters:
           logs:
             level: error
           metrics:
-            exemplars:
-              filter: always_off
             readers:
             - pull:
                 exporter:
@@ -5658,8 +5654,6 @@ Cluster filter should match snapshot with exclude_namespaces:
           logs:
             level: error
           metrics:
-            exemplars:
-              filter: always_off
             readers:
             - pull:
                 exporter:
@@ -7548,8 +7542,6 @@ Cluster filter should match snapshot with exclude_namespaces_regex:
           logs:
             level: error
           metrics:
-            exemplars:
-              filter: always_off
             readers:
             - pull:
                 exporter:
@@ -9436,8 +9428,6 @@ Cluster filter should match snapshot with include_namespaces:
           logs:
             level: error
           metrics:
-            exemplars:
-              filter: always_off
             readers:
             - pull:
                 exporter:
@@ -11326,8 +11316,6 @@ Cluster filter should match snapshot with include_namespaces_regex:
           logs:
             level: error
           metrics:
-            exemplars:
-              filter: always_off
             readers:
             - pull:
                 exporter:
@@ -13207,8 +13195,6 @@ Custom logs filter with new syntax:
           logs:
             level: error
           metrics:
-            exemplars:
-              filter: always_off
             readers:
             - pull:
                 exporter:
@@ -15172,8 +15158,6 @@ Custom logs filter with old syntax:
           logs:
             level: error
           metrics:
-            exemplars:
-              filter: always_off
             readers:
             - pull:
                 exporter:
@@ -16988,8 +16972,6 @@ Node collector config should match snapshot when autodiscovery is disabled:
           logs:
             level: error
           metrics:
-            exemplars:
-              filter: always_off
             readers:
             - pull:
                 exporter:
@@ -18783,8 +18765,6 @@ Node collector config should match snapshot when fargate is enabled:
           logs:
             level: error
           metrics:
-            exemplars:
-              filter: always_off
             readers:
             - pull:
                 exporter:
@@ -20499,8 +20479,6 @@ Node collector config should match snapshot when fargate is enabled and autodisc
           logs:
             level: error
           metrics:
-            exemplars:
-              filter: always_off
             readers:
             - pull:
                 exporter:
@@ -22375,8 +22353,6 @@ Node collector config should match snapshot when using default values:
           logs:
             level: error
           metrics:
-            exemplars:
-              filter: always_off
             readers:
             - pull:
                 exporter:

--- a/deploy/helm/tests/__snapshot__/node-collector-config-map_test.yaml.snap
+++ b/deploy/helm/tests/__snapshot__/node-collector-config-map_test.yaml.snap
@@ -1880,12 +1880,16 @@ Cluster filter should match snapshot with combined exclude filters:
           logs:
             level: error
           metrics:
+            exemplars:
+              filter: always_off
             readers:
             - pull:
                 exporter:
                   prometheus:
                     host: 0.0.0.0
                     port: 8888
+          traces:
+            level: none
 Cluster filter should match snapshot with combined include filters:
   1: |
     logs.config: |
@@ -3764,12 +3768,16 @@ Cluster filter should match snapshot with combined include filters:
           logs:
             level: error
           metrics:
+            exemplars:
+              filter: always_off
             readers:
             - pull:
                 exporter:
                   prometheus:
                     host: 0.0.0.0
                     port: 8888
+          traces:
+            level: none
 Cluster filter should match snapshot with exclude_namespaces:
   1: |
     logs.config: |
@@ -5650,12 +5658,16 @@ Cluster filter should match snapshot with exclude_namespaces:
           logs:
             level: error
           metrics:
+            exemplars:
+              filter: always_off
             readers:
             - pull:
                 exporter:
                   prometheus:
                     host: 0.0.0.0
                     port: 8888
+          traces:
+            level: none
 Cluster filter should match snapshot with exclude_namespaces_regex:
   1: |
     logs.config: |
@@ -7536,12 +7548,16 @@ Cluster filter should match snapshot with exclude_namespaces_regex:
           logs:
             level: error
           metrics:
+            exemplars:
+              filter: always_off
             readers:
             - pull:
                 exporter:
                   prometheus:
                     host: 0.0.0.0
                     port: 8888
+          traces:
+            level: none
 Cluster filter should match snapshot with include_namespaces:
   1: |
     logs.config: |
@@ -9420,12 +9436,16 @@ Cluster filter should match snapshot with include_namespaces:
           logs:
             level: error
           metrics:
+            exemplars:
+              filter: always_off
             readers:
             - pull:
                 exporter:
                   prometheus:
                     host: 0.0.0.0
                     port: 8888
+          traces:
+            level: none
 Cluster filter should match snapshot with include_namespaces_regex:
   1: |
     logs.config: |
@@ -11306,12 +11326,16 @@ Cluster filter should match snapshot with include_namespaces_regex:
           logs:
             level: error
           metrics:
+            exemplars:
+              filter: always_off
             readers:
             - pull:
                 exporter:
                   prometheus:
                     host: 0.0.0.0
                     port: 8888
+          traces:
+            level: none
 Custom logs filter with new syntax:
   1: |
     logs.config: |
@@ -13183,12 +13207,16 @@ Custom logs filter with new syntax:
           logs:
             level: error
           metrics:
+            exemplars:
+              filter: always_off
             readers:
             - pull:
                 exporter:
                   prometheus:
                     host: 0.0.0.0
                     port: 8888
+          traces:
+            level: none
 Custom logs filter with old syntax:
   1: |
     logs.config: |
@@ -15144,12 +15172,16 @@ Custom logs filter with old syntax:
           logs:
             level: error
           metrics:
+            exemplars:
+              filter: always_off
             readers:
             - pull:
                 exporter:
                   prometheus:
                     host: 0.0.0.0
                     port: 8888
+          traces:
+            level: none
 Node collector config should match snapshot when autodiscovery is disabled:
   1: |
     logs.config: |
@@ -16956,12 +16988,16 @@ Node collector config should match snapshot when autodiscovery is disabled:
           logs:
             level: error
           metrics:
+            exemplars:
+              filter: always_off
             readers:
             - pull:
                 exporter:
                   prometheus:
                     host: 0.0.0.0
                     port: 8888
+          traces:
+            level: none
 Node collector config should match snapshot when fargate is enabled:
   1: |
     logs.config: |
@@ -18747,12 +18783,16 @@ Node collector config should match snapshot when fargate is enabled:
           logs:
             level: error
           metrics:
+            exemplars:
+              filter: always_off
             readers:
             - pull:
                 exporter:
                   prometheus:
                     host: 0.0.0.0
                     port: 8888
+          traces:
+            level: none
 Node collector config should match snapshot when fargate is enabled and autodiscovery is disabled:
   1: |
     logs.config: |
@@ -20459,12 +20499,16 @@ Node collector config should match snapshot when fargate is enabled and autodisc
           logs:
             level: error
           metrics:
+            exemplars:
+              filter: always_off
             readers:
             - pull:
                 exporter:
                   prometheus:
                     host: 0.0.0.0
                     port: 8888
+          traces:
+            level: none
 Node collector config should match snapshot when using default values:
   1: |
     logs.config: |
@@ -22331,9 +22375,13 @@ Node collector config should match snapshot when using default values:
           logs:
             level: error
           metrics:
+            exemplars:
+              filter: always_off
             readers:
             - pull:
                 exporter:
                   prometheus:
                     host: 0.0.0.0
                     port: 8888
+          traces:
+            level: none


### PR DESCRIPTION
Settings changed:

traces.level: none
The OTEL collector SDK creates internal recording spans for every log batch it processes (via ObsReport.StartLogsOp/EndLogsOp). Each span accumulates span events in an evictedQueue that grows unboundedly because no trace exporter is configured — the spans are never flushed. Setting level: none disables this internal tracing entirely, preventing the spans from being created.

agent also recommended to remove exemplars from metrics (not done for now)
metrics.exemplars.filter: always_off
The OTEL metric SDK allocates a FixedSizeReservoir for exemplar storage for every unique attribute combination seen on a counter (e.g. per pipeline name, per receiver name, per resource type). These entries are never evicted. In a cluster with pod/resource churn, new attribute combinations keep appearing, growing the metric registry indefinitely. Setting always_off disables exemplar collection, preventing new reservoirs from being allocated.