### PR TITLE
Add EntityRefs to Container logs

### DIFF
--- a/deploy/helm/Chart.yaml
+++ b/deploy/helm/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: swo-k8s-collector
 version: 5.3.0-alpha.4
-appVersion: 0.150.0
+appVersion: 0.152.0
 description: SolarWinds Kubernetes Integration
 keywords:
   - monitoring

--- a/deploy/helm/node-collector-config.yaml
+++ b/deploy/helm/node-collector-config.yaml
@@ -182,6 +182,51 @@ processors:
       - key: k8s.node.name
         value: ${NODE_NAME}
         action: insert
+
+  swootelentityref/container_logs:
+    action: insert
+    entity_refs:
+      - type: KubernetesContainer
+        id_keys:
+          - sw.k8s.cluster.uid
+          - k8s.namespace.name
+          - k8s.pod.name
+          - k8s.container.name
+      - type: KubernetesPod
+        id_keys:
+          - sw.k8s.cluster.uid
+          - k8s.namespace.name
+          - k8s.pod.name
+      - type: KubernetesNode
+        id_keys:
+          - sw.k8s.cluster.uid
+          - k8s.node.name
+      - type: KubernetesDeployment
+        id_keys:
+          - sw.k8s.cluster.uid
+          - k8s.namespace.name
+          - k8s.deployment.name
+      - type: KubernetesStatefulSet
+        id_keys:
+          - sw.k8s.cluster.uid
+          - k8s.namespace.name
+          - k8s.statefulset.name
+      - type: KubernetesDaemonSet
+        id_keys:
+          - sw.k8s.cluster.uid
+          - k8s.namespace.name
+          - k8s.daemonset.name
+      - type: KubernetesJob
+        id_keys:
+          - sw.k8s.cluster.uid
+          - k8s.namespace.name
+          - k8s.job.name
+      - type: KubernetesCronJob
+        id_keys:
+          - sw.k8s.cluster.uid
+          - k8s.namespace.name
+          - k8s.cronjob.name
+
 {{- if and (not .isWindows) .Values.otel.logs.journal }}
   resource/journal:
     attributes:
@@ -633,6 +678,7 @@ service:
         - groupbyattrs/common-all
         - resource/container
         - k8s_attributes
+        - swootelentityref/container_logs
 {{- if eq (include "isNamespacesFilterEnabled" .) "true" }}
         - filter/namespaces_logs
 {{- end }}           

--- a/deploy/helm/node-collector-config.yaml
+++ b/deploy/helm/node-collector-config.yaml
@@ -206,6 +206,11 @@ processors:
           - sw.k8s.cluster.uid
           - k8s.namespace.name
           - k8s.deployment.name
+      - type: KubernetesReplicaSet
+        id_keys:
+          - sw.k8s.cluster.uid
+          - k8s.namespace.name
+          - k8s.replicaset.name
       - type: KubernetesStatefulSet
         id_keys:
           - sw.k8s.cluster.uid

--- a/deploy/helm/tests/__snapshot__/node-collector-config-map-windows_test.yaml.snap
+++ b/deploy/helm/tests/__snapshot__/node-collector-config-map-windows_test.yaml.snap
@@ -1355,6 +1355,11 @@ Node collector config for windows nodes should match snapshot when using default
           - id_keys:
             - sw.k8s.cluster.uid
             - k8s.namespace.name
+            - k8s.replicaset.name
+            type: KubernetesReplicaSet
+          - id_keys:
+            - sw.k8s.cluster.uid
+            - k8s.namespace.name
             - k8s.statefulset.name
             type: KubernetesStatefulSet
           - id_keys:
@@ -3241,6 +3246,11 @@ Node collector config for windows nodes should match snapshot when using legacy 
             - k8s.namespace.name
             - k8s.deployment.name
             type: KubernetesDeployment
+          - id_keys:
+            - sw.k8s.cluster.uid
+            - k8s.namespace.name
+            - k8s.replicaset.name
+            type: KubernetesReplicaSet
           - id_keys:
             - sw.k8s.cluster.uid
             - k8s.namespace.name

--- a/deploy/helm/tests/__snapshot__/node-collector-config-map-windows_test.yaml.snap
+++ b/deploy/helm/tests/__snapshot__/node-collector-config-map-windows_test.yaml.snap
@@ -1329,6 +1329,49 @@ Node collector config for windows nodes should match snapshot when using default
             name_attr: destination_service_name
             namespace_attr: destination_service_namespace
             workload_type_attr: destination_service_type
+        swootelentityref/container_logs:
+          action: insert
+          entity_refs:
+          - id_keys:
+            - sw.k8s.cluster.uid
+            - k8s.namespace.name
+            - k8s.pod.name
+            - k8s.container.name
+            type: KubernetesContainer
+          - id_keys:
+            - sw.k8s.cluster.uid
+            - k8s.namespace.name
+            - k8s.pod.name
+            type: KubernetesPod
+          - id_keys:
+            - sw.k8s.cluster.uid
+            - k8s.node.name
+            type: KubernetesNode
+          - id_keys:
+            - sw.k8s.cluster.uid
+            - k8s.namespace.name
+            - k8s.deployment.name
+            type: KubernetesDeployment
+          - id_keys:
+            - sw.k8s.cluster.uid
+            - k8s.namespace.name
+            - k8s.statefulset.name
+            type: KubernetesStatefulSet
+          - id_keys:
+            - sw.k8s.cluster.uid
+            - k8s.namespace.name
+            - k8s.daemonset.name
+            type: KubernetesDaemonSet
+          - id_keys:
+            - sw.k8s.cluster.uid
+            - k8s.namespace.name
+            - k8s.job.name
+            type: KubernetesJob
+          - id_keys:
+            - sw.k8s.cluster.uid
+            - k8s.namespace.name
+            - k8s.cronjob.name
+            type: KubernetesCronJob
         transform/istio-metric-datapoints:
           metric_statements:
           - statements:
@@ -1666,6 +1709,7 @@ Node collector config for windows nodes should match snapshot when using default
             - groupbyattrs/common-all
             - resource/container
             - k8s_attributes
+            - swootelentityref/container_logs
             receivers:
             - file_log
           logs/stateevents-entities:
@@ -3172,6 +3216,49 @@ Node collector config for windows nodes should match snapshot when using legacy 
             name_attr: destination_service_name
             namespace_attr: destination_service_namespace
             workload_type_attr: destination_service_type
+        swootelentityref/container_logs:
+          action: insert
+          entity_refs:
+          - id_keys:
+            - sw.k8s.cluster.uid
+            - k8s.namespace.name
+            - k8s.pod.name
+            - k8s.container.name
+            type: KubernetesContainer
+          - id_keys:
+            - sw.k8s.cluster.uid
+            - k8s.namespace.name
+            - k8s.pod.name
+            type: KubernetesPod
+          - id_keys:
+            - sw.k8s.cluster.uid
+            - k8s.node.name
+            type: KubernetesNode
+          - id_keys:
+            - sw.k8s.cluster.uid
+            - k8s.namespace.name
+            - k8s.deployment.name
+            type: KubernetesDeployment
+          - id_keys:
+            - sw.k8s.cluster.uid
+            - k8s.namespace.name
+            - k8s.statefulset.name
+            type: KubernetesStatefulSet
+          - id_keys:
+            - sw.k8s.cluster.uid
+            - k8s.namespace.name
+            - k8s.daemonset.name
+            type: KubernetesDaemonSet
+          - id_keys:
+            - sw.k8s.cluster.uid
+            - k8s.namespace.name
+            - k8s.job.name
+            type: KubernetesJob
+          - id_keys:
+            - sw.k8s.cluster.uid
+            - k8s.namespace.name
+            - k8s.cronjob.name
+            type: KubernetesCronJob
         transform/istio-metric-datapoints:
           metric_statements:
           - statements:
@@ -3591,6 +3678,7 @@ Node collector config for windows nodes should match snapshot when using legacy 
             - groupbyattrs/common-all
             - resource/container
             - k8s_attributes
+            - swootelentityref/container_logs
             receivers:
             - file_log
           logs/stateevents-entities:

--- a/deploy/helm/tests/__snapshot__/node-collector-config-map_test.yaml.snap
+++ b/deploy/helm/tests/__snapshot__/node-collector-config-map_test.yaml.snap
@@ -1389,6 +1389,11 @@ Cluster filter should match snapshot with combined exclude filters:
           - id_keys:
             - sw.k8s.cluster.uid
             - k8s.namespace.name
+            - k8s.replicaset.name
+            type: KubernetesReplicaSet
+          - id_keys:
+            - sw.k8s.cluster.uid
+            - k8s.namespace.name
             - k8s.statefulset.name
             type: KubernetesStatefulSet
           - id_keys:
@@ -3316,6 +3321,11 @@ Cluster filter should match snapshot with combined include filters:
             - k8s.namespace.name
             - k8s.deployment.name
             type: KubernetesDeployment
+          - id_keys:
+            - sw.k8s.cluster.uid
+            - k8s.namespace.name
+            - k8s.replicaset.name
+            type: KubernetesReplicaSet
           - id_keys:
             - sw.k8s.cluster.uid
             - k8s.namespace.name
@@ -5251,6 +5261,11 @@ Cluster filter should match snapshot with exclude_namespaces:
           - id_keys:
             - sw.k8s.cluster.uid
             - k8s.namespace.name
+            - k8s.replicaset.name
+            type: KubernetesReplicaSet
+          - id_keys:
+            - sw.k8s.cluster.uid
+            - k8s.namespace.name
             - k8s.statefulset.name
             type: KubernetesStatefulSet
           - id_keys:
@@ -7183,6 +7198,11 @@ Cluster filter should match snapshot with exclude_namespaces_regex:
           - id_keys:
             - sw.k8s.cluster.uid
             - k8s.namespace.name
+            - k8s.replicaset.name
+            type: KubernetesReplicaSet
+          - id_keys:
+            - sw.k8s.cluster.uid
+            - k8s.namespace.name
             - k8s.statefulset.name
             type: KubernetesStatefulSet
           - id_keys:
@@ -9110,6 +9130,11 @@ Cluster filter should match snapshot with include_namespaces:
             - k8s.namespace.name
             - k8s.deployment.name
             type: KubernetesDeployment
+          - id_keys:
+            - sw.k8s.cluster.uid
+            - k8s.namespace.name
+            - k8s.replicaset.name
+            type: KubernetesReplicaSet
           - id_keys:
             - sw.k8s.cluster.uid
             - k8s.namespace.name
@@ -11045,6 +11070,11 @@ Cluster filter should match snapshot with include_namespaces_regex:
           - id_keys:
             - sw.k8s.cluster.uid
             - k8s.namespace.name
+            - k8s.replicaset.name
+            type: KubernetesReplicaSet
+          - id_keys:
+            - sw.k8s.cluster.uid
+            - k8s.namespace.name
             - k8s.statefulset.name
             type: KubernetesStatefulSet
           - id_keys:
@@ -12966,6 +12996,11 @@ Custom logs filter with new syntax:
             - k8s.namespace.name
             - k8s.deployment.name
             type: KubernetesDeployment
+          - id_keys:
+            - sw.k8s.cluster.uid
+            - k8s.namespace.name
+            - k8s.replicaset.name
+            type: KubernetesReplicaSet
           - id_keys:
             - sw.k8s.cluster.uid
             - k8s.namespace.name
@@ -14892,6 +14927,11 @@ Custom logs filter with old syntax:
             - k8s.namespace.name
             - k8s.deployment.name
             type: KubernetesDeployment
+          - id_keys:
+            - sw.k8s.cluster.uid
+            - k8s.namespace.name
+            - k8s.replicaset.name
+            type: KubernetesReplicaSet
           - id_keys:
             - sw.k8s.cluster.uid
             - k8s.namespace.name
@@ -16895,6 +16935,11 @@ Node collector config should match snapshot when autodiscovery is disabled:
           - id_keys:
             - sw.k8s.cluster.uid
             - k8s.namespace.name
+            - k8s.replicaset.name
+            type: KubernetesReplicaSet
+          - id_keys:
+            - sw.k8s.cluster.uid
+            - k8s.namespace.name
             - k8s.statefulset.name
             type: KubernetesStatefulSet
           - id_keys:
@@ -18750,6 +18795,11 @@ Node collector config should match snapshot when fargate is enabled:
           - id_keys:
             - sw.k8s.cluster.uid
             - k8s.namespace.name
+            - k8s.replicaset.name
+            type: KubernetesReplicaSet
+          - id_keys:
+            - sw.k8s.cluster.uid
+            - k8s.namespace.name
             - k8s.statefulset.name
             type: KubernetesStatefulSet
           - id_keys:
@@ -20581,6 +20631,11 @@ Node collector config should match snapshot when fargate is enabled and autodisc
           - id_keys:
             - sw.k8s.cluster.uid
             - k8s.namespace.name
+            - k8s.replicaset.name
+            type: KubernetesReplicaSet
+          - id_keys:
+            - sw.k8s.cluster.uid
+            - k8s.namespace.name
             - k8s.statefulset.name
             type: KubernetesStatefulSet
           - id_keys:
@@ -22345,6 +22400,11 @@ Node collector config should match snapshot when using default values:
             - k8s.namespace.name
             - k8s.deployment.name
             type: KubernetesDeployment
+          - id_keys:
+            - sw.k8s.cluster.uid
+            - k8s.namespace.name
+            - k8s.replicaset.name
+            type: KubernetesReplicaSet
           - id_keys:
             - sw.k8s.cluster.uid
             - k8s.namespace.name

--- a/deploy/helm/tests/__snapshot__/node-collector-config-map_test.yaml.snap
+++ b/deploy/helm/tests/__snapshot__/node-collector-config-map_test.yaml.snap
@@ -1363,6 +1363,49 @@ Cluster filter should match snapshot with combined exclude filters:
             name_attr: destination_service_name
             namespace_attr: destination_service_namespace
             workload_type_attr: destination_service_type
+        swootelentityref/container_logs:
+          action: insert
+          entity_refs:
+          - id_keys:
+            - sw.k8s.cluster.uid
+            - k8s.namespace.name
+            - k8s.pod.name
+            - k8s.container.name
+            type: KubernetesContainer
+          - id_keys:
+            - sw.k8s.cluster.uid
+            - k8s.namespace.name
+            - k8s.pod.name
+            type: KubernetesPod
+          - id_keys:
+            - sw.k8s.cluster.uid
+            - k8s.node.name
+            type: KubernetesNode
+          - id_keys:
+            - sw.k8s.cluster.uid
+            - k8s.namespace.name
+            - k8s.deployment.name
+            type: KubernetesDeployment
+          - id_keys:
+            - sw.k8s.cluster.uid
+            - k8s.namespace.name
+            - k8s.statefulset.name
+            type: KubernetesStatefulSet
+          - id_keys:
+            - sw.k8s.cluster.uid
+            - k8s.namespace.name
+            - k8s.daemonset.name
+            type: KubernetesDaemonSet
+          - id_keys:
+            - sw.k8s.cluster.uid
+            - k8s.namespace.name
+            - k8s.job.name
+            type: KubernetesJob
+          - id_keys:
+            - sw.k8s.cluster.uid
+            - k8s.namespace.name
+            - k8s.cronjob.name
+            type: KubernetesCronJob
         transform/istio-metric-datapoints:
           metric_statements:
           - statements:
@@ -1707,6 +1750,7 @@ Cluster filter should match snapshot with combined exclude filters:
             - groupbyattrs/common-all
             - resource/container
             - k8s_attributes
+            - swootelentityref/container_logs
             - filter/namespaces_logs
             receivers:
             - file_log
@@ -3247,6 +3291,49 @@ Cluster filter should match snapshot with combined include filters:
             name_attr: destination_service_name
             namespace_attr: destination_service_namespace
             workload_type_attr: destination_service_type
+        swootelentityref/container_logs:
+          action: insert
+          entity_refs:
+          - id_keys:
+            - sw.k8s.cluster.uid
+            - k8s.namespace.name
+            - k8s.pod.name
+            - k8s.container.name
+            type: KubernetesContainer
+          - id_keys:
+            - sw.k8s.cluster.uid
+            - k8s.namespace.name
+            - k8s.pod.name
+            type: KubernetesPod
+          - id_keys:
+            - sw.k8s.cluster.uid
+            - k8s.node.name
+            type: KubernetesNode
+          - id_keys:
+            - sw.k8s.cluster.uid
+            - k8s.namespace.name
+            - k8s.deployment.name
+            type: KubernetesDeployment
+          - id_keys:
+            - sw.k8s.cluster.uid
+            - k8s.namespace.name
+            - k8s.statefulset.name
+            type: KubernetesStatefulSet
+          - id_keys:
+            - sw.k8s.cluster.uid
+            - k8s.namespace.name
+            - k8s.daemonset.name
+            type: KubernetesDaemonSet
+          - id_keys:
+            - sw.k8s.cluster.uid
+            - k8s.namespace.name
+            - k8s.job.name
+            type: KubernetesJob
+          - id_keys:
+            - sw.k8s.cluster.uid
+            - k8s.namespace.name
+            - k8s.cronjob.name
+            type: KubernetesCronJob
         transform/istio-metric-datapoints:
           metric_statements:
           - statements:
@@ -3591,6 +3678,7 @@ Cluster filter should match snapshot with combined include filters:
             - groupbyattrs/common-all
             - resource/container
             - k8s_attributes
+            - swootelentityref/container_logs
             - filter/namespaces_logs
             receivers:
             - file_log
@@ -5133,6 +5221,49 @@ Cluster filter should match snapshot with exclude_namespaces:
             name_attr: destination_service_name
             namespace_attr: destination_service_namespace
             workload_type_attr: destination_service_type
+        swootelentityref/container_logs:
+          action: insert
+          entity_refs:
+          - id_keys:
+            - sw.k8s.cluster.uid
+            - k8s.namespace.name
+            - k8s.pod.name
+            - k8s.container.name
+            type: KubernetesContainer
+          - id_keys:
+            - sw.k8s.cluster.uid
+            - k8s.namespace.name
+            - k8s.pod.name
+            type: KubernetesPod
+          - id_keys:
+            - sw.k8s.cluster.uid
+            - k8s.node.name
+            type: KubernetesNode
+          - id_keys:
+            - sw.k8s.cluster.uid
+            - k8s.namespace.name
+            - k8s.deployment.name
+            type: KubernetesDeployment
+          - id_keys:
+            - sw.k8s.cluster.uid
+            - k8s.namespace.name
+            - k8s.statefulset.name
+            type: KubernetesStatefulSet
+          - id_keys:
+            - sw.k8s.cluster.uid
+            - k8s.namespace.name
+            - k8s.daemonset.name
+            type: KubernetesDaemonSet
+          - id_keys:
+            - sw.k8s.cluster.uid
+            - k8s.namespace.name
+            - k8s.job.name
+            type: KubernetesJob
+          - id_keys:
+            - sw.k8s.cluster.uid
+            - k8s.namespace.name
+            - k8s.cronjob.name
+            type: KubernetesCronJob
         transform/istio-metric-datapoints:
           metric_statements:
           - statements:
@@ -5477,6 +5608,7 @@ Cluster filter should match snapshot with exclude_namespaces:
             - groupbyattrs/common-all
             - resource/container
             - k8s_attributes
+            - swootelentityref/container_logs
             - filter/namespaces_logs
             receivers:
             - file_log
@@ -7019,6 +7151,49 @@ Cluster filter should match snapshot with exclude_namespaces_regex:
             name_attr: destination_service_name
             namespace_attr: destination_service_namespace
             workload_type_attr: destination_service_type
+        swootelentityref/container_logs:
+          action: insert
+          entity_refs:
+          - id_keys:
+            - sw.k8s.cluster.uid
+            - k8s.namespace.name
+            - k8s.pod.name
+            - k8s.container.name
+            type: KubernetesContainer
+          - id_keys:
+            - sw.k8s.cluster.uid
+            - k8s.namespace.name
+            - k8s.pod.name
+            type: KubernetesPod
+          - id_keys:
+            - sw.k8s.cluster.uid
+            - k8s.node.name
+            type: KubernetesNode
+          - id_keys:
+            - sw.k8s.cluster.uid
+            - k8s.namespace.name
+            - k8s.deployment.name
+            type: KubernetesDeployment
+          - id_keys:
+            - sw.k8s.cluster.uid
+            - k8s.namespace.name
+            - k8s.statefulset.name
+            type: KubernetesStatefulSet
+          - id_keys:
+            - sw.k8s.cluster.uid
+            - k8s.namespace.name
+            - k8s.daemonset.name
+            type: KubernetesDaemonSet
+          - id_keys:
+            - sw.k8s.cluster.uid
+            - k8s.namespace.name
+            - k8s.job.name
+            type: KubernetesJob
+          - id_keys:
+            - sw.k8s.cluster.uid
+            - k8s.namespace.name
+            - k8s.cronjob.name
+            type: KubernetesCronJob
         transform/istio-metric-datapoints:
           metric_statements:
           - statements:
@@ -7363,6 +7538,7 @@ Cluster filter should match snapshot with exclude_namespaces_regex:
             - groupbyattrs/common-all
             - resource/container
             - k8s_attributes
+            - swootelentityref/container_logs
             - filter/namespaces_logs
             receivers:
             - file_log
@@ -8903,6 +9079,49 @@ Cluster filter should match snapshot with include_namespaces:
             name_attr: destination_service_name
             namespace_attr: destination_service_namespace
             workload_type_attr: destination_service_type
+        swootelentityref/container_logs:
+          action: insert
+          entity_refs:
+          - id_keys:
+            - sw.k8s.cluster.uid
+            - k8s.namespace.name
+            - k8s.pod.name
+            - k8s.container.name
+            type: KubernetesContainer
+          - id_keys:
+            - sw.k8s.cluster.uid
+            - k8s.namespace.name
+            - k8s.pod.name
+            type: KubernetesPod
+          - id_keys:
+            - sw.k8s.cluster.uid
+            - k8s.node.name
+            type: KubernetesNode
+          - id_keys:
+            - sw.k8s.cluster.uid
+            - k8s.namespace.name
+            - k8s.deployment.name
+            type: KubernetesDeployment
+          - id_keys:
+            - sw.k8s.cluster.uid
+            - k8s.namespace.name
+            - k8s.statefulset.name
+            type: KubernetesStatefulSet
+          - id_keys:
+            - sw.k8s.cluster.uid
+            - k8s.namespace.name
+            - k8s.daemonset.name
+            type: KubernetesDaemonSet
+          - id_keys:
+            - sw.k8s.cluster.uid
+            - k8s.namespace.name
+            - k8s.job.name
+            type: KubernetesJob
+          - id_keys:
+            - sw.k8s.cluster.uid
+            - k8s.namespace.name
+            - k8s.cronjob.name
+            type: KubernetesCronJob
         transform/istio-metric-datapoints:
           metric_statements:
           - statements:
@@ -9247,6 +9466,7 @@ Cluster filter should match snapshot with include_namespaces:
             - groupbyattrs/common-all
             - resource/container
             - k8s_attributes
+            - swootelentityref/container_logs
             - filter/namespaces_logs
             receivers:
             - file_log
@@ -10789,6 +11009,49 @@ Cluster filter should match snapshot with include_namespaces_regex:
             name_attr: destination_service_name
             namespace_attr: destination_service_namespace
             workload_type_attr: destination_service_type
+        swootelentityref/container_logs:
+          action: insert
+          entity_refs:
+          - id_keys:
+            - sw.k8s.cluster.uid
+            - k8s.namespace.name
+            - k8s.pod.name
+            - k8s.container.name
+            type: KubernetesContainer
+          - id_keys:
+            - sw.k8s.cluster.uid
+            - k8s.namespace.name
+            - k8s.pod.name
+            type: KubernetesPod
+          - id_keys:
+            - sw.k8s.cluster.uid
+            - k8s.node.name
+            type: KubernetesNode
+          - id_keys:
+            - sw.k8s.cluster.uid
+            - k8s.namespace.name
+            - k8s.deployment.name
+            type: KubernetesDeployment
+          - id_keys:
+            - sw.k8s.cluster.uid
+            - k8s.namespace.name
+            - k8s.statefulset.name
+            type: KubernetesStatefulSet
+          - id_keys:
+            - sw.k8s.cluster.uid
+            - k8s.namespace.name
+            - k8s.daemonset.name
+            type: KubernetesDaemonSet
+          - id_keys:
+            - sw.k8s.cluster.uid
+            - k8s.namespace.name
+            - k8s.job.name
+            type: KubernetesJob
+          - id_keys:
+            - sw.k8s.cluster.uid
+            - k8s.namespace.name
+            - k8s.cronjob.name
+            type: KubernetesCronJob
         transform/istio-metric-datapoints:
           metric_statements:
           - statements:
@@ -11133,6 +11396,7 @@ Cluster filter should match snapshot with include_namespaces_regex:
             - groupbyattrs/common-all
             - resource/container
             - k8s_attributes
+            - swootelentityref/container_logs
             - filter/namespaces_logs
             receivers:
             - file_log
@@ -12667,6 +12931,49 @@ Custom logs filter with new syntax:
             name_attr: destination_service_name
             namespace_attr: destination_service_namespace
             workload_type_attr: destination_service_type
+        swootelentityref/container_logs:
+          action: insert
+          entity_refs:
+          - id_keys:
+            - sw.k8s.cluster.uid
+            - k8s.namespace.name
+            - k8s.pod.name
+            - k8s.container.name
+            type: KubernetesContainer
+          - id_keys:
+            - sw.k8s.cluster.uid
+            - k8s.namespace.name
+            - k8s.pod.name
+            type: KubernetesPod
+          - id_keys:
+            - sw.k8s.cluster.uid
+            - k8s.node.name
+            type: KubernetesNode
+          - id_keys:
+            - sw.k8s.cluster.uid
+            - k8s.namespace.name
+            - k8s.deployment.name
+            type: KubernetesDeployment
+          - id_keys:
+            - sw.k8s.cluster.uid
+            - k8s.namespace.name
+            - k8s.statefulset.name
+            type: KubernetesStatefulSet
+          - id_keys:
+            - sw.k8s.cluster.uid
+            - k8s.namespace.name
+            - k8s.daemonset.name
+            type: KubernetesDaemonSet
+          - id_keys:
+            - sw.k8s.cluster.uid
+            - k8s.namespace.name
+            - k8s.job.name
+            type: KubernetesJob
+          - id_keys:
+            - sw.k8s.cluster.uid
+            - k8s.namespace.name
+            - k8s.cronjob.name
+            type: KubernetesCronJob
         transform/istio-metric-datapoints:
           metric_statements:
           - statements:
@@ -13011,6 +13318,7 @@ Custom logs filter with new syntax:
             - groupbyattrs/common-all
             - resource/container
             - k8s_attributes
+            - swootelentityref/container_logs
             - filter/logs
             receivers:
             - file_log
@@ -14547,6 +14855,49 @@ Custom logs filter with old syntax:
             name_attr: destination_service_name
             namespace_attr: destination_service_namespace
             workload_type_attr: destination_service_type
+        swootelentityref/container_logs:
+          action: insert
+          entity_refs:
+          - id_keys:
+            - sw.k8s.cluster.uid
+            - k8s.namespace.name
+            - k8s.pod.name
+            - k8s.container.name
+            type: KubernetesContainer
+          - id_keys:
+            - sw.k8s.cluster.uid
+            - k8s.namespace.name
+            - k8s.pod.name
+            type: KubernetesPod
+          - id_keys:
+            - sw.k8s.cluster.uid
+            - k8s.node.name
+            type: KubernetesNode
+          - id_keys:
+            - sw.k8s.cluster.uid
+            - k8s.namespace.name
+            - k8s.deployment.name
+            type: KubernetesDeployment
+          - id_keys:
+            - sw.k8s.cluster.uid
+            - k8s.namespace.name
+            - k8s.statefulset.name
+            type: KubernetesStatefulSet
+          - id_keys:
+            - sw.k8s.cluster.uid
+            - k8s.namespace.name
+            - k8s.daemonset.name
+            type: KubernetesDaemonSet
+          - id_keys:
+            - sw.k8s.cluster.uid
+            - k8s.namespace.name
+            - k8s.job.name
+            type: KubernetesJob
+          - id_keys:
+            - sw.k8s.cluster.uid
+            - k8s.namespace.name
+            - k8s.cronjob.name
+            type: KubernetesCronJob
         transform/istio-metric-datapoints:
           metric_statements:
           - statements:
@@ -14973,6 +15324,7 @@ Custom logs filter with old syntax:
             - groupbyattrs/common-all
             - resource/container
             - k8s_attributes
+            - swootelentityref/container_logs
             receivers:
             - file_log
           logs/journal:
@@ -16501,6 +16853,49 @@ Node collector config should match snapshot when autodiscovery is disabled:
             name_attr: destination_service_name
             namespace_attr: destination_service_namespace
             workload_type_attr: destination_service_type
+        swootelentityref/container_logs:
+          action: insert
+          entity_refs:
+          - id_keys:
+            - sw.k8s.cluster.uid
+            - k8s.namespace.name
+            - k8s.pod.name
+            - k8s.container.name
+            type: KubernetesContainer
+          - id_keys:
+            - sw.k8s.cluster.uid
+            - k8s.namespace.name
+            - k8s.pod.name
+            type: KubernetesPod
+          - id_keys:
+            - sw.k8s.cluster.uid
+            - k8s.node.name
+            type: KubernetesNode
+          - id_keys:
+            - sw.k8s.cluster.uid
+            - k8s.namespace.name
+            - k8s.deployment.name
+            type: KubernetesDeployment
+          - id_keys:
+            - sw.k8s.cluster.uid
+            - k8s.namespace.name
+            - k8s.statefulset.name
+            type: KubernetesStatefulSet
+          - id_keys:
+            - sw.k8s.cluster.uid
+            - k8s.namespace.name
+            - k8s.daemonset.name
+            type: KubernetesDaemonSet
+          - id_keys:
+            - sw.k8s.cluster.uid
+            - k8s.namespace.name
+            - k8s.job.name
+            type: KubernetesJob
+          - id_keys:
+            - sw.k8s.cluster.uid
+            - k8s.namespace.name
+            - k8s.cronjob.name
+            type: KubernetesCronJob
         transform/istio-metric-datapoints:
           metric_statements:
           - statements:
@@ -16785,6 +17180,7 @@ Node collector config should match snapshot when autodiscovery is disabled:
             - groupbyattrs/common-all
             - resource/container
             - k8s_attributes
+            - swootelentityref/container_logs
             receivers:
             - file_log
           logs/journal:
@@ -18310,6 +18706,49 @@ Node collector config should match snapshot when fargate is enabled:
             name_attr: destination_service_name
             namespace_attr: destination_service_namespace
             workload_type_attr: destination_service_type
+        swootelentityref/container_logs:
+          action: insert
+          entity_refs:
+          - id_keys:
+            - sw.k8s.cluster.uid
+            - k8s.namespace.name
+            - k8s.pod.name
+            - k8s.container.name
+            type: KubernetesContainer
+          - id_keys:
+            - sw.k8s.cluster.uid
+            - k8s.namespace.name
+            - k8s.pod.name
+            type: KubernetesPod
+          - id_keys:
+            - sw.k8s.cluster.uid
+            - k8s.node.name
+            type: KubernetesNode
+          - id_keys:
+            - sw.k8s.cluster.uid
+            - k8s.namespace.name
+            - k8s.deployment.name
+            type: KubernetesDeployment
+          - id_keys:
+            - sw.k8s.cluster.uid
+            - k8s.namespace.name
+            - k8s.statefulset.name
+            type: KubernetesStatefulSet
+          - id_keys:
+            - sw.k8s.cluster.uid
+            - k8s.namespace.name
+            - k8s.daemonset.name
+            type: KubernetesDaemonSet
+          - id_keys:
+            - sw.k8s.cluster.uid
+            - k8s.namespace.name
+            - k8s.job.name
+            type: KubernetesJob
+          - id_keys:
+            - sw.k8s.cluster.uid
+            - k8s.namespace.name
+            - k8s.cronjob.name
+            type: KubernetesCronJob
         transform/istio-metric-datapoints:
           metric_statements:
           - statements:
@@ -18599,6 +19038,7 @@ Node collector config should match snapshot when fargate is enabled:
             - groupbyattrs/common-all
             - resource/container
             - k8s_attributes
+            - swootelentityref/container_logs
             receivers:
             - file_log
           logs/journal:
@@ -20095,6 +20535,49 @@ Node collector config should match snapshot when fargate is enabled and autodisc
             name_attr: destination_service_name
             namespace_attr: destination_service_namespace
             workload_type_attr: destination_service_type
+        swootelentityref/container_logs:
+          action: insert
+          entity_refs:
+          - id_keys:
+            - sw.k8s.cluster.uid
+            - k8s.namespace.name
+            - k8s.pod.name
+            - k8s.container.name
+            type: KubernetesContainer
+          - id_keys:
+            - sw.k8s.cluster.uid
+            - k8s.namespace.name
+            - k8s.pod.name
+            type: KubernetesPod
+          - id_keys:
+            - sw.k8s.cluster.uid
+            - k8s.node.name
+            type: KubernetesNode
+          - id_keys:
+            - sw.k8s.cluster.uid
+            - k8s.namespace.name
+            - k8s.deployment.name
+            type: KubernetesDeployment
+          - id_keys:
+            - sw.k8s.cluster.uid
+            - k8s.namespace.name
+            - k8s.statefulset.name
+            type: KubernetesStatefulSet
+          - id_keys:
+            - sw.k8s.cluster.uid
+            - k8s.namespace.name
+            - k8s.daemonset.name
+            type: KubernetesDaemonSet
+          - id_keys:
+            - sw.k8s.cluster.uid
+            - k8s.namespace.name
+            - k8s.job.name
+            type: KubernetesJob
+          - id_keys:
+            - sw.k8s.cluster.uid
+            - k8s.namespace.name
+            - k8s.cronjob.name
+            type: KubernetesCronJob
         transform/istio-metric-datapoints:
           metric_statements:
           - statements:
@@ -20323,6 +20806,7 @@ Node collector config should match snapshot when fargate is enabled and autodisc
             - groupbyattrs/common-all
             - resource/container
             - k8s_attributes
+            - swootelentityref/container_logs
             receivers:
             - file_log
           logs/journal:
@@ -21816,6 +22300,49 @@ Node collector config should match snapshot when using default values:
             name_attr: destination_service_name
             namespace_attr: destination_service_namespace
             workload_type_attr: destination_service_type
+        swootelentityref/container_logs:
+          action: insert
+          entity_refs:
+          - id_keys:
+            - sw.k8s.cluster.uid
+            - k8s.namespace.name
+            - k8s.pod.name
+            - k8s.container.name
+            type: KubernetesContainer
+          - id_keys:
+            - sw.k8s.cluster.uid
+            - k8s.namespace.name
+            - k8s.pod.name
+            type: KubernetesPod
+          - id_keys:
+            - sw.k8s.cluster.uid
+            - k8s.node.name
+            type: KubernetesNode
+          - id_keys:
+            - sw.k8s.cluster.uid
+            - k8s.namespace.name
+            - k8s.deployment.name
+            type: KubernetesDeployment
+          - id_keys:
+            - sw.k8s.cluster.uid
+            - k8s.namespace.name
+            - k8s.statefulset.name
+            type: KubernetesStatefulSet
+          - id_keys:
+            - sw.k8s.cluster.uid
+            - k8s.namespace.name
+            - k8s.daemonset.name
+            type: KubernetesDaemonSet
+          - id_keys:
+            - sw.k8s.cluster.uid
+            - k8s.namespace.name
+            - k8s.job.name
+            type: KubernetesJob
+          - id_keys:
+            - sw.k8s.cluster.uid
+            - k8s.namespace.name
+            - k8s.cronjob.name
+            type: KubernetesCronJob
         transform/istio-metric-datapoints:
           metric_statements:
           - statements:
@@ -22160,6 +22687,7 @@ Node collector config should match snapshot when using default values:
             - groupbyattrs/common-all
             - resource/container
             - k8s_attributes
+            - swootelentityref/container_logs
             receivers:
             - file_log
           logs/journal:


### PR DESCRIPTION
It will make entity inference more reliable than when just using Resource attributes.

Depends on https://github.com/solarwinds/solarwinds-otel-collector-contrib/pull/318

The `EntityRefs` section of the OTEL message is not exposed through the integration test database, so there is no integration test for this.