### PR TITLE
Upgrade APM Python 6.1.1

### DIFF
--- a/deploy/helm/values.yaml
+++ b/deploy/helm/values.yaml
@@ -1255,7 +1255,7 @@ operator:
         tag: ""
       python:
         repository: "solarwinds/autoinstrumentation-python"
-        tag: "6.1.0"
+        tag: "6.1.1"
       dotnet:
         repository: ""
         tag: ""


### PR DESCRIPTION
Upgrade to APM Python 6.1.1, released May 28 2026.