### PR TITLE
Upgrade APM Python 6.2.0

### DIFF
--- a/deploy/helm/values.yaml
+++ b/deploy/helm/values.yaml
@@ -1255,7 +1255,7 @@ operator:
         tag: ""
       python:
         repository: "solarwinds/autoinstrumentation-python"
-        tag: "6.1.1"
+        tag: "6.2.0"
       dotnet:
         repository: ""
         tag: ""


### PR DESCRIPTION
Upgrade to APM Python 6.2.0, released June 1 2026.