### PR TITLE
Stabilize integration tests

### DIFF
--- a/.github/actions/run-integration-tests/action.yaml
+++ b/.github/actions/run-integration-tests/action.yaml
@@ -5,7 +5,22 @@ runs:
   steps:
     - name: Run Integration tests
       run: |
-        kubectl wait --for=condition=ready --timeout=60s pod -l app=timeseries-mock-service -n test-namespace
+        # workaround for bug in kubectl - once only >= 1.33 is supported, "kubectl wait --for=create ..." will work and we can remove this workaround
+        echo "Waiting for timeseries-mock-service pod to be created"
+        timeout=60
+        elapsed=0
+        until kubectl get pod -l app=timeseries-mock-service -n test-namespace 2>/dev/null | grep -q timeseries-mock-service; do
+            if [[ $elapsed -ge $timeout ]]; then
+                echo "Timed out waiting for timeseries-mock-service pod to be created"
+                exit 1
+            fi
+            echo -n "."
+            sleep 3
+            elapsed=$((elapsed + 3))
+        done
+        echo "timeseries-mock-service pod found"
+
+        kubectl wait --for=condition=ready --for=create --timeout=60s pod -l app=timeseries-mock-service -n test-namespace
 
         # wait till vulnerability scans are finished
         echo "Waiting for vulnerability scans to complete"
@@ -22,7 +37,22 @@ runs:
 
         kubectl create job --from=cronjob/integration-test integration-test-manual -n test-namespace
 
-        kubectl wait --for=condition=ready --timeout=60s pod -l job-name=integration-test-manual -n test-namespace
+        # workaround for bug in kubectl - once only >= 1.33 is supported, "kubectl wait --for=create ..." will work and we can remove this workaround
+        echo "Waiting for integration-test-manual pod to be created"
+        timeout=60
+        elapsed=0
+        until kubectl get pod -l job-name=integration-test-manual -n test-namespace 2>/dev/null | grep -q integration-test-manual; do
+            if [[ $elapsed -ge $timeout ]]; then
+                echo "Timed out waiting for integration-test-manual pod to be created"
+                exit 1
+            fi
+            echo -n "."
+            sleep 3
+            elapsed=$((elapsed + 3))
+        done
+        echo "integration-test-manual pod found"
+
+        kubectl wait --for=condition=ready --for=create --timeout=60s pod -l job-name=integration-test-manual -n test-namespace
         kubetail -l job-name=integration-test-manual -n test-namespace &  
 
         # Wait for either complete or failed

--- a/.github/workflows/buildAndDeploy.yml
+++ b/.github/workflows/buildAndDeploy.yml
@@ -36,9 +36,9 @@ jobs:
       - name: Create k8s Kind Cluster
         uses: helm/kind-action@v1.14.0
         with:
-          version: v0.31.0
-          kubectl_version: v1.35.0
-          node_image: kindest/node:v1.35.0
+          version: v0.32.0
+          kubectl_version: v1.36.1
+          node_image: kindest/node:v1.36.1
           cluster_name: kind
           ignore_failed_clean: true
 

--- a/.github/workflows/buildAndTestHelm.yml
+++ b/.github/workflows/buildAndTestHelm.yml
@@ -62,12 +62,12 @@ jobs:
       matrix:
         # Kubernetes versions to test on
         kubernetes_version:
-          - v1.30.13
           - v1.31.14
           - v1.32.11
-          - v1.33.7
-          - v1.34.3
-          - v1.35.0
+          - v1.33.12
+          - v1.34.8
+          - v1.35.5
+          - v1.36.1
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -78,7 +78,7 @@ jobs:
       - name: Create k8s Kind Cluster
         uses: helm/kind-action@v1.14.0
         with:
-          version: v0.31.0
+          version: v0.32.0
           kubectl_version: ${{ matrix.kubernetes_version }}
           node_image: kindest/node:${{ matrix.kubernetes_version }}
           cluster_name: kind
@@ -225,7 +225,7 @@ jobs:
           kubectl create job --from=cronjob/helm-autoupdate helm-autoupdate-manual-trigger -n swo-k8s-collector
           
           # Wait for the job to complete
-          kubectl wait --for=condition=complete --timeout=300s job/helm-autoupdate-manual-trigger -n swo-k8s-collector
+          kubectl wait --for=condition=complete --for=create --timeout=300s job/helm-autoupdate-manual-trigger -n swo-k8s-collector
           
           # Get the job's success and failure status
           JOB_SUCCEEDED=$(kubectl get job helm-autoupdate-manual-trigger -n swo-k8s-collector -o=jsonpath='{.status.succeeded}')

--- a/Makefile
+++ b/Makefile
@@ -36,7 +36,7 @@ integration-test-run: ## Internal target: Build, deploy and run tests
 	@echo "Step 3/3: Running integration tests..."
 	@echo "-----------------------------------------"
 	@echo "Waiting for timeseries-mock-service to be ready..."
-	kubectl wait --for=condition=ready --timeout=$(KUBECTL_TIMEOUT) pod -l app=timeseries-mock-service -n $(TEST_NAMESPACE)
+	kubectl wait --for=condition=ready --for=create --timeout=$(KUBECTL_TIMEOUT) pod -l app=timeseries-mock-service -n $(TEST_NAMESPACE)
 	@echo ""
 	@echo "Cleaning up any previous integration test jobs or pods..."
 	@kubectl delete job $(TEST_JOB_NAME) -n $(TEST_NAMESPACE) --ignore-not-found=true >/dev/null 2>&1 || true
@@ -46,7 +46,7 @@ integration-test-run: ## Internal target: Build, deploy and run tests
 	kubectl create job --from=cronjob/integration-test $(TEST_JOB_NAME) -n $(TEST_NAMESPACE)
 	@echo ""
 	@echo "Waiting for test pod to be ready..."
-	kubectl wait --for=condition=ready --timeout=$(KUBECTL_TIMEOUT) pod -l job-name=$(TEST_JOB_NAME) -n $(TEST_NAMESPACE)
+	kubectl wait --for=condition=ready --for=create --timeout=$(KUBECTL_TIMEOUT) pod -l job-name=$(TEST_JOB_NAME) -n $(TEST_NAMESPACE)
 	@echo ""
 	@echo "Test pod is ready. Starting log streaming in background..."
 	@LOG_PID=$$(kubectl logs -f -l job-name=$(TEST_JOB_NAME) -n $(TEST_NAMESPACE) 2>/dev/null & echo $$!); \


### PR DESCRIPTION
`kubectl wait` could fail with error if executed too quickly after resource creation.