### PR TITLE
Add sandbox skaffold profile

### DIFF
--- a/doc/development.md
+++ b/doc/development.md
@@ -192,32 +192,34 @@ Run `skaffold dev` inside a sandbox to develop and test collector changes withou
 
 ### Prerequisites
 
-- **k3s** must be running under the `local` kubeContext. The sandbox harness provides `start-k3s` as a built-in binary installed by the Claude Code sandbox image. Run it once before starting Skaffold:
+- **k3s** must be running under the `local` kubeContext. The sandbox harness provides `start-k3s` as a built-in binary. Run it once per session before starting Skaffold:
 
   ```shell
   start-k3s
   ```
 
-- **Docker Hub credentials** (or another accessible registry) must be available in the sandbox. k3s does not share the Docker daemon, so images must be pushed to a registry and pulled back by k3s. If you have Docker Hub credentials, configure them via `docker login`. Alternatively, pass `--default-repo` pointing to any registry the sandbox can reach.
+- **Local registry** must be configured as the Skaffold default. The sandbox already runs a `registry:2` container at `localhost:5000` (started by `start-k3s`). Register it once as the global default:
+
+  ```shell
+  skaffold config set --global default-repo localhost:5000
+  ```
+
+  This persists across `skaffold dev` invocations and eliminates the need for `--default-repo` flags.
 
 ### Running skaffold dev
 
+Once k3s is running and the registry is configured, simply run:
+
 ```shell
-skaffold dev -p sandbox,build-collector
+skaffold dev
 ```
 
-Why `-p build-collector` is required: the base artifact list in `skaffold.yaml` only contains `integration-test` and `test-communicator`. The collector image itself is added by the `build-collector` profile, so it must always be passed explicitly.
+The `sandbox` profile activates automatically when the active kubeContext is `local` (set by `start-k3s`). It configures `kubeContext: local`, `push: true`, disables `network_topology` (eBPF is not available in the sandbox), and skips the `monitoring` Prometheus stack (not needed for collector development).
 
-The `sandbox` profile sets `kubeContext: local` (matching the k3s context) and configures registry handling for the sandbox environment. It activates automatically when the `SANDBOX_VM_ID` environment variable is set, which the Claude Code sandbox harness always sets. This means `-p sandbox` can be omitted when running inside a sandbox:
+If you are developing local changes to the collector image itself, also pass `-p build-collector` to build and push it:
 
 ```shell
 skaffold dev -p build-collector
-```
-
-If you need to push images to a specific registry, add `--default-repo`:
-
-```shell
-skaffold dev -p build-collector --default-repo=<your-registry>
 ```
 
 ## Develop against remote prometheus

--- a/doc/development.md
+++ b/doc/development.md
@@ -5,6 +5,8 @@
 - [Contribution Guidelines](#contribution-guidelines)
 - [Prerequisites](#prerequisites)
 - [Deployment](#deployment)
+- [Develop against remote cluster](#develop-against-remote-cluster)
+- [Developing in a Claude Code sandbox](#developing-in-a-claude-code-sandbox)
 - [Develop against remote prometheus](#develop-against-remote-prometheus)
 - [Helm Unit tests](#helm-unit-tests)
 - [Integration tests](#integration-tests)
@@ -183,6 +185,40 @@ otel.metrics.batch.send_batch_size: 1024
 otel.metrics.batch.send_batch_max_size: 1024
 ```
 * Run `skaffold dev -p=test-cluster --default-repo=<Your ECR repository>`
+
+## Developing in a Claude Code sandbox
+
+Run `skaffold dev` inside a sandbox to develop and test collector changes without a local Kubernetes cluster.
+
+### Prerequisites
+
+- **k3s** must be running under the `local` kubeContext. The sandbox harness provides `start-k3s` as a built-in binary installed by the Claude Code sandbox image. Run it once before starting Skaffold:
+
+  ```shell
+  start-k3s
+  ```
+
+- **Docker Hub credentials** (or another accessible registry) must be available in the sandbox. k3s does not share the Docker daemon, so images must be pushed to a registry and pulled back by k3s. If you have Docker Hub credentials, configure them via `docker login`. Alternatively, pass `--default-repo` pointing to any registry the sandbox can reach.
+
+### Running skaffold dev
+
+```shell
+skaffold dev -p sandbox,build-collector
+```
+
+Why `-p build-collector` is required: the base artifact list in `skaffold.yaml` only contains `integration-test` and `test-communicator`. The collector image itself is added by the `build-collector` profile, so it must always be passed explicitly.
+
+The `sandbox` profile sets `kubeContext: local` (matching the k3s context) and configures registry handling for the sandbox environment. It activates automatically when the `SANDBOX_VM_ID` environment variable is set, which the Claude Code sandbox harness always sets. This means `-p sandbox` can be omitted when running inside a sandbox:
+
+```shell
+skaffold dev -p build-collector
+```
+
+If you need to push images to a specific registry, add `--default-repo`:
+
+```shell
+skaffold dev -p build-collector --default-repo=<your-registry>
+```
 
 ## Develop against remote prometheus
 

--- a/doc/development.md
+++ b/doc/development.md
@@ -6,7 +6,7 @@
 - [Prerequisites](#prerequisites)
 - [Deployment](#deployment)
 - [Develop against remote cluster](#develop-against-remote-cluster)
-- [Developing in a Claude Code sandbox](#developing-in-a-claude-code-sandbox)
+- [Developing in a sandbox](#developing-in-a-sandbox)
 - [Develop against remote prometheus](#develop-against-remote-prometheus)
 - [Helm Unit tests](#helm-unit-tests)
 - [Integration tests](#integration-tests)
@@ -186,37 +186,19 @@ otel.metrics.batch.send_batch_max_size: 1024
 ```
 * Run `skaffold dev -p=test-cluster --default-repo=<Your ECR repository>`
 
-## Developing in a Claude Code sandbox
+## Developing in a sandbox
 
-Run `skaffold dev` inside a sandbox to develop and test collector changes without a local Kubernetes cluster.
+To run `skaffold dev` in a Linux sandbox (e.g. a container-based dev environment), you need:
 
-### Prerequisites
-
-- **k3s** must be running under the `local` kubeContext. The sandbox harness provides `start-k3s` as a built-in binary. Run it once per session before starting Skaffold:
-
-  ```shell
-  start-k3s
-  ```
-
-- **Local registry** must be configured as the Skaffold default. The sandbox already runs a `registry:2` container at `localhost:5000` (started by `start-k3s`). Register it once as the global default:
-
+- **k3s** running under the `local` kubeContext
+- **A local registry** at `localhost:5000` configured as the Skaffold default:
   ```shell
   skaffold config set --global default-repo localhost:5000
   ```
 
-  This persists across `skaffold dev` invocations and eliminates the need for `--default-repo` flags.
+Once those prerequisites are met, `skaffold dev` with no flags will automatically activate the `sandbox` profile (triggers on `kubeContext: local`). The profile enables `push: true`, disables `network_topology` (eBPF unavailable in containers), and skips the Prometheus monitoring stack.
 
-### Running skaffold dev
-
-Once k3s is running and the registry is configured, simply run:
-
-```shell
-skaffold dev
-```
-
-The `sandbox` profile activates automatically when the active kubeContext is `local` (set by `start-k3s`). It configures `kubeContext: local`, `push: true`, disables `network_topology` (eBPF is not available in the sandbox), and skips the `monitoring` Prometheus stack (not needed for collector development).
-
-If you are developing local changes to the collector image itself, also pass `-p build-collector` to build and push it:
+To also build the collector image locally, add `-p build-collector`:
 
 ```shell
 skaffold dev -p build-collector

--- a/skaffold.yaml
+++ b/skaffold.yaml
@@ -316,3 +316,18 @@ profiles:
           resourceName: timeseries-mock-service
           namespace: '{{ env "TEST_CLUSTER_NAMESPACE" | default "test-namespace" }}'
           port: 8088
+  - name: sandbox
+    activation:
+      - env: "SANDBOX_VM_ID=*"
+    build:
+      local:
+        push: true
+        useBuildkit: true
+        concurrency: 0
+    deploy:
+      kubeContext: local
+    # patches augment the inline deploy override above — valid in Skaffold v4
+    patches:
+      - op: add
+        path: /deploy/helm/releases/1/setValueTemplates/network_topology.enabled
+        value: "false"

--- a/skaffold.yaml
+++ b/skaffold.yaml
@@ -318,12 +318,23 @@ profiles:
           port: 8088
   - name: sandbox
     activation:
-      - env: "SANDBOX_VM_ID=*"
+      - kubeContext: local
     build:
       local:
         push: true
         useBuildkit: true
         concurrency: 0
+      hooks:
+        after:
+          - command:
+              - sh
+              - -c
+              - |
+                helm repo add prometheus-community https://prometheus-community.github.io/helm-charts --force-update
+                helm repo add open-telemetry https://open-telemetry.github.io/opentelemetry-helm-charts --force-update
+                helm repo add jetstack https://charts.jetstack.io --force-update
+                helm repo add aqua https://aquasecurity.github.io/helm-charts --force-update
+                helm repo update
     deploy:
       kubeContext: local
     # patches augment the inline deploy override above — valid in Skaffold v4
@@ -331,3 +342,13 @@ profiles:
       - op: add
         path: /deploy/helm/releases/1/setValueTemplates/network_topology.enabled
         value: "false"
+      # Remove prometheus/kube-prometheus-stack — not needed in sandbox and its
+      # pre-install webhook-cert Job times out on fresh k3s clusters.
+      - op: remove
+        path: /deploy/helm/releases/2
+      - op: remove
+        path: /portForward/2
+      # Install Prometheus CRDs directly so the collector's ServiceMonitors can be applied.
+      - op: add
+        path: /deploy/helm/releases/1/setValueTemplates/prometheusCRDs.install
+        value: true


### PR DESCRIPTION
Making it possible to develop in the sandbox, where:
* kube-context is set to `local` k3s (installable into Docker Sandboxes)
* this is compatible with Docker Sandboxes harness we use in the company