### PR TITLE
Fix filtering of EntityStateEvents by namespace

### DIFF
--- a/deploy/helm/Chart.yaml
+++ b/deploy/helm/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: swo-k8s-collector
-version: 5.3.0-alpha.5
-appVersion: 0.152.2
+version: 5.3.0-alpha.6
+appVersion: 0.152.3
 description: SolarWinds Kubernetes Integration
 keywords:
   - monitoring

--- a/deploy/helm/events-collector-config.yaml
+++ b/deploy/helm/events-collector-config.yaml
@@ -859,14 +859,12 @@ service:
         - resource/mandatory
         - resource/manifest
         - resourcedetection/providers
-        - k8seventgeneration
-        - transform/remove_deployed_by_collector_label_if_from_different_namespace
-        - groupbyattrs/serviceendpointsmapping
-        - transform/serviceendpointsmapping-renamepodip
         - k8s_attributes
 {{- if eq (include "isNamespacesFilterEnabled" .) "true" }}
         - filter/namespaces_manifests
 {{- end }}
+        - k8seventgeneration
+        - transform/remove_deployed_by_collector_label_if_from_different_namespace
 {{- if .Values.otel.manifests.filter }}
         - filter/manifests
 {{- end }}
@@ -878,6 +876,9 @@ service:
         - routing/manifests
       processors:
         - memory_limiter
+        - groupbyattrs/serviceendpointsmapping
+        - transform/serviceendpointsmapping-renamepodip
+        - k8s_attributes
         - transform/serviceendpointsmapping
       exporters:
         - solarwindsentity/serviceendpointsmapping
@@ -907,11 +908,11 @@ service:
         - resource/mandatory
         - resource/manifest
         - k8s_attributes
-        - k8seventgeneration
-        - transform/remove_deployed_by_collector_label_if_from_different_namespace
 {{- if eq (include "isNamespacesFilterEnabled" .) "true" }}
         - filter/namespaces_manifests
 {{- end }}
+        - k8seventgeneration
+        - transform/remove_deployed_by_collector_label_if_from_different_namespace
 {{- if .Values.otel.manifests.filter }}
         - filter/manifests
 {{- end }}

--- a/deploy/helm/tests/__snapshot__/events-collector-config-map_test.yaml.snap
+++ b/deploy/helm/tests/__snapshot__/events-collector-config-map_test.yaml.snap
@@ -964,12 +964,10 @@ Cluster filter should match snapshot with combined exclude filters:
             - resource/mandatory
             - resource/manifest
             - resourcedetection/providers
-            - k8seventgeneration
-            - transform/remove_deployed_by_collector_label_if_from_different_namespace
-            - groupbyattrs/serviceendpointsmapping
-            - transform/serviceendpointsmapping-renamepodip
             - k8s_attributes
             - filter/namespaces_manifests
+            - k8seventgeneration
+            - transform/remove_deployed_by_collector_label_if_from_different_namespace
             receivers:
             - swok8sobjects
           logs/manifests-export:
@@ -992,9 +990,9 @@ Cluster filter should match snapshot with combined exclude filters:
             - resource/mandatory
             - resource/manifest
             - k8s_attributes
+            - filter/namespaces_manifests
             - k8seventgeneration
             - transform/remove_deployed_by_collector_label_if_from_different_namespace
-            - filter/namespaces_manifests
             receivers:
             - swok8sobjects/keepalive
           logs/serviceendpointsmapping:
@@ -1002,6 +1000,9 @@ Cluster filter should match snapshot with combined exclude filters:
             - solarwindsentity/serviceendpointsmapping
             processors:
             - memory_limiter
+            - groupbyattrs/serviceendpointsmapping
+            - transform/serviceendpointsmapping-renamepodip
+            - k8s_attributes
             - transform/serviceendpointsmapping
             receivers:
             - routing/manifests
@@ -1994,12 +1995,10 @@ Cluster filter should match snapshot with combined include filters:
             - resource/mandatory
             - resource/manifest
             - resourcedetection/providers
-            - k8seventgeneration
-            - transform/remove_deployed_by_collector_label_if_from_different_namespace
-            - groupbyattrs/serviceendpointsmapping
-            - transform/serviceendpointsmapping-renamepodip
             - k8s_attributes
             - filter/namespaces_manifests
+            - k8seventgeneration
+            - transform/remove_deployed_by_collector_label_if_from_different_namespace
             receivers:
             - swok8sobjects
           logs/manifests-export:
@@ -2022,9 +2021,9 @@ Cluster filter should match snapshot with combined include filters:
             - resource/mandatory
             - resource/manifest
             - k8s_attributes
+            - filter/namespaces_manifests
             - k8seventgeneration
             - transform/remove_deployed_by_collector_label_if_from_different_namespace
-            - filter/namespaces_manifests
             receivers:
             - swok8sobjects/keepalive
           logs/serviceendpointsmapping:
@@ -2032,6 +2031,9 @@ Cluster filter should match snapshot with combined include filters:
             - solarwindsentity/serviceendpointsmapping
             processors:
             - memory_limiter
+            - groupbyattrs/serviceendpointsmapping
+            - transform/serviceendpointsmapping-renamepodip
+            - k8s_attributes
             - transform/serviceendpointsmapping
             receivers:
             - routing/manifests
@@ -3024,12 +3026,10 @@ Cluster filter should match snapshot with exclude_namespaces:
             - resource/mandatory
             - resource/manifest
             - resourcedetection/providers
-            - k8seventgeneration
-            - transform/remove_deployed_by_collector_label_if_from_different_namespace
-            - groupbyattrs/serviceendpointsmapping
-            - transform/serviceendpointsmapping-renamepodip
             - k8s_attributes
             - filter/namespaces_manifests
+            - k8seventgeneration
+            - transform/remove_deployed_by_collector_label_if_from_different_namespace
             receivers:
             - swok8sobjects
           logs/manifests-export:
@@ -3052,9 +3052,9 @@ Cluster filter should match snapshot with exclude_namespaces:
             - resource/mandatory
             - resource/manifest
             - k8s_attributes
+            - filter/namespaces_manifests
             - k8seventgeneration
             - transform/remove_deployed_by_collector_label_if_from_different_namespace
-            - filter/namespaces_manifests
             receivers:
             - swok8sobjects/keepalive
           logs/serviceendpointsmapping:
@@ -3062,6 +3062,9 @@ Cluster filter should match snapshot with exclude_namespaces:
             - solarwindsentity/serviceendpointsmapping
             processors:
             - memory_limiter
+            - groupbyattrs/serviceendpointsmapping
+            - transform/serviceendpointsmapping-renamepodip
+            - k8s_attributes
             - transform/serviceendpointsmapping
             receivers:
             - routing/manifests
@@ -4058,12 +4061,10 @@ Cluster filter should match snapshot with exclude_namespaces_regex:
             - resource/mandatory
             - resource/manifest
             - resourcedetection/providers
-            - k8seventgeneration
-            - transform/remove_deployed_by_collector_label_if_from_different_namespace
-            - groupbyattrs/serviceendpointsmapping
-            - transform/serviceendpointsmapping-renamepodip
             - k8s_attributes
             - filter/namespaces_manifests
+            - k8seventgeneration
+            - transform/remove_deployed_by_collector_label_if_from_different_namespace
             receivers:
             - swok8sobjects
           logs/manifests-export:
@@ -4086,9 +4087,9 @@ Cluster filter should match snapshot with exclude_namespaces_regex:
             - resource/mandatory
             - resource/manifest
             - k8s_attributes
+            - filter/namespaces_manifests
             - k8seventgeneration
             - transform/remove_deployed_by_collector_label_if_from_different_namespace
-            - filter/namespaces_manifests
             receivers:
             - swok8sobjects/keepalive
           logs/serviceendpointsmapping:
@@ -4096,6 +4097,9 @@ Cluster filter should match snapshot with exclude_namespaces_regex:
             - solarwindsentity/serviceendpointsmapping
             processors:
             - memory_limiter
+            - groupbyattrs/serviceendpointsmapping
+            - transform/serviceendpointsmapping-renamepodip
+            - k8s_attributes
             - transform/serviceendpointsmapping
             receivers:
             - routing/manifests
@@ -5088,12 +5092,10 @@ Cluster filter should match snapshot with include_namespaces:
             - resource/mandatory
             - resource/manifest
             - resourcedetection/providers
-            - k8seventgeneration
-            - transform/remove_deployed_by_collector_label_if_from_different_namespace
-            - groupbyattrs/serviceendpointsmapping
-            - transform/serviceendpointsmapping-renamepodip
             - k8s_attributes
             - filter/namespaces_manifests
+            - k8seventgeneration
+            - transform/remove_deployed_by_collector_label_if_from_different_namespace
             receivers:
             - swok8sobjects
           logs/manifests-export:
@@ -5116,9 +5118,9 @@ Cluster filter should match snapshot with include_namespaces:
             - resource/mandatory
             - resource/manifest
             - k8s_attributes
+            - filter/namespaces_manifests
             - k8seventgeneration
             - transform/remove_deployed_by_collector_label_if_from_different_namespace
-            - filter/namespaces_manifests
             receivers:
             - swok8sobjects/keepalive
           logs/serviceendpointsmapping:
@@ -5126,6 +5128,9 @@ Cluster filter should match snapshot with include_namespaces:
             - solarwindsentity/serviceendpointsmapping
             processors:
             - memory_limiter
+            - groupbyattrs/serviceendpointsmapping
+            - transform/serviceendpointsmapping-renamepodip
+            - k8s_attributes
             - transform/serviceendpointsmapping
             receivers:
             - routing/manifests
@@ -6119,12 +6124,10 @@ Cluster filter should match snapshot with include_namespaces_regex:
             - resource/mandatory
             - resource/manifest
             - resourcedetection/providers
-            - k8seventgeneration
-            - transform/remove_deployed_by_collector_label_if_from_different_namespace
-            - groupbyattrs/serviceendpointsmapping
-            - transform/serviceendpointsmapping-renamepodip
             - k8s_attributes
             - filter/namespaces_manifests
+            - k8seventgeneration
+            - transform/remove_deployed_by_collector_label_if_from_different_namespace
             receivers:
             - swok8sobjects
           logs/manifests-export:
@@ -6147,9 +6150,9 @@ Cluster filter should match snapshot with include_namespaces_regex:
             - resource/mandatory
             - resource/manifest
             - k8s_attributes
+            - filter/namespaces_manifests
             - k8seventgeneration
             - transform/remove_deployed_by_collector_label_if_from_different_namespace
-            - filter/namespaces_manifests
             receivers:
             - swok8sobjects/keepalive
           logs/serviceendpointsmapping:
@@ -6157,6 +6160,9 @@ Cluster filter should match snapshot with include_namespaces_regex:
             - solarwindsentity/serviceendpointsmapping
             processors:
             - memory_limiter
+            - groupbyattrs/serviceendpointsmapping
+            - transform/serviceendpointsmapping-renamepodip
+            - k8s_attributes
             - transform/serviceendpointsmapping
             receivers:
             - routing/manifests
@@ -7139,11 +7145,9 @@ Custom events filter with new syntax:
             - resource/mandatory
             - resource/manifest
             - resourcedetection/providers
+            - k8s_attributes
             - k8seventgeneration
             - transform/remove_deployed_by_collector_label_if_from_different_namespace
-            - groupbyattrs/serviceendpointsmapping
-            - transform/serviceendpointsmapping-renamepodip
-            - k8s_attributes
             receivers:
             - swok8sobjects
           logs/manifests-export:
@@ -7175,6 +7179,9 @@ Custom events filter with new syntax:
             - solarwindsentity/serviceendpointsmapping
             processors:
             - memory_limiter
+            - groupbyattrs/serviceendpointsmapping
+            - transform/serviceendpointsmapping-renamepodip
+            - k8s_attributes
             - transform/serviceendpointsmapping
             receivers:
             - routing/manifests
@@ -8160,11 +8167,9 @@ Custom events filter with old syntax:
             - resource/mandatory
             - resource/manifest
             - resourcedetection/providers
+            - k8s_attributes
             - k8seventgeneration
             - transform/remove_deployed_by_collector_label_if_from_different_namespace
-            - groupbyattrs/serviceendpointsmapping
-            - transform/serviceendpointsmapping-renamepodip
-            - k8s_attributes
             receivers:
             - swok8sobjects
           logs/manifests-export:
@@ -8196,6 +8201,9 @@ Custom events filter with old syntax:
             - solarwindsentity/serviceendpointsmapping
             processors:
             - memory_limiter
+            - groupbyattrs/serviceendpointsmapping
+            - transform/serviceendpointsmapping-renamepodip
+            - k8s_attributes
             - transform/serviceendpointsmapping
             receivers:
             - routing/manifests
@@ -9173,11 +9181,9 @@ Events config should match snapshot when using default values:
             - resource/mandatory
             - resource/manifest
             - resourcedetection/providers
+            - k8s_attributes
             - k8seventgeneration
             - transform/remove_deployed_by_collector_label_if_from_different_namespace
-            - groupbyattrs/serviceendpointsmapping
-            - transform/serviceendpointsmapping-renamepodip
-            - k8s_attributes
             receivers:
             - swok8sobjects
           logs/manifests-export:
@@ -9209,6 +9215,9 @@ Events config should match snapshot when using default values:
             - solarwindsentity/serviceendpointsmapping
             processors:
             - memory_limiter
+            - groupbyattrs/serviceendpointsmapping
+            - transform/serviceendpointsmapping-renamepodip
+            - k8s_attributes
             - transform/serviceendpointsmapping
             receivers:
             - routing/manifests
@@ -9889,11 +9898,9 @@ Events config should not contain manifest collection pipeline when disabled:
             - resource/mandatory
             - resource/manifest
             - resourcedetection/providers
+            - k8s_attributes
             - k8seventgeneration
             - transform/remove_deployed_by_collector_label_if_from_different_namespace
-            - groupbyattrs/serviceendpointsmapping
-            - transform/serviceendpointsmapping-renamepodip
-            - k8s_attributes
             receivers:
             - swok8sobjects
           logs/manifests-export:
@@ -9911,6 +9918,9 @@ Events config should not contain manifest collection pipeline when disabled:
             - solarwindsentity/serviceendpointsmapping
             processors:
             - memory_limiter
+            - groupbyattrs/serviceendpointsmapping
+            - transform/serviceendpointsmapping-renamepodip
+            - k8s_attributes
             - transform/serviceendpointsmapping
             receivers:
             - routing/manifests


### PR DESCRIPTION
Filtering is now applied on the resource manifests before they are used to generate EntityStateEvents.

Also, moved the `ServiceEndpointMapping` processing into its own pipeline (that already existed) to make the main manifest pipeline a bit more readable and to not call `k8sattributes` processor on other data unnecessarily.

Release it as a new alpha with the latest image.