### PR TITLE
Update OBI to v0.9.0

### DIFF
--- a/deploy/helm/gateway-collector-config.yaml
+++ b/deploy/helm/gateway-collector-config.yaml
@@ -218,6 +218,17 @@ processors:
           - pods
           - nodes
 
+  transform/obi-delete-unreliable-attributes:
+    metric_statements:
+      - statements:
+        - set(resource.cache["obi_k8s_attrs"], resource.attributes)
+        # OBI may set incorrect data into attributes like "k8s.deployment.name". "k8s.owner.name" may also be wrong, but since it is used for detection of source/target workload in OBI, we need to keep it.
+        - keep_matching_keys(resource.cache["obi_k8s_attrs"], "^k8s\\.namespace\\.name|k8s\\.pod\\.name|k8s\\.pod\\.uid|k8s\\.container\\.name|k8s\\.container\\.id|k8s\\.owner\\.name$")
+        - delete_matching_keys(resource.attributes, "k8s\\..*")
+        - merge_maps(resource.attributes, resource.cache["obi_k8s_attrs"], "insert")
+        # OBI may insert Pod info into the "host.*" attributes.
+        - delete_matching_keys(resource.attributes, "host\\..*")
+
   transform/obi-fqdn-attribute:
     metric_statements:
       - statements:
@@ -727,6 +738,7 @@ service:
         - routing/metrics
       processors:
         - memory_limiter
+        - transform/obi-delete-unreliable-attributes
         - swok8sworkloadtype/obi
         - transform/obi-fqdn-attribute
         - groupbyattrs/obi-entity-ids

--- a/deploy/helm/templates/obi/configmap.yaml
+++ b/deploy/helm/templates/obi/configmap.yaml
@@ -17,6 +17,7 @@ data:
       protocol: grpc
       interval: {{ quote .Values.otel.metrics.prometheus.scrape_interval }}
       features: ["application", "network"]
+      instrumentations: ["http", "grpc"]
     {{- end }}
     {{- if not .Values.network_topology.config.ebpf }}
     ebpf:

--- a/deploy/helm/tests/__snapshot__/gateway-config-map_test.yaml.snap
+++ b/deploy/helm/tests/__snapshot__/gateway-config-map_test.yaml.snap
@@ -634,6 +634,14 @@ Gateway config should match snapshot when using default values:
             workload_name_attr: sw.k8s.src.workload.name
             workload_namespace_attr: sw.k8s.src.workload.namespace
             workload_type_attr: sw.k8s.src.workload.type
+        transform/obi-delete-unreliable-attributes:
+          metric_statements:
+          - statements:
+            - set(resource.cache["obi_k8s_attrs"], resource.attributes)
+            - keep_matching_keys(resource.cache["obi_k8s_attrs"], "^k8s\\.namespace\\.name|k8s\\.pod\\.name|k8s\\.pod\\.uid|k8s\\.container\\.name|k8s\\.container\\.id|k8s\\.owner\\.name$")
+            - delete_matching_keys(resource.attributes, "k8s\\..*")
+            - merge_maps(resource.attributes, resource.cache["obi_k8s_attrs"], "insert")
+            - delete_matching_keys(resource.attributes, "host\\..*")
         transform/obi-entity-ids:
           metric_statements:
           - conditions:
@@ -853,6 +861,7 @@ Gateway config should match snapshot when using default values:
             - solarwindsentity/obi-entities
             processors:
             - memory_limiter
+            - transform/obi-delete-unreliable-attributes
             - swok8sworkloadtype/obi
             - transform/obi-fqdn-attribute
             - groupbyattrs/obi-entity-ids

--- a/deploy/helm/tests/__snapshot__/obi-configmap_test.yaml.snap
+++ b/deploy/helm/tests/__snapshot__/obi-configmap_test.yaml.snap
@@ -6,6 +6,7 @@ ConfigMap spec should match snapshot when network_topology is enabled:
         protocol: grpc
         interval: "60s"
         features: ["application", "network"]
+        instrumentations: ["http", "grpc"]
       ebpf:
         context_propagation: disabled
       network:

--- a/deploy/helm/tests/__snapshot__/obi-daemonset_test.yaml.snap
+++ b/deploy/helm/tests/__snapshot__/obi-daemonset_test.yaml.snap
@@ -15,17 +15,17 @@ DaemonSet spec should match snapshot when network_topology is enabled:
             value: /etc/obi/config/obi-config.yml
           - name: OTEL_EXPORTER_OTLP_INSECURE
             value: "true"
-        image: ghcr.io/open-telemetry/opentelemetry-ebpf-instrumentation/ebpf-instrument:v0.6.0
+        image: ghcr.io/open-telemetry/opentelemetry-ebpf-instrumentation/ebpf-instrument:v0.9.0
         imagePullPolicy: IfNotPresent
         name: obi
         ports: null
         resources:
           limits:
             cpu: 500m
-            memory: 768Mi
+            memory: 3072Mi
           requests:
             cpu: 100m
-            memory: 128Mi
+            memory: 512Mi
         securityContext:
           capabilities:
             add:

--- a/deploy/helm/values.yaml
+++ b/deploy/helm/values.yaml
@@ -1310,16 +1310,16 @@ network_topology:
 
   image:
     repository: "ghcr.io/open-telemetry/opentelemetry-ebpf-instrumentation/ebpf-instrument"
-    tag: "v0.6.0"
+    tag: "v0.9.0"
     pullPolicy: IfNotPresent
 
   resources:
     requests:
       cpu: 100m
-      memory: 128Mi
+      memory: 512Mi
     limits:
       cpu: 500m
-      memory: 768Mi
+      memory: 3072Mi
 
   # Scheduling configurations
   nodeSelector: {}


### PR DESCRIPTION
Increase memory requirements to match real-world scenarios and increased OBI size.

Explicitly set that we are interested only in HTTP/TCP/RPC metrics.

Remove all `k8s.*` attributes that OBI can set incorrectly. We use `k8s_attributes` processor to get that data anyway.

This could be a breaking change if anyone used the `host.*` attributes on these metrics. But these were unreliable, with a random content, so I don't consider removing them as a problem.