### PR TITLE
Fix memory and cpu metrics on windows nodes

### DIFF
--- a/deploy/helm/node-collector-config.yaml
+++ b/deploy/helm/node-collector-config.yaml
@@ -122,6 +122,44 @@ processors:
       - k8s.node.cpu.usage.seconds.rate
 {{- end }}
 
+{{- if and (not .isWindows) .Values.otel.metrics.kubeletstats.enabled .Values.otel.metrics.enabled (not .Values.aws_fargate.enabled) }}
+  # Drop CPU metrics from cAdvisor pipeline to avoid duplicates when kubeletstats is collecting them.
+  filter/cadvisor-cpu:
+    error_mode: ignore
+    metrics:
+      metric:
+        - name == "k8s.node.cpu.usage.seconds.rate"
+        - name == "k8s.pod.cpu.usage.seconds.rate"
+        - name == "k8s.container.cpu.usage.seconds.rate"
+
+  metrics_transform/linux-kubeletstats:
+    transforms:
+      - include: k8s.container.cpu.time
+        action: update
+        new_name: k8s.container.cpu.usage.seconds.rate
+      - include: k8s.pod.cpu.time
+        action: update
+        new_name: k8s.pod.cpu.usage.seconds.rate
+      - include: k8s.node.cpu.time
+        action: update
+        new_name: k8s.node.cpu.usage.seconds.rate
+
+  cumulativetodelta/linux-kubeletstats:
+    max_staleness: {{ include "common.maxStaleness" . }}
+    include:
+      metrics:
+        - k8s.container.cpu.usage.seconds.rate
+        - k8s.pod.cpu.usage.seconds.rate
+        - k8s.node.cpu.usage.seconds.rate
+      match_type: strict
+
+  deltatorate/linux-kubeletstats:
+    metrics:
+      - k8s.container.cpu.usage.seconds.rate
+      - k8s.pod.cpu.usage.seconds.rate
+      - k8s.node.cpu.usage.seconds.rate
+{{- end }}
+
   {{- include "common-config.groupbyattrs-node" . | nindent 2 }}
   {{- include "common-config.groupbyattrs-pod" . | nindent 2 }}
   {{- include "common-config.groupbyattrs-all" . | nindent 2 }}
@@ -704,6 +742,18 @@ receivers:
       - node
 {{- end }}
 
+{{- if and (not .isWindows) .Values.otel.metrics.kubeletstats.enabled .Values.otel.metrics.enabled (not .Values.aws_fargate.enabled) }}
+  kubelet_stats/linux:
+    collection_interval: {{ quote .Values.otel.metrics.prometheus.scrape_interval }}
+    auth_type: "serviceAccount"
+    endpoint: "https://${NODE_IP}:10250"
+    insecure_skip_verify: true
+    metric_groups:
+      - container
+      - pod
+      - node
+{{- end }}
+
 service:
   extensions:
     - file_storage/checkpoints
@@ -786,6 +836,9 @@ service:
         - metrics_transform/preprocessing
         - filter/remove_internal_postprocessing
         - attributes/remove_temp
+{{- if and (not .isWindows) .Values.otel.metrics.kubeletstats.enabled }}
+        - filter/cadvisor-cpu
+{{- end }}
         - cumulativetodelta/cadvisor
         - deltatorate/cadvisor
         - groupbyattrs/node
@@ -805,6 +858,19 @@ service:
         - metrics_transform/windows-kubeletstats
         - cumulativetodelta/windows-kubeletstats
         - deltatorate/windows-kubeletstats
+        - resource/all
+      exporters:
+        - forward/metric-exporter
+{{- end }}
+{{- if and (not .isWindows) .Values.otel.metrics.kubeletstats.enabled .Values.otel.metrics.enabled (not .Values.aws_fargate.enabled) }}
+    metrics/node-kubeletstats:
+      receivers:
+        - kubelet_stats/linux
+      processors:
+        - memory_limiter
+        - metrics_transform/linux-kubeletstats
+        - cumulativetodelta/linux-kubeletstats
+        - deltatorate/linux-kubeletstats
         - resource/all
       exporters:
         - forward/metric-exporter

--- a/deploy/helm/node-collector-config.yaml
+++ b/deploy/helm/node-collector-config.yaml
@@ -92,6 +92,36 @@ processors:
     metrics:
       {{- include "common-config.cumulativetorate-cadvisor" . | nindent 6}}
 
+{{- if and .isWindows .Values.otel.metrics.enabled (not .Values.aws_fargate.enabled) }}
+  # Rename kubeletstats CPU time metrics to the expected rate metric names before conversion.
+  metrics_transform/windows-kubeletstats:
+    transforms:
+      - include: k8s.container.cpu.time
+        action: update
+        new_name: k8s.container.cpu.usage.seconds.rate
+      - include: k8s.pod.cpu.time
+        action: update
+        new_name: k8s.pod.cpu.usage.seconds.rate
+      - include: k8s.node.cpu.time
+        action: update
+        new_name: k8s.node.cpu.usage.seconds.rate
+
+  cumulativetodelta/windows-kubeletstats:
+    max_staleness: {{ include "common.maxStaleness" . }}
+    include:
+      metrics:
+        - k8s.container.cpu.usage.seconds.rate
+        - k8s.pod.cpu.usage.seconds.rate
+        - k8s.node.cpu.usage.seconds.rate
+      match_type: strict
+
+  deltatorate/windows-kubeletstats:
+    metrics:
+      - k8s.container.cpu.usage.seconds.rate
+      - k8s.pod.cpu.usage.seconds.rate
+      - k8s.node.cpu.usage.seconds.rate
+{{- end }}
+
   {{- include "common-config.groupbyattrs-node" . | nindent 2 }}
   {{- include "common-config.groupbyattrs-pod" . | nindent 2 }}
   {{- include "common-config.groupbyattrs-all" . | nindent 2 }}
@@ -626,6 +656,7 @@ receivers:
         config:
           config:
             scrape_configs:
+{{- if not .isWindows }}
               - job_name: 'kubernetes-nodes-cadvisor'
                 scheme: "https"
                 scrape_interval: {{ quote .Values.otel.metrics.prometheus.scrape_interval }}
@@ -641,6 +672,7 @@ receivers:
                 static_configs:
                   - targets:
                       - '`endpoint`:`kubelet_endpoint_port`'
+{{- end }}
               - job_name: 'kubernetes-nodes'
                 scheme: "https"
                 scrape_interval: {{ quote .Values.otel.metrics.prometheus.scrape_interval }}
@@ -656,6 +688,20 @@ receivers:
                 static_configs:
                   - targets:
                       - '`endpoint`:`kubelet_endpoint_port`'
+{{- end }}
+
+{{- if and .isWindows .Values.otel.metrics.enabled (not .Values.aws_fargate.enabled) }}
+  # kubeletstats receiver provides container CPU metrics on Windows nodes where cAdvisor is unavailable.
+  # Requires kubeletstatsreceiver in the collector k8s distribution.
+  kubelet_stats/windows:
+    collection_interval: {{ quote .Values.otel.metrics.prometheus.scrape_interval }}
+    auth_type: "serviceAccount"
+    endpoint: "https://${NODE_IP}:10250"
+    insecure_skip_verify: true
+    metric_groups:
+      - container
+      - pod
+      - node
 {{- end }}
 
 service:
@@ -746,6 +792,19 @@ service:
         - groupbyattrs/pod
         - groupbyattrs/all
         - resource/metrics
+        - resource/all
+      exporters:
+        - forward/metric-exporter
+{{- end }}
+{{- if and .isWindows .Values.otel.metrics.enabled (not .Values.aws_fargate.enabled) }}
+    metrics/node-windows:
+      receivers:
+        - kubelet_stats/windows
+      processors:
+        - memory_limiter
+        - metrics_transform/windows-kubeletstats
+        - cumulativetodelta/windows-kubeletstats
+        - deltatorate/windows-kubeletstats
         - resource/all
       exporters:
         - forward/metric-exporter

--- a/deploy/helm/templates/cluster-role.yaml
+++ b/deploy/helm/templates/cluster-role.yaml
@@ -18,6 +18,7 @@ rules:
       - nodes/spec
       - nodes/proxy
       - nodes/metrics
+      - nodes/stats
       - pods
       - pods/status
       - replicationcontrollers

--- a/deploy/helm/templates/node-collector-daemon-set-windows.yaml
+++ b/deploy/helm/templates/node-collector-daemon-set-windows.yaml
@@ -111,6 +111,10 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: spec.nodeName
+            - name: NODE_IP
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.hostIP
             - name: SOLARWINDS_API_TOKEN
               valueFrom:
                 secretKeyRef:

--- a/deploy/helm/templates/node-collector-daemon-set.yaml
+++ b/deploy/helm/templates/node-collector-daemon-set.yaml
@@ -138,6 +138,10 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: spec.nodeName
+            - name: NODE_IP
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.hostIP
             - name: SOLARWINDS_API_TOKEN
               valueFrom:
                 secretKeyRef:

--- a/deploy/helm/tests/__snapshot__/node-collector-config-map-windows_test.yaml.snap
+++ b/deploy/helm/tests/__snapshot__/node-collector-config-map-windows_test.yaml.snap
@@ -443,6 +443,14 @@ Node collector config for windows nodes should match snapshot when using default
             - k8s.istio_tcp_sent_bytes.delta
             - k8s.istio_tcp_received_bytes.delta
           max_staleness: 180s
+        cumulativetodelta/windows-kubeletstats:
+          include:
+            match_type: strict
+            metrics:
+            - k8s.container.cpu.usage.seconds.rate
+            - k8s.pod.cpu.usage.seconds.rate
+            - k8s.node.cpu.usage.seconds.rate
+          max_staleness: 180s
         deltatorate/cadvisor:
           metrics:
           - k8s.node.cpu.usage.seconds.rate
@@ -481,6 +489,11 @@ Node collector config for windows nodes should match snapshot when using default
           - k8s.istio_requests.rate
           - k8s.istio_tcp_sent_bytes.rate
           - k8s.istio_tcp_received_bytes.rate
+        deltatorate/windows-kubeletstats:
+          metrics:
+          - k8s.container.cpu.usage.seconds.rate
+          - k8s.pod.cpu.usage.seconds.rate
+          - k8s.node.cpu.usage.seconds.rate
         filter/deduplicate-dual-attribute-metrics:
           error_mode: ignore
           metrics:
@@ -1145,6 +1158,17 @@ Node collector config for windows nodes should match snapshot when using default
             include: ^k8s.(rpc\..*)$$
             match_type: regexp
             new_name: $${1}
+        metrics_transform/windows-kubeletstats:
+          transforms:
+          - action: update
+            include: k8s.container.cpu.time
+            new_name: k8s.container.cpu.usage.seconds.rate
+          - action: update
+            include: k8s.pod.cpu.time
+            new_name: k8s.pod.cpu.usage.seconds.rate
+          - action: update
+            include: k8s.node.cpu.time
+            new_name: k8s.node.cpu.usage.seconds.rate
         metricsgeneration/istio-metrics:
           rules:
           - metric1: k8s.istio_request_duration_milliseconds_sum__swo_temp
@@ -1519,6 +1543,15 @@ Node collector config for windows nodes should match snapshot when using default
           poll_interval: 200ms
           start_at: end
           storage: file_storage/checkpoints
+        kubelet_stats/windows:
+          auth_type: serviceAccount
+          collection_interval: 60s
+          endpoint: https://${NODE_IP}:10250
+          insecure_skip_verify: true
+          metric_groups:
+          - container
+          - pod
+          - node
         receiver_creator/discovery:
           receivers:
             prometheus/controller-manager:
@@ -1643,29 +1676,6 @@ Node collector config for windows nodes should match snapshot when using default
               config:
                 config:
                   scrape_configs:
-                  - bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
-                    honor_labels: true
-                    honor_timestamps: false
-                    job_name: kubernetes-nodes-cadvisor
-                    metric_relabel_configs:
-                    - action: replace
-                      regex: (.+)
-                      replacement: $1
-                      source_labels:
-                      - service_name
-                      target_label: job
-                    - action: labeldrop
-                      regex: ^service_name$
-                    metrics_path: /metrics/cadvisor
-                    scheme: https
-                    scrape_interval: 60s
-                    scrape_timeout: 10s
-                    static_configs:
-                    - targets:
-                      - '`endpoint`:`kubelet_endpoint_port`'
-                    tls_config:
-                      ca_file: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
-                      insecure_skip_verify: true
                   - bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
                     honor_labels: true
                     honor_timestamps: false
@@ -1802,6 +1812,17 @@ Node collector config for windows nodes should match snapshot when using default
             - resource/all
             receivers:
             - receiver_creator/node
+          metrics/node-windows:
+            exporters:
+            - forward/metric-exporter
+            processors:
+            - memory_limiter
+            - metrics_transform/windows-kubeletstats
+            - cumulativetodelta/windows-kubeletstats
+            - deltatorate/windows-kubeletstats
+            - resource/all
+            receivers:
+            - kubelet_stats/windows
           metrics/not-relationship-state-events-preparation:
             exporters:
             - forward/discovery-istio-metrics-clean
@@ -2311,6 +2332,14 @@ Node collector config for windows nodes should match snapshot when using legacy 
             - k8s.istio_tcp_sent_bytes.delta
             - k8s.istio_tcp_received_bytes.delta
           max_staleness: 180s
+        cumulativetodelta/windows-kubeletstats:
+          include:
+            match_type: strict
+            metrics:
+            - k8s.container.cpu.usage.seconds.rate
+            - k8s.pod.cpu.usage.seconds.rate
+            - k8s.node.cpu.usage.seconds.rate
+          max_staleness: 180s
         deltatorate/cadvisor:
           metrics:
           - k8s.node.cpu.usage.seconds.rate
@@ -2349,6 +2378,11 @@ Node collector config for windows nodes should match snapshot when using legacy 
           - k8s.istio_requests.rate
           - k8s.istio_tcp_sent_bytes.rate
           - k8s.istio_tcp_received_bytes.rate
+        deltatorate/windows-kubeletstats:
+          metrics:
+          - k8s.container.cpu.usage.seconds.rate
+          - k8s.pod.cpu.usage.seconds.rate
+          - k8s.node.cpu.usage.seconds.rate
         filter/deduplicate-dual-attribute-metrics:
           error_mode: ignore
           metrics:
@@ -3020,6 +3054,17 @@ Node collector config for windows nodes should match snapshot when using legacy 
             include: ^k8s.(rpc\..*)$$
             match_type: regexp
             new_name: $${1}
+        metrics_transform/windows-kubeletstats:
+          transforms:
+          - action: update
+            include: k8s.container.cpu.time
+            new_name: k8s.container.cpu.usage.seconds.rate
+          - action: update
+            include: k8s.pod.cpu.time
+            new_name: k8s.pod.cpu.usage.seconds.rate
+          - action: update
+            include: k8s.node.cpu.time
+            new_name: k8s.node.cpu.usage.seconds.rate
         metricsgeneration/istio-metrics:
           rules:
           - metric1: k8s.istio_request_duration_milliseconds_sum__swo_temp
@@ -3475,6 +3520,15 @@ Node collector config for windows nodes should match snapshot when using legacy 
           poll_interval: 200ms
           start_at: end
           storage: file_storage/checkpoints
+        kubelet_stats/windows:
+          auth_type: serviceAccount
+          collection_interval: 60s
+          endpoint: https://${NODE_IP}:10250
+          insecure_skip_verify: true
+          metric_groups:
+          - container
+          - pod
+          - node
         receiver_creator/discovery:
           receivers:
             prometheus/controller-manager:
@@ -3599,29 +3653,6 @@ Node collector config for windows nodes should match snapshot when using legacy 
               config:
                 config:
                   scrape_configs:
-                  - bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
-                    honor_labels: true
-                    honor_timestamps: false
-                    job_name: kubernetes-nodes-cadvisor
-                    metric_relabel_configs:
-                    - action: replace
-                      regex: (.+)
-                      replacement: $1
-                      source_labels:
-                      - service_name
-                      target_label: job
-                    - action: labeldrop
-                      regex: ^service_name$
-                    metrics_path: /metrics/cadvisor
-                    scheme: https
-                    scrape_interval: 60s
-                    scrape_timeout: 10s
-                    static_configs:
-                    - targets:
-                      - '`endpoint`:`kubelet_endpoint_port`'
-                    tls_config:
-                      ca_file: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
-                      insecure_skip_verify: true
                   - bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
                     honor_labels: true
                     honor_timestamps: false
@@ -3758,6 +3789,17 @@ Node collector config for windows nodes should match snapshot when using legacy 
             - resource/all
             receivers:
             - receiver_creator/node
+          metrics/node-windows:
+            exporters:
+            - forward/metric-exporter
+            processors:
+            - memory_limiter
+            - metrics_transform/windows-kubeletstats
+            - cumulativetodelta/windows-kubeletstats
+            - deltatorate/windows-kubeletstats
+            - resource/all
+            receivers:
+            - kubelet_stats/windows
           metrics/not-relationship-state-events-preparation:
             exporters:
             - forward/discovery-istio-metrics-clean

--- a/deploy/helm/tests/__snapshot__/node-collector-daemon-set-windows_test.yaml.snap
+++ b/deploy/helm/tests/__snapshot__/node-collector-daemon-set-windows_test.yaml.snap
@@ -28,6 +28,10 @@ DaemonSet spec for windows nodes should match snapshot when overriding cluster I
             valueFrom:
               fieldRef:
                 fieldPath: spec.nodeName
+          - name: NODE_IP
+            valueFrom:
+              fieldRef:
+                fieldPath: status.hostIP
           - name: SOLARWINDS_API_TOKEN
             valueFrom:
               secretKeyRef:
@@ -157,6 +161,10 @@ DaemonSet spec for windows nodes should match snapshot when using default values
             valueFrom:
               fieldRef:
                 fieldPath: spec.nodeName
+          - name: NODE_IP
+            valueFrom:
+              fieldRef:
+                fieldPath: status.hostIP
           - name: SOLARWINDS_API_TOKEN
             valueFrom:
               secretKeyRef:

--- a/deploy/helm/tests/__snapshot__/node-collector-daemon-set_test.yaml.snap
+++ b/deploy/helm/tests/__snapshot__/node-collector-daemon-set_test.yaml.snap
@@ -37,6 +37,10 @@ DaemonSet spec should match snapshot when ebpfNetworkMonitoring is enabled:
             valueFrom:
               fieldRef:
                 fieldPath: spec.nodeName
+          - name: NODE_IP
+            valueFrom:
+              fieldRef:
+                fieldPath: status.hostIP
           - name: SOLARWINDS_API_TOKEN
             valueFrom:
               secretKeyRef:
@@ -193,6 +197,10 @@ DaemonSet spec should match snapshot when openshift is enabled:
             valueFrom:
               fieldRef:
                 fieldPath: spec.nodeName
+          - name: NODE_IP
+            valueFrom:
+              fieldRef:
+                fieldPath: status.hostIP
           - name: SOLARWINDS_API_TOKEN
             valueFrom:
               secretKeyRef:
@@ -356,6 +364,10 @@ DaemonSet spec should match snapshot when overriding cluster ID:
             valueFrom:
               fieldRef:
                 fieldPath: spec.nodeName
+          - name: NODE_IP
+            valueFrom:
+              fieldRef:
+                fieldPath: status.hostIP
           - name: SOLARWINDS_API_TOKEN
             valueFrom:
               secretKeyRef:
@@ -512,6 +524,10 @@ DaemonSet spec should match snapshot when setting cluster name with spaces:
             valueFrom:
               fieldRef:
                 fieldPath: spec.nodeName
+          - name: NODE_IP
+            valueFrom:
+              fieldRef:
+                fieldPath: status.hostIP
           - name: SOLARWINDS_API_TOKEN
             valueFrom:
               secretKeyRef:
@@ -668,6 +684,10 @@ DaemonSet spec should match snapshot when using default values:
             valueFrom:
               fieldRef:
                 fieldPath: spec.nodeName
+          - name: NODE_IP
+            valueFrom:
+              fieldRef:
+                fieldPath: status.hostIP
           - name: SOLARWINDS_API_TOKEN
             valueFrom:
               secretKeyRef:

--- a/deploy/helm/tests/node-collector-config-map-windows_test.yaml
+++ b/deploy/helm/tests/node-collector-config-map-windows_test.yaml
@@ -36,3 +36,9 @@ tests:
       - matchRegex:
           path: data["logs.config"]
           pattern: "pprof"
+  - it: kubernetes-nodes-cadvisor scrape job should not be present in windows config
+    template: node-collector-config-map-windows.yaml
+    asserts:
+      - notMatchRegex:
+          path: data["logs.config"]
+          pattern: "kubernetes-nodes-cadvisor"

--- a/deploy/helm/values.schema.json
+++ b/deploy/helm/values.schema.json
@@ -1118,6 +1118,16 @@
                             "type": "boolean",
                             "description": "Filter out histogram metrics before sending to SWO. Enabled by default due to SWO current limitations (SWO cannot aggregate on histograms)."
                         },
+                        "kubeletstats": {
+                            "type": "object",
+                            "description": "Use kubeletstats receiver instead of cAdvisor for CPU and memory metrics on Linux nodes.",
+                            "properties": {
+                                "enabled": {
+                                    "type": "boolean"
+                                }
+                            },
+                            "additionalProperties": false
+                        },
                         "extra_scrape_metrics": {
                             "type": "array",
                             "items": {

--- a/deploy/helm/values.yaml
+++ b/deploy/helm/values.yaml
@@ -93,6 +93,11 @@ otel:
     # Enabled by default due to SWO current limitations.
     filter_histograms: true
 
+    # Use kubeletstats receiver instead of cAdvisor for CPU and memory metrics on Linux nodes.
+    # Set to true to switch; false restores cAdvisor-based collection.
+    kubeletstats:
+      enabled: false
+
     # configuration for metric discovery
     autodiscovery:
       # Discovery collector is responsible for discovering and scraping based on Prometheus CRDs - ServiceMonitors, PodMonitors and ScrapeConfigs


### PR DESCRIPTION
cAdvisor is not avilable on windows nodes. We switched to kubeletstats on windows nodes for now. 