### PR TITLE
Update `swotelcol` image to 0.152.0

### DIFF
--- a/deploy/helm/gateway-collector-config.yaml
+++ b/deploy/helm/gateway-collector-config.yaml
@@ -43,7 +43,7 @@ processors:
   k8s_attributes:
 {{ include "common.k8s-instrumentation" . | indent 4 }}
 
-  metricstransform/rename-following-otel-semantics:
+  metrics_transform/rename-following-otel-semantics:
     transforms:
 {{ include "common-config.metricstransform-rename" .Values.otel.gateway.prefix | indent 6 }}
 
@@ -358,7 +358,7 @@ processors:
             resource.attributes["source.k8s.namespace.name"] == resource.attributes["dest.k8s.namespace.name"] and resource.attributes["source.k8s.namespace.name"] != nil
           )
 
-  logdedup/solarwindsentity: {}
+  log_dedup/solarwindsentity: {}
 
 receivers:
   otlp:
@@ -687,7 +687,7 @@ service:
         - memory_limiter
         - k8s_attributes
 {{- if .Values.otel.gateway.prefix }}
-        - metricstransform/rename-following-otel-semantics
+        - metrics_transform/rename-following-otel-semantics
 {{- end }}
         - attributes/clean-attributes-otlp-metrics
         - resource/clean-temporary-attributes
@@ -756,7 +756,7 @@ service:
       processors:
         - memory_limiter
         - transform/scope
-        - logdedup/solarwindsentity
+        - log_dedup/solarwindsentity
         - batch
       exporters:
         - otlp_grpc
@@ -766,7 +766,7 @@ service:
       processors:
         - memory_limiter
         - transform/scope
-        - logdedup/solarwindsentity
+        - log_dedup/solarwindsentity
         - batch
       exporters:
         - otlp_grpc

--- a/deploy/helm/metrics-collector-config.yaml
+++ b/deploy/helm/metrics-collector-config.yaml
@@ -194,7 +194,7 @@ processors:
         from_attribute: configmap
         action: insert
 
-  metricstransform/rename:
+  metrics_transform/rename:
     transforms:
       # add `k8s.` suffix to all metrics that are clearly provided by Kubernetes
       - include: ^(trivy_|kube_|container_|kubernetes_|kubelet_|workqueue_|apiserver_|coredns_|etcd_|certmanager_)(.*)$$
@@ -203,7 +203,7 @@ processors:
         new_name: k8s.$${1}$${2}
 
   # Transformations done on all metrics before any grouping
-  metricstransform/preprocessing:
+  metrics_transform/preprocessing:
     transforms:
       - include: k8s.kube_node_status_condition
         experimental_match_labels: { "condition": "Ready" }
@@ -624,7 +624,7 @@ processors:
     keys:
       - k8s.node.name
   # Transformations done after grouping per k8s.node.name
-  metricstransform/aggregate_node_level:
+  metrics_transform/aggregate_node_level:
     transforms:
       - include: k8s.kube_pod_info
         action: insert
@@ -639,7 +639,7 @@ processors:
       - namespace
       - pod
   # Transformations done after grouping per pod
-  metricstransform/aggregate_pod_level:
+  metrics_transform/aggregate_pod_level:
     transforms:
       - include: k8s.kube_pod_container_info
         action: insert
@@ -764,7 +764,7 @@ processors:
           # adds severity to metric name (metrics are grouped by severity)
           - set(name, Format("%s_%s", [metric.name, ToLowerCase(resource.attributes["severity"])])) where resource.attributes["severity"] != nil
 
-  metricstransform/trivy-operator-metrics-aggregation-by-image:
+  metrics_transform/trivy-operator-metrics-aggregation-by-image:
     transforms:
       - include: ^k8s.trivy_.*$
         match_type: regexp
@@ -786,7 +786,7 @@ processors:
     - k8s.replicaset.name
     - severity
       
-  metricstransform/trivy-operator-metrics-aggregation:
+  metrics_transform/trivy-operator-metrics-aggregation:
     transforms:
       - include: ^k8s.trivy_.*$
         match_type: regexp
@@ -1179,19 +1179,19 @@ service:
         - memory_limiter
         - filter/trivy-operator-metrics
         - transform/trivy-operator-metrics-attributes
-        - metricstransform/rename
+        - metrics_transform/rename
         # Single groupbyattrs moves workload identity + severity to resource attrs.
         # image_digest stays as a datapoint attribute so that the two-stage aggregation
         # (MAX per image, then SUM across images) works correctly for multi-image workloads.
         - groupbyattrs/trivy-operator-metrics
-        - metricstransform/trivy-operator-metrics-aggregation-by-image
+        - metrics_transform/trivy-operator-metrics-aggregation-by-image
 {{- if eq (include "isNamespacesFilterEnabled" .) "true" }}
         - filter/namespaces
 {{- end }}
 {{- if .Values.otel.metrics.filter }}
         - filter
 {{- end }}
-        - metricstransform/trivy-operator-metrics-aggregation
+        - metrics_transform/trivy-operator-metrics-aggregation
         - transform/trivy-operator-metrics-split
       exporters:
         - forward/metric-exporter
@@ -1218,8 +1218,8 @@ service:
         - attributes/unify_configmap_attribute
         - attributes/identify_init_container
         - attributes/identify_standard_container
-        - metricstransform/rename
-        - metricstransform/preprocessing
+        - metrics_transform/rename
+        - metrics_transform/preprocessing
         - filter/preprocessing
         - filter/remove_internal_postprocessing
         - attributes/remove_temp
@@ -1228,9 +1228,9 @@ service:
         - deltatorate
         - metricsgeneration/cluster
         - groupbyattrs/node
-        - metricstransform/aggregate_node_level
+        - metrics_transform/aggregate_node_level
         - groupbyattrs/pod
-        - metricstransform/aggregate_pod_level
+        - metrics_transform/aggregate_pod_level
         - groupbyattrs/all
         - resource/metrics
         - k8s_attributes

--- a/deploy/helm/node-collector-config.yaml
+++ b/deploy/helm/node-collector-config.yaml
@@ -74,7 +74,7 @@ processors:
 
   {{- include "common-config.transform-node-attributes" . | nindent 2 }}
 
-  metricstransform/preprocessing:
+  metrics_transform/preprocessing:
     transforms:
       {{- include "common-config.metricstransform-preprocessing-cadvisor" . | nindent 6 }}
 
@@ -301,7 +301,7 @@ processors:
           - from: resource_attribute
             name: k8s.namespace.name
 
-  metricstransform/rename-following-otel-semantics:
+  metrics_transform/rename-following-otel-semantics:
     transforms:
 {{ include "common-config.metricstransform-rename" "k8s." | indent 6 }}
 
@@ -733,8 +733,8 @@ service:
         - attributes/remove_prometheus_attributes
         - attributes/unify_node_attribute
         - transform/unify_node_attribute
-        - metricstransform/rename-following-otel-semantics
-        - metricstransform/preprocessing
+        - metrics_transform/rename-following-otel-semantics
+        - metrics_transform/preprocessing
         - filter/remove_internal_postprocessing
         - attributes/remove_temp
         - cumulativetodelta/cadvisor

--- a/deploy/helm/templates/_common-discovery-config.tpl
+++ b/deploy/helm/templates/_common-discovery-config.tpl
@@ -5,7 +5,7 @@ filter/metrics-discovery:
 {{ toYaml .Values.otel.metrics.autodiscovery.prometheusEndpoints.filter | indent 4 }}
 {{- end }}
 
-logdedup/solarwindsentity: {}
+log_dedup/solarwindsentity: {}
 
 filter/keep-entity-state-events:
   logs:
@@ -17,7 +17,7 @@ filter/keep-relationship-state-events:
     log_record:
       - not(attributes["otel.entity.event.type"] == "entity_relationship_state")
 
-metricstransform/rename-following-otel-semantics/discovery:
+metrics_transform/rename-following-otel-semantics/discovery:
   transforms:
 {{ include "common-config.metricstransform-rename" .Values.otel.metrics.autodiscovery.prefix | indent 4 }}
 
@@ -47,7 +47,7 @@ metricstransform/rename-following-otel-semantics/discovery:
   "workqueue_depth"
   "workqueue_queue_duration_seconds"
 }}
-metricstransform/copy-required-metrics:
+metrics_transform/copy-required-metrics:
   transforms:
   {{- $root := . }}
   {{- range $index, $metric := $arrayOfRequiredMetrics }}
@@ -73,7 +73,7 @@ deltatorate/discovery:
 {{- end }}
 {{- end }}
 
-metricstransform/istio-metrics:
+metrics_transform/istio-metrics:
   transforms:
     - include: {{ .Values.otel.metrics.autodiscovery.prefix }}istio_request_bytes_sum
       action: insert
@@ -585,10 +585,10 @@ metrics/discovery-scrape:
     - filter/metrics-discovery
 {{- end }}
 {{- if $context.Values.otel.metrics.autodiscovery.prefix }}
-    - metricstransform/rename-following-otel-semantics/discovery
+    - metrics_transform/rename-following-otel-semantics/discovery
 {{- end }}
 {{- if ne $context.Values.otel.metrics.autodiscovery.prefix "k8s." }}
-    - metricstransform/copy-required-metrics
+    - metrics_transform/copy-required-metrics
 {{- end }}
   exporters:
     - routing/discovered_metrics
@@ -602,7 +602,7 @@ metrics/discovery-istio:
     - swok8sworkloadtype/istio
     - transform/istio-metrics
     - transform/istio-metric-datapoints
-    - metricstransform/istio-metrics
+    - metrics_transform/istio-metrics
     - cumulativetodelta/istio-metrics
     - deltatorate/istio-metrics
     - metricsgeneration/istio-metrics
@@ -691,7 +691,7 @@ logs/stateevents-entities:
     - memory_limiter
     - filter/keep-entity-state-events
     - transform/scope
-    - logdedup/solarwindsentity
+    - log_dedup/solarwindsentity
     - batch/stateevents
   exporters:
     - otlp_grpc
@@ -704,7 +704,7 @@ logs/stateevents-relationships:
     - memory_limiter
     - filter/keep-relationship-state-events
     - transform/scope
-    - logdedup/solarwindsentity
+    - log_dedup/solarwindsentity
     - batch/stateevents
   exporters:
     - otlp_grpc

--- a/deploy/helm/tests/__snapshot__/gateway-config-map_test.yaml.snap
+++ b/deploy/helm/tests/__snapshot__/gateway-config-map_test.yaml.snap
@@ -496,12 +496,12 @@ Gateway config should match snapshot when using default values:
               name: k8s.pod.ip
             - from: resource_attribute
               name: k8s.namespace.name
-        logdedup/solarwindsentity: {}
+        log_dedup/solarwindsentity: {}
         memory_limiter:
           check_interval: 1s
           limit_percentage: 80
           spike_limit_percentage: 25
-        metricstransform/rename-following-otel-semantics:
+        metrics_transform/rename-following-otel-semantics:
           transforms:
           - action: update
             include: ^(.*)$$
@@ -803,7 +803,7 @@ Gateway config should match snapshot when using default values:
             processors:
             - memory_limiter
             - transform/scope
-            - logdedup/solarwindsentity
+            - log_dedup/solarwindsentity
             - batch
             receivers:
             - solarwindsentity/obi-entities
@@ -813,7 +813,7 @@ Gateway config should match snapshot when using default values:
             processors:
             - memory_limiter
             - transform/scope
-            - logdedup/solarwindsentity
+            - log_dedup/solarwindsentity
             - batch
             receivers:
             - solarwindsentity/obi-relationships
@@ -838,7 +838,7 @@ Gateway config should match snapshot when using default values:
             processors:
             - memory_limiter
             - k8s_attributes
-            - metricstransform/rename-following-otel-semantics
+            - metrics_transform/rename-following-otel-semantics
             - attributes/clean-attributes-otlp-metrics
             - resource/clean-temporary-attributes
             - resource

--- a/deploy/helm/tests/__snapshot__/metrics-collector-config-map-fargate_test.yaml.snap
+++ b/deploy/helm/tests/__snapshot__/metrics-collector-config-map-fargate_test.yaml.snap
@@ -428,15 +428,7 @@ Metrics config should match snapshot when using default values:
           check_interval: 1s
           limit_mib: 2560
           spike_limit_mib: 512
-        metricsgeneration/cluster:
-          rules:
-          - metric1: apiserver_request_not_failed__swo_temp
-            metric2: apiserver_request_total__swo_temp
-            name: k8s.apiserver.request.successrate
-            operation: percent
-            type: calculate
-            unit: Percent
-        metricstransform/aggregate_node_level:
+        metrics_transform/aggregate_node_level:
           transforms:
           - action: insert
             include: k8s.kube_pod_info
@@ -446,7 +438,7 @@ Metrics config should match snapshot when using default values:
               aggregation_type: sum
               label_set:
               - dummy_label_workaround
-        metricstransform/aggregate_pod_level:
+        metrics_transform/aggregate_pod_level:
           transforms:
           - action: insert
             include: k8s.kube_pod_container_info
@@ -456,7 +448,7 @@ Metrics config should match snapshot when using default values:
               aggregation_type: sum
               label_set:
               - dummy_label_workaround
-        metricstransform/preprocessing:
+        metrics_transform/preprocessing:
           transforms:
           - action: insert
             experimental_match_labels:
@@ -1298,13 +1290,13 @@ Metrics config should match snapshot when using default values:
             - action: update_label
               label: owner_name
               new_label: cronjob
-        metricstransform/rename:
+        metrics_transform/rename:
           transforms:
           - action: update
             include: ^(trivy_|kube_|container_|kubernetes_|kubelet_|workqueue_|apiserver_|coredns_|etcd_|certmanager_)(.*)$$
             match_type: regexp
             new_name: k8s.$${1}$${2}
-        metricstransform/trivy-operator-metrics-aggregation:
+        metrics_transform/trivy-operator-metrics-aggregation:
           transforms:
           - action: update
             include: ^k8s.trivy_.*$
@@ -1314,7 +1306,7 @@ Metrics config should match snapshot when using default values:
               aggregation_type: sum
               label_set:
               - dummy_label_workaround
-        metricstransform/trivy-operator-metrics-aggregation-by-image:
+        metrics_transform/trivy-operator-metrics-aggregation-by-image:
           transforms:
           - action: update
             include: ^k8s.trivy_.*$
@@ -1324,6 +1316,14 @@ Metrics config should match snapshot when using default values:
               aggregation_type: max
               label_set:
               - image_digest
+        metricsgeneration/cluster:
+          rules:
+          - metric1: apiserver_request_not_failed__swo_temp
+            metric2: apiserver_request_total__swo_temp
+            name: k8s.apiserver.request.successrate
+            operation: percent
+            type: calculate
+            unit: Percent
         resource/metrics:
           attributes:
           - action: delete
@@ -1700,8 +1700,8 @@ Metrics config should match snapshot when using default values:
             - attributes/unify_configmap_attribute
             - attributes/identify_init_container
             - attributes/identify_standard_container
-            - metricstransform/rename
-            - metricstransform/preprocessing
+            - metrics_transform/rename
+            - metrics_transform/preprocessing
             - filter/preprocessing
             - filter/remove_internal_postprocessing
             - attributes/remove_temp
@@ -1710,9 +1710,9 @@ Metrics config should match snapshot when using default values:
             - deltatorate
             - metricsgeneration/cluster
             - groupbyattrs/node
-            - metricstransform/aggregate_node_level
+            - metrics_transform/aggregate_node_level
             - groupbyattrs/pod
-            - metricstransform/aggregate_pod_level
+            - metrics_transform/aggregate_pod_level
             - groupbyattrs/all
             - resource/metrics
             - k8s_attributes
@@ -1735,10 +1735,10 @@ Metrics config should match snapshot when using default values:
             - memory_limiter
             - filter/trivy-operator-metrics
             - transform/trivy-operator-metrics-attributes
-            - metricstransform/rename
+            - metrics_transform/rename
             - groupbyattrs/trivy-operator-metrics
-            - metricstransform/trivy-operator-metrics-aggregation-by-image
-            - metricstransform/trivy-operator-metrics-aggregation
+            - metrics_transform/trivy-operator-metrics-aggregation-by-image
+            - metrics_transform/trivy-operator-metrics-aggregation
             - transform/trivy-operator-metrics-split
             receivers:
             - prometheus/trivy-operator-metrics

--- a/deploy/helm/tests/__snapshot__/metrics-collector-config-map_test.yaml.snap
+++ b/deploy/helm/tests/__snapshot__/metrics-collector-config-map_test.yaml.snap
@@ -438,15 +438,7 @@ Cluster filter should match snapshot with combined exclude filters:
           check_interval: 1s
           limit_mib: 2560
           spike_limit_mib: 512
-        metricsgeneration/cluster:
-          rules:
-          - metric1: apiserver_request_not_failed__swo_temp
-            metric2: apiserver_request_total__swo_temp
-            name: k8s.apiserver.request.successrate
-            operation: percent
-            type: calculate
-            unit: Percent
-        metricstransform/aggregate_node_level:
+        metrics_transform/aggregate_node_level:
           transforms:
           - action: insert
             include: k8s.kube_pod_info
@@ -456,7 +448,7 @@ Cluster filter should match snapshot with combined exclude filters:
               aggregation_type: sum
               label_set:
               - dummy_label_workaround
-        metricstransform/aggregate_pod_level:
+        metrics_transform/aggregate_pod_level:
           transforms:
           - action: insert
             include: k8s.kube_pod_container_info
@@ -466,7 +458,7 @@ Cluster filter should match snapshot with combined exclude filters:
               aggregation_type: sum
               label_set:
               - dummy_label_workaround
-        metricstransform/preprocessing:
+        metrics_transform/preprocessing:
           transforms:
           - action: insert
             experimental_match_labels:
@@ -1308,13 +1300,13 @@ Cluster filter should match snapshot with combined exclude filters:
             - action: update_label
               label: owner_name
               new_label: cronjob
-        metricstransform/rename:
+        metrics_transform/rename:
           transforms:
           - action: update
             include: ^(trivy_|kube_|container_|kubernetes_|kubelet_|workqueue_|apiserver_|coredns_|etcd_|certmanager_)(.*)$$
             match_type: regexp
             new_name: k8s.$${1}$${2}
-        metricstransform/trivy-operator-metrics-aggregation:
+        metrics_transform/trivy-operator-metrics-aggregation:
           transforms:
           - action: update
             include: ^k8s.trivy_.*$
@@ -1324,7 +1316,7 @@ Cluster filter should match snapshot with combined exclude filters:
               aggregation_type: sum
               label_set:
               - dummy_label_workaround
-        metricstransform/trivy-operator-metrics-aggregation-by-image:
+        metrics_transform/trivy-operator-metrics-aggregation-by-image:
           transforms:
           - action: update
             include: ^k8s.trivy_.*$
@@ -1334,6 +1326,14 @@ Cluster filter should match snapshot with combined exclude filters:
               aggregation_type: max
               label_set:
               - image_digest
+        metricsgeneration/cluster:
+          rules:
+          - metric1: apiserver_request_not_failed__swo_temp
+            metric2: apiserver_request_total__swo_temp
+            name: k8s.apiserver.request.successrate
+            operation: percent
+            type: calculate
+            unit: Percent
         resource/metrics:
           attributes:
           - action: delete
@@ -1630,8 +1630,8 @@ Cluster filter should match snapshot with combined exclude filters:
             - attributes/unify_configmap_attribute
             - attributes/identify_init_container
             - attributes/identify_standard_container
-            - metricstransform/rename
-            - metricstransform/preprocessing
+            - metrics_transform/rename
+            - metrics_transform/preprocessing
             - filter/preprocessing
             - filter/remove_internal_postprocessing
             - attributes/remove_temp
@@ -1640,9 +1640,9 @@ Cluster filter should match snapshot with combined exclude filters:
             - deltatorate
             - metricsgeneration/cluster
             - groupbyattrs/node
-            - metricstransform/aggregate_node_level
+            - metrics_transform/aggregate_node_level
             - groupbyattrs/pod
-            - metricstransform/aggregate_pod_level
+            - metrics_transform/aggregate_pod_level
             - groupbyattrs/all
             - resource/metrics
             - k8s_attributes
@@ -1666,11 +1666,11 @@ Cluster filter should match snapshot with combined exclude filters:
             - memory_limiter
             - filter/trivy-operator-metrics
             - transform/trivy-operator-metrics-attributes
-            - metricstransform/rename
+            - metrics_transform/rename
             - groupbyattrs/trivy-operator-metrics
-            - metricstransform/trivy-operator-metrics-aggregation-by-image
+            - metrics_transform/trivy-operator-metrics-aggregation-by-image
             - filter/namespaces
-            - metricstransform/trivy-operator-metrics-aggregation
+            - metrics_transform/trivy-operator-metrics-aggregation
             - transform/trivy-operator-metrics-split
             receivers:
             - prometheus/trivy-operator-metrics
@@ -2124,15 +2124,7 @@ Cluster filter should match snapshot with combined include filters:
           check_interval: 1s
           limit_mib: 2560
           spike_limit_mib: 512
-        metricsgeneration/cluster:
-          rules:
-          - metric1: apiserver_request_not_failed__swo_temp
-            metric2: apiserver_request_total__swo_temp
-            name: k8s.apiserver.request.successrate
-            operation: percent
-            type: calculate
-            unit: Percent
-        metricstransform/aggregate_node_level:
+        metrics_transform/aggregate_node_level:
           transforms:
           - action: insert
             include: k8s.kube_pod_info
@@ -2142,7 +2134,7 @@ Cluster filter should match snapshot with combined include filters:
               aggregation_type: sum
               label_set:
               - dummy_label_workaround
-        metricstransform/aggregate_pod_level:
+        metrics_transform/aggregate_pod_level:
           transforms:
           - action: insert
             include: k8s.kube_pod_container_info
@@ -2152,7 +2144,7 @@ Cluster filter should match snapshot with combined include filters:
               aggregation_type: sum
               label_set:
               - dummy_label_workaround
-        metricstransform/preprocessing:
+        metrics_transform/preprocessing:
           transforms:
           - action: insert
             experimental_match_labels:
@@ -2994,13 +2986,13 @@ Cluster filter should match snapshot with combined include filters:
             - action: update_label
               label: owner_name
               new_label: cronjob
-        metricstransform/rename:
+        metrics_transform/rename:
           transforms:
           - action: update
             include: ^(trivy_|kube_|container_|kubernetes_|kubelet_|workqueue_|apiserver_|coredns_|etcd_|certmanager_)(.*)$$
             match_type: regexp
             new_name: k8s.$${1}$${2}
-        metricstransform/trivy-operator-metrics-aggregation:
+        metrics_transform/trivy-operator-metrics-aggregation:
           transforms:
           - action: update
             include: ^k8s.trivy_.*$
@@ -3010,7 +3002,7 @@ Cluster filter should match snapshot with combined include filters:
               aggregation_type: sum
               label_set:
               - dummy_label_workaround
-        metricstransform/trivy-operator-metrics-aggregation-by-image:
+        metrics_transform/trivy-operator-metrics-aggregation-by-image:
           transforms:
           - action: update
             include: ^k8s.trivy_.*$
@@ -3020,6 +3012,14 @@ Cluster filter should match snapshot with combined include filters:
               aggregation_type: max
               label_set:
               - image_digest
+        metricsgeneration/cluster:
+          rules:
+          - metric1: apiserver_request_not_failed__swo_temp
+            metric2: apiserver_request_total__swo_temp
+            name: k8s.apiserver.request.successrate
+            operation: percent
+            type: calculate
+            unit: Percent
         resource/metrics:
           attributes:
           - action: delete
@@ -3316,8 +3316,8 @@ Cluster filter should match snapshot with combined include filters:
             - attributes/unify_configmap_attribute
             - attributes/identify_init_container
             - attributes/identify_standard_container
-            - metricstransform/rename
-            - metricstransform/preprocessing
+            - metrics_transform/rename
+            - metrics_transform/preprocessing
             - filter/preprocessing
             - filter/remove_internal_postprocessing
             - attributes/remove_temp
@@ -3326,9 +3326,9 @@ Cluster filter should match snapshot with combined include filters:
             - deltatorate
             - metricsgeneration/cluster
             - groupbyattrs/node
-            - metricstransform/aggregate_node_level
+            - metrics_transform/aggregate_node_level
             - groupbyattrs/pod
-            - metricstransform/aggregate_pod_level
+            - metrics_transform/aggregate_pod_level
             - groupbyattrs/all
             - resource/metrics
             - k8s_attributes
@@ -3352,11 +3352,11 @@ Cluster filter should match snapshot with combined include filters:
             - memory_limiter
             - filter/trivy-operator-metrics
             - transform/trivy-operator-metrics-attributes
-            - metricstransform/rename
+            - metrics_transform/rename
             - groupbyattrs/trivy-operator-metrics
-            - metricstransform/trivy-operator-metrics-aggregation-by-image
+            - metrics_transform/trivy-operator-metrics-aggregation-by-image
             - filter/namespaces
-            - metricstransform/trivy-operator-metrics-aggregation
+            - metrics_transform/trivy-operator-metrics-aggregation
             - transform/trivy-operator-metrics-split
             receivers:
             - prometheus/trivy-operator-metrics
@@ -3811,15 +3811,7 @@ Cluster filter should match snapshot with exclude_namespaces:
           check_interval: 1s
           limit_mib: 2560
           spike_limit_mib: 512
-        metricsgeneration/cluster:
-          rules:
-          - metric1: apiserver_request_not_failed__swo_temp
-            metric2: apiserver_request_total__swo_temp
-            name: k8s.apiserver.request.successrate
-            operation: percent
-            type: calculate
-            unit: Percent
-        metricstransform/aggregate_node_level:
+        metrics_transform/aggregate_node_level:
           transforms:
           - action: insert
             include: k8s.kube_pod_info
@@ -3829,7 +3821,7 @@ Cluster filter should match snapshot with exclude_namespaces:
               aggregation_type: sum
               label_set:
               - dummy_label_workaround
-        metricstransform/aggregate_pod_level:
+        metrics_transform/aggregate_pod_level:
           transforms:
           - action: insert
             include: k8s.kube_pod_container_info
@@ -3839,7 +3831,7 @@ Cluster filter should match snapshot with exclude_namespaces:
               aggregation_type: sum
               label_set:
               - dummy_label_workaround
-        metricstransform/preprocessing:
+        metrics_transform/preprocessing:
           transforms:
           - action: insert
             experimental_match_labels:
@@ -4681,13 +4673,13 @@ Cluster filter should match snapshot with exclude_namespaces:
             - action: update_label
               label: owner_name
               new_label: cronjob
-        metricstransform/rename:
+        metrics_transform/rename:
           transforms:
           - action: update
             include: ^(trivy_|kube_|container_|kubernetes_|kubelet_|workqueue_|apiserver_|coredns_|etcd_|certmanager_)(.*)$$
             match_type: regexp
             new_name: k8s.$${1}$${2}
-        metricstransform/trivy-operator-metrics-aggregation:
+        metrics_transform/trivy-operator-metrics-aggregation:
           transforms:
           - action: update
             include: ^k8s.trivy_.*$
@@ -4697,7 +4689,7 @@ Cluster filter should match snapshot with exclude_namespaces:
               aggregation_type: sum
               label_set:
               - dummy_label_workaround
-        metricstransform/trivy-operator-metrics-aggregation-by-image:
+        metrics_transform/trivy-operator-metrics-aggregation-by-image:
           transforms:
           - action: update
             include: ^k8s.trivy_.*$
@@ -4707,6 +4699,14 @@ Cluster filter should match snapshot with exclude_namespaces:
               aggregation_type: max
               label_set:
               - image_digest
+        metricsgeneration/cluster:
+          rules:
+          - metric1: apiserver_request_not_failed__swo_temp
+            metric2: apiserver_request_total__swo_temp
+            name: k8s.apiserver.request.successrate
+            operation: percent
+            type: calculate
+            unit: Percent
         resource/metrics:
           attributes:
           - action: delete
@@ -5003,8 +5003,8 @@ Cluster filter should match snapshot with exclude_namespaces:
             - attributes/unify_configmap_attribute
             - attributes/identify_init_container
             - attributes/identify_standard_container
-            - metricstransform/rename
-            - metricstransform/preprocessing
+            - metrics_transform/rename
+            - metrics_transform/preprocessing
             - filter/preprocessing
             - filter/remove_internal_postprocessing
             - attributes/remove_temp
@@ -5013,9 +5013,9 @@ Cluster filter should match snapshot with exclude_namespaces:
             - deltatorate
             - metricsgeneration/cluster
             - groupbyattrs/node
-            - metricstransform/aggregate_node_level
+            - metrics_transform/aggregate_node_level
             - groupbyattrs/pod
-            - metricstransform/aggregate_pod_level
+            - metrics_transform/aggregate_pod_level
             - groupbyattrs/all
             - resource/metrics
             - k8s_attributes
@@ -5039,11 +5039,11 @@ Cluster filter should match snapshot with exclude_namespaces:
             - memory_limiter
             - filter/trivy-operator-metrics
             - transform/trivy-operator-metrics-attributes
-            - metricstransform/rename
+            - metrics_transform/rename
             - groupbyattrs/trivy-operator-metrics
-            - metricstransform/trivy-operator-metrics-aggregation-by-image
+            - metrics_transform/trivy-operator-metrics-aggregation-by-image
             - filter/namespaces
-            - metricstransform/trivy-operator-metrics-aggregation
+            - metrics_transform/trivy-operator-metrics-aggregation
             - transform/trivy-operator-metrics-split
             receivers:
             - prometheus/trivy-operator-metrics
@@ -5498,15 +5498,7 @@ Cluster filter should match snapshot with exclude_namespaces_regex:
           check_interval: 1s
           limit_mib: 2560
           spike_limit_mib: 512
-        metricsgeneration/cluster:
-          rules:
-          - metric1: apiserver_request_not_failed__swo_temp
-            metric2: apiserver_request_total__swo_temp
-            name: k8s.apiserver.request.successrate
-            operation: percent
-            type: calculate
-            unit: Percent
-        metricstransform/aggregate_node_level:
+        metrics_transform/aggregate_node_level:
           transforms:
           - action: insert
             include: k8s.kube_pod_info
@@ -5516,7 +5508,7 @@ Cluster filter should match snapshot with exclude_namespaces_regex:
               aggregation_type: sum
               label_set:
               - dummy_label_workaround
-        metricstransform/aggregate_pod_level:
+        metrics_transform/aggregate_pod_level:
           transforms:
           - action: insert
             include: k8s.kube_pod_container_info
@@ -5526,7 +5518,7 @@ Cluster filter should match snapshot with exclude_namespaces_regex:
               aggregation_type: sum
               label_set:
               - dummy_label_workaround
-        metricstransform/preprocessing:
+        metrics_transform/preprocessing:
           transforms:
           - action: insert
             experimental_match_labels:
@@ -6368,13 +6360,13 @@ Cluster filter should match snapshot with exclude_namespaces_regex:
             - action: update_label
               label: owner_name
               new_label: cronjob
-        metricstransform/rename:
+        metrics_transform/rename:
           transforms:
           - action: update
             include: ^(trivy_|kube_|container_|kubernetes_|kubelet_|workqueue_|apiserver_|coredns_|etcd_|certmanager_)(.*)$$
             match_type: regexp
             new_name: k8s.$${1}$${2}
-        metricstransform/trivy-operator-metrics-aggregation:
+        metrics_transform/trivy-operator-metrics-aggregation:
           transforms:
           - action: update
             include: ^k8s.trivy_.*$
@@ -6384,7 +6376,7 @@ Cluster filter should match snapshot with exclude_namespaces_regex:
               aggregation_type: sum
               label_set:
               - dummy_label_workaround
-        metricstransform/trivy-operator-metrics-aggregation-by-image:
+        metrics_transform/trivy-operator-metrics-aggregation-by-image:
           transforms:
           - action: update
             include: ^k8s.trivy_.*$
@@ -6394,6 +6386,14 @@ Cluster filter should match snapshot with exclude_namespaces_regex:
               aggregation_type: max
               label_set:
               - image_digest
+        metricsgeneration/cluster:
+          rules:
+          - metric1: apiserver_request_not_failed__swo_temp
+            metric2: apiserver_request_total__swo_temp
+            name: k8s.apiserver.request.successrate
+            operation: percent
+            type: calculate
+            unit: Percent
         resource/metrics:
           attributes:
           - action: delete
@@ -6690,8 +6690,8 @@ Cluster filter should match snapshot with exclude_namespaces_regex:
             - attributes/unify_configmap_attribute
             - attributes/identify_init_container
             - attributes/identify_standard_container
-            - metricstransform/rename
-            - metricstransform/preprocessing
+            - metrics_transform/rename
+            - metrics_transform/preprocessing
             - filter/preprocessing
             - filter/remove_internal_postprocessing
             - attributes/remove_temp
@@ -6700,9 +6700,9 @@ Cluster filter should match snapshot with exclude_namespaces_regex:
             - deltatorate
             - metricsgeneration/cluster
             - groupbyattrs/node
-            - metricstransform/aggregate_node_level
+            - metrics_transform/aggregate_node_level
             - groupbyattrs/pod
-            - metricstransform/aggregate_pod_level
+            - metrics_transform/aggregate_pod_level
             - groupbyattrs/all
             - resource/metrics
             - k8s_attributes
@@ -6726,11 +6726,11 @@ Cluster filter should match snapshot with exclude_namespaces_regex:
             - memory_limiter
             - filter/trivy-operator-metrics
             - transform/trivy-operator-metrics-attributes
-            - metricstransform/rename
+            - metrics_transform/rename
             - groupbyattrs/trivy-operator-metrics
-            - metricstransform/trivy-operator-metrics-aggregation-by-image
+            - metrics_transform/trivy-operator-metrics-aggregation-by-image
             - filter/namespaces
-            - metricstransform/trivy-operator-metrics-aggregation
+            - metrics_transform/trivy-operator-metrics-aggregation
             - transform/trivy-operator-metrics-split
             receivers:
             - prometheus/trivy-operator-metrics
@@ -7184,15 +7184,7 @@ Cluster filter should match snapshot with include_namespaces:
           check_interval: 1s
           limit_mib: 2560
           spike_limit_mib: 512
-        metricsgeneration/cluster:
-          rules:
-          - metric1: apiserver_request_not_failed__swo_temp
-            metric2: apiserver_request_total__swo_temp
-            name: k8s.apiserver.request.successrate
-            operation: percent
-            type: calculate
-            unit: Percent
-        metricstransform/aggregate_node_level:
+        metrics_transform/aggregate_node_level:
           transforms:
           - action: insert
             include: k8s.kube_pod_info
@@ -7202,7 +7194,7 @@ Cluster filter should match snapshot with include_namespaces:
               aggregation_type: sum
               label_set:
               - dummy_label_workaround
-        metricstransform/aggregate_pod_level:
+        metrics_transform/aggregate_pod_level:
           transforms:
           - action: insert
             include: k8s.kube_pod_container_info
@@ -7212,7 +7204,7 @@ Cluster filter should match snapshot with include_namespaces:
               aggregation_type: sum
               label_set:
               - dummy_label_workaround
-        metricstransform/preprocessing:
+        metrics_transform/preprocessing:
           transforms:
           - action: insert
             experimental_match_labels:
@@ -8054,13 +8046,13 @@ Cluster filter should match snapshot with include_namespaces:
             - action: update_label
               label: owner_name
               new_label: cronjob
-        metricstransform/rename:
+        metrics_transform/rename:
           transforms:
           - action: update
             include: ^(trivy_|kube_|container_|kubernetes_|kubelet_|workqueue_|apiserver_|coredns_|etcd_|certmanager_)(.*)$$
             match_type: regexp
             new_name: k8s.$${1}$${2}
-        metricstransform/trivy-operator-metrics-aggregation:
+        metrics_transform/trivy-operator-metrics-aggregation:
           transforms:
           - action: update
             include: ^k8s.trivy_.*$
@@ -8070,7 +8062,7 @@ Cluster filter should match snapshot with include_namespaces:
               aggregation_type: sum
               label_set:
               - dummy_label_workaround
-        metricstransform/trivy-operator-metrics-aggregation-by-image:
+        metrics_transform/trivy-operator-metrics-aggregation-by-image:
           transforms:
           - action: update
             include: ^k8s.trivy_.*$
@@ -8080,6 +8072,14 @@ Cluster filter should match snapshot with include_namespaces:
               aggregation_type: max
               label_set:
               - image_digest
+        metricsgeneration/cluster:
+          rules:
+          - metric1: apiserver_request_not_failed__swo_temp
+            metric2: apiserver_request_total__swo_temp
+            name: k8s.apiserver.request.successrate
+            operation: percent
+            type: calculate
+            unit: Percent
         resource/metrics:
           attributes:
           - action: delete
@@ -8376,8 +8376,8 @@ Cluster filter should match snapshot with include_namespaces:
             - attributes/unify_configmap_attribute
             - attributes/identify_init_container
             - attributes/identify_standard_container
-            - metricstransform/rename
-            - metricstransform/preprocessing
+            - metrics_transform/rename
+            - metrics_transform/preprocessing
             - filter/preprocessing
             - filter/remove_internal_postprocessing
             - attributes/remove_temp
@@ -8386,9 +8386,9 @@ Cluster filter should match snapshot with include_namespaces:
             - deltatorate
             - metricsgeneration/cluster
             - groupbyattrs/node
-            - metricstransform/aggregate_node_level
+            - metrics_transform/aggregate_node_level
             - groupbyattrs/pod
-            - metricstransform/aggregate_pod_level
+            - metrics_transform/aggregate_pod_level
             - groupbyattrs/all
             - resource/metrics
             - k8s_attributes
@@ -8412,11 +8412,11 @@ Cluster filter should match snapshot with include_namespaces:
             - memory_limiter
             - filter/trivy-operator-metrics
             - transform/trivy-operator-metrics-attributes
-            - metricstransform/rename
+            - metrics_transform/rename
             - groupbyattrs/trivy-operator-metrics
-            - metricstransform/trivy-operator-metrics-aggregation-by-image
+            - metrics_transform/trivy-operator-metrics-aggregation-by-image
             - filter/namespaces
-            - metricstransform/trivy-operator-metrics-aggregation
+            - metrics_transform/trivy-operator-metrics-aggregation
             - transform/trivy-operator-metrics-split
             receivers:
             - prometheus/trivy-operator-metrics
@@ -8870,15 +8870,7 @@ Cluster filter should match snapshot with include_namespaces_regex:
           check_interval: 1s
           limit_mib: 2560
           spike_limit_mib: 512
-        metricsgeneration/cluster:
-          rules:
-          - metric1: apiserver_request_not_failed__swo_temp
-            metric2: apiserver_request_total__swo_temp
-            name: k8s.apiserver.request.successrate
-            operation: percent
-            type: calculate
-            unit: Percent
-        metricstransform/aggregate_node_level:
+        metrics_transform/aggregate_node_level:
           transforms:
           - action: insert
             include: k8s.kube_pod_info
@@ -8888,7 +8880,7 @@ Cluster filter should match snapshot with include_namespaces_regex:
               aggregation_type: sum
               label_set:
               - dummy_label_workaround
-        metricstransform/aggregate_pod_level:
+        metrics_transform/aggregate_pod_level:
           transforms:
           - action: insert
             include: k8s.kube_pod_container_info
@@ -8898,7 +8890,7 @@ Cluster filter should match snapshot with include_namespaces_regex:
               aggregation_type: sum
               label_set:
               - dummy_label_workaround
-        metricstransform/preprocessing:
+        metrics_transform/preprocessing:
           transforms:
           - action: insert
             experimental_match_labels:
@@ -9740,13 +9732,13 @@ Cluster filter should match snapshot with include_namespaces_regex:
             - action: update_label
               label: owner_name
               new_label: cronjob
-        metricstransform/rename:
+        metrics_transform/rename:
           transforms:
           - action: update
             include: ^(trivy_|kube_|container_|kubernetes_|kubelet_|workqueue_|apiserver_|coredns_|etcd_|certmanager_)(.*)$$
             match_type: regexp
             new_name: k8s.$${1}$${2}
-        metricstransform/trivy-operator-metrics-aggregation:
+        metrics_transform/trivy-operator-metrics-aggregation:
           transforms:
           - action: update
             include: ^k8s.trivy_.*$
@@ -9756,7 +9748,7 @@ Cluster filter should match snapshot with include_namespaces_regex:
               aggregation_type: sum
               label_set:
               - dummy_label_workaround
-        metricstransform/trivy-operator-metrics-aggregation-by-image:
+        metrics_transform/trivy-operator-metrics-aggregation-by-image:
           transforms:
           - action: update
             include: ^k8s.trivy_.*$
@@ -9766,6 +9758,14 @@ Cluster filter should match snapshot with include_namespaces_regex:
               aggregation_type: max
               label_set:
               - image_digest
+        metricsgeneration/cluster:
+          rules:
+          - metric1: apiserver_request_not_failed__swo_temp
+            metric2: apiserver_request_total__swo_temp
+            name: k8s.apiserver.request.successrate
+            operation: percent
+            type: calculate
+            unit: Percent
         resource/metrics:
           attributes:
           - action: delete
@@ -10062,8 +10062,8 @@ Cluster filter should match snapshot with include_namespaces_regex:
             - attributes/unify_configmap_attribute
             - attributes/identify_init_container
             - attributes/identify_standard_container
-            - metricstransform/rename
-            - metricstransform/preprocessing
+            - metrics_transform/rename
+            - metrics_transform/preprocessing
             - filter/preprocessing
             - filter/remove_internal_postprocessing
             - attributes/remove_temp
@@ -10072,9 +10072,9 @@ Cluster filter should match snapshot with include_namespaces_regex:
             - deltatorate
             - metricsgeneration/cluster
             - groupbyattrs/node
-            - metricstransform/aggregate_node_level
+            - metrics_transform/aggregate_node_level
             - groupbyattrs/pod
-            - metricstransform/aggregate_pod_level
+            - metrics_transform/aggregate_pod_level
             - groupbyattrs/all
             - resource/metrics
             - k8s_attributes
@@ -10098,11 +10098,11 @@ Cluster filter should match snapshot with include_namespaces_regex:
             - memory_limiter
             - filter/trivy-operator-metrics
             - transform/trivy-operator-metrics-attributes
-            - metricstransform/rename
+            - metrics_transform/rename
             - groupbyattrs/trivy-operator-metrics
-            - metricstransform/trivy-operator-metrics-aggregation-by-image
+            - metrics_transform/trivy-operator-metrics-aggregation-by-image
             - filter/namespaces
-            - metricstransform/trivy-operator-metrics-aggregation
+            - metrics_transform/trivy-operator-metrics-aggregation
             - transform/trivy-operator-metrics-split
             receivers:
             - prometheus/trivy-operator-metrics
@@ -10548,15 +10548,7 @@ Metrics config should match snapshot when fargate is enabled:
           check_interval: 1s
           limit_mib: 2560
           spike_limit_mib: 512
-        metricsgeneration/cluster:
-          rules:
-          - metric1: apiserver_request_not_failed__swo_temp
-            metric2: apiserver_request_total__swo_temp
-            name: k8s.apiserver.request.successrate
-            operation: percent
-            type: calculate
-            unit: Percent
-        metricstransform/aggregate_node_level:
+        metrics_transform/aggregate_node_level:
           transforms:
           - action: insert
             include: k8s.kube_pod_info
@@ -10566,7 +10558,7 @@ Metrics config should match snapshot when fargate is enabled:
               aggregation_type: sum
               label_set:
               - dummy_label_workaround
-        metricstransform/aggregate_pod_level:
+        metrics_transform/aggregate_pod_level:
           transforms:
           - action: insert
             include: k8s.kube_pod_container_info
@@ -10576,7 +10568,7 @@ Metrics config should match snapshot when fargate is enabled:
               aggregation_type: sum
               label_set:
               - dummy_label_workaround
-        metricstransform/preprocessing:
+        metrics_transform/preprocessing:
           transforms:
           - action: insert
             experimental_match_labels:
@@ -11418,13 +11410,13 @@ Metrics config should match snapshot when fargate is enabled:
             - action: update_label
               label: owner_name
               new_label: cronjob
-        metricstransform/rename:
+        metrics_transform/rename:
           transforms:
           - action: update
             include: ^(trivy_|kube_|container_|kubernetes_|kubelet_|workqueue_|apiserver_|coredns_|etcd_|certmanager_)(.*)$$
             match_type: regexp
             new_name: k8s.$${1}$${2}
-        metricstransform/trivy-operator-metrics-aggregation:
+        metrics_transform/trivy-operator-metrics-aggregation:
           transforms:
           - action: update
             include: ^k8s.trivy_.*$
@@ -11434,7 +11426,7 @@ Metrics config should match snapshot when fargate is enabled:
               aggregation_type: sum
               label_set:
               - dummy_label_workaround
-        metricstransform/trivy-operator-metrics-aggregation-by-image:
+        metrics_transform/trivy-operator-metrics-aggregation-by-image:
           transforms:
           - action: update
             include: ^k8s.trivy_.*$
@@ -11444,6 +11436,14 @@ Metrics config should match snapshot when fargate is enabled:
               aggregation_type: max
               label_set:
               - image_digest
+        metricsgeneration/cluster:
+          rules:
+          - metric1: apiserver_request_not_failed__swo_temp
+            metric2: apiserver_request_total__swo_temp
+            name: k8s.apiserver.request.successrate
+            operation: percent
+            type: calculate
+            unit: Percent
         resource/metrics:
           attributes:
           - action: delete
@@ -11820,8 +11820,8 @@ Metrics config should match snapshot when fargate is enabled:
             - attributes/unify_configmap_attribute
             - attributes/identify_init_container
             - attributes/identify_standard_container
-            - metricstransform/rename
-            - metricstransform/preprocessing
+            - metrics_transform/rename
+            - metrics_transform/preprocessing
             - filter/preprocessing
             - filter/remove_internal_postprocessing
             - attributes/remove_temp
@@ -11830,9 +11830,9 @@ Metrics config should match snapshot when fargate is enabled:
             - deltatorate
             - metricsgeneration/cluster
             - groupbyattrs/node
-            - metricstransform/aggregate_node_level
+            - metrics_transform/aggregate_node_level
             - groupbyattrs/pod
-            - metricstransform/aggregate_pod_level
+            - metrics_transform/aggregate_pod_level
             - groupbyattrs/all
             - resource/metrics
             - k8s_attributes
@@ -11855,10 +11855,10 @@ Metrics config should match snapshot when fargate is enabled:
             - memory_limiter
             - filter/trivy-operator-metrics
             - transform/trivy-operator-metrics-attributes
-            - metricstransform/rename
+            - metrics_transform/rename
             - groupbyattrs/trivy-operator-metrics
-            - metricstransform/trivy-operator-metrics-aggregation-by-image
-            - metricstransform/trivy-operator-metrics-aggregation
+            - metrics_transform/trivy-operator-metrics-aggregation-by-image
+            - metrics_transform/trivy-operator-metrics-aggregation
             - transform/trivy-operator-metrics-split
             receivers:
             - prometheus/trivy-operator-metrics
@@ -12315,15 +12315,7 @@ Metrics config should match snapshot when using Prometheus url with extra_scrape
           check_interval: 1s
           limit_mib: 2560
           spike_limit_mib: 512
-        metricsgeneration/cluster:
-          rules:
-          - metric1: apiserver_request_not_failed__swo_temp
-            metric2: apiserver_request_total__swo_temp
-            name: k8s.apiserver.request.successrate
-            operation: percent
-            type: calculate
-            unit: Percent
-        metricstransform/aggregate_node_level:
+        metrics_transform/aggregate_node_level:
           transforms:
           - action: insert
             include: k8s.kube_pod_info
@@ -12333,7 +12325,7 @@ Metrics config should match snapshot when using Prometheus url with extra_scrape
               aggregation_type: sum
               label_set:
               - dummy_label_workaround
-        metricstransform/aggregate_pod_level:
+        metrics_transform/aggregate_pod_level:
           transforms:
           - action: insert
             include: k8s.kube_pod_container_info
@@ -12343,7 +12335,7 @@ Metrics config should match snapshot when using Prometheus url with extra_scrape
               aggregation_type: sum
               label_set:
               - dummy_label_workaround
-        metricstransform/preprocessing:
+        metrics_transform/preprocessing:
           transforms:
           - action: insert
             experimental_match_labels:
@@ -13185,13 +13177,13 @@ Metrics config should match snapshot when using Prometheus url with extra_scrape
             - action: update_label
               label: owner_name
               new_label: cronjob
-        metricstransform/rename:
+        metrics_transform/rename:
           transforms:
           - action: update
             include: ^(trivy_|kube_|container_|kubernetes_|kubelet_|workqueue_|apiserver_|coredns_|etcd_|certmanager_)(.*)$$
             match_type: regexp
             new_name: k8s.$${1}$${2}
-        metricstransform/trivy-operator-metrics-aggregation:
+        metrics_transform/trivy-operator-metrics-aggregation:
           transforms:
           - action: update
             include: ^k8s.trivy_.*$
@@ -13201,7 +13193,7 @@ Metrics config should match snapshot when using Prometheus url with extra_scrape
               aggregation_type: sum
               label_set:
               - dummy_label_workaround
-        metricstransform/trivy-operator-metrics-aggregation-by-image:
+        metrics_transform/trivy-operator-metrics-aggregation-by-image:
           transforms:
           - action: update
             include: ^k8s.trivy_.*$
@@ -13211,6 +13203,14 @@ Metrics config should match snapshot when using Prometheus url with extra_scrape
               aggregation_type: max
               label_set:
               - image_digest
+        metricsgeneration/cluster:
+          rules:
+          - metric1: apiserver_request_not_failed__swo_temp
+            metric2: apiserver_request_total__swo_temp
+            name: k8s.apiserver.request.successrate
+            operation: percent
+            type: calculate
+            unit: Percent
         resource/metrics:
           attributes:
           - action: delete
@@ -13546,8 +13546,8 @@ Metrics config should match snapshot when using Prometheus url with extra_scrape
             - attributes/unify_configmap_attribute
             - attributes/identify_init_container
             - attributes/identify_standard_container
-            - metricstransform/rename
-            - metricstransform/preprocessing
+            - metrics_transform/rename
+            - metrics_transform/preprocessing
             - filter/preprocessing
             - filter/remove_internal_postprocessing
             - attributes/remove_temp
@@ -13556,9 +13556,9 @@ Metrics config should match snapshot when using Prometheus url with extra_scrape
             - deltatorate
             - metricsgeneration/cluster
             - groupbyattrs/node
-            - metricstransform/aggregate_node_level
+            - metrics_transform/aggregate_node_level
             - groupbyattrs/pod
-            - metricstransform/aggregate_pod_level
+            - metrics_transform/aggregate_pod_level
             - groupbyattrs/all
             - resource/metrics
             - k8s_attributes
@@ -13601,10 +13601,10 @@ Metrics config should match snapshot when using Prometheus url with extra_scrape
             - memory_limiter
             - filter/trivy-operator-metrics
             - transform/trivy-operator-metrics-attributes
-            - metricstransform/rename
+            - metrics_transform/rename
             - groupbyattrs/trivy-operator-metrics
-            - metricstransform/trivy-operator-metrics-aggregation-by-image
-            - metricstransform/trivy-operator-metrics-aggregation
+            - metrics_transform/trivy-operator-metrics-aggregation-by-image
+            - metrics_transform/trivy-operator-metrics-aggregation
             - transform/trivy-operator-metrics-split
             receivers:
             - prometheus/trivy-operator-metrics
@@ -14053,15 +14053,7 @@ Metrics config should match snapshot when using default values:
           check_interval: 1s
           limit_mib: 2560
           spike_limit_mib: 512
-        metricsgeneration/cluster:
-          rules:
-          - metric1: apiserver_request_not_failed__swo_temp
-            metric2: apiserver_request_total__swo_temp
-            name: k8s.apiserver.request.successrate
-            operation: percent
-            type: calculate
-            unit: Percent
-        metricstransform/aggregate_node_level:
+        metrics_transform/aggregate_node_level:
           transforms:
           - action: insert
             include: k8s.kube_pod_info
@@ -14071,7 +14063,7 @@ Metrics config should match snapshot when using default values:
               aggregation_type: sum
               label_set:
               - dummy_label_workaround
-        metricstransform/aggregate_pod_level:
+        metrics_transform/aggregate_pod_level:
           transforms:
           - action: insert
             include: k8s.kube_pod_container_info
@@ -14081,7 +14073,7 @@ Metrics config should match snapshot when using default values:
               aggregation_type: sum
               label_set:
               - dummy_label_workaround
-        metricstransform/preprocessing:
+        metrics_transform/preprocessing:
           transforms:
           - action: insert
             experimental_match_labels:
@@ -14923,13 +14915,13 @@ Metrics config should match snapshot when using default values:
             - action: update_label
               label: owner_name
               new_label: cronjob
-        metricstransform/rename:
+        metrics_transform/rename:
           transforms:
           - action: update
             include: ^(trivy_|kube_|container_|kubernetes_|kubelet_|workqueue_|apiserver_|coredns_|etcd_|certmanager_)(.*)$$
             match_type: regexp
             new_name: k8s.$${1}$${2}
-        metricstransform/trivy-operator-metrics-aggregation:
+        metrics_transform/trivy-operator-metrics-aggregation:
           transforms:
           - action: update
             include: ^k8s.trivy_.*$
@@ -14939,7 +14931,7 @@ Metrics config should match snapshot when using default values:
               aggregation_type: sum
               label_set:
               - dummy_label_workaround
-        metricstransform/trivy-operator-metrics-aggregation-by-image:
+        metrics_transform/trivy-operator-metrics-aggregation-by-image:
           transforms:
           - action: update
             include: ^k8s.trivy_.*$
@@ -14949,6 +14941,14 @@ Metrics config should match snapshot when using default values:
               aggregation_type: max
               label_set:
               - image_digest
+        metricsgeneration/cluster:
+          rules:
+          - metric1: apiserver_request_not_failed__swo_temp
+            metric2: apiserver_request_total__swo_temp
+            name: k8s.apiserver.request.successrate
+            operation: percent
+            type: calculate
+            unit: Percent
         resource/metrics:
           attributes:
           - action: delete
@@ -15245,8 +15245,8 @@ Metrics config should match snapshot when using default values:
             - attributes/unify_configmap_attribute
             - attributes/identify_init_container
             - attributes/identify_standard_container
-            - metricstransform/rename
-            - metricstransform/preprocessing
+            - metrics_transform/rename
+            - metrics_transform/preprocessing
             - filter/preprocessing
             - filter/remove_internal_postprocessing
             - attributes/remove_temp
@@ -15255,9 +15255,9 @@ Metrics config should match snapshot when using default values:
             - deltatorate
             - metricsgeneration/cluster
             - groupbyattrs/node
-            - metricstransform/aggregate_node_level
+            - metrics_transform/aggregate_node_level
             - groupbyattrs/pod
-            - metricstransform/aggregate_pod_level
+            - metrics_transform/aggregate_pod_level
             - groupbyattrs/all
             - resource/metrics
             - k8s_attributes
@@ -15280,10 +15280,10 @@ Metrics config should match snapshot when using default values:
             - memory_limiter
             - filter/trivy-operator-metrics
             - transform/trivy-operator-metrics-attributes
-            - metricstransform/rename
+            - metrics_transform/rename
             - groupbyattrs/trivy-operator-metrics
-            - metricstransform/trivy-operator-metrics-aggregation-by-image
-            - metricstransform/trivy-operator-metrics-aggregation
+            - metrics_transform/trivy-operator-metrics-aggregation-by-image
+            - metrics_transform/trivy-operator-metrics-aggregation
             - transform/trivy-operator-metrics-split
             receivers:
             - prometheus/trivy-operator-metrics

--- a/deploy/helm/tests/__snapshot__/metrics-discovery-config-map_test.yaml.snap
+++ b/deploy/helm/tests/__snapshot__/metrics-discovery-config-map_test.yaml.snap
@@ -486,19 +486,12 @@ Metrics discovery config should match snapshot when Fargate is enabled:
               name: k8s.pod.ip
             - from: resource_attribute
               name: k8s.namespace.name
-        logdedup/solarwindsentity: {}
+        log_dedup/solarwindsentity: {}
         memory_limiter:
           check_interval: 1s
           limit_mib: 2560
           spike_limit_mib: 512
-        metricsgeneration/istio-metrics:
-          rules:
-          - metric1: k8s.istio_request_duration_milliseconds_sum__swo_temp
-            metric2: k8s.istio_request_duration_milliseconds_count__swo_temp
-            name: k8s.istio_request_duration_milliseconds.rate
-            operation: divide
-            type: calculate
-        metricstransform/istio-metrics:
+        metrics_transform/istio-metrics:
           transforms:
           - action: insert
             include: k8s.istio_request_bytes_sum
@@ -530,7 +523,7 @@ Metrics discovery config should match snapshot when Fargate is enabled:
           - action: insert
             include: k8s.istio_tcp_received_bytes.rate
             new_name: k8s.istio_tcp_received_bytes.delta
-        metricstransform/rename-following-otel-semantics/discovery:
+        metrics_transform/rename-following-otel-semantics/discovery:
           transforms:
           - action: update
             include: ^(.*)$$
@@ -544,6 +537,13 @@ Metrics discovery config should match snapshot when Fargate is enabled:
             include: ^k8s.(rpc\..*)$$
             match_type: regexp
             new_name: $${1}
+        metricsgeneration/istio-metrics:
+          rules:
+          - metric1: k8s.istio_request_duration_milliseconds_sum__swo_temp
+            metric2: k8s.istio_request_duration_milliseconds_count__swo_temp
+            name: k8s.istio_request_duration_milliseconds.rate
+            operation: divide
+            type: calculate
         resource/all:
           attributes:
           - action: insert
@@ -768,7 +768,7 @@ Metrics discovery config should match snapshot when Fargate is enabled:
             - memory_limiter
             - filter/keep-entity-state-events
             - transform/scope
-            - logdedup/solarwindsentity
+            - log_dedup/solarwindsentity
             - batch/stateevents
             receivers:
             - solarwindsentity/istio-workload-workload
@@ -780,7 +780,7 @@ Metrics discovery config should match snapshot when Fargate is enabled:
             - memory_limiter
             - filter/keep-relationship-state-events
             - transform/scope
-            - logdedup/solarwindsentity
+            - log_dedup/solarwindsentity
             - batch/stateevents
             receivers:
             - solarwindsentity/istio-workload-workload
@@ -817,7 +817,7 @@ Metrics discovery config should match snapshot when Fargate is enabled:
             - swok8sworkloadtype/istio
             - transform/istio-metrics
             - transform/istio-metric-datapoints
-            - metricstransform/istio-metrics
+            - metrics_transform/istio-metrics
             - cumulativetodelta/istio-metrics
             - deltatorate/istio-metrics
             - metricsgeneration/istio-metrics
@@ -839,7 +839,7 @@ Metrics discovery config should match snapshot when Fargate is enabled:
             - routing/discovered_metrics
             processors:
             - memory_limiter
-            - metricstransform/rename-following-otel-semantics/discovery
+            - metrics_transform/rename-following-otel-semantics/discovery
             receivers:
             - receiver_creator/discovery
           metrics/not-relationship-state-events-preparation:

--- a/deploy/helm/tests/__snapshot__/node-collector-config-map-windows_test.yaml.snap
+++ b/deploy/helm/tests/__snapshot__/node-collector-config-map-windows_test.yaml.snap
@@ -647,19 +647,12 @@ Node collector config for windows nodes should match snapshot when using default
               name: k8s.pod.name
             - from: resource_attribute
               name: k8s.namespace.name
-        logdedup/solarwindsentity: {}
+        log_dedup/solarwindsentity: {}
         memory_limiter:
           check_interval: 1s
           limit_mib: 800
           spike_limit_mib: 300
-        metricsgeneration/istio-metrics:
-          rules:
-          - metric1: k8s.istio_request_duration_milliseconds_sum__swo_temp
-            metric2: k8s.istio_request_duration_milliseconds_count__swo_temp
-            name: k8s.istio_request_duration_milliseconds.rate
-            operation: divide
-            type: calculate
-        metricstransform/istio-metrics:
+        metrics_transform/istio-metrics:
           transforms:
           - action: insert
             include: k8s.istio_request_bytes_sum
@@ -691,7 +684,7 @@ Node collector config for windows nodes should match snapshot when using default
           - action: insert
             include: k8s.istio_tcp_received_bytes.rate
             new_name: k8s.istio_tcp_received_bytes.delta
-        metricstransform/preprocessing:
+        metrics_transform/preprocessing:
           transforms:
           - action: insert
             include: k8s.container_fs_reads_total
@@ -1125,7 +1118,7 @@ Node collector config for windows nodes should match snapshot when using default
               aggregation_type: sum
               label_set:
               - k8s.node.name
-        metricstransform/rename-following-otel-semantics:
+        metrics_transform/rename-following-otel-semantics:
           transforms:
           - action: update
             include: ^(.*)$$
@@ -1139,7 +1132,7 @@ Node collector config for windows nodes should match snapshot when using default
             include: ^k8s.(rpc\..*)$$
             match_type: regexp
             new_name: $${1}
-        metricstransform/rename-following-otel-semantics/discovery:
+        metrics_transform/rename-following-otel-semantics/discovery:
           transforms:
           - action: update
             include: ^(.*)$$
@@ -1153,6 +1146,13 @@ Node collector config for windows nodes should match snapshot when using default
             include: ^k8s.(rpc\..*)$$
             match_type: regexp
             new_name: $${1}
+        metricsgeneration/istio-metrics:
+          rules:
+          - metric1: k8s.istio_request_duration_milliseconds_sum__swo_temp
+            metric2: k8s.istio_request_duration_milliseconds_count__swo_temp
+            name: k8s.istio_request_duration_milliseconds.rate
+            operation: divide
+            type: calculate
         resource/all:
           attributes:
           - action: insert
@@ -1724,7 +1724,7 @@ Node collector config for windows nodes should match snapshot when using default
             - memory_limiter
             - filter/keep-entity-state-events
             - transform/scope
-            - logdedup/solarwindsentity
+            - log_dedup/solarwindsentity
             - batch/stateevents
             receivers:
             - solarwindsentity/istio-workload-workload
@@ -1736,7 +1736,7 @@ Node collector config for windows nodes should match snapshot when using default
             - memory_limiter
             - filter/keep-relationship-state-events
             - transform/scope
-            - logdedup/solarwindsentity
+            - log_dedup/solarwindsentity
             - batch/stateevents
             receivers:
             - solarwindsentity/istio-workload-workload
@@ -1773,7 +1773,7 @@ Node collector config for windows nodes should match snapshot when using default
             - swok8sworkloadtype/istio
             - transform/istio-metrics
             - transform/istio-metric-datapoints
-            - metricstransform/istio-metrics
+            - metrics_transform/istio-metrics
             - cumulativetodelta/istio-metrics
             - deltatorate/istio-metrics
             - metricsgeneration/istio-metrics
@@ -1795,7 +1795,7 @@ Node collector config for windows nodes should match snapshot when using default
             - routing/discovered_metrics
             processors:
             - memory_limiter
-            - metricstransform/rename-following-otel-semantics/discovery
+            - metrics_transform/rename-following-otel-semantics/discovery
             receivers:
             - receiver_creator/discovery
           metrics/node:
@@ -1808,8 +1808,8 @@ Node collector config for windows nodes should match snapshot when using default
             - attributes/remove_prometheus_attributes
             - attributes/unify_node_attribute
             - transform/unify_node_attribute
-            - metricstransform/rename-following-otel-semantics
-            - metricstransform/preprocessing
+            - metrics_transform/rename-following-otel-semantics
+            - metrics_transform/preprocessing
             - filter/remove_internal_postprocessing
             - attributes/remove_temp
             - cumulativetodelta/cadvisor
@@ -2541,19 +2541,12 @@ Node collector config for windows nodes should match snapshot when using legacy 
               name: k8s.pod.name
             - from: resource_attribute
               name: k8s.namespace.name
-        logdedup/solarwindsentity: {}
+        log_dedup/solarwindsentity: {}
         memory_limiter:
           check_interval: 1s
           limit_mib: 800
           spike_limit_mib: 300
-        metricsgeneration/istio-metrics:
-          rules:
-          - metric1: k8s.istio_request_duration_milliseconds_sum__swo_temp
-            metric2: k8s.istio_request_duration_milliseconds_count__swo_temp
-            name: k8s.istio_request_duration_milliseconds.rate
-            operation: divide
-            type: calculate
-        metricstransform/istio-metrics:
+        metrics_transform/istio-metrics:
           transforms:
           - action: insert
             include: k8s.istio_request_bytes_sum
@@ -2585,7 +2578,7 @@ Node collector config for windows nodes should match snapshot when using legacy 
           - action: insert
             include: k8s.istio_tcp_received_bytes.rate
             new_name: k8s.istio_tcp_received_bytes.delta
-        metricstransform/preprocessing:
+        metrics_transform/preprocessing:
           transforms:
           - action: insert
             include: k8s.container_fs_reads_total
@@ -3019,7 +3012,7 @@ Node collector config for windows nodes should match snapshot when using legacy 
               aggregation_type: sum
               label_set:
               - k8s.node.name
-        metricstransform/rename-following-otel-semantics:
+        metrics_transform/rename-following-otel-semantics:
           transforms:
           - action: update
             include: ^(.*)$$
@@ -3033,7 +3026,7 @@ Node collector config for windows nodes should match snapshot when using legacy 
             include: ^k8s.(rpc\..*)$$
             match_type: regexp
             new_name: $${1}
-        metricstransform/rename-following-otel-semantics/discovery:
+        metrics_transform/rename-following-otel-semantics/discovery:
           transforms:
           - action: update
             include: ^(.*)$$
@@ -3047,6 +3040,13 @@ Node collector config for windows nodes should match snapshot when using legacy 
             include: ^k8s.(rpc\..*)$$
             match_type: regexp
             new_name: $${1}
+        metricsgeneration/istio-metrics:
+          rules:
+          - metric1: k8s.istio_request_duration_milliseconds_sum__swo_temp
+            metric2: k8s.istio_request_duration_milliseconds_count__swo_temp
+            name: k8s.istio_request_duration_milliseconds.rate
+            operation: divide
+            type: calculate
         resource/all:
           attributes:
           - action: insert
@@ -3700,7 +3700,7 @@ Node collector config for windows nodes should match snapshot when using legacy 
             - memory_limiter
             - filter/keep-entity-state-events
             - transform/scope
-            - logdedup/solarwindsentity
+            - log_dedup/solarwindsentity
             - batch/stateevents
             receivers:
             - solarwindsentity/istio-workload-workload
@@ -3712,7 +3712,7 @@ Node collector config for windows nodes should match snapshot when using legacy 
             - memory_limiter
             - filter/keep-relationship-state-events
             - transform/scope
-            - logdedup/solarwindsentity
+            - log_dedup/solarwindsentity
             - batch/stateevents
             receivers:
             - solarwindsentity/istio-workload-workload
@@ -3749,7 +3749,7 @@ Node collector config for windows nodes should match snapshot when using legacy 
             - swok8sworkloadtype/istio
             - transform/istio-metrics
             - transform/istio-metric-datapoints
-            - metricstransform/istio-metrics
+            - metrics_transform/istio-metrics
             - cumulativetodelta/istio-metrics
             - deltatorate/istio-metrics
             - metricsgeneration/istio-metrics
@@ -3771,7 +3771,7 @@ Node collector config for windows nodes should match snapshot when using legacy 
             - routing/discovered_metrics
             processors:
             - memory_limiter
-            - metricstransform/rename-following-otel-semantics/discovery
+            - metrics_transform/rename-following-otel-semantics/discovery
             receivers:
             - receiver_creator/discovery
           metrics/node:
@@ -3784,8 +3784,8 @@ Node collector config for windows nodes should match snapshot when using legacy 
             - attributes/remove_prometheus_attributes
             - attributes/unify_node_attribute
             - transform/unify_node_attribute
-            - metricstransform/rename-following-otel-semantics
-            - metricstransform/preprocessing
+            - metrics_transform/rename-following-otel-semantics
+            - metrics_transform/preprocessing
             - filter/remove_internal_postprocessing
             - attributes/remove_temp
             - cumulativetodelta/cadvisor

--- a/deploy/helm/tests/__snapshot__/node-collector-config-map_test.yaml.snap
+++ b/deploy/helm/tests/__snapshot__/node-collector-config-map_test.yaml.snap
@@ -661,19 +661,12 @@ Cluster filter should match snapshot with combined exclude filters:
               name: k8s.pod.name
             - from: resource_attribute
               name: k8s.namespace.name
-        logdedup/solarwindsentity: {}
+        log_dedup/solarwindsentity: {}
         memory_limiter:
           check_interval: 1s
           limit_mib: 800
           spike_limit_mib: 300
-        metricsgeneration/istio-metrics:
-          rules:
-          - metric1: k8s.istio_request_duration_milliseconds_sum__swo_temp
-            metric2: k8s.istio_request_duration_milliseconds_count__swo_temp
-            name: k8s.istio_request_duration_milliseconds.rate
-            operation: divide
-            type: calculate
-        metricstransform/istio-metrics:
+        metrics_transform/istio-metrics:
           transforms:
           - action: insert
             include: k8s.istio_request_bytes_sum
@@ -705,7 +698,7 @@ Cluster filter should match snapshot with combined exclude filters:
           - action: insert
             include: k8s.istio_tcp_received_bytes.rate
             new_name: k8s.istio_tcp_received_bytes.delta
-        metricstransform/preprocessing:
+        metrics_transform/preprocessing:
           transforms:
           - action: insert
             include: k8s.container_fs_reads_total
@@ -1139,7 +1132,7 @@ Cluster filter should match snapshot with combined exclude filters:
               aggregation_type: sum
               label_set:
               - k8s.node.name
-        metricstransform/rename-following-otel-semantics:
+        metrics_transform/rename-following-otel-semantics:
           transforms:
           - action: update
             include: ^(.*)$$
@@ -1153,7 +1146,7 @@ Cluster filter should match snapshot with combined exclude filters:
             include: ^k8s.(rpc\..*)$$
             match_type: regexp
             new_name: $${1}
-        metricstransform/rename-following-otel-semantics/discovery:
+        metrics_transform/rename-following-otel-semantics/discovery:
           transforms:
           - action: update
             include: ^(.*)$$
@@ -1167,6 +1160,13 @@ Cluster filter should match snapshot with combined exclude filters:
             include: ^k8s.(rpc\..*)$$
             match_type: regexp
             new_name: $${1}
+        metricsgeneration/istio-metrics:
+          rules:
+          - metric1: k8s.istio_request_duration_milliseconds_sum__swo_temp
+            metric2: k8s.istio_request_duration_milliseconds_count__swo_temp
+            name: k8s.istio_request_duration_milliseconds.rate
+            operation: divide
+            type: calculate
         resource/all:
           attributes:
           - action: insert
@@ -1775,7 +1775,7 @@ Cluster filter should match snapshot with combined exclude filters:
             - memory_limiter
             - filter/keep-entity-state-events
             - transform/scope
-            - logdedup/solarwindsentity
+            - log_dedup/solarwindsentity
             - batch/stateevents
             receivers:
             - solarwindsentity/istio-workload-workload
@@ -1787,7 +1787,7 @@ Cluster filter should match snapshot with combined exclude filters:
             - memory_limiter
             - filter/keep-relationship-state-events
             - transform/scope
-            - logdedup/solarwindsentity
+            - log_dedup/solarwindsentity
             - batch/stateevents
             receivers:
             - solarwindsentity/istio-workload-workload
@@ -1825,7 +1825,7 @@ Cluster filter should match snapshot with combined exclude filters:
             - swok8sworkloadtype/istio
             - transform/istio-metrics
             - transform/istio-metric-datapoints
-            - metricstransform/istio-metrics
+            - metrics_transform/istio-metrics
             - cumulativetodelta/istio-metrics
             - deltatorate/istio-metrics
             - metricsgeneration/istio-metrics
@@ -1847,7 +1847,7 @@ Cluster filter should match snapshot with combined exclude filters:
             - routing/discovered_metrics
             processors:
             - memory_limiter
-            - metricstransform/rename-following-otel-semantics/discovery
+            - metrics_transform/rename-following-otel-semantics/discovery
             receivers:
             - receiver_creator/discovery
           metrics/node:
@@ -1860,8 +1860,8 @@ Cluster filter should match snapshot with combined exclude filters:
             - attributes/remove_prometheus_attributes
             - attributes/unify_node_attribute
             - transform/unify_node_attribute
-            - metricstransform/rename-following-otel-semantics
-            - metricstransform/preprocessing
+            - metrics_transform/rename-following-otel-semantics
+            - metrics_transform/preprocessing
             - filter/remove_internal_postprocessing
             - attributes/remove_temp
             - cumulativetodelta/cadvisor
@@ -2596,19 +2596,12 @@ Cluster filter should match snapshot with combined include filters:
               name: k8s.pod.name
             - from: resource_attribute
               name: k8s.namespace.name
-        logdedup/solarwindsentity: {}
+        log_dedup/solarwindsentity: {}
         memory_limiter:
           check_interval: 1s
           limit_mib: 800
           spike_limit_mib: 300
-        metricsgeneration/istio-metrics:
-          rules:
-          - metric1: k8s.istio_request_duration_milliseconds_sum__swo_temp
-            metric2: k8s.istio_request_duration_milliseconds_count__swo_temp
-            name: k8s.istio_request_duration_milliseconds.rate
-            operation: divide
-            type: calculate
-        metricstransform/istio-metrics:
+        metrics_transform/istio-metrics:
           transforms:
           - action: insert
             include: k8s.istio_request_bytes_sum
@@ -2640,7 +2633,7 @@ Cluster filter should match snapshot with combined include filters:
           - action: insert
             include: k8s.istio_tcp_received_bytes.rate
             new_name: k8s.istio_tcp_received_bytes.delta
-        metricstransform/preprocessing:
+        metrics_transform/preprocessing:
           transforms:
           - action: insert
             include: k8s.container_fs_reads_total
@@ -3074,7 +3067,7 @@ Cluster filter should match snapshot with combined include filters:
               aggregation_type: sum
               label_set:
               - k8s.node.name
-        metricstransform/rename-following-otel-semantics:
+        metrics_transform/rename-following-otel-semantics:
           transforms:
           - action: update
             include: ^(.*)$$
@@ -3088,7 +3081,7 @@ Cluster filter should match snapshot with combined include filters:
             include: ^k8s.(rpc\..*)$$
             match_type: regexp
             new_name: $${1}
-        metricstransform/rename-following-otel-semantics/discovery:
+        metrics_transform/rename-following-otel-semantics/discovery:
           transforms:
           - action: update
             include: ^(.*)$$
@@ -3102,6 +3095,13 @@ Cluster filter should match snapshot with combined include filters:
             include: ^k8s.(rpc\..*)$$
             match_type: regexp
             new_name: $${1}
+        metricsgeneration/istio-metrics:
+          rules:
+          - metric1: k8s.istio_request_duration_milliseconds_sum__swo_temp
+            metric2: k8s.istio_request_duration_milliseconds_count__swo_temp
+            name: k8s.istio_request_duration_milliseconds.rate
+            operation: divide
+            type: calculate
         resource/all:
           attributes:
           - action: insert
@@ -3710,7 +3710,7 @@ Cluster filter should match snapshot with combined include filters:
             - memory_limiter
             - filter/keep-entity-state-events
             - transform/scope
-            - logdedup/solarwindsentity
+            - log_dedup/solarwindsentity
             - batch/stateevents
             receivers:
             - solarwindsentity/istio-workload-workload
@@ -3722,7 +3722,7 @@ Cluster filter should match snapshot with combined include filters:
             - memory_limiter
             - filter/keep-relationship-state-events
             - transform/scope
-            - logdedup/solarwindsentity
+            - log_dedup/solarwindsentity
             - batch/stateevents
             receivers:
             - solarwindsentity/istio-workload-workload
@@ -3760,7 +3760,7 @@ Cluster filter should match snapshot with combined include filters:
             - swok8sworkloadtype/istio
             - transform/istio-metrics
             - transform/istio-metric-datapoints
-            - metricstransform/istio-metrics
+            - metrics_transform/istio-metrics
             - cumulativetodelta/istio-metrics
             - deltatorate/istio-metrics
             - metricsgeneration/istio-metrics
@@ -3782,7 +3782,7 @@ Cluster filter should match snapshot with combined include filters:
             - routing/discovered_metrics
             processors:
             - memory_limiter
-            - metricstransform/rename-following-otel-semantics/discovery
+            - metrics_transform/rename-following-otel-semantics/discovery
             receivers:
             - receiver_creator/discovery
           metrics/node:
@@ -3795,8 +3795,8 @@ Cluster filter should match snapshot with combined include filters:
             - attributes/remove_prometheus_attributes
             - attributes/unify_node_attribute
             - transform/unify_node_attribute
-            - metricstransform/rename-following-otel-semantics
-            - metricstransform/preprocessing
+            - metrics_transform/rename-following-otel-semantics
+            - metrics_transform/preprocessing
             - filter/remove_internal_postprocessing
             - attributes/remove_temp
             - cumulativetodelta/cadvisor
@@ -4533,19 +4533,12 @@ Cluster filter should match snapshot with exclude_namespaces:
               name: k8s.pod.name
             - from: resource_attribute
               name: k8s.namespace.name
-        logdedup/solarwindsentity: {}
+        log_dedup/solarwindsentity: {}
         memory_limiter:
           check_interval: 1s
           limit_mib: 800
           spike_limit_mib: 300
-        metricsgeneration/istio-metrics:
-          rules:
-          - metric1: k8s.istio_request_duration_milliseconds_sum__swo_temp
-            metric2: k8s.istio_request_duration_milliseconds_count__swo_temp
-            name: k8s.istio_request_duration_milliseconds.rate
-            operation: divide
-            type: calculate
-        metricstransform/istio-metrics:
+        metrics_transform/istio-metrics:
           transforms:
           - action: insert
             include: k8s.istio_request_bytes_sum
@@ -4577,7 +4570,7 @@ Cluster filter should match snapshot with exclude_namespaces:
           - action: insert
             include: k8s.istio_tcp_received_bytes.rate
             new_name: k8s.istio_tcp_received_bytes.delta
-        metricstransform/preprocessing:
+        metrics_transform/preprocessing:
           transforms:
           - action: insert
             include: k8s.container_fs_reads_total
@@ -5011,7 +5004,7 @@ Cluster filter should match snapshot with exclude_namespaces:
               aggregation_type: sum
               label_set:
               - k8s.node.name
-        metricstransform/rename-following-otel-semantics:
+        metrics_transform/rename-following-otel-semantics:
           transforms:
           - action: update
             include: ^(.*)$$
@@ -5025,7 +5018,7 @@ Cluster filter should match snapshot with exclude_namespaces:
             include: ^k8s.(rpc\..*)$$
             match_type: regexp
             new_name: $${1}
-        metricstransform/rename-following-otel-semantics/discovery:
+        metrics_transform/rename-following-otel-semantics/discovery:
           transforms:
           - action: update
             include: ^(.*)$$
@@ -5039,6 +5032,13 @@ Cluster filter should match snapshot with exclude_namespaces:
             include: ^k8s.(rpc\..*)$$
             match_type: regexp
             new_name: $${1}
+        metricsgeneration/istio-metrics:
+          rules:
+          - metric1: k8s.istio_request_duration_milliseconds_sum__swo_temp
+            metric2: k8s.istio_request_duration_milliseconds_count__swo_temp
+            name: k8s.istio_request_duration_milliseconds.rate
+            operation: divide
+            type: calculate
         resource/all:
           attributes:
           - action: insert
@@ -5647,7 +5647,7 @@ Cluster filter should match snapshot with exclude_namespaces:
             - memory_limiter
             - filter/keep-entity-state-events
             - transform/scope
-            - logdedup/solarwindsentity
+            - log_dedup/solarwindsentity
             - batch/stateevents
             receivers:
             - solarwindsentity/istio-workload-workload
@@ -5659,7 +5659,7 @@ Cluster filter should match snapshot with exclude_namespaces:
             - memory_limiter
             - filter/keep-relationship-state-events
             - transform/scope
-            - logdedup/solarwindsentity
+            - log_dedup/solarwindsentity
             - batch/stateevents
             receivers:
             - solarwindsentity/istio-workload-workload
@@ -5697,7 +5697,7 @@ Cluster filter should match snapshot with exclude_namespaces:
             - swok8sworkloadtype/istio
             - transform/istio-metrics
             - transform/istio-metric-datapoints
-            - metricstransform/istio-metrics
+            - metrics_transform/istio-metrics
             - cumulativetodelta/istio-metrics
             - deltatorate/istio-metrics
             - metricsgeneration/istio-metrics
@@ -5719,7 +5719,7 @@ Cluster filter should match snapshot with exclude_namespaces:
             - routing/discovered_metrics
             processors:
             - memory_limiter
-            - metricstransform/rename-following-otel-semantics/discovery
+            - metrics_transform/rename-following-otel-semantics/discovery
             receivers:
             - receiver_creator/discovery
           metrics/node:
@@ -5732,8 +5732,8 @@ Cluster filter should match snapshot with exclude_namespaces:
             - attributes/remove_prometheus_attributes
             - attributes/unify_node_attribute
             - transform/unify_node_attribute
-            - metricstransform/rename-following-otel-semantics
-            - metricstransform/preprocessing
+            - metrics_transform/rename-following-otel-semantics
+            - metrics_transform/preprocessing
             - filter/remove_internal_postprocessing
             - attributes/remove_temp
             - cumulativetodelta/cadvisor
@@ -6470,19 +6470,12 @@ Cluster filter should match snapshot with exclude_namespaces_regex:
               name: k8s.pod.name
             - from: resource_attribute
               name: k8s.namespace.name
-        logdedup/solarwindsentity: {}
+        log_dedup/solarwindsentity: {}
         memory_limiter:
           check_interval: 1s
           limit_mib: 800
           spike_limit_mib: 300
-        metricsgeneration/istio-metrics:
-          rules:
-          - metric1: k8s.istio_request_duration_milliseconds_sum__swo_temp
-            metric2: k8s.istio_request_duration_milliseconds_count__swo_temp
-            name: k8s.istio_request_duration_milliseconds.rate
-            operation: divide
-            type: calculate
-        metricstransform/istio-metrics:
+        metrics_transform/istio-metrics:
           transforms:
           - action: insert
             include: k8s.istio_request_bytes_sum
@@ -6514,7 +6507,7 @@ Cluster filter should match snapshot with exclude_namespaces_regex:
           - action: insert
             include: k8s.istio_tcp_received_bytes.rate
             new_name: k8s.istio_tcp_received_bytes.delta
-        metricstransform/preprocessing:
+        metrics_transform/preprocessing:
           transforms:
           - action: insert
             include: k8s.container_fs_reads_total
@@ -6948,7 +6941,7 @@ Cluster filter should match snapshot with exclude_namespaces_regex:
               aggregation_type: sum
               label_set:
               - k8s.node.name
-        metricstransform/rename-following-otel-semantics:
+        metrics_transform/rename-following-otel-semantics:
           transforms:
           - action: update
             include: ^(.*)$$
@@ -6962,7 +6955,7 @@ Cluster filter should match snapshot with exclude_namespaces_regex:
             include: ^k8s.(rpc\..*)$$
             match_type: regexp
             new_name: $${1}
-        metricstransform/rename-following-otel-semantics/discovery:
+        metrics_transform/rename-following-otel-semantics/discovery:
           transforms:
           - action: update
             include: ^(.*)$$
@@ -6976,6 +6969,13 @@ Cluster filter should match snapshot with exclude_namespaces_regex:
             include: ^k8s.(rpc\..*)$$
             match_type: regexp
             new_name: $${1}
+        metricsgeneration/istio-metrics:
+          rules:
+          - metric1: k8s.istio_request_duration_milliseconds_sum__swo_temp
+            metric2: k8s.istio_request_duration_milliseconds_count__swo_temp
+            name: k8s.istio_request_duration_milliseconds.rate
+            operation: divide
+            type: calculate
         resource/all:
           attributes:
           - action: insert
@@ -7584,7 +7584,7 @@ Cluster filter should match snapshot with exclude_namespaces_regex:
             - memory_limiter
             - filter/keep-entity-state-events
             - transform/scope
-            - logdedup/solarwindsentity
+            - log_dedup/solarwindsentity
             - batch/stateevents
             receivers:
             - solarwindsentity/istio-workload-workload
@@ -7596,7 +7596,7 @@ Cluster filter should match snapshot with exclude_namespaces_regex:
             - memory_limiter
             - filter/keep-relationship-state-events
             - transform/scope
-            - logdedup/solarwindsentity
+            - log_dedup/solarwindsentity
             - batch/stateevents
             receivers:
             - solarwindsentity/istio-workload-workload
@@ -7634,7 +7634,7 @@ Cluster filter should match snapshot with exclude_namespaces_regex:
             - swok8sworkloadtype/istio
             - transform/istio-metrics
             - transform/istio-metric-datapoints
-            - metricstransform/istio-metrics
+            - metrics_transform/istio-metrics
             - cumulativetodelta/istio-metrics
             - deltatorate/istio-metrics
             - metricsgeneration/istio-metrics
@@ -7656,7 +7656,7 @@ Cluster filter should match snapshot with exclude_namespaces_regex:
             - routing/discovered_metrics
             processors:
             - memory_limiter
-            - metricstransform/rename-following-otel-semantics/discovery
+            - metrics_transform/rename-following-otel-semantics/discovery
             receivers:
             - receiver_creator/discovery
           metrics/node:
@@ -7669,8 +7669,8 @@ Cluster filter should match snapshot with exclude_namespaces_regex:
             - attributes/remove_prometheus_attributes
             - attributes/unify_node_attribute
             - transform/unify_node_attribute
-            - metricstransform/rename-following-otel-semantics
-            - metricstransform/preprocessing
+            - metrics_transform/rename-following-otel-semantics
+            - metrics_transform/preprocessing
             - filter/remove_internal_postprocessing
             - attributes/remove_temp
             - cumulativetodelta/cadvisor
@@ -8405,19 +8405,12 @@ Cluster filter should match snapshot with include_namespaces:
               name: k8s.pod.name
             - from: resource_attribute
               name: k8s.namespace.name
-        logdedup/solarwindsentity: {}
+        log_dedup/solarwindsentity: {}
         memory_limiter:
           check_interval: 1s
           limit_mib: 800
           spike_limit_mib: 300
-        metricsgeneration/istio-metrics:
-          rules:
-          - metric1: k8s.istio_request_duration_milliseconds_sum__swo_temp
-            metric2: k8s.istio_request_duration_milliseconds_count__swo_temp
-            name: k8s.istio_request_duration_milliseconds.rate
-            operation: divide
-            type: calculate
-        metricstransform/istio-metrics:
+        metrics_transform/istio-metrics:
           transforms:
           - action: insert
             include: k8s.istio_request_bytes_sum
@@ -8449,7 +8442,7 @@ Cluster filter should match snapshot with include_namespaces:
           - action: insert
             include: k8s.istio_tcp_received_bytes.rate
             new_name: k8s.istio_tcp_received_bytes.delta
-        metricstransform/preprocessing:
+        metrics_transform/preprocessing:
           transforms:
           - action: insert
             include: k8s.container_fs_reads_total
@@ -8883,7 +8876,7 @@ Cluster filter should match snapshot with include_namespaces:
               aggregation_type: sum
               label_set:
               - k8s.node.name
-        metricstransform/rename-following-otel-semantics:
+        metrics_transform/rename-following-otel-semantics:
           transforms:
           - action: update
             include: ^(.*)$$
@@ -8897,7 +8890,7 @@ Cluster filter should match snapshot with include_namespaces:
             include: ^k8s.(rpc\..*)$$
             match_type: regexp
             new_name: $${1}
-        metricstransform/rename-following-otel-semantics/discovery:
+        metrics_transform/rename-following-otel-semantics/discovery:
           transforms:
           - action: update
             include: ^(.*)$$
@@ -8911,6 +8904,13 @@ Cluster filter should match snapshot with include_namespaces:
             include: ^k8s.(rpc\..*)$$
             match_type: regexp
             new_name: $${1}
+        metricsgeneration/istio-metrics:
+          rules:
+          - metric1: k8s.istio_request_duration_milliseconds_sum__swo_temp
+            metric2: k8s.istio_request_duration_milliseconds_count__swo_temp
+            name: k8s.istio_request_duration_milliseconds.rate
+            operation: divide
+            type: calculate
         resource/all:
           attributes:
           - action: insert
@@ -9519,7 +9519,7 @@ Cluster filter should match snapshot with include_namespaces:
             - memory_limiter
             - filter/keep-entity-state-events
             - transform/scope
-            - logdedup/solarwindsentity
+            - log_dedup/solarwindsentity
             - batch/stateevents
             receivers:
             - solarwindsentity/istio-workload-workload
@@ -9531,7 +9531,7 @@ Cluster filter should match snapshot with include_namespaces:
             - memory_limiter
             - filter/keep-relationship-state-events
             - transform/scope
-            - logdedup/solarwindsentity
+            - log_dedup/solarwindsentity
             - batch/stateevents
             receivers:
             - solarwindsentity/istio-workload-workload
@@ -9569,7 +9569,7 @@ Cluster filter should match snapshot with include_namespaces:
             - swok8sworkloadtype/istio
             - transform/istio-metrics
             - transform/istio-metric-datapoints
-            - metricstransform/istio-metrics
+            - metrics_transform/istio-metrics
             - cumulativetodelta/istio-metrics
             - deltatorate/istio-metrics
             - metricsgeneration/istio-metrics
@@ -9591,7 +9591,7 @@ Cluster filter should match snapshot with include_namespaces:
             - routing/discovered_metrics
             processors:
             - memory_limiter
-            - metricstransform/rename-following-otel-semantics/discovery
+            - metrics_transform/rename-following-otel-semantics/discovery
             receivers:
             - receiver_creator/discovery
           metrics/node:
@@ -9604,8 +9604,8 @@ Cluster filter should match snapshot with include_namespaces:
             - attributes/remove_prometheus_attributes
             - attributes/unify_node_attribute
             - transform/unify_node_attribute
-            - metricstransform/rename-following-otel-semantics
-            - metricstransform/preprocessing
+            - metrics_transform/rename-following-otel-semantics
+            - metrics_transform/preprocessing
             - filter/remove_internal_postprocessing
             - attributes/remove_temp
             - cumulativetodelta/cadvisor
@@ -10342,19 +10342,12 @@ Cluster filter should match snapshot with include_namespaces_regex:
               name: k8s.pod.name
             - from: resource_attribute
               name: k8s.namespace.name
-        logdedup/solarwindsentity: {}
+        log_dedup/solarwindsentity: {}
         memory_limiter:
           check_interval: 1s
           limit_mib: 800
           spike_limit_mib: 300
-        metricsgeneration/istio-metrics:
-          rules:
-          - metric1: k8s.istio_request_duration_milliseconds_sum__swo_temp
-            metric2: k8s.istio_request_duration_milliseconds_count__swo_temp
-            name: k8s.istio_request_duration_milliseconds.rate
-            operation: divide
-            type: calculate
-        metricstransform/istio-metrics:
+        metrics_transform/istio-metrics:
           transforms:
           - action: insert
             include: k8s.istio_request_bytes_sum
@@ -10386,7 +10379,7 @@ Cluster filter should match snapshot with include_namespaces_regex:
           - action: insert
             include: k8s.istio_tcp_received_bytes.rate
             new_name: k8s.istio_tcp_received_bytes.delta
-        metricstransform/preprocessing:
+        metrics_transform/preprocessing:
           transforms:
           - action: insert
             include: k8s.container_fs_reads_total
@@ -10820,7 +10813,7 @@ Cluster filter should match snapshot with include_namespaces_regex:
               aggregation_type: sum
               label_set:
               - k8s.node.name
-        metricstransform/rename-following-otel-semantics:
+        metrics_transform/rename-following-otel-semantics:
           transforms:
           - action: update
             include: ^(.*)$$
@@ -10834,7 +10827,7 @@ Cluster filter should match snapshot with include_namespaces_regex:
             include: ^k8s.(rpc\..*)$$
             match_type: regexp
             new_name: $${1}
-        metricstransform/rename-following-otel-semantics/discovery:
+        metrics_transform/rename-following-otel-semantics/discovery:
           transforms:
           - action: update
             include: ^(.*)$$
@@ -10848,6 +10841,13 @@ Cluster filter should match snapshot with include_namespaces_regex:
             include: ^k8s.(rpc\..*)$$
             match_type: regexp
             new_name: $${1}
+        metricsgeneration/istio-metrics:
+          rules:
+          - metric1: k8s.istio_request_duration_milliseconds_sum__swo_temp
+            metric2: k8s.istio_request_duration_milliseconds_count__swo_temp
+            name: k8s.istio_request_duration_milliseconds.rate
+            operation: divide
+            type: calculate
         resource/all:
           attributes:
           - action: insert
@@ -11456,7 +11456,7 @@ Cluster filter should match snapshot with include_namespaces_regex:
             - memory_limiter
             - filter/keep-entity-state-events
             - transform/scope
-            - logdedup/solarwindsentity
+            - log_dedup/solarwindsentity
             - batch/stateevents
             receivers:
             - solarwindsentity/istio-workload-workload
@@ -11468,7 +11468,7 @@ Cluster filter should match snapshot with include_namespaces_regex:
             - memory_limiter
             - filter/keep-relationship-state-events
             - transform/scope
-            - logdedup/solarwindsentity
+            - log_dedup/solarwindsentity
             - batch/stateevents
             receivers:
             - solarwindsentity/istio-workload-workload
@@ -11506,7 +11506,7 @@ Cluster filter should match snapshot with include_namespaces_regex:
             - swok8sworkloadtype/istio
             - transform/istio-metrics
             - transform/istio-metric-datapoints
-            - metricstransform/istio-metrics
+            - metrics_transform/istio-metrics
             - cumulativetodelta/istio-metrics
             - deltatorate/istio-metrics
             - metricsgeneration/istio-metrics
@@ -11528,7 +11528,7 @@ Cluster filter should match snapshot with include_namespaces_regex:
             - routing/discovered_metrics
             processors:
             - memory_limiter
-            - metricstransform/rename-following-otel-semantics/discovery
+            - metrics_transform/rename-following-otel-semantics/discovery
             receivers:
             - receiver_creator/discovery
           metrics/node:
@@ -11541,8 +11541,8 @@ Cluster filter should match snapshot with include_namespaces_regex:
             - attributes/remove_prometheus_attributes
             - attributes/unify_node_attribute
             - transform/unify_node_attribute
-            - metricstransform/rename-following-otel-semantics
-            - metricstransform/preprocessing
+            - metrics_transform/rename-following-otel-semantics
+            - metrics_transform/preprocessing
             - filter/remove_internal_postprocessing
             - attributes/remove_temp
             - cumulativetodelta/cadvisor
@@ -12271,19 +12271,12 @@ Custom logs filter with new syntax:
               name: k8s.pod.name
             - from: resource_attribute
               name: k8s.namespace.name
-        logdedup/solarwindsentity: {}
+        log_dedup/solarwindsentity: {}
         memory_limiter:
           check_interval: 1s
           limit_mib: 800
           spike_limit_mib: 300
-        metricsgeneration/istio-metrics:
-          rules:
-          - metric1: k8s.istio_request_duration_milliseconds_sum__swo_temp
-            metric2: k8s.istio_request_duration_milliseconds_count__swo_temp
-            name: k8s.istio_request_duration_milliseconds.rate
-            operation: divide
-            type: calculate
-        metricstransform/istio-metrics:
+        metrics_transform/istio-metrics:
           transforms:
           - action: insert
             include: k8s.istio_request_bytes_sum
@@ -12315,7 +12308,7 @@ Custom logs filter with new syntax:
           - action: insert
             include: k8s.istio_tcp_received_bytes.rate
             new_name: k8s.istio_tcp_received_bytes.delta
-        metricstransform/preprocessing:
+        metrics_transform/preprocessing:
           transforms:
           - action: insert
             include: k8s.container_fs_reads_total
@@ -12749,7 +12742,7 @@ Custom logs filter with new syntax:
               aggregation_type: sum
               label_set:
               - k8s.node.name
-        metricstransform/rename-following-otel-semantics:
+        metrics_transform/rename-following-otel-semantics:
           transforms:
           - action: update
             include: ^(.*)$$
@@ -12763,7 +12756,7 @@ Custom logs filter with new syntax:
             include: ^k8s.(rpc\..*)$$
             match_type: regexp
             new_name: $${1}
-        metricstransform/rename-following-otel-semantics/discovery:
+        metrics_transform/rename-following-otel-semantics/discovery:
           transforms:
           - action: update
             include: ^(.*)$$
@@ -12777,6 +12770,13 @@ Custom logs filter with new syntax:
             include: ^k8s.(rpc\..*)$$
             match_type: regexp
             new_name: $${1}
+        metricsgeneration/istio-metrics:
+          rules:
+          - metric1: k8s.istio_request_duration_milliseconds_sum__swo_temp
+            metric2: k8s.istio_request_duration_milliseconds_count__swo_temp
+            name: k8s.istio_request_duration_milliseconds.rate
+            operation: divide
+            type: calculate
         resource/all:
           attributes:
           - action: insert
@@ -13385,7 +13385,7 @@ Custom logs filter with new syntax:
             - memory_limiter
             - filter/keep-entity-state-events
             - transform/scope
-            - logdedup/solarwindsentity
+            - log_dedup/solarwindsentity
             - batch/stateevents
             receivers:
             - solarwindsentity/istio-workload-workload
@@ -13397,7 +13397,7 @@ Custom logs filter with new syntax:
             - memory_limiter
             - filter/keep-relationship-state-events
             - transform/scope
-            - logdedup/solarwindsentity
+            - log_dedup/solarwindsentity
             - batch/stateevents
             receivers:
             - solarwindsentity/istio-workload-workload
@@ -13434,7 +13434,7 @@ Custom logs filter with new syntax:
             - swok8sworkloadtype/istio
             - transform/istio-metrics
             - transform/istio-metric-datapoints
-            - metricstransform/istio-metrics
+            - metrics_transform/istio-metrics
             - cumulativetodelta/istio-metrics
             - deltatorate/istio-metrics
             - metricsgeneration/istio-metrics
@@ -13456,7 +13456,7 @@ Custom logs filter with new syntax:
             - routing/discovered_metrics
             processors:
             - memory_limiter
-            - metricstransform/rename-following-otel-semantics/discovery
+            - metrics_transform/rename-following-otel-semantics/discovery
             receivers:
             - receiver_creator/discovery
           metrics/node:
@@ -13469,8 +13469,8 @@ Custom logs filter with new syntax:
             - attributes/remove_prometheus_attributes
             - attributes/unify_node_attribute
             - transform/unify_node_attribute
-            - metricstransform/rename-following-otel-semantics
-            - metricstransform/preprocessing
+            - metrics_transform/rename-following-otel-semantics
+            - metrics_transform/preprocessing
             - filter/remove_internal_postprocessing
             - attributes/remove_temp
             - cumulativetodelta/cadvisor
@@ -14202,19 +14202,12 @@ Custom logs filter with old syntax:
               name: k8s.pod.name
             - from: resource_attribute
               name: k8s.namespace.name
-        logdedup/solarwindsentity: {}
+        log_dedup/solarwindsentity: {}
         memory_limiter:
           check_interval: 1s
           limit_mib: 800
           spike_limit_mib: 300
-        metricsgeneration/istio-metrics:
-          rules:
-          - metric1: k8s.istio_request_duration_milliseconds_sum__swo_temp
-            metric2: k8s.istio_request_duration_milliseconds_count__swo_temp
-            name: k8s.istio_request_duration_milliseconds.rate
-            operation: divide
-            type: calculate
-        metricstransform/istio-metrics:
+        metrics_transform/istio-metrics:
           transforms:
           - action: insert
             include: k8s.istio_request_bytes_sum
@@ -14246,7 +14239,7 @@ Custom logs filter with old syntax:
           - action: insert
             include: k8s.istio_tcp_received_bytes.rate
             new_name: k8s.istio_tcp_received_bytes.delta
-        metricstransform/preprocessing:
+        metrics_transform/preprocessing:
           transforms:
           - action: insert
             include: k8s.container_fs_reads_total
@@ -14680,7 +14673,7 @@ Custom logs filter with old syntax:
               aggregation_type: sum
               label_set:
               - k8s.node.name
-        metricstransform/rename-following-otel-semantics:
+        metrics_transform/rename-following-otel-semantics:
           transforms:
           - action: update
             include: ^(.*)$$
@@ -14694,7 +14687,7 @@ Custom logs filter with old syntax:
             include: ^k8s.(rpc\..*)$$
             match_type: regexp
             new_name: $${1}
-        metricstransform/rename-following-otel-semantics/discovery:
+        metrics_transform/rename-following-otel-semantics/discovery:
           transforms:
           - action: update
             include: ^(.*)$$
@@ -14708,6 +14701,13 @@ Custom logs filter with old syntax:
             include: ^k8s.(rpc\..*)$$
             match_type: regexp
             new_name: $${1}
+        metricsgeneration/istio-metrics:
+          rules:
+          - metric1: k8s.istio_request_duration_milliseconds_sum__swo_temp
+            metric2: k8s.istio_request_duration_milliseconds_count__swo_temp
+            name: k8s.istio_request_duration_milliseconds.rate
+            operation: divide
+            type: calculate
         resource/all:
           attributes:
           - action: insert
@@ -15397,7 +15397,7 @@ Custom logs filter with old syntax:
             - memory_limiter
             - filter/keep-entity-state-events
             - transform/scope
-            - logdedup/solarwindsentity
+            - log_dedup/solarwindsentity
             - batch/stateevents
             receivers:
             - solarwindsentity/istio-workload-workload
@@ -15409,7 +15409,7 @@ Custom logs filter with old syntax:
             - memory_limiter
             - filter/keep-relationship-state-events
             - transform/scope
-            - logdedup/solarwindsentity
+            - log_dedup/solarwindsentity
             - batch/stateevents
             receivers:
             - solarwindsentity/istio-workload-workload
@@ -15446,7 +15446,7 @@ Custom logs filter with old syntax:
             - swok8sworkloadtype/istio
             - transform/istio-metrics
             - transform/istio-metric-datapoints
-            - metricstransform/istio-metrics
+            - metrics_transform/istio-metrics
             - cumulativetodelta/istio-metrics
             - deltatorate/istio-metrics
             - metricsgeneration/istio-metrics
@@ -15468,7 +15468,7 @@ Custom logs filter with old syntax:
             - routing/discovered_metrics
             processors:
             - memory_limiter
-            - metricstransform/rename-following-otel-semantics/discovery
+            - metrics_transform/rename-following-otel-semantics/discovery
             receivers:
             - receiver_creator/discovery
           metrics/node:
@@ -15481,8 +15481,8 @@ Custom logs filter with old syntax:
             - attributes/remove_prometheus_attributes
             - attributes/unify_node_attribute
             - transform/unify_node_attribute
-            - metricstransform/rename-following-otel-semantics
-            - metricstransform/preprocessing
+            - metrics_transform/rename-following-otel-semantics
+            - metrics_transform/preprocessing
             - filter/remove_internal_postprocessing
             - attributes/remove_temp
             - cumulativetodelta/cadvisor
@@ -16207,19 +16207,12 @@ Node collector config should match snapshot when autodiscovery is disabled:
               name: k8s.pod.name
             - from: resource_attribute
               name: k8s.namespace.name
-        logdedup/solarwindsentity: {}
+        log_dedup/solarwindsentity: {}
         memory_limiter:
           check_interval: 1s
           limit_mib: 800
           spike_limit_mib: 300
-        metricsgeneration/istio-metrics:
-          rules:
-          - metric1: k8s.istio_request_duration_milliseconds_sum__swo_temp
-            metric2: k8s.istio_request_duration_milliseconds_count__swo_temp
-            name: k8s.istio_request_duration_milliseconds.rate
-            operation: divide
-            type: calculate
-        metricstransform/istio-metrics:
+        metrics_transform/istio-metrics:
           transforms:
           - action: insert
             include: k8s.istio_request_bytes_sum
@@ -16251,7 +16244,7 @@ Node collector config should match snapshot when autodiscovery is disabled:
           - action: insert
             include: k8s.istio_tcp_received_bytes.rate
             new_name: k8s.istio_tcp_received_bytes.delta
-        metricstransform/preprocessing:
+        metrics_transform/preprocessing:
           transforms:
           - action: insert
             include: k8s.container_fs_reads_total
@@ -16685,7 +16678,7 @@ Node collector config should match snapshot when autodiscovery is disabled:
               aggregation_type: sum
               label_set:
               - k8s.node.name
-        metricstransform/rename-following-otel-semantics:
+        metrics_transform/rename-following-otel-semantics:
           transforms:
           - action: update
             include: ^(.*)$$
@@ -16699,7 +16692,7 @@ Node collector config should match snapshot when autodiscovery is disabled:
             include: ^k8s.(rpc\..*)$$
             match_type: regexp
             new_name: $${1}
-        metricstransform/rename-following-otel-semantics/discovery:
+        metrics_transform/rename-following-otel-semantics/discovery:
           transforms:
           - action: update
             include: ^(.*)$$
@@ -16713,6 +16706,13 @@ Node collector config should match snapshot when autodiscovery is disabled:
             include: ^k8s.(rpc\..*)$$
             match_type: regexp
             new_name: $${1}
+        metricsgeneration/istio-metrics:
+          rules:
+          - metric1: k8s.istio_request_duration_milliseconds_sum__swo_temp
+            metric2: k8s.istio_request_duration_milliseconds_count__swo_temp
+            name: k8s.istio_request_duration_milliseconds.rate
+            operation: divide
+            type: calculate
         resource/all:
           attributes:
           - action: insert
@@ -17260,7 +17260,7 @@ Node collector config should match snapshot when autodiscovery is disabled:
             - memory_limiter
             - filter/keep-entity-state-events
             - transform/scope
-            - logdedup/solarwindsentity
+            - log_dedup/solarwindsentity
             - batch/stateevents
             receivers:
             - solarwindsentity/istio-workload-workload
@@ -17272,7 +17272,7 @@ Node collector config should match snapshot when autodiscovery is disabled:
             - memory_limiter
             - filter/keep-relationship-state-events
             - transform/scope
-            - logdedup/solarwindsentity
+            - log_dedup/solarwindsentity
             - batch/stateevents
             receivers:
             - solarwindsentity/istio-workload-workload
@@ -17309,7 +17309,7 @@ Node collector config should match snapshot when autodiscovery is disabled:
             - swok8sworkloadtype/istio
             - transform/istio-metrics
             - transform/istio-metric-datapoints
-            - metricstransform/istio-metrics
+            - metrics_transform/istio-metrics
             - cumulativetodelta/istio-metrics
             - deltatorate/istio-metrics
             - metricsgeneration/istio-metrics
@@ -17331,7 +17331,7 @@ Node collector config should match snapshot when autodiscovery is disabled:
             - routing/discovered_metrics
             processors:
             - memory_limiter
-            - metricstransform/rename-following-otel-semantics/discovery
+            - metrics_transform/rename-following-otel-semantics/discovery
             receivers:
             - receiver_creator/discovery
           metrics/node:
@@ -17344,8 +17344,8 @@ Node collector config should match snapshot when autodiscovery is disabled:
             - attributes/remove_prometheus_attributes
             - attributes/unify_node_attribute
             - transform/unify_node_attribute
-            - metricstransform/rename-following-otel-semantics
-            - metricstransform/preprocessing
+            - metrics_transform/rename-following-otel-semantics
+            - metrics_transform/preprocessing
             - filter/remove_internal_postprocessing
             - attributes/remove_temp
             - cumulativetodelta/cadvisor
@@ -18067,19 +18067,12 @@ Node collector config should match snapshot when fargate is enabled:
               name: k8s.pod.name
             - from: resource_attribute
               name: k8s.namespace.name
-        logdedup/solarwindsentity: {}
+        log_dedup/solarwindsentity: {}
         memory_limiter:
           check_interval: 1s
           limit_mib: 800
           spike_limit_mib: 300
-        metricsgeneration/istio-metrics:
-          rules:
-          - metric1: k8s.istio_request_duration_milliseconds_sum__swo_temp
-            metric2: k8s.istio_request_duration_milliseconds_count__swo_temp
-            name: k8s.istio_request_duration_milliseconds.rate
-            operation: divide
-            type: calculate
-        metricstransform/istio-metrics:
+        metrics_transform/istio-metrics:
           transforms:
           - action: insert
             include: k8s.istio_request_bytes_sum
@@ -18111,7 +18104,7 @@ Node collector config should match snapshot when fargate is enabled:
           - action: insert
             include: k8s.istio_tcp_received_bytes.rate
             new_name: k8s.istio_tcp_received_bytes.delta
-        metricstransform/preprocessing:
+        metrics_transform/preprocessing:
           transforms:
           - action: insert
             include: k8s.container_fs_reads_total
@@ -18545,7 +18538,7 @@ Node collector config should match snapshot when fargate is enabled:
               aggregation_type: sum
               label_set:
               - k8s.node.name
-        metricstransform/rename-following-otel-semantics:
+        metrics_transform/rename-following-otel-semantics:
           transforms:
           - action: update
             include: ^(.*)$$
@@ -18559,7 +18552,7 @@ Node collector config should match snapshot when fargate is enabled:
             include: ^k8s.(rpc\..*)$$
             match_type: regexp
             new_name: $${1}
-        metricstransform/rename-following-otel-semantics/discovery:
+        metrics_transform/rename-following-otel-semantics/discovery:
           transforms:
           - action: update
             include: ^(.*)$$
@@ -18573,6 +18566,13 @@ Node collector config should match snapshot when fargate is enabled:
             include: ^k8s.(rpc\..*)$$
             match_type: regexp
             new_name: $${1}
+        metricsgeneration/istio-metrics:
+          rules:
+          - metric1: k8s.istio_request_duration_milliseconds_sum__swo_temp
+            metric2: k8s.istio_request_duration_milliseconds_count__swo_temp
+            name: k8s.istio_request_duration_milliseconds.rate
+            operation: divide
+            type: calculate
         resource/all:
           attributes:
           - action: insert
@@ -19125,7 +19125,7 @@ Node collector config should match snapshot when fargate is enabled:
             - memory_limiter
             - filter/keep-entity-state-events
             - transform/scope
-            - logdedup/solarwindsentity
+            - log_dedup/solarwindsentity
             - batch/stateevents
             receivers:
             - solarwindsentity/istio-workload-workload
@@ -19137,7 +19137,7 @@ Node collector config should match snapshot when fargate is enabled:
             - memory_limiter
             - filter/keep-relationship-state-events
             - transform/scope
-            - logdedup/solarwindsentity
+            - log_dedup/solarwindsentity
             - batch/stateevents
             receivers:
             - solarwindsentity/istio-workload-workload
@@ -19174,7 +19174,7 @@ Node collector config should match snapshot when fargate is enabled:
             - swok8sworkloadtype/istio
             - transform/istio-metrics
             - transform/istio-metric-datapoints
-            - metricstransform/istio-metrics
+            - metrics_transform/istio-metrics
             - cumulativetodelta/istio-metrics
             - deltatorate/istio-metrics
             - metricsgeneration/istio-metrics
@@ -19196,7 +19196,7 @@ Node collector config should match snapshot when fargate is enabled:
             - routing/discovered_metrics
             processors:
             - memory_limiter
-            - metricstransform/rename-following-otel-semantics/discovery
+            - metrics_transform/rename-following-otel-semantics/discovery
             receivers:
             - receiver_creator/discovery
           metrics/not-relationship-state-events-preparation:
@@ -19903,19 +19903,12 @@ Node collector config should match snapshot when fargate is enabled and autodisc
               name: k8s.pod.name
             - from: resource_attribute
               name: k8s.namespace.name
-        logdedup/solarwindsentity: {}
+        log_dedup/solarwindsentity: {}
         memory_limiter:
           check_interval: 1s
           limit_mib: 800
           spike_limit_mib: 300
-        metricsgeneration/istio-metrics:
-          rules:
-          - metric1: k8s.istio_request_duration_milliseconds_sum__swo_temp
-            metric2: k8s.istio_request_duration_milliseconds_count__swo_temp
-            name: k8s.istio_request_duration_milliseconds.rate
-            operation: divide
-            type: calculate
-        metricstransform/istio-metrics:
+        metrics_transform/istio-metrics:
           transforms:
           - action: insert
             include: k8s.istio_request_bytes_sum
@@ -19947,7 +19940,7 @@ Node collector config should match snapshot when fargate is enabled and autodisc
           - action: insert
             include: k8s.istio_tcp_received_bytes.rate
             new_name: k8s.istio_tcp_received_bytes.delta
-        metricstransform/preprocessing:
+        metrics_transform/preprocessing:
           transforms:
           - action: insert
             include: k8s.container_fs_reads_total
@@ -20381,7 +20374,7 @@ Node collector config should match snapshot when fargate is enabled and autodisc
               aggregation_type: sum
               label_set:
               - k8s.node.name
-        metricstransform/rename-following-otel-semantics:
+        metrics_transform/rename-following-otel-semantics:
           transforms:
           - action: update
             include: ^(.*)$$
@@ -20395,7 +20388,7 @@ Node collector config should match snapshot when fargate is enabled and autodisc
             include: ^k8s.(rpc\..*)$$
             match_type: regexp
             new_name: $${1}
-        metricstransform/rename-following-otel-semantics/discovery:
+        metrics_transform/rename-following-otel-semantics/discovery:
           transforms:
           - action: update
             include: ^(.*)$$
@@ -20409,6 +20402,13 @@ Node collector config should match snapshot when fargate is enabled and autodisc
             include: ^k8s.(rpc\..*)$$
             match_type: regexp
             new_name: $${1}
+        metricsgeneration/istio-metrics:
+          rules:
+          - metric1: k8s.istio_request_duration_milliseconds_sum__swo_temp
+            metric2: k8s.istio_request_duration_milliseconds_count__swo_temp
+            name: k8s.istio_request_duration_milliseconds.rate
+            operation: divide
+            type: calculate
         resource/all:
           attributes:
           - action: insert
@@ -20900,7 +20900,7 @@ Node collector config should match snapshot when fargate is enabled and autodisc
             - memory_limiter
             - filter/keep-entity-state-events
             - transform/scope
-            - logdedup/solarwindsentity
+            - log_dedup/solarwindsentity
             - batch/stateevents
             receivers:
             - solarwindsentity/istio-workload-workload
@@ -20912,7 +20912,7 @@ Node collector config should match snapshot when fargate is enabled and autodisc
             - memory_limiter
             - filter/keep-relationship-state-events
             - transform/scope
-            - logdedup/solarwindsentity
+            - log_dedup/solarwindsentity
             - batch/stateevents
             receivers:
             - solarwindsentity/istio-workload-workload
@@ -20937,7 +20937,7 @@ Node collector config should match snapshot when fargate is enabled and autodisc
             - swok8sworkloadtype/istio
             - transform/istio-metrics
             - transform/istio-metric-datapoints
-            - metricstransform/istio-metrics
+            - metrics_transform/istio-metrics
             - cumulativetodelta/istio-metrics
             - deltatorate/istio-metrics
             - metricsgeneration/istio-metrics
@@ -20959,7 +20959,7 @@ Node collector config should match snapshot when fargate is enabled and autodisc
             - routing/discovered_metrics
             processors:
             - memory_limiter
-            - metricstransform/rename-following-otel-semantics/discovery
+            - metrics_transform/rename-following-otel-semantics/discovery
             receivers:
             - receiver_creator/discovery
           metrics/not-relationship-state-events-preparation:
@@ -21675,19 +21675,12 @@ Node collector config should match snapshot when using default values:
               name: k8s.pod.name
             - from: resource_attribute
               name: k8s.namespace.name
-        logdedup/solarwindsentity: {}
+        log_dedup/solarwindsentity: {}
         memory_limiter:
           check_interval: 1s
           limit_mib: 800
           spike_limit_mib: 300
-        metricsgeneration/istio-metrics:
-          rules:
-          - metric1: k8s.istio_request_duration_milliseconds_sum__swo_temp
-            metric2: k8s.istio_request_duration_milliseconds_count__swo_temp
-            name: k8s.istio_request_duration_milliseconds.rate
-            operation: divide
-            type: calculate
-        metricstransform/istio-metrics:
+        metrics_transform/istio-metrics:
           transforms:
           - action: insert
             include: k8s.istio_request_bytes_sum
@@ -21719,7 +21712,7 @@ Node collector config should match snapshot when using default values:
           - action: insert
             include: k8s.istio_tcp_received_bytes.rate
             new_name: k8s.istio_tcp_received_bytes.delta
-        metricstransform/preprocessing:
+        metrics_transform/preprocessing:
           transforms:
           - action: insert
             include: k8s.container_fs_reads_total
@@ -22153,7 +22146,7 @@ Node collector config should match snapshot when using default values:
               aggregation_type: sum
               label_set:
               - k8s.node.name
-        metricstransform/rename-following-otel-semantics:
+        metrics_transform/rename-following-otel-semantics:
           transforms:
           - action: update
             include: ^(.*)$$
@@ -22167,7 +22160,7 @@ Node collector config should match snapshot when using default values:
             include: ^k8s.(rpc\..*)$$
             match_type: regexp
             new_name: $${1}
-        metricstransform/rename-following-otel-semantics/discovery:
+        metrics_transform/rename-following-otel-semantics/discovery:
           transforms:
           - action: update
             include: ^(.*)$$
@@ -22181,6 +22174,13 @@ Node collector config should match snapshot when using default values:
             include: ^k8s.(rpc\..*)$$
             match_type: regexp
             new_name: $${1}
+        metricsgeneration/istio-metrics:
+          rules:
+          - metric1: k8s.istio_request_duration_milliseconds_sum__swo_temp
+            metric2: k8s.istio_request_duration_milliseconds_count__swo_temp
+            name: k8s.istio_request_duration_milliseconds.rate
+            operation: divide
+            type: calculate
         resource/all:
           attributes:
           - action: insert
@@ -22788,7 +22788,7 @@ Node collector config should match snapshot when using default values:
             - memory_limiter
             - filter/keep-entity-state-events
             - transform/scope
-            - logdedup/solarwindsentity
+            - log_dedup/solarwindsentity
             - batch/stateevents
             receivers:
             - solarwindsentity/istio-workload-workload
@@ -22800,7 +22800,7 @@ Node collector config should match snapshot when using default values:
             - memory_limiter
             - filter/keep-relationship-state-events
             - transform/scope
-            - logdedup/solarwindsentity
+            - log_dedup/solarwindsentity
             - batch/stateevents
             receivers:
             - solarwindsentity/istio-workload-workload
@@ -22837,7 +22837,7 @@ Node collector config should match snapshot when using default values:
             - swok8sworkloadtype/istio
             - transform/istio-metrics
             - transform/istio-metric-datapoints
-            - metricstransform/istio-metrics
+            - metrics_transform/istio-metrics
             - cumulativetodelta/istio-metrics
             - deltatorate/istio-metrics
             - metricsgeneration/istio-metrics
@@ -22859,7 +22859,7 @@ Node collector config should match snapshot when using default values:
             - routing/discovered_metrics
             processors:
             - memory_limiter
-            - metricstransform/rename-following-otel-semantics/discovery
+            - metrics_transform/rename-following-otel-semantics/discovery
             receivers:
             - receiver_creator/discovery
           metrics/node:
@@ -22872,8 +22872,8 @@ Node collector config should match snapshot when using default values:
             - attributes/remove_prometheus_attributes
             - attributes/unify_node_attribute
             - transform/unify_node_attribute
-            - metricstransform/rename-following-otel-semantics
-            - metricstransform/preprocessing
+            - metrics_transform/rename-following-otel-semantics
+            - metrics_transform/preprocessing
             - filter/remove_internal_postprocessing
             - attributes/remove_temp
             - cumulativetodelta/cadvisor

--- a/deploy/helm/values.yaml
+++ b/deploy/helm/values.yaml
@@ -180,7 +180,6 @@ otel:
           timeout: 1s
 
         # Telemetry information of the collector
-        # see https://github.com/open-telemetry/opentelemetry-collector/blob/main/docs/troubleshooting.md#observability for configuration reference
         telemetry:
           logs:
             enabled: true
@@ -421,7 +420,6 @@ otel:
         excludePattern: ""
 
     # Telemetry information of the collector
-    # see https://github.com/open-telemetry/opentelemetry-collector/blob/main/docs/troubleshooting.md#observability for configuration reference
     telemetry:
       logs:
         enabled: true
@@ -536,7 +534,6 @@ otel:
         memory: 1000Mi
 
     # Telemetry information of the collector
-    # see https://github.com/open-telemetry/opentelemetry-collector/blob/main/docs/troubleshooting.md#observability for configuration reference
     telemetry:
       logs:
         enabled: true
@@ -677,7 +674,6 @@ otel:
         excludePattern: ""
 
     # Telemetry information of the collector
-    # see https://github.com/open-telemetry/opentelemetry-collector/blob/main/docs/troubleshooting.md#observability for configuration reference
     telemetry:
       logs:
         enabled: true
@@ -1121,7 +1117,6 @@ aws_fargate:
         max_elapsed_time: 300s
 
       # Telemetry information of the collector
-      # see https://github.com/open-telemetry/opentelemetry-collector/blob/main/docs/troubleshooting.md#observability for configuration reference
       telemetry:
         logs:
           enabled: true

--- a/tests/deploy/timeseries-mock-service/values.yaml
+++ b/tests/deploy/timeseries-mock-service/values.yaml
@@ -1,6 +1,6 @@
 otel:
   port: 9082
-  image: otel/opentelemetry-collector-contrib:0.150.1
+  image: otel/opentelemetry-collector-contrib:0.152.1
 
 fileProvider:
   # Enable file-based export (deprecated, will be replaced by ClickHouse)


### PR DESCRIPTION
* Updated OTEL Collector processor/... names since they were renamed in the OTEL Collector
* Removed no longer valid documentation links
* Updated image of the `timeseries-mock-service`
* The image reference itself was already merged in 96c84ba7106a205dafd697ff3c3e98e7fba64cbc