### PR TITLE
second memory leak fix

### DIFF
--- a/deploy/helm/Chart.yaml
+++ b/deploy/helm/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: swo-k8s-collector
-version: 5.3.0-alpha.3
+version: 5.3.0-alpha.4
 appVersion: 0.150.0
 description: SolarWinds Kubernetes Integration
 keywords:

--- a/deploy/helm/templates/common-env-config-map.yaml
+++ b/deploy/helm/templates/common-env-config-map.yaml
@@ -14,6 +14,8 @@ data:
   OTEL_ENVOY_ADDRESS_TLS_INSECURE: {{ quote .Values.otel.tls_insecure }}
   MANIFEST_VERSION: {{ quote .Chart.Version }}
   APP_VERSION: {{ quote .Chart.AppVersion }}
+  # Disable exemplar storage to prevent unbounded FixedSizeReservoir growth (memory leak)
+  OTEL_METRICS_EXEMPLAR_FILTER: "always_off"
 {{ if .Values.otel.https_proxy_url }}
   HTTPS_PROXY: {{ quote .Values.otel.https_proxy_url }}
 {{ end }}


### PR DESCRIPTION
Fix: Eliminate unbounded exemplar FixedSizeReservoir memory leak in collector pods

The OTel metrics SDK allocates a FixedSizeReservoir per unique attribute-set combination via limitedSyncMap.LoadOrStoreAttr. These reservoirs are never evicted. In Kubernetes environments with high pod churn, the number of unique label combinations grows without bound as k8sattributesprocessor enriches metrics with pod-scoped attributes (pod name, namespace, etc.). This causes two compounding effects:

Permanent heap growth — new unique attribute combinations from pod churn continuously add new reservoir entries that are never freed
Per-Prometheus-scrape transient allocation spike — on every scrape of the collector's own metrics endpoint, collectExemplars iterates over all stored reservoir entries to serialize exemplar data, allocating proportionally to the number of accumulated combinations
Both effects grow together as the cluster runs longer, eventually contributing to OOMKill of collector pods.

The service.telemetry.metrics.exemplars config key does not exist in MetricsConfigV030 (the schema used by service@v0.119.0), so this cannot be set in the collector YAML config. The correct fix is the standard OTel SDK environment variable  OTEL_METRICS_EXEMPLAR_FILTER: "always_off" in the shared common-env-config-map.yaml, which is mounted in all collector containers via envFrom. This disables exemplar sampling at the SDK level — no reservoirs are created and no per-scrape exemplar collection overhead occurs.