### PR TITLE
Include "k8s.cluster.name" in EntityRef's "description_keys" from container logs

### DIFF
--- a/deploy/helm/Chart.yaml
+++ b/deploy/helm/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: swo-k8s-collector
 version: 5.4.0-alpha.4
-appVersion: 0.152.6
+appVersion: 0.157.0
 description: SolarWinds Kubernetes Integration
 keywords:
   - monitoring

--- a/deploy/helm/node-collector-config.yaml
+++ b/deploy/helm/node-collector-config.yaml
@@ -189,51 +189,71 @@ processors:
       - type: KubernetesCluster
         id_keys:
           - sw.k8s.cluster.uid
+        description_keys:
+          - k8s.cluster.name
       - type: KubernetesContainer
         id_keys:
           - sw.k8s.cluster.uid
           - k8s.namespace.name
           - k8s.pod.name
           - k8s.container.name
+        description_keys:
+          - k8s.cluster.name
       - type: KubernetesPod
         id_keys:
           - sw.k8s.cluster.uid
           - k8s.namespace.name
           - k8s.pod.name
+        description_keys:
+          - k8s.cluster.name
       - type: KubernetesNode
         id_keys:
           - sw.k8s.cluster.uid
           - k8s.node.name
+        description_keys:
+          - k8s.cluster.name
       - type: KubernetesDeployment
         id_keys:
           - sw.k8s.cluster.uid
           - k8s.namespace.name
           - k8s.deployment.name
+        description_keys:
+          - k8s.cluster.name
       - type: KubernetesReplicaSet
         id_keys:
           - sw.k8s.cluster.uid
           - k8s.namespace.name
           - k8s.replicaset.name
+        description_keys:
+          - k8s.cluster.name
       - type: KubernetesStatefulSet
         id_keys:
           - sw.k8s.cluster.uid
           - k8s.namespace.name
           - k8s.statefulset.name
+        description_keys:
+          - k8s.cluster.name
       - type: KubernetesDaemonSet
         id_keys:
           - sw.k8s.cluster.uid
           - k8s.namespace.name
           - k8s.daemonset.name
+        description_keys:
+          - k8s.cluster.name
       - type: KubernetesJob
         id_keys:
           - sw.k8s.cluster.uid
           - k8s.namespace.name
           - k8s.job.name
+        description_keys:
+          - k8s.cluster.name
       - type: KubernetesCronJob
         id_keys:
           - sw.k8s.cluster.uid
           - k8s.namespace.name
           - k8s.cronjob.name
+        description_keys:
+          - k8s.cluster.name
 
 {{- if and (not .isWindows) .Values.otel.logs.journal }}
   resource/journal:

--- a/deploy/helm/tests/__snapshot__/node-collector-config-map-windows_test.yaml.snap
+++ b/deploy/helm/tests/__snapshot__/node-collector-config-map-windows_test.yaml.snap
@@ -1331,50 +1331,70 @@ Node collector config for windows nodes should match snapshot when using default
         swootelentityref/container_logs:
           action: insert
           entity_refs:
-          - id_keys:
+          - description_keys:
+            - k8s.cluster.name
+            id_keys:
             - sw.k8s.cluster.uid
             type: KubernetesCluster
-          - id_keys:
+          - description_keys:
+            - k8s.cluster.name
+            id_keys:
             - sw.k8s.cluster.uid
             - k8s.namespace.name
             - k8s.pod.name
             - k8s.container.name
             type: KubernetesContainer
-          - id_keys:
+          - description_keys:
+            - k8s.cluster.name
+            id_keys:
             - sw.k8s.cluster.uid
             - k8s.namespace.name
             - k8s.pod.name
             type: KubernetesPod
-          - id_keys:
+          - description_keys:
+            - k8s.cluster.name
+            id_keys:
             - sw.k8s.cluster.uid
             - k8s.node.name
             type: KubernetesNode
-          - id_keys:
+          - description_keys:
+            - k8s.cluster.name
+            id_keys:
             - sw.k8s.cluster.uid
             - k8s.namespace.name
             - k8s.deployment.name
             type: KubernetesDeployment
-          - id_keys:
+          - description_keys:
+            - k8s.cluster.name
+            id_keys:
             - sw.k8s.cluster.uid
             - k8s.namespace.name
             - k8s.replicaset.name
             type: KubernetesReplicaSet
-          - id_keys:
+          - description_keys:
+            - k8s.cluster.name
+            id_keys:
             - sw.k8s.cluster.uid
             - k8s.namespace.name
             - k8s.statefulset.name
             type: KubernetesStatefulSet
-          - id_keys:
+          - description_keys:
+            - k8s.cluster.name
+            id_keys:
             - sw.k8s.cluster.uid
             - k8s.namespace.name
             - k8s.daemonset.name
             type: KubernetesDaemonSet
-          - id_keys:
+          - description_keys:
+            - k8s.cluster.name
+            id_keys:
             - sw.k8s.cluster.uid
             - k8s.namespace.name
             - k8s.job.name
             type: KubernetesJob
-          - id_keys:
+          - description_keys:
+            - k8s.cluster.name
+            id_keys:
             - sw.k8s.cluster.uid
             - k8s.namespace.name
             - k8s.cronjob.name
@@ -3209,50 +3229,70 @@ Node collector config for windows nodes should match snapshot when using legacy 
         swootelentityref/container_logs:
           action: insert
           entity_refs:
-          - id_keys:
+          - description_keys:
+            - k8s.cluster.name
+            id_keys:
             - sw.k8s.cluster.uid
             type: KubernetesCluster
-          - id_keys:
+          - description_keys:
+            - k8s.cluster.name
+            id_keys:
             - sw.k8s.cluster.uid
             - k8s.namespace.name
             - k8s.pod.name
             - k8s.container.name
             type: KubernetesContainer
-          - id_keys:
+          - description_keys:
+            - k8s.cluster.name
+            id_keys:
             - sw.k8s.cluster.uid
             - k8s.namespace.name
             - k8s.pod.name
             type: KubernetesPod
-          - id_keys:
+          - description_keys:
+            - k8s.cluster.name
+            id_keys:
             - sw.k8s.cluster.uid
             - k8s.node.name
             type: KubernetesNode
-          - id_keys:
+          - description_keys:
+            - k8s.cluster.name
+            id_keys:
             - sw.k8s.cluster.uid
             - k8s.namespace.name
             - k8s.deployment.name
             type: KubernetesDeployment
-          - id_keys:
+          - description_keys:
+            - k8s.cluster.name
+            id_keys:
             - sw.k8s.cluster.uid
             - k8s.namespace.name
             - k8s.replicaset.name
             type: KubernetesReplicaSet
-          - id_keys:
+          - description_keys:
+            - k8s.cluster.name
+            id_keys:
             - sw.k8s.cluster.uid
             - k8s.namespace.name
             - k8s.statefulset.name
             type: KubernetesStatefulSet
-          - id_keys:
+          - description_keys:
+            - k8s.cluster.name
+            id_keys:
             - sw.k8s.cluster.uid
             - k8s.namespace.name
             - k8s.daemonset.name
             type: KubernetesDaemonSet
-          - id_keys:
+          - description_keys:
+            - k8s.cluster.name
+            id_keys:
             - sw.k8s.cluster.uid
             - k8s.namespace.name
             - k8s.job.name
             type: KubernetesJob
-          - id_keys:
+          - description_keys:
+            - k8s.cluster.name
+            id_keys:
             - sw.k8s.cluster.uid
             - k8s.namespace.name
             - k8s.cronjob.name

--- a/deploy/helm/tests/__snapshot__/node-collector-config-map_test.yaml.snap
+++ b/deploy/helm/tests/__snapshot__/node-collector-config-map_test.yaml.snap
@@ -1365,50 +1365,70 @@ Cluster filter should match snapshot with combined exclude filters:
         swootelentityref/container_logs:
           action: insert
           entity_refs:
-          - id_keys:
+          - description_keys:
+            - k8s.cluster.name
+            id_keys:
             - sw.k8s.cluster.uid
             type: KubernetesCluster
-          - id_keys:
+          - description_keys:
+            - k8s.cluster.name
+            id_keys:
             - sw.k8s.cluster.uid
             - k8s.namespace.name
             - k8s.pod.name
             - k8s.container.name
             type: KubernetesContainer
-          - id_keys:
+          - description_keys:
+            - k8s.cluster.name
+            id_keys:
             - sw.k8s.cluster.uid
             - k8s.namespace.name
             - k8s.pod.name
             type: KubernetesPod
-          - id_keys:
+          - description_keys:
+            - k8s.cluster.name
+            id_keys:
             - sw.k8s.cluster.uid
             - k8s.node.name
             type: KubernetesNode
-          - id_keys:
+          - description_keys:
+            - k8s.cluster.name
+            id_keys:
             - sw.k8s.cluster.uid
             - k8s.namespace.name
             - k8s.deployment.name
             type: KubernetesDeployment
-          - id_keys:
+          - description_keys:
+            - k8s.cluster.name
+            id_keys:
             - sw.k8s.cluster.uid
             - k8s.namespace.name
             - k8s.replicaset.name
             type: KubernetesReplicaSet
-          - id_keys:
+          - description_keys:
+            - k8s.cluster.name
+            id_keys:
             - sw.k8s.cluster.uid
             - k8s.namespace.name
             - k8s.statefulset.name
             type: KubernetesStatefulSet
-          - id_keys:
+          - description_keys:
+            - k8s.cluster.name
+            id_keys:
             - sw.k8s.cluster.uid
             - k8s.namespace.name
             - k8s.daemonset.name
             type: KubernetesDaemonSet
-          - id_keys:
+          - description_keys:
+            - k8s.cluster.name
+            id_keys:
             - sw.k8s.cluster.uid
             - k8s.namespace.name
             - k8s.job.name
             type: KubernetesJob
-          - id_keys:
+          - description_keys:
+            - k8s.cluster.name
+            id_keys:
             - sw.k8s.cluster.uid
             - k8s.namespace.name
             - k8s.cronjob.name
@@ -3274,50 +3294,70 @@ Cluster filter should match snapshot with combined include filters:
         swootelentityref/container_logs:
           action: insert
           entity_refs:
-          - id_keys:
+          - description_keys:
+            - k8s.cluster.name
+            id_keys:
             - sw.k8s.cluster.uid
             type: KubernetesCluster
-          - id_keys:
+          - description_keys:
+            - k8s.cluster.name
+            id_keys:
             - sw.k8s.cluster.uid
             - k8s.namespace.name
             - k8s.pod.name
             - k8s.container.name
             type: KubernetesContainer
-          - id_keys:
+          - description_keys:
+            - k8s.cluster.name
+            id_keys:
             - sw.k8s.cluster.uid
             - k8s.namespace.name
             - k8s.pod.name
             type: KubernetesPod
-          - id_keys:
+          - description_keys:
+            - k8s.cluster.name
+            id_keys:
             - sw.k8s.cluster.uid
             - k8s.node.name
             type: KubernetesNode
-          - id_keys:
+          - description_keys:
+            - k8s.cluster.name
+            id_keys:
             - sw.k8s.cluster.uid
             - k8s.namespace.name
             - k8s.deployment.name
             type: KubernetesDeployment
-          - id_keys:
+          - description_keys:
+            - k8s.cluster.name
+            id_keys:
             - sw.k8s.cluster.uid
             - k8s.namespace.name
             - k8s.replicaset.name
             type: KubernetesReplicaSet
-          - id_keys:
+          - description_keys:
+            - k8s.cluster.name
+            id_keys:
             - sw.k8s.cluster.uid
             - k8s.namespace.name
             - k8s.statefulset.name
             type: KubernetesStatefulSet
-          - id_keys:
+          - description_keys:
+            - k8s.cluster.name
+            id_keys:
             - sw.k8s.cluster.uid
             - k8s.namespace.name
             - k8s.daemonset.name
             type: KubernetesDaemonSet
-          - id_keys:
+          - description_keys:
+            - k8s.cluster.name
+            id_keys:
             - sw.k8s.cluster.uid
             - k8s.namespace.name
             - k8s.job.name
             type: KubernetesJob
-          - id_keys:
+          - description_keys:
+            - k8s.cluster.name
+            id_keys:
             - sw.k8s.cluster.uid
             - k8s.namespace.name
             - k8s.cronjob.name
@@ -5185,50 +5225,70 @@ Cluster filter should match snapshot with exclude_namespaces:
         swootelentityref/container_logs:
           action: insert
           entity_refs:
-          - id_keys:
+          - description_keys:
+            - k8s.cluster.name
+            id_keys:
             - sw.k8s.cluster.uid
             type: KubernetesCluster
-          - id_keys:
+          - description_keys:
+            - k8s.cluster.name
+            id_keys:
             - sw.k8s.cluster.uid
             - k8s.namespace.name
             - k8s.pod.name
             - k8s.container.name
             type: KubernetesContainer
-          - id_keys:
+          - description_keys:
+            - k8s.cluster.name
+            id_keys:
             - sw.k8s.cluster.uid
             - k8s.namespace.name
             - k8s.pod.name
             type: KubernetesPod
-          - id_keys:
+          - description_keys:
+            - k8s.cluster.name
+            id_keys:
             - sw.k8s.cluster.uid
             - k8s.node.name
             type: KubernetesNode
-          - id_keys:
+          - description_keys:
+            - k8s.cluster.name
+            id_keys:
             - sw.k8s.cluster.uid
             - k8s.namespace.name
             - k8s.deployment.name
             type: KubernetesDeployment
-          - id_keys:
+          - description_keys:
+            - k8s.cluster.name
+            id_keys:
             - sw.k8s.cluster.uid
             - k8s.namespace.name
             - k8s.replicaset.name
             type: KubernetesReplicaSet
-          - id_keys:
+          - description_keys:
+            - k8s.cluster.name
+            id_keys:
             - sw.k8s.cluster.uid
             - k8s.namespace.name
             - k8s.statefulset.name
             type: KubernetesStatefulSet
-          - id_keys:
+          - description_keys:
+            - k8s.cluster.name
+            id_keys:
             - sw.k8s.cluster.uid
             - k8s.namespace.name
             - k8s.daemonset.name
             type: KubernetesDaemonSet
-          - id_keys:
+          - description_keys:
+            - k8s.cluster.name
+            id_keys:
             - sw.k8s.cluster.uid
             - k8s.namespace.name
             - k8s.job.name
             type: KubernetesJob
-          - id_keys:
+          - description_keys:
+            - k8s.cluster.name
+            id_keys:
             - sw.k8s.cluster.uid
             - k8s.namespace.name
             - k8s.cronjob.name
@@ -7096,50 +7156,70 @@ Cluster filter should match snapshot with exclude_namespaces_regex:
         swootelentityref/container_logs:
           action: insert
           entity_refs:
-          - id_keys:
+          - description_keys:
+            - k8s.cluster.name
+            id_keys:
             - sw.k8s.cluster.uid
             type: KubernetesCluster
-          - id_keys:
+          - description_keys:
+            - k8s.cluster.name
+            id_keys:
             - sw.k8s.cluster.uid
             - k8s.namespace.name
             - k8s.pod.name
             - k8s.container.name
             type: KubernetesContainer
-          - id_keys:
+          - description_keys:
+            - k8s.cluster.name
+            id_keys:
             - sw.k8s.cluster.uid
             - k8s.namespace.name
             - k8s.pod.name
             type: KubernetesPod
-          - id_keys:
+          - description_keys:
+            - k8s.cluster.name
+            id_keys:
             - sw.k8s.cluster.uid
             - k8s.node.name
             type: KubernetesNode
-          - id_keys:
+          - description_keys:
+            - k8s.cluster.name
+            id_keys:
             - sw.k8s.cluster.uid
             - k8s.namespace.name
             - k8s.deployment.name
             type: KubernetesDeployment
-          - id_keys:
+          - description_keys:
+            - k8s.cluster.name
+            id_keys:
             - sw.k8s.cluster.uid
             - k8s.namespace.name
             - k8s.replicaset.name
             type: KubernetesReplicaSet
-          - id_keys:
+          - description_keys:
+            - k8s.cluster.name
+            id_keys:
             - sw.k8s.cluster.uid
             - k8s.namespace.name
             - k8s.statefulset.name
             type: KubernetesStatefulSet
-          - id_keys:
+          - description_keys:
+            - k8s.cluster.name
+            id_keys:
             - sw.k8s.cluster.uid
             - k8s.namespace.name
             - k8s.daemonset.name
             type: KubernetesDaemonSet
-          - id_keys:
+          - description_keys:
+            - k8s.cluster.name
+            id_keys:
             - sw.k8s.cluster.uid
             - k8s.namespace.name
             - k8s.job.name
             type: KubernetesJob
-          - id_keys:
+          - description_keys:
+            - k8s.cluster.name
+            id_keys:
             - sw.k8s.cluster.uid
             - k8s.namespace.name
             - k8s.cronjob.name
@@ -9005,50 +9085,70 @@ Cluster filter should match snapshot with include_namespaces:
         swootelentityref/container_logs:
           action: insert
           entity_refs:
-          - id_keys:
+          - description_keys:
+            - k8s.cluster.name
+            id_keys:
             - sw.k8s.cluster.uid
             type: KubernetesCluster
-          - id_keys:
+          - description_keys:
+            - k8s.cluster.name
+            id_keys:
             - sw.k8s.cluster.uid
             - k8s.namespace.name
             - k8s.pod.name
             - k8s.container.name
             type: KubernetesContainer
-          - id_keys:
+          - description_keys:
+            - k8s.cluster.name
+            id_keys:
             - sw.k8s.cluster.uid
             - k8s.namespace.name
             - k8s.pod.name
             type: KubernetesPod
-          - id_keys:
+          - description_keys:
+            - k8s.cluster.name
+            id_keys:
             - sw.k8s.cluster.uid
             - k8s.node.name
             type: KubernetesNode
-          - id_keys:
+          - description_keys:
+            - k8s.cluster.name
+            id_keys:
             - sw.k8s.cluster.uid
             - k8s.namespace.name
             - k8s.deployment.name
             type: KubernetesDeployment
-          - id_keys:
+          - description_keys:
+            - k8s.cluster.name
+            id_keys:
             - sw.k8s.cluster.uid
             - k8s.namespace.name
             - k8s.replicaset.name
             type: KubernetesReplicaSet
-          - id_keys:
+          - description_keys:
+            - k8s.cluster.name
+            id_keys:
             - sw.k8s.cluster.uid
             - k8s.namespace.name
             - k8s.statefulset.name
             type: KubernetesStatefulSet
-          - id_keys:
+          - description_keys:
+            - k8s.cluster.name
+            id_keys:
             - sw.k8s.cluster.uid
             - k8s.namespace.name
             - k8s.daemonset.name
             type: KubernetesDaemonSet
-          - id_keys:
+          - description_keys:
+            - k8s.cluster.name
+            id_keys:
             - sw.k8s.cluster.uid
             - k8s.namespace.name
             - k8s.job.name
             type: KubernetesJob
-          - id_keys:
+          - description_keys:
+            - k8s.cluster.name
+            id_keys:
             - sw.k8s.cluster.uid
             - k8s.namespace.name
             - k8s.cronjob.name
@@ -10916,50 +11016,70 @@ Cluster filter should match snapshot with include_namespaces_regex:
         swootelentityref/container_logs:
           action: insert
           entity_refs:
-          - id_keys:
+          - description_keys:
+            - k8s.cluster.name
+            id_keys:
             - sw.k8s.cluster.uid
             type: KubernetesCluster
-          - id_keys:
+          - description_keys:
+            - k8s.cluster.name
+            id_keys:
             - sw.k8s.cluster.uid
             - k8s.namespace.name
             - k8s.pod.name
             - k8s.container.name
             type: KubernetesContainer
-          - id_keys:
+          - description_keys:
+            - k8s.cluster.name
+            id_keys:
             - sw.k8s.cluster.uid
             - k8s.namespace.name
             - k8s.pod.name
             type: KubernetesPod
-          - id_keys:
+          - description_keys:
+            - k8s.cluster.name
+            id_keys:
             - sw.k8s.cluster.uid
             - k8s.node.name
             type: KubernetesNode
-          - id_keys:
+          - description_keys:
+            - k8s.cluster.name
+            id_keys:
             - sw.k8s.cluster.uid
             - k8s.namespace.name
             - k8s.deployment.name
             type: KubernetesDeployment
-          - id_keys:
+          - description_keys:
+            - k8s.cluster.name
+            id_keys:
             - sw.k8s.cluster.uid
             - k8s.namespace.name
             - k8s.replicaset.name
             type: KubernetesReplicaSet
-          - id_keys:
+          - description_keys:
+            - k8s.cluster.name
+            id_keys:
             - sw.k8s.cluster.uid
             - k8s.namespace.name
             - k8s.statefulset.name
             type: KubernetesStatefulSet
-          - id_keys:
+          - description_keys:
+            - k8s.cluster.name
+            id_keys:
             - sw.k8s.cluster.uid
             - k8s.namespace.name
             - k8s.daemonset.name
             type: KubernetesDaemonSet
-          - id_keys:
+          - description_keys:
+            - k8s.cluster.name
+            id_keys:
             - sw.k8s.cluster.uid
             - k8s.namespace.name
             - k8s.job.name
             type: KubernetesJob
-          - id_keys:
+          - description_keys:
+            - k8s.cluster.name
+            id_keys:
             - sw.k8s.cluster.uid
             - k8s.namespace.name
             - k8s.cronjob.name
@@ -12819,50 +12939,70 @@ Custom logs filter with new syntax:
         swootelentityref/container_logs:
           action: insert
           entity_refs:
-          - id_keys:
+          - description_keys:
+            - k8s.cluster.name
+            id_keys:
             - sw.k8s.cluster.uid
             type: KubernetesCluster
-          - id_keys:
+          - description_keys:
+            - k8s.cluster.name
+            id_keys:
             - sw.k8s.cluster.uid
             - k8s.namespace.name
             - k8s.pod.name
             - k8s.container.name
             type: KubernetesContainer
-          - id_keys:
+          - description_keys:
+            - k8s.cluster.name
+            id_keys:
             - sw.k8s.cluster.uid
             - k8s.namespace.name
             - k8s.pod.name
             type: KubernetesPod
-          - id_keys:
+          - description_keys:
+            - k8s.cluster.name
+            id_keys:
             - sw.k8s.cluster.uid
             - k8s.node.name
             type: KubernetesNode
-          - id_keys:
+          - description_keys:
+            - k8s.cluster.name
+            id_keys:
             - sw.k8s.cluster.uid
             - k8s.namespace.name
             - k8s.deployment.name
             type: KubernetesDeployment
-          - id_keys:
+          - description_keys:
+            - k8s.cluster.name
+            id_keys:
             - sw.k8s.cluster.uid
             - k8s.namespace.name
             - k8s.replicaset.name
             type: KubernetesReplicaSet
-          - id_keys:
+          - description_keys:
+            - k8s.cluster.name
+            id_keys:
             - sw.k8s.cluster.uid
             - k8s.namespace.name
             - k8s.statefulset.name
             type: KubernetesStatefulSet
-          - id_keys:
+          - description_keys:
+            - k8s.cluster.name
+            id_keys:
             - sw.k8s.cluster.uid
             - k8s.namespace.name
             - k8s.daemonset.name
             type: KubernetesDaemonSet
-          - id_keys:
+          - description_keys:
+            - k8s.cluster.name
+            id_keys:
             - sw.k8s.cluster.uid
             - k8s.namespace.name
             - k8s.job.name
             type: KubernetesJob
-          - id_keys:
+          - description_keys:
+            - k8s.cluster.name
+            id_keys:
             - sw.k8s.cluster.uid
             - k8s.namespace.name
             - k8s.cronjob.name
@@ -14724,50 +14864,70 @@ Custom logs filter with old syntax:
         swootelentityref/container_logs:
           action: insert
           entity_refs:
-          - id_keys:
+          - description_keys:
+            - k8s.cluster.name
+            id_keys:
             - sw.k8s.cluster.uid
             type: KubernetesCluster
-          - id_keys:
+          - description_keys:
+            - k8s.cluster.name
+            id_keys:
             - sw.k8s.cluster.uid
             - k8s.namespace.name
             - k8s.pod.name
             - k8s.container.name
             type: KubernetesContainer
-          - id_keys:
+          - description_keys:
+            - k8s.cluster.name
+            id_keys:
             - sw.k8s.cluster.uid
             - k8s.namespace.name
             - k8s.pod.name
             type: KubernetesPod
-          - id_keys:
+          - description_keys:
+            - k8s.cluster.name
+            id_keys:
             - sw.k8s.cluster.uid
             - k8s.node.name
             type: KubernetesNode
-          - id_keys:
+          - description_keys:
+            - k8s.cluster.name
+            id_keys:
             - sw.k8s.cluster.uid
             - k8s.namespace.name
             - k8s.deployment.name
             type: KubernetesDeployment
-          - id_keys:
+          - description_keys:
+            - k8s.cluster.name
+            id_keys:
             - sw.k8s.cluster.uid
             - k8s.namespace.name
             - k8s.replicaset.name
             type: KubernetesReplicaSet
-          - id_keys:
+          - description_keys:
+            - k8s.cluster.name
+            id_keys:
             - sw.k8s.cluster.uid
             - k8s.namespace.name
             - k8s.statefulset.name
             type: KubernetesStatefulSet
-          - id_keys:
+          - description_keys:
+            - k8s.cluster.name
+            id_keys:
             - sw.k8s.cluster.uid
             - k8s.namespace.name
             - k8s.daemonset.name
             type: KubernetesDaemonSet
-          - id_keys:
+          - description_keys:
+            - k8s.cluster.name
+            id_keys:
             - sw.k8s.cluster.uid
             - k8s.namespace.name
             - k8s.job.name
             type: KubernetesJob
-          - id_keys:
+          - description_keys:
+            - k8s.cluster.name
+            id_keys:
             - sw.k8s.cluster.uid
             - k8s.namespace.name
             - k8s.cronjob.name
@@ -16703,50 +16863,70 @@ Node collector config should match snapshot when autodiscovery is disabled:
         swootelentityref/container_logs:
           action: insert
           entity_refs:
-          - id_keys:
+          - description_keys:
+            - k8s.cluster.name
+            id_keys:
             - sw.k8s.cluster.uid
             type: KubernetesCluster
-          - id_keys:
+          - description_keys:
+            - k8s.cluster.name
+            id_keys:
             - sw.k8s.cluster.uid
             - k8s.namespace.name
             - k8s.pod.name
             - k8s.container.name
             type: KubernetesContainer
-          - id_keys:
+          - description_keys:
+            - k8s.cluster.name
+            id_keys:
             - sw.k8s.cluster.uid
             - k8s.namespace.name
             - k8s.pod.name
             type: KubernetesPod
-          - id_keys:
+          - description_keys:
+            - k8s.cluster.name
+            id_keys:
             - sw.k8s.cluster.uid
             - k8s.node.name
             type: KubernetesNode
-          - id_keys:
+          - description_keys:
+            - k8s.cluster.name
+            id_keys:
             - sw.k8s.cluster.uid
             - k8s.namespace.name
             - k8s.deployment.name
             type: KubernetesDeployment
-          - id_keys:
+          - description_keys:
+            - k8s.cluster.name
+            id_keys:
             - sw.k8s.cluster.uid
             - k8s.namespace.name
             - k8s.replicaset.name
             type: KubernetesReplicaSet
-          - id_keys:
+          - description_keys:
+            - k8s.cluster.name
+            id_keys:
             - sw.k8s.cluster.uid
             - k8s.namespace.name
             - k8s.statefulset.name
             type: KubernetesStatefulSet
-          - id_keys:
+          - description_keys:
+            - k8s.cluster.name
+            id_keys:
             - sw.k8s.cluster.uid
             - k8s.namespace.name
             - k8s.daemonset.name
             type: KubernetesDaemonSet
-          - id_keys:
+          - description_keys:
+            - k8s.cluster.name
+            id_keys:
             - sw.k8s.cluster.uid
             - k8s.namespace.name
             - k8s.job.name
             type: KubernetesJob
-          - id_keys:
+          - description_keys:
+            - k8s.cluster.name
+            id_keys:
             - sw.k8s.cluster.uid
             - k8s.namespace.name
             - k8s.cronjob.name
@@ -18538,50 +18718,70 @@ Node collector config should match snapshot when fargate is enabled:
         swootelentityref/container_logs:
           action: insert
           entity_refs:
-          - id_keys:
+          - description_keys:
+            - k8s.cluster.name
+            id_keys:
             - sw.k8s.cluster.uid
             type: KubernetesCluster
-          - id_keys:
+          - description_keys:
+            - k8s.cluster.name
+            id_keys:
             - sw.k8s.cluster.uid
             - k8s.namespace.name
             - k8s.pod.name
             - k8s.container.name
             type: KubernetesContainer
-          - id_keys:
+          - description_keys:
+            - k8s.cluster.name
+            id_keys:
             - sw.k8s.cluster.uid
             - k8s.namespace.name
             - k8s.pod.name
             type: KubernetesPod
-          - id_keys:
+          - description_keys:
+            - k8s.cluster.name
+            id_keys:
             - sw.k8s.cluster.uid
             - k8s.node.name
             type: KubernetesNode
-          - id_keys:
+          - description_keys:
+            - k8s.cluster.name
+            id_keys:
             - sw.k8s.cluster.uid
             - k8s.namespace.name
             - k8s.deployment.name
             type: KubernetesDeployment
-          - id_keys:
+          - description_keys:
+            - k8s.cluster.name
+            id_keys:
             - sw.k8s.cluster.uid
             - k8s.namespace.name
             - k8s.replicaset.name
             type: KubernetesReplicaSet
-          - id_keys:
+          - description_keys:
+            - k8s.cluster.name
+            id_keys:
             - sw.k8s.cluster.uid
             - k8s.namespace.name
             - k8s.statefulset.name
             type: KubernetesStatefulSet
-          - id_keys:
+          - description_keys:
+            - k8s.cluster.name
+            id_keys:
             - sw.k8s.cluster.uid
             - k8s.namespace.name
             - k8s.daemonset.name
             type: KubernetesDaemonSet
-          - id_keys:
+          - description_keys:
+            - k8s.cluster.name
+            id_keys:
             - sw.k8s.cluster.uid
             - k8s.namespace.name
             - k8s.job.name
             type: KubernetesJob
-          - id_keys:
+          - description_keys:
+            - k8s.cluster.name
+            id_keys:
             - sw.k8s.cluster.uid
             - k8s.namespace.name
             - k8s.cronjob.name
@@ -20349,50 +20549,70 @@ Node collector config should match snapshot when fargate is enabled and autodisc
         swootelentityref/container_logs:
           action: insert
           entity_refs:
-          - id_keys:
+          - description_keys:
+            - k8s.cluster.name
+            id_keys:
             - sw.k8s.cluster.uid
             type: KubernetesCluster
-          - id_keys:
+          - description_keys:
+            - k8s.cluster.name
+            id_keys:
             - sw.k8s.cluster.uid
             - k8s.namespace.name
             - k8s.pod.name
             - k8s.container.name
             type: KubernetesContainer
-          - id_keys:
+          - description_keys:
+            - k8s.cluster.name
+            id_keys:
             - sw.k8s.cluster.uid
             - k8s.namespace.name
             - k8s.pod.name
             type: KubernetesPod
-          - id_keys:
+          - description_keys:
+            - k8s.cluster.name
+            id_keys:
             - sw.k8s.cluster.uid
             - k8s.node.name
             type: KubernetesNode
-          - id_keys:
+          - description_keys:
+            - k8s.cluster.name
+            id_keys:
             - sw.k8s.cluster.uid
             - k8s.namespace.name
             - k8s.deployment.name
             type: KubernetesDeployment
-          - id_keys:
+          - description_keys:
+            - k8s.cluster.name
+            id_keys:
             - sw.k8s.cluster.uid
             - k8s.namespace.name
             - k8s.replicaset.name
             type: KubernetesReplicaSet
-          - id_keys:
+          - description_keys:
+            - k8s.cluster.name
+            id_keys:
             - sw.k8s.cluster.uid
             - k8s.namespace.name
             - k8s.statefulset.name
             type: KubernetesStatefulSet
-          - id_keys:
+          - description_keys:
+            - k8s.cluster.name
+            id_keys:
             - sw.k8s.cluster.uid
             - k8s.namespace.name
             - k8s.daemonset.name
             type: KubernetesDaemonSet
-          - id_keys:
+          - description_keys:
+            - k8s.cluster.name
+            id_keys:
             - sw.k8s.cluster.uid
             - k8s.namespace.name
             - k8s.job.name
             type: KubernetesJob
-          - id_keys:
+          - description_keys:
+            - k8s.cluster.name
+            id_keys:
             - sw.k8s.cluster.uid
             - k8s.namespace.name
             - k8s.cronjob.name
@@ -22096,50 +22316,70 @@ Node collector config should match snapshot when using default values:
         swootelentityref/container_logs:
           action: insert
           entity_refs:
-          - id_keys:
+          - description_keys:
+            - k8s.cluster.name
+            id_keys:
             - sw.k8s.cluster.uid
             type: KubernetesCluster
-          - id_keys:
+          - description_keys:
+            - k8s.cluster.name
+            id_keys:
             - sw.k8s.cluster.uid
             - k8s.namespace.name
             - k8s.pod.name
             - k8s.container.name
             type: KubernetesContainer
-          - id_keys:
+          - description_keys:
+            - k8s.cluster.name
+            id_keys:
             - sw.k8s.cluster.uid
             - k8s.namespace.name
             - k8s.pod.name
             type: KubernetesPod
-          - id_keys:
+          - description_keys:
+            - k8s.cluster.name
+            id_keys:
             - sw.k8s.cluster.uid
             - k8s.node.name
             type: KubernetesNode
-          - id_keys:
+          - description_keys:
+            - k8s.cluster.name
+            id_keys:
             - sw.k8s.cluster.uid
             - k8s.namespace.name
             - k8s.deployment.name
             type: KubernetesDeployment
-          - id_keys:
+          - description_keys:
+            - k8s.cluster.name
+            id_keys:
             - sw.k8s.cluster.uid
             - k8s.namespace.name
             - k8s.replicaset.name
             type: KubernetesReplicaSet
-          - id_keys:
+          - description_keys:
+            - k8s.cluster.name
+            id_keys:
             - sw.k8s.cluster.uid
             - k8s.namespace.name
             - k8s.statefulset.name
             type: KubernetesStatefulSet
-          - id_keys:
+          - description_keys:
+            - k8s.cluster.name
+            id_keys:
             - sw.k8s.cluster.uid
             - k8s.namespace.name
             - k8s.daemonset.name
             type: KubernetesDaemonSet
-          - id_keys:
+          - description_keys:
+            - k8s.cluster.name
+            id_keys:
             - sw.k8s.cluster.uid
             - k8s.namespace.name
             - k8s.job.name
             type: KubernetesJob
-          - id_keys:
+          - description_keys:
+            - k8s.cluster.name
+            id_keys:
             - sw.k8s.cluster.uid
             - k8s.namespace.name
             - k8s.cronjob.name


### PR DESCRIPTION
This ensures that if only container logs are sent to SWO and nothing else, the cluster will have a set name.

This PR is blocked by https://github.com/solarwinds/solarwinds-otel-collector-contrib/pull/358