### PR TITLE
Show error when deploying trivy-operator to OpenShift cluster

### DIFF
--- a/deploy/helm/README.md
+++ b/deploy/helm/README.md
@@ -554,6 +554,8 @@ If there already is another instance of the operator deployed in the cluster, th
 
 SolarWinds does not provide any warranty or guarantee with respect to the accuracy, reliability, or completeness or of any information or insights provided to You through Your use of Aqua Security Trivy-Operator, and Your use of any such information, which is derived from third party sources, is at Your own risk.
 
+Note: This feature is not supported when deploying to an OpenShift cluster.
+
 ## Receive 3rd party metrics
 
 SWO K8s Collector has an OTEL service endpoint which is able to forward metrics, logs and traces into SolarWinds Observability. All incoming data is properly associated with current cluster. Additionally, metrics are decorated by default with prefix `k8s.` (prefix can be configured).

--- a/deploy/helm/templates/NOTES.txt
+++ b/deploy/helm/templates/NOTES.txt
@@ -163,7 +163,7 @@ WARNING: Deploying Aqua Security Trivy-Operator. SolarWinds does not provide any
 {{- end -}}
 
 
-{{- if index .Values.ebpfNetworkMonitoring.enabled -}}
+{{- if .Values.ebpfNetworkMonitoring.enabled -}}
 WARNING: Configuration `ebpfNetworkMonitoring.enabled` (the old network topology) is deprecated and will be removed in a future release. Switch to the new network topology by removing the setting 'ebpfNetworkMonitoring.enabled' from your Helm values.
 {{- println -}}
 {{- end -}}

--- a/deploy/helm/templates/asserts.yaml
+++ b/deploy/helm/templates/asserts.yaml
@@ -39,5 +39,9 @@
 {{- if .Values.network_topology.enabled }}
 {{- if not .Values.otel.gateway.enabled }}
 {{- fail "The network topology feature requires `otel.gateway.enabled` to be set to `true`." }}
-{{- end }}
-{{- end }}
+{{- end -}}
+{{- end -}}
+
+{{- if and (index .Values "trivy-operator").enabled .Values.openshift.enabled -}}
+{{ fail "Deploying Aqua Security Trivy-Operator to an OpenShift cluster using this Helm chart is not supported. Please deploy Trivy-Operator separately following its official documentation." }}
+{{- end -}}

--- a/deploy/helm/tests/assert_test.yaml
+++ b/deploy/helm/tests/assert_test.yaml
@@ -45,3 +45,26 @@ tests:
     asserts:
       - failedTemplate:
           errorMessage: The network topology feature requires `otel.gateway.enabled` to be set to `true`.
+  - it: should fail when Trivy-Operator is enabled on an OpenShift cluster
+    set:
+      trivy-operator.enabled: true
+      openshift.enabled: true
+    asserts:
+      - failedTemplate:
+          errorMessage: Deploying Aqua Security Trivy-Operator to an OpenShift cluster using this Helm chart is not supported. Please deploy Trivy-Operator separately following its official documentation.
+  - it: should not fail when OpenShift is enabled but Trivy-Operator is disabled
+    set:
+      openshift.enabled: true
+      trivy-operator.enabled: false
+    template: "asserts.yaml"
+    asserts:
+      - hasDocuments:
+          count: 0
+  - it: should not fail when OpenShift is disabled but Trivy-Operator is enabled
+    set:
+      openshift.enabled: false
+      trivy-operator.enabled: true
+    template: "asserts.yaml"
+    asserts:
+      - hasDocuments:
+          count: 0

--- a/deploy/helm/tests/notes_test.yaml
+++ b/deploy/helm/tests/notes_test.yaml
@@ -6,7 +6,7 @@ tests:
   - it: There should be no notes with default values
     asserts:
       - equalRaw:
-          value: 
+          value: ""
 
   - it: should pass the notes file with extra_scrape_metrics and prometheus.enabled
     set:


### PR DESCRIPTION
It's very likely that the user needs to configure image pull secrets to be able to scan most of the deployed images. And it also causes issues with upgrades.

So we are disabling this option.