### PR TITLE
Upgrade to APM Python 7.1.0

### DIFF
--- a/deploy/helm/values.yaml
+++ b/deploy/helm/values.yaml
@@ -1341,7 +1341,7 @@ operator:
         tag: ""
       python:
         repository: "solarwinds/autoinstrumentation-python"
-        tag: "7.0.0"
+        tag: "7.1.0"
       dotnet:
         repository: ""
         tag: ""


### PR DESCRIPTION
Upgrade to APM Python 7.1.0, released July 21 2026.